### PR TITLE
ci(coverage): run the direct test legs under nextest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,8 @@ jobs:
     # Non-gating: a coverage report, never a merge blocker. The number undercounts
     # by design (see scripts/coverage.sh): glass-windows Win32 FFI is
     # cfg(windows) so it isn't measured here; the Wayland suite needs a sway this job does not
-    # fetch, so it self-skips, and glass-wayland's own tests are `#[ignore]`d for the same reason.
+    # fetch, so it self-skips, and glass-wayland's own tests are `#[ignore]`d for the same reason;
+    # and nextest runs no doctests, which costs nothing while the workspace has none.
     continue-on-error: true
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -241,6 +242,9 @@ jobs:
         run: rustup show
       - name: Add llvm-tools (required by cargo-llvm-cov)
         run: rustup component add llvm-tools-preview
+      # cargo-nextest as well as cargo-llvm-cov: scripts/coverage.sh runs its direct test legs
+      # under nextest and hard-exits without it, which this `continue-on-error` job would report
+      # as a pass that measured nothing.
       - uses: taiki-e/install-action@ed67fa35ac944f3a9b33f12c4dd43b6f31a47e20 # v2.83.3
         with:
           tool: cargo-llvm-cov,cargo-nextest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,7 +234,7 @@ jobs:
     # by design (see scripts/coverage.sh): glass-windows Win32 FFI is
     # cfg(windows) so it isn't measured here; the Wayland suite needs a sway this job does not
     # fetch, so it self-skips, and glass-wayland's own tests are `#[ignore]`d for the same reason;
-    # and nextest runs no doctests, which costs nothing while the workspace has none.
+    # and nextest runs no doctests — the workspace has none.
     continue-on-error: true
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -242,9 +242,8 @@ jobs:
         run: rustup show
       - name: Add llvm-tools (required by cargo-llvm-cov)
         run: rustup component add llvm-tools-preview
-      # cargo-nextest as well as cargo-llvm-cov: scripts/coverage.sh runs its direct test legs
-      # under nextest and hard-exits without it, which this `continue-on-error` job would report
-      # as a pass that measured nothing.
+      # scripts/coverage.sh runs its direct test legs under nextest and hard-exits without it —
+      # which this `continue-on-error` job would report as a pass that measured nothing.
       - uses: taiki-e/install-action@ed67fa35ac944f3a9b33f12c4dd43b6f31a47e20 # v2.83.3
         with:
           tool: cargo-llvm-cov,cargo-nextest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,7 @@ jobs:
         run: rustup component add llvm-tools-preview
       - uses: taiki-e/install-action@ed67fa35ac944f3a9b33f12c4dd43b6f31a47e20 # v2.83.3
         with:
-          tool: cargo-llvm-cov
+          tool: cargo-llvm-cov,cargo-nextest
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: .

--- a/docs/how-to/verify-a-change.md
+++ b/docs/how-to/verify-a-change.md
@@ -127,7 +127,7 @@ Fourteen run locally. One drives another machine.
 | **`test-windows.sh`** | **drives a REMOTE Windows box over SSH**; skips cleanly when none is configured |
 | `sandbox-xvfb.sh` | manage the sandbox X display glass-mcp drives |
 | `bench.sh` | run the benchmarks, or flamegraph one |
-| `coverage.sh` | coverage via cargo-llvm-cov |
+| `coverage.sh` | coverage via cargo-llvm-cov + cargo-nextest |
 | `mutants.sh` | mutation-test glass-core (CI does this; see the table above) |
 | `build-bundle.sh` | build the distribution bundle |
 | `verification-cost.sh` | measure what the verification loop costs |

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -13,14 +13,10 @@
 # prerequisites are absent), and finally combines them into one report.
 #
 # The direct test runs are `cargo nextest run`; the harness scripts below still run libtest.
-# nextest gives each test its own process, so a test that aborts or corrupts process-global
-# state takes down itself rather than the rest of its binary, and with `--no-tests=fail` it
-# exits 4 where libtest exits 0 on a run that selected nothing. It also pools every binary's
-# tests together instead of running one binary at a time, so tests from different crates now
-# overlap; nothing in the workspace serializes on a fixed port, path or display, and a test
-# that needs to would have to say so itself. nextest runs no doctests — the workspace has
-# none (every rustdoc fence is ```text or ```sh), and the `check` job's `cargo test` would
-# still run one.
+# Each test gets its own process, so one that aborts takes down itself rather than its whole
+# binary — and every binary's tests share one pool, so tests from different crates overlap for
+# the first time. Nothing here serializes on a fixed port, path or display; a test that needs to
+# must say so itself. nextest runs no doctests, and the workspace has none.
 #
 # CAVEAT (always true on Linux): the glass-windows Win32 FFI code (capture, input,
 # clipboard, process, util, windows) is cfg(windows) and is NOT compiled or run
@@ -68,10 +64,9 @@ while [ $# -gt 0 ]; do
     shift
 done
 
-# Export the instrumentation env so every test run below — the direct `cargo nextest run`s and
-# the `cargo test`s the integration harnesses run — writes .profraw into the shared coverage
-# target dir. `LLVM_PROFILE_FILE` carries `%p`: that is what keeps nextest's process-per-test
-# from having every test clobber one file.
+# Export the instrumentation env so every test run below — the direct nextest runs and the
+# `cargo test`s the harnesses run — writes .profraw into the shared coverage target dir.
+# `LLVM_PROFILE_FILE` carries `%p`; without it nextest's process-per-test clobbers one file.
 # shellcheck disable=SC1090
 source <(cargo llvm-cov show-env --sh)
 cargo llvm-cov clean --workspace
@@ -106,14 +101,13 @@ classify_suite() {  # label cmd...
 # sentinel the way `classify_suite` does — a self-skipping test prints "skipping" too, and one
 # of them would file the whole run as skipped.
 #
-# Exit status decides it instead. `--no-fail-fast` keeps a single failing test from costing the
-# rest of the run its coverage, and `--no-tests=fail` exits 4 when every test was filtered or
-# ignored, which libtest exits 0 on and which records an empty run as coverage. The check is per
-# invocation, so it catches a `-p` leg that ran nothing but not one silent crate inside
-# `--workspace`.
+# Exit status decides it. `--no-fail-fast` keeps one failing test from costing the rest of the
+# run its coverage; `--no-tests=fail` exits 4 where libtest exits 0 on a run that selected
+# nothing and records it as coverage. Per invocation, so it catches a `-p` leg that ran nothing,
+# not one silent crate inside `--workspace`.
 #
-# Named for the runner because it hardcodes it: a leg needing libtest — a doctest one, say,
-# which nextest cannot run — needs its own helper, not this one with different arguments.
+# It hardcodes the runner, hence the name: a leg needing libtest — a doctest one, which nextest
+# cannot run — needs its own helper, not this one with different arguments.
 run_nextest() { # label nextest-args...
     local label="$1" out rc
     shift
@@ -122,7 +116,7 @@ run_nextest() { # label nextest-args...
     if [ "$rc" -eq 0 ]; then
         ran+=("$label")
     else
-        # Distinct from a test failure: "coverage still collected" is false for an empty run.
+        # Exit 4 ran nothing, so the summary below must not credit it with coverage.
         [ "$rc" -eq 4 ] && label="$label (ran no tests)"
         failed+=("$label")
         tail -n 30 <<<"$out"

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -12,10 +12,15 @@
 # the unit tests AND each integration harness (each self-skips when its
 # prerequisites are absent), and finally combines them into one report.
 #
-# The direct `cargo test` runs are `cargo nextest run` instead: nextest gives each test
-# its own process, so a test that leaves the host dirty cannot be masked by an in-process
-# neighbour, and it exits 4 rather than 0 when a filter selects nothing. The harness
-# scripts below still run libtest — their suites are `--test-threads=1` by design.
+# The direct test runs are `cargo nextest run`; the harness scripts below still run libtest.
+# nextest gives each test its own process, so a test that aborts or corrupts process-global
+# state takes down itself rather than the rest of its binary, and with `--no-tests=fail` it
+# exits 4 where libtest exits 0 on a run that selected nothing. It also pools every binary's
+# tests together instead of running one binary at a time, so tests from different crates now
+# overlap; nothing in the workspace serializes on a fixed port, path or display, and a test
+# that needs to would have to say so itself. nextest runs no doctests — the workspace has
+# none (every rustdoc fence is ```text or ```sh), and the `check` job's `cargo test` would
+# still run one.
 #
 # CAVEAT (always true on Linux): the glass-windows Win32 FFI code (capture, input,
 # clipboard, process, util, windows) is cfg(windows) and is NOT compiled or run
@@ -63,8 +68,10 @@ while [ $# -gt 0 ]; do
     shift
 done
 
-# Export the instrumentation env so every `cargo test` below (incl. the ones the
-# integration harnesses run) writes .profraw into the shared coverage target dir.
+# Export the instrumentation env so every test run below — the direct `cargo nextest run`s and
+# the `cargo test`s the integration harnesses run — writes .profraw into the shared coverage
+# target dir. `LLVM_PROFILE_FILE` carries `%p`: that is what keeps nextest's process-per-test
+# from having every test clobber one file.
 # shellcheck disable=SC1090
 source <(cargo llvm-cov show-env --sh)
 cargo llvm-cov clean --workspace
@@ -99,24 +106,32 @@ classify_suite() {  # label cmd...
 # sentinel the way `classify_suite` does — a self-skipping test prints "skipping" too, and one
 # of them would file the whole run as skipped.
 #
-# Exit status decides it, because `--no-tests=fail` makes nextest exit 4 when every test was
-# filtered or ignored. Recording an empty run as coverage is how a crate drops out of the
-# report unseen, and libtest exits 0 on one.
-run_tests() { # label cargo-args...
-    local label="$1" out
+# Exit status decides it instead. `--no-fail-fast` keeps a single failing test from costing the
+# rest of the run its coverage, and `--no-tests=fail` exits 4 when every test was filtered or
+# ignored, which libtest exits 0 on and which records an empty run as coverage. The check is per
+# invocation, so it catches a `-p` leg that ran nothing but not one silent crate inside
+# `--workspace`.
+#
+# Named for the runner because it hardcodes it: a leg needing libtest — a doctest one, say,
+# which nextest cannot run — needs its own helper, not this one with different arguments.
+run_nextest() { # label nextest-args...
+    local label="$1" out rc
     shift
-    if out=$(cargo nextest run --no-fail-fast --no-tests=fail "$@" 2>&1); then
+    out=$(cargo nextest run --no-fail-fast --no-tests=fail "$@" 2>&1)
+    rc=$?
+    if [ "$rc" -eq 0 ]; then
         ran+=("$label")
     else
+        # Distinct from a test failure: "coverage still collected" is false for an empty run.
+        [ "$rc" -eq 4 ] && label="$label (ran no tests)"
         failed+=("$label")
         tail -n 30 <<<"$out"
     fi
 }
 
-# Always: the workspace unit tests (and the always-on integration tests). Keep
-# going on failure so a single failing test still yields a coverage report.
+# Always: the workspace unit tests (and the always-on integration tests).
 echo "coverage: running workspace unit tests…"
-run_tests unit --workspace
+run_nextest unit --workspace
 
 if [ "$unit_only" -eq 0 ]; then
     # Each harness exits 0 and self-skips when its prerequisites are missing, so we
@@ -126,7 +141,7 @@ if [ "$unit_only" -eq 0 ]; then
     if command -v Xvfb >/dev/null 2>&1; then
         # The workspace run above skipped glass-x11's `#[ignore]`d display tests — half the
         # crate's coverage.
-        run_tests x11-unit -p glass-x11 --run-ignored=all
+        run_nextest x11-unit -p glass-x11 --run-ignored=all
         classify_suite x11 ./scripts/test-x11.sh
     else
         skipped+=("x11-unit (no Xvfb)" "x11 (no Xvfb)")
@@ -134,7 +149,7 @@ if [ "$unit_only" -eq 0 ]; then
 
     echo "coverage: running Wayland integration suite (needs sway >=1.12)…"
     if have_sway; then
-        run_tests wayland-unit -p glass-wayland --run-ignored=all
+        run_nextest wayland-unit -p glass-wayland --run-ignored=all
     else
         skipped+=("wayland-unit (no sway)")
     fi
@@ -163,7 +178,7 @@ fi
 echo
 echo "coverage: suites run:     ${ran[*]:-none}"
 echo "coverage: suites skipped: ${skipped[*]:-none}"
-[ ${#failed[@]} -gt 0 ] && echo "coverage: suites with failing tests (coverage still collected): ${failed[*]}"
+[ ${#failed[@]} -gt 0 ] && echo "coverage: suites that failed (a failing suite still contributes its coverage): ${failed[*]}"
 echo "coverage: NOTE glass-windows Win32 FFI is cfg(windows) — not measured on Linux (on-box only)."
 # Exit non-zero only if the unit suite itself failed to build/run; integration
 # flakiness shouldn't fail a coverage report.

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -12,6 +12,11 @@
 # the unit tests AND each integration harness (each self-skips when its
 # prerequisites are absent), and finally combines them into one report.
 #
+# The direct `cargo test` runs are `cargo nextest run` instead: nextest gives each test
+# its own process, so a test that leaves the host dirty cannot be masked by an in-process
+# neighbour, and it exits 4 rather than 0 when a filter selects nothing. The harness
+# scripts below still run libtest — their suites are `--test-threads=1` by design.
+#
 # CAVEAT (always true on Linux): the glass-windows Win32 FFI code (capture, input,
 # clipboard, process, util, windows) is cfg(windows) and is NOT compiled or run
 # here, so it never appears in this report. Its pure modules (dpi/jobpids/vkmap/
@@ -32,6 +37,12 @@ if ! cargo llvm-cov --version >/dev/null 2>&1; then
     echo "coverage: cargo-llvm-cov is not installed." >&2
     echo "          install it with:  cargo install cargo-llvm-cov" >&2
     echo "          and the llvm-tools component:  rustup component add llvm-tools-preview" >&2
+    exit 1
+fi
+
+if ! cargo nextest --version >/dev/null 2>&1; then
+    echo "coverage: cargo-nextest is not installed." >&2
+    echo "          install it with:  cargo install cargo-nextest --locked" >&2
     exit 1
 fi
 
@@ -84,30 +95,28 @@ classify_suite() {  # label cmd...
     fi
 }
 
-# A plain `cargo test` run rather than a harness. Its output must NOT be grepped for the skip
+# A direct nextest run rather than a harness. Its output must NOT be grepped for the skip
 # sentinel the way `classify_suite` does — a self-skipping test prints "skipping" too, and one
 # of them would file the whole run as skipped.
-classify_tests() { # label cmd...
+#
+# Exit status decides it, because `--no-tests=fail` makes nextest exit 4 when every test was
+# filtered or ignored. Recording an empty run as coverage is how a crate drops out of the
+# report unseen, and libtest exits 0 on one.
+run_tests() { # label cargo-args...
     local label="$1" out
     shift
-    if ! out=$("$@" 2>&1); then
+    if out=$(cargo nextest run --no-fail-fast --no-tests=fail "$@" 2>&1); then
+        ran+=("$label")
+    else
         failed+=("$label")
         tail -n 30 <<<"$out"
-    elif ! grep -qE '^test result: ok\. [1-9][0-9]* passed' <<<"$out"; then
-        # Exit 0 having run nothing: every test filtered or ignored. Recording that as
-        # coverage is how a crate drops out of the report unseen. Look for a target that DID
-        # run something — a crate reports one line per target, and the empty ones read
-        # `0 passed` however well the rest went.
-        failed+=("$label (ran no tests)")
-    else
-        ran+=("$label")
     fi
 }
 
 # Always: the workspace unit tests (and the always-on integration tests). Keep
 # going on failure so a single failing test still yields a coverage report.
 echo "coverage: running workspace unit tests…"
-classify_tests unit cargo test --workspace --no-fail-fast
+run_tests unit --workspace
 
 if [ "$unit_only" -eq 0 ]; then
     # Each harness exits 0 and self-skips when its prerequisites are missing, so we
@@ -117,7 +126,7 @@ if [ "$unit_only" -eq 0 ]; then
     if command -v Xvfb >/dev/null 2>&1; then
         # The workspace run above skipped glass-x11's `#[ignore]`d display tests — half the
         # crate's coverage.
-        classify_tests x11-unit cargo test -p glass-x11 --no-fail-fast -- --include-ignored
+        run_tests x11-unit -p glass-x11 --run-ignored=all
         classify_suite x11 ./scripts/test-x11.sh
     else
         skipped+=("x11-unit (no Xvfb)" "x11 (no Xvfb)")
@@ -125,7 +134,7 @@ if [ "$unit_only" -eq 0 ]; then
 
     echo "coverage: running Wayland integration suite (needs sway >=1.12)…"
     if have_sway; then
-        classify_tests wayland-unit cargo test -p glass-wayland --no-fail-fast -- --include-ignored
+        run_tests wayland-unit -p glass-wayland --run-ignored=all
     else
         skipped+=("wayland-unit (no sway)")
     fi


### PR DESCRIPTION
Runs the coverage job's three direct test legs — `unit`, `x11-unit`, `wayland-unit` — under
`cargo nextest run` instead of `cargo test`. The three integration harnesses it also calls
(`test-x11.sh`, `test-wayland.sh`, `test-a11y.sh`) stay on libtest.

Each test gets its own process, so one that aborts takes down itself rather than its whole
binary. The concrete gain is the empty-run guard: libtest exits 0 when every test is filtered or
ignored, so the script hand-scanned output for a `test result: ok. N passed` line to catch a leg
that measured nothing. `--no-tests=fail` makes nextest exit 4 instead, and `run_nextest` labels
that case distinctly so the summary does not report an empty run as a failing suite that still
contributed coverage.

`--include-ignored` becomes nextest's `--run-ignored=all`. `LLVM_PROFILE_FILE` already carries
`%p`, which is what keeps process-per-test from having every test clobber one profraw. The CI job
installs `cargo-nextest` alongside `cargo-llvm-cov`; the script hard-exits without it rather than
letting a `continue-on-error` job pass having measured nothing.

## Verification

`scripts/coverage.sh --lcov` before and after, same box, same warm target dir:

| | `cargo test` | `cargo nextest run` |
|---|---|---|
| TOTAL regions | 86.49% | 86.49% |
| TOTAL lines | 86.58% | 86.58% |
| wall | 98.1 s | 101.1 s |
| suites | unit x11-unit wayland-unit wayland | identical |

Coverage is unchanged and there is no speedup on a 20-core box. A later run with every
prerequisite present is green across all six suites (`unit x11-unit x11 wayland-unit wayland
a11y`, none skipped) at 88.06% regions.

Exit statuses are ablated in both directions: an empty selection exits 4, an all-ignored
selection exits 4, a real selection exits 0.

## Notes

nextest runs no doctests. The workspace has none — every rustdoc fence is ```text or ```sh — and
the `check` job's `cargo test --workspace` would still run one if it appeared.

nextest pools every binary's tests rather than running one binary at a time, so tests from
different crates overlap for the first time. Nothing in the workspace serializes on a fixed port,
path or display.
