### PR TITLE
fix(test): stop every session the in-process MCP tests start

### DIFF
--- a/crates/glass-testapp/tests/common/mcp_cost.rs
+++ b/crates/glass-testapp/tests/common/mcp_cost.rs
@@ -626,10 +626,16 @@ pub async fn run_verification_cost(client: &Peer<RoleClient>) -> (ArmReport, Arm
     (a1, b)
 }
 
-/// Stop and relaunch the fixture for a clean UI between arms. `glass_stop` takes no
-/// arguments (see `glass_mcp::server::glass_stop`).
-async fn restart_fixture(client: &Peer<RoleClient>) {
+/// Stop the fixture session. Cancelling the client does not: glass-mcp only reaches its own
+/// teardown when the serve loop returns, and dropping the test runtime instead leaves the
+/// backend's `Drop` running on a thread nothing joins (glass#415).
+pub async fn stop_fixture(client: &Peer<RoleClient>) {
     call(client, "glass_stop", json!({})).await;
+}
+
+/// Stop and relaunch the fixture for a clean UI between arms.
+async fn restart_fixture(client: &Peer<RoleClient>) {
+    stop_fixture(client).await;
     start_fixture(client).await;
 }
 

--- a/crates/glass-testapp/tests/common/mcp_cost.rs
+++ b/crates/glass-testapp/tests/common/mcp_cost.rs
@@ -626,9 +626,8 @@ pub async fn run_verification_cost(client: &Peer<RoleClient>) -> (ArmReport, Arm
     (a1, b)
 }
 
-/// Stop the fixture session. Cancelling the client does not: glass-mcp only reaches its own
-/// teardown when the serve loop returns, and dropping the test runtime instead leaves the
-/// backend's `Drop` running on a thread nothing joins (glass#415).
+/// Stop the fixture session — cancelling the client does not, and the backend's `Drop` is no
+/// fallback here (glass#415).
 pub async fn stop_fixture(client: &Peer<RoleClient>) {
     call(client, "glass_stop", json!({})).await;
 }

--- a/crates/glass-testapp/tests/common/mcp_ignore.rs
+++ b/crates/glass-testapp/tests/common/mcp_ignore.rs
@@ -174,5 +174,10 @@ pub async fn assert_blink_region_e2e(testapp: &str, backend: &str, start_timeout
         "the mask must exclude exactly its own area: {diff}"
     );
 
+    // Stop the session this test started. Cancelling the client only closes the connection, and
+    // the server's own teardown runs when its serve loop returns — which dropping the test's
+    // runtime skips. That leaves `Drop for WaylandPlatform`, which needs seconds it does not get
+    // before the test binary exits, so without this the compositor is orphaned (glass#415).
+    call(&client, "glass_stop", json!({})).await;
     client.cancel().await.ok();
 }

--- a/crates/glass-testapp/tests/common/mcp_ignore.rs
+++ b/crates/glass-testapp/tests/common/mcp_ignore.rs
@@ -29,10 +29,11 @@ fn blink_region_json() -> Value {
     json!({ "x": x, "y": y, "width": width, "height": height })
 }
 
-/// Call `tool` with `args` (a JSON object), assert it did not error, and return the parsed
-/// success envelope's `result` object — see glass-mcp's `tools::envelope`
-/// (`{"ok":true,"tool":..., "result": {...}}`).
-async fn call(client: &Peer<RoleClient>, tool: &str, args: Value) -> Value {
+/// One tool call: `Ok` with the parsed success envelope's `result` object (see glass-mcp's
+/// `tools::envelope`, `{"ok":true,"tool":..., "result": {...}}`), `Err` with the tool's error
+/// text. Same contract as `mcp_cost::try_call` — a transport failure still panics, being an
+/// infrastructure fault rather than an outcome any caller here branches on.
+async fn try_call(client: &Peer<RoleClient>, tool: &str, args: Value) -> Result<Value, String> {
     let arguments = args
         .as_object()
         .unwrap_or_else(|| panic!("{tool} args must be a JSON object: {args}"))
@@ -41,19 +42,41 @@ async fn call(client: &Peer<RoleClient>, tool: &str, args: Value) -> Value {
         .call_tool(CallToolRequestParams::new(tool.to_string()).with_arguments(arguments))
         .await
         .unwrap_or_else(|e| panic!("{tool} call failed: {e}"));
-    assert_ne!(
-        result.is_error,
-        Some(true),
-        "{tool} returned an error result: {result:?}"
-    );
     let text = result
         .content
         .iter()
-        .find_map(|c| c.as_text().map(|t| t.text.clone()))
-        .unwrap_or_else(|| panic!("{tool} returned no text content: {result:?}"));
+        .find_map(|c| c.as_text().map(|t| t.text.clone()));
+    if result.is_error == Some(true) {
+        return Err(text.unwrap_or_else(|| format!("{result:?}")));
+    }
+    let text = text.unwrap_or_else(|| panic!("{tool} returned no text content: {result:?}"));
     let envelope: Value = serde_json::from_str(&text)
         .unwrap_or_else(|e| panic!("{tool} text content is not JSON ({e}): {text}"));
-    envelope["result"].clone()
+    Ok(envelope["result"].clone())
+}
+
+/// [`try_call`], asserting the tool did not error.
+async fn call(client: &Peer<RoleClient>, tool: &str, args: Value) -> Value {
+    try_call(client, tool, args)
+        .await
+        .unwrap_or_else(|e| panic!("{tool} returned an error result: {e}"))
+}
+
+/// Stop the session, then prove it is gone by requiring a second `glass_stop` to fail with
+/// `NoActiveSession`.
+///
+/// The second call is what gives the first one teeth. Stopping can only fail when no session
+/// exists, so asserting the stop succeeded asserts nothing a passing test could violate —
+/// delete the stop and every assertion here still passes while the compositor leaks (glass#415).
+async fn stop_and_confirm(client: &Peer<RoleClient>) -> Result<(), String> {
+    try_call(client, "glass_stop", json!({}))
+        .await
+        .map_err(|e| format!("glass_stop failed: {e}"))?;
+    match try_call(client, "glass_stop", json!({})).await {
+        Err(e) if e.contains("no active session") => Ok(()),
+        Err(e) => Err(format!("stopping twice failed for the wrong reason: {e}")),
+        Ok(_) => Err("a second glass_stop succeeded — the first left the session running".into()),
+    }
 }
 
 /// Drive a real `glass-mcp` server end to end against `testapp --blink` launched under
@@ -61,6 +84,8 @@ async fn call(client: &Peer<RoleClient>, tool: &str, args: Value) -> Value {
 /// (the region really is changing), must settle once masked (and never count the masked
 /// motion as `saw_motion`), and a baseline diff with the same mask must report zero real
 /// change plus exactly the masked pixel count.
+///
+/// Returns with no active session: the helper stops what it started.
 pub async fn assert_blink_region_e2e(testapp: &str, backend: &str, start_timeout_ms: u64) {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
@@ -85,8 +110,40 @@ pub async fn assert_blink_region_e2e(testapp: &str, backend: &str, start_timeout
             .await
             .expect("initialize over http");
 
+    // The assertions run as a task so a failing one arrives here as a value rather than
+    // unwinding past the stop below. glass-mcp tears a session down on a detached thread
+    // nothing joins (`GlassServer::new`), so a skipped stop does not merely postpone cleanup to
+    // process exit — it loses it, orphaning the compositor and the session's private a11y bus
+    // (glass#415).
+    let peer = client.peer().clone();
+    let testapp = testapp.to_string();
+    let backend = backend.to_string();
+    let asserted =
+        tokio::spawn(
+            async move { blink_region(&peer, &testapp, &backend, start_timeout_ms).await },
+        )
+        .await;
+
+    let stopped = stop_and_confirm(&client).await;
+    client.cancel().await.ok();
+
+    // A failing assertion is the interesting failure — re-raise it before reporting the stop.
+    if let Err(e) = asserted {
+        std::panic::resume_unwind(e.into_panic());
+    }
+    if let Err(e) = stopped {
+        panic!("{e}");
+    }
+}
+
+async fn blink_region(
+    client: &Peer<RoleClient>,
+    testapp: &str,
+    backend: &str,
+    start_timeout_ms: u64,
+) {
     call(
-        &client,
+        client,
         "glass_start",
         json!({
             "run": [testapp, "--blink"],
@@ -99,7 +156,7 @@ pub async fn assert_blink_region_e2e(testapp: &str, backend: &str, start_timeout
     // No ignore: the blink rect changes on every ~5ms tick, far faster than the 50ms poll
     // interval, so 3 consecutive identical polls (settle_frames) never happen within 400ms.
     let unmasked = call(
-        &client,
+        client,
         "glass_wait_stable",
         json!({
             "interval_ms": 50,
@@ -124,7 +181,7 @@ pub async fn assert_blink_region_e2e(testapp: &str, backend: &str, start_timeout
     // and the masked motion must never be reported as saw_motion (proves the mask, not a
     // merely-generous timeout, is why this settled).
     let masked = call(
-        &client,
+        client,
         "glass_wait_stable",
         json!({
             "interval_ms": 50,
@@ -146,13 +203,13 @@ pub async fn assert_blink_region_e2e(testapp: &str, backend: &str, start_timeout
         "motion confined to the ignore rect must never set saw_motion: {masked}"
     );
 
-    call(&client, "glass_baseline_save", json!({ "name": "e2e" })).await;
+    call(client, "glass_baseline_save", json!({ "name": "e2e" })).await;
     // Let the blink keep animating so the diff below genuinely exercises live, masked motion —
     // not two captures that happen to land in the same ~5ms tick.
     tokio::time::sleep(Duration::from_millis(150)).await;
 
     let diff = call(
-        &client,
+        client,
         "glass_diff",
         json!({
             "name": "e2e",
@@ -173,11 +230,4 @@ pub async fn assert_blink_region_e2e(testapp: &str, backend: &str, start_timeout
         json!(u64::from(w * h)),
         "the mask must exclude exactly its own area: {diff}"
     );
-
-    // Stop the session this test started. Cancelling the client only closes the connection, and
-    // the server's own teardown runs when its serve loop returns — which dropping the test's
-    // runtime skips. That leaves `Drop for WaylandPlatform`, which needs seconds it does not get
-    // before the test binary exits, so without this the compositor is orphaned (glass#415).
-    call(&client, "glass_stop", json!({})).await;
-    client.cancel().await.ok();
 }

--- a/crates/glass-testapp/tests/common/mcp_ignore.rs
+++ b/crates/glass-testapp/tests/common/mcp_ignore.rs
@@ -31,8 +31,7 @@ fn blink_region_json() -> Value {
 
 /// One tool call: `Ok` with the parsed success envelope's `result` object (see glass-mcp's
 /// `tools::envelope`, `{"ok":true,"tool":..., "result": {...}}`), `Err` with the tool's error
-/// text. Same contract as `mcp_cost::try_call` — a transport failure still panics, being an
-/// infrastructure fault rather than an outcome any caller here branches on.
+/// text. Same contract as `mcp_cost::try_call`; a transport failure still panics.
 async fn try_call(client: &Peer<RoleClient>, tool: &str, args: Value) -> Result<Value, String> {
     let arguments = args
         .as_object()
@@ -65,9 +64,9 @@ async fn call(client: &Peer<RoleClient>, tool: &str, args: Value) -> Value {
 /// Stop the session, then prove it is gone by requiring a second `glass_stop` to fail with
 /// `NoActiveSession`.
 ///
-/// The second call is what gives the first one teeth. Stopping can only fail when no session
-/// exists, so asserting the stop succeeded asserts nothing a passing test could violate —
-/// delete the stop and every assertion here still passes while the compositor leaks (glass#415).
+/// Stopping can only fail when no session exists, so asserting the stop succeeded asserts
+/// nothing a passing test could violate — delete the stop and every assertion here still passes
+/// while the compositor leaks (glass#415).
 async fn stop_and_confirm(client: &Peer<RoleClient>) -> Result<(), String> {
     try_call(client, "glass_stop", json!({}))
         .await
@@ -110,11 +109,9 @@ pub async fn assert_blink_region_e2e(testapp: &str, backend: &str, start_timeout
             .await
             .expect("initialize over http");
 
-    // The assertions run as a task so a failing one arrives here as a value rather than
-    // unwinding past the stop below. glass-mcp tears a session down on a detached thread
-    // nothing joins (`GlassServer::new`), so a skipped stop does not merely postpone cleanup to
-    // process exit — it loses it, orphaning the compositor and the session's private a11y bus
-    // (glass#415).
+    // The assertions run as a task so a failing one arrives as a value instead of unwinding past
+    // the stop below — a skipped stop is not deferred cleanup but none at all (see
+    // `Drop for WaylandPlatform`, glass#415).
     let peer = client.peer().clone();
     let testapp = testapp.to_string();
     let backend = backend.to_string();

--- a/crates/glass-testapp/tests/host_conformance.rs
+++ b/crates/glass-testapp/tests/host_conformance.rs
@@ -410,6 +410,11 @@ async fn http_host_can_initialize_list_tools_and_get_an_image() {
         "screenshot response carried no text block alongside the image: {shot:?}"
     );
 
+    // The stdio arm above stops its session; this one must too, or it outlives the test
+    // (glass#415).
+    let _ = client
+        .call_tool(CallToolRequestParams::new("glass_stop"))
+        .await;
     client.cancel().await.ok();
 }
 

--- a/crates/glass-testapp/tests/network.rs
+++ b/crates/glass-testapp/tests/network.rs
@@ -106,8 +106,7 @@ async fn network_screenshot_over_http() {
         "frame is uniform/blank — image content did not cross the wire"
     );
 
-    // Stop the session: cancelling the client does not, and glass-mcp reaches its own teardown
-    // only when the serve loop returns, which dropping the test runtime skips (glass#415).
+    // Stop the session — cancelling the client does not (glass#415).
     let _ = client
         .call_tool(CallToolRequestParams::new("glass_stop"))
         .await;

--- a/crates/glass-testapp/tests/network.rs
+++ b/crates/glass-testapp/tests/network.rs
@@ -106,5 +106,10 @@ async fn network_screenshot_over_http() {
         "frame is uniform/blank — image content did not cross the wire"
     );
 
+    // Stop the session: cancelling the client does not, and glass-mcp reaches its own teardown
+    // only when the serve loop returns, which dropping the test runtime skips (glass#415).
+    let _ = client
+        .call_tool(CallToolRequestParams::new("glass_stop"))
+        .await;
     client.cancel().await.ok();
 }

--- a/crates/glass-testapp/tests/verification_cost.rs
+++ b/crates/glass-testapp/tests/verification_cost.rs
@@ -42,6 +42,7 @@ async fn probe_fixture_a11y_tree_is_reachable() {
         "editable text field not addressable in the a11y tree:\n{outline}"
     );
 
+    mcp_cost::stop_fixture(&client).await;
     client.cancel().await.ok();
 }
 
@@ -67,6 +68,7 @@ async fn arm_a_is_text_only_and_completes() {
         "arm A must carry no image bytes: {report}"
     );
 
+    mcp_cost::stop_fixture(&client).await;
     client.cancel().await.ok();
 }
 
@@ -91,6 +93,7 @@ async fn arm_b_uses_images_and_completes() {
         "arm B must record image dims: {report}"
     );
 
+    mcp_cost::stop_fixture(&client).await;
     client.cancel().await.ok();
 }
 
@@ -133,6 +136,7 @@ async fn verification_cost_semantic_beats_screenshot() {
     );
     assert!(a.text_bytes > 0 && b.text_bytes > 0);
 
+    mcp_cost::stop_fixture(&client).await;
     client.cancel().await.ok();
 }
 

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -218,9 +218,10 @@ fn request_close(ipc: &mut Ipc) -> Asked {
 impl Drop for WaylandPlatform {
     fn drop(&mut self) {
         // Last resort for a `stop_app` that never happened (panicking test, early return), not a
-        // guarantee: with a session still active this asks the app to close, waits `CLOSE_GRACE`
-        // and reaps the tree, so a caller that exits the process right after dropping leaves sway
-        // orphaned mid-teardown (glass#415). Call `stop_app`.
+        // guarantee: this asks the app to close, waits up to `CLOSE_GRACE`, reaps the tree and
+        // only then drops the private bus. glass-mcp runs it on a detached thread nothing joins,
+        // so a process exiting right after the drop kills it partway and orphans sway and the
+        // bus (glass#415) — a shorter grace would not help. Call `stop_app`.
         self.kill_session();
     }
 }

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -217,8 +217,10 @@ fn request_close(ipc: &mut Ipc) -> Asked {
 
 impl Drop for WaylandPlatform {
     fn drop(&mut self) {
-        // Tear down the compositor subtree even if stop_app was never called
-        // (panicking test, early return), so we never leak sway + Xwayland + app.
+        // Last resort for a `stop_app` that never happened (panicking test, early return), not a
+        // guarantee: with a session still active this asks the app to close, waits `CLOSE_GRACE`
+        // and reaps the tree, so a caller that exits the process right after dropping leaves sway
+        // orphaned mid-teardown (glass#415). Call `stop_app`.
         self.kill_session();
     }
 }

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -1328,9 +1328,11 @@ fn hint_matches(name: Option<&str>, class: Option<(&str, &str)>, hint: &WindowHi
 }
 
 impl Drop for X11Platform {
-    /// Reap the launched app on drop — parity with the Wayland/Windows backends, so
-    /// a backend dropped without an explicit `stop_app()` (panic-unwind, or the
-    /// process-exit backstop path) does not orphan its app. `kill_child` uses
+    /// Reap the launched app on drop — parity with the Wayland/Windows backends, for a backend
+    /// dropped without an explicit `stop_app()` (panic-unwind, or the process-exit backstop
+    /// path). Not a guarantee: glass-mcp drops on a detached thread nothing joins, so a process
+    /// exiting right after kills this partway (glass#415). It stays clean where the Wayland one
+    /// does not only because it is short, which is luck rather than design. `kill_child` uses
     /// `self.child.take()`, so this is idempotent with `stop_app`. Field order then
     /// drops `xvfb`, tearing down any private display we spawned.
     fn drop(&mut self) {

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -1331,8 +1331,8 @@ impl Drop for X11Platform {
     /// Reap the launched app on drop — parity with the Wayland/Windows backends, for a backend
     /// dropped without an explicit `stop_app()` (panic-unwind, or the process-exit backstop
     /// path). Not a guarantee: glass-mcp drops on a detached thread nothing joins, so a process
-    /// exiting right after kills this partway (glass#415). It stays clean where the Wayland one
-    /// does not only because it is short, which is luck rather than design. `kill_child` uses
+    /// exiting right after kills this partway (glass#415) — it stays clean where the Wayland one
+    /// does not only by being short. `kill_child` uses
     /// `self.child.take()`, so this is idempotent with `stop_app`. Field order then
     /// drops `xvfb`, tearing down any private display we spawned.
     fn drop(&mut self) {

--- a/scripts/test-wayland.sh
+++ b/scripts/test-wayland.sh
@@ -19,4 +19,21 @@ if ! have_sway; then
 fi
 # --test-threads=1: each test spawns its own sway (and Xwayland); serialize
 # so concurrent compositors don't contend for the display.
-exec cargo test -p glass-testapp --test wayland --test wayland_ignore_regions_e2e -- --ignored --test-threads=1 "$@"
+marker="$(mktemp)"
+status=0
+cargo test -p glass-testapp --test wayland --test wayland_ignore_regions_e2e -- --ignored --test-threads=1 "$@" || status=$?
+
+# A session's private runtime dir is dropped by the same teardown that reaps its compositor, so
+# one left behind is a session whose teardown never finished — an orphaned sway holding the app
+# and the session's a11y bus. Only dirs newer than the marker count, so an earlier run's residue
+# is not this run's failure. Tests pass while this happens (glass#415), which is why it is
+# checked here rather than asserted in any one of them.
+leaked=$(find /tmp -maxdepth 1 -name 'glass-wl.*' -newer "$marker" 2>/dev/null || true)
+rm -f "$marker"
+if [ -n "$leaked" ]; then
+    echo "FAIL: the suite leaked $(printf '%s\n' "$leaked" | wc -l) compositor session(s):" >&2
+    printf '%s\n' "$leaked" >&2
+    echo "Each is a live sway; the test that started it never stopped its session." >&2
+    status=1
+fi
+exit "$status"

--- a/scripts/test-wayland.sh
+++ b/scripts/test-wayland.sh
@@ -23,11 +23,10 @@ marker="$(mktemp)"
 status=0
 cargo test -p glass-testapp --test wayland --test wayland_ignore_regions_e2e -- --ignored --test-threads=1 "$@" || status=$?
 
-# A session's private runtime dir is dropped by the same teardown that reaps its compositor, so
-# one left behind is a session whose teardown never finished — an orphaned sway holding the app
-# and the session's a11y bus. Only dirs newer than the marker count, so an earlier run's residue
-# is not this run's failure. Tests pass while this happens (glass#415), which is why it is
-# checked here rather than asserted in any one of them.
+# A session's runtime dir is dropped by the same teardown that reaps its compositor, so one left
+# behind is a teardown that never finished — a live sway still holding the app and the session's
+# a11y bus. Newer than the marker only, so an earlier run's residue is not this run's failure.
+# Checked here rather than in a test because the tests pass while it happens (glass#415).
 leaked=$(find /tmp -maxdepth 1 -name 'glass-wl.*' -newer "$marker" 2>/dev/null || true)
 rm -f "$marker"
 if [ -n "$leaked" ]; then


### PR DESCRIPTION
Fixes #415.

Every test that hosts glass-mcp in-process was starting a session and never stopping it. The
server only reaches its own `run_shutdown` when the serve loop returns, which dropping the test
runtime skips, so teardown fell to the backend's `Drop` — which `GlassServer::new` runs on a
detached thread nothing joins. The process exits and takes it out partway. Not a slow teardown:
it has no guaranteed time at all, and a shorter grace would not have helped.

The Wayland suite orphaned one `sway` per run, still holding the launched app and the session's
private a11y bus. The X11 tests share the same defect and stayed clean only because their
teardown is short enough to usually win the race.

## What changed

- `mcp_ignore.rs` stops the session it starts, and its assertions run in a `tokio::spawn` so a
  failing one arrives as a value instead of unwinding past the stop. `stop_and_confirm` requires
  a second `glass_stop` to fail with `NoActiveSession` — without that the stop asserts nothing a
  passing test could violate, since stopping can only fail when no session exists.
- The same stop added to `network.rs`, `host_conformance.rs`'s HTTP arm (its stdio arm already
  had one), and the four `verification_cost.rs` tests via a new `mcp_cost::stop_fixture`.
- `scripts/test-wayland.sh` fails when the suite leaves a `/tmp/glass-wl.*` runtime dir behind.
  That dir is dropped by the same teardown that reaps the compositor, so one surviving a run is
  a session that never tore down.
- Both `Drop` comments corrected. The Wayland one claimed it meant "we never leak sway +
  Xwayland + app"; the X11 one still claimed a backend dropped without `stop_app` "does not
  orphan its app".

## Verification

Root cause was measured, not inferred: a temporary `eprintln!` in `Drop for WaylandPlatform`
showed it entered with `active=true` and never returned, against `active=false` + returned for
the tests that call `stop_app` first.

| | orphans |
|---|---|
| `wayland_ignore_regions_e2e` before | 4 of 4 |
| after | 0 of 5, including three full-suite runs |

Both guards are ablated rather than assumed:

- Remove the stop, keep the check: the test fails with `a second glass_stop succeeded — the
  first left the session running`.
- Delete the whole stop: all 25 tests still pass and `test-wayland.sh` exits 1 naming the leaked
  dir. That is the #415 failure mode — a green suite hiding a leak — and it is now caught.

`cargo test --workspace --locked` (82 targets), clippy `-D warnings`, `cargo fmt --all --check`,
`./scripts/test-wayland.sh` (24+1), `./scripts/test-x11.sh` (51), and one `verification_cost`
test for the new `stop_fixture`. No orphaned compositor or bus after any of them.

## Not included

`host_conformance.rs`'s `Drop for StdioServer` SIGKILLs its child, so that child never runs its
own shutdown; and `glass-mcp/tests/android_session_loop.rs` never stops its session. Both are
the same shape but neither is Linux-desktop, and neither is covered by the guard added here.
