### PR TITLE
fix(test): ask the stdio glass-mcp to stop before killing it

### DIFF
--- a/crates/glass-testapp/tests/host_conformance.rs
+++ b/crates/glass-testapp/tests/host_conformance.rs
@@ -249,8 +249,11 @@ impl StdioServer {
 
 impl Drop for StdioServer {
     fn drop(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait(); // closes stdout, so the reader thread's read_line returns EOF.
+        // SIGTERM first so the server reaches its own shutdown and stops the session it holds.
+        // `kill()` alone is SIGKILL, which cannot be handled — a test panicking before its
+        // `glass_stop` left the session's private a11y bus running (glass#418). Reaping waits,
+        // which closes stdout and so ends the reader thread.
+        glass_proc_linux::reap_graceful(&mut self.child, glass_proc_linux::REAP_GRACE);
         if let Some(reader) = self.reader.take() {
             let _ = reader.join();
         }

--- a/crates/glass-testapp/tests/host_conformance.rs
+++ b/crates/glass-testapp/tests/host_conformance.rs
@@ -40,10 +40,9 @@ const TESTAPP: &str = env!("CARGO_BIN_EXE_glass-testapp");
 /// job timeout.
 const READ_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// How long the server gets to shut down before SIGKILL. Derived from its own budget rather than
-/// `glass_proc_linux::REAP_GRACE`, which at 2s is shorter: glass-mcp's `run_shutdown` may take
-/// the full `TEARDOWN_BUDGET` before exiting, so killing at 2s lands inside a legitimate teardown
-/// and reinstates the leak this Drop exists to prevent (glass#418).
+/// How long the server gets to shut down before SIGKILL. Not `glass_proc_linux::REAP_GRACE`: at
+/// 2s it is shorter than the `TEARDOWN_BUDGET` glass-mcp's `run_shutdown` may take, so it would
+/// kill inside a legitimate teardown and reinstate the leak (glass#418).
 const SERVER_REAP_GRACE: Duration = Duration::from_secs(glass_core::TEARDOWN_BUDGET.as_secs() + 1);
 
 /// Path to the `glass-mcp` binary. `env!("CARGO_BIN_EXE_glass-mcp")` isn't usable here:
@@ -255,10 +254,9 @@ impl StdioServer {
 
 impl Drop for StdioServer {
     fn drop(&mut self) {
-        // SIGTERM first so the server reaches its own shutdown and stops the session it holds.
-        // `kill()` alone is SIGKILL, which cannot be handled — a test panicking before its
-        // `glass_stop` left the session's private a11y bus running (glass#418). Reaping then
-        // `wait`s, so the child is gone and the reader thread's `read_line` returns EOF.
+        // SIGTERM first so the server runs its own shutdown: `kill()` alone is SIGKILL, which
+        // cannot be handled, and a test panicking before its `glass_stop` left the session's
+        // private a11y bus running (glass#418). Reaping `wait`s, so the reader thread sees EOF.
         glass_proc_linux::reap_graceful(&mut self.child, SERVER_REAP_GRACE);
         if let Some(reader) = self.reader.take() {
             let _ = reader.join();

--- a/crates/glass-testapp/tests/host_conformance.rs
+++ b/crates/glass-testapp/tests/host_conformance.rs
@@ -40,6 +40,12 @@ const TESTAPP: &str = env!("CARGO_BIN_EXE_glass-testapp");
 /// job timeout.
 const READ_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// How long the server gets to shut down before SIGKILL. Derived from its own budget rather than
+/// `glass_proc_linux::REAP_GRACE`, which at 2s is shorter: glass-mcp's `run_shutdown` may take
+/// the full `TEARDOWN_BUDGET` before exiting, so killing at 2s lands inside a legitimate teardown
+/// and reinstates the leak this Drop exists to prevent (glass#418).
+const SERVER_REAP_GRACE: Duration = Duration::from_secs(glass_core::TEARDOWN_BUDGET.as_secs() + 1);
+
 /// Path to the `glass-mcp` binary. `env!("CARGO_BIN_EXE_glass-mcp")` isn't usable here:
 /// Cargo only injects `CARGO_BIN_EXE_<name>` for binaries owned by the package the test
 /// itself belongs to, and this test lives in `glass-testapp`, not `glass-mcp`. Every
@@ -251,9 +257,9 @@ impl Drop for StdioServer {
     fn drop(&mut self) {
         // SIGTERM first so the server reaches its own shutdown and stops the session it holds.
         // `kill()` alone is SIGKILL, which cannot be handled — a test panicking before its
-        // `glass_stop` left the session's private a11y bus running (glass#418). Reaping waits,
-        // which closes stdout and so ends the reader thread.
-        glass_proc_linux::reap_graceful(&mut self.child, glass_proc_linux::REAP_GRACE);
+        // `glass_stop` left the session's private a11y bus running (glass#418). Reaping then
+        // `wait`s, so the child is gone and the reader thread's `read_line` returns EOF.
+        glass_proc_linux::reap_graceful(&mut self.child, SERVER_REAP_GRACE);
         if let Some(reader) = self.reader.take() {
             let _ = reader.join();
         }

--- a/scripts/lib/session-residue.sh
+++ b/scripts/lib/session-residue.sh
@@ -5,29 +5,42 @@
 # the same teardown that reaps their processes, so one surviving a run is a live sway or
 # dbus-daemon nobody owns (glass#415, glass#418). The tests pass while it happens, which is why
 # this is checked around a suite rather than asserted inside one.
+#
+# Both dirs are `tempfile` temp dirs, so they follow `$TMPDIR` exactly as `mktemp` does — scan
+# where they are actually created, or the check silently passes forever.
 
-# A file whose mtime is "now". Pass it to `session_residue`, then delete it.
-residue_marker() { mktemp; }
-
-# Print the session dirs created since $1, one per line. Empty means none. Scoping to "newer
-# than the marker" keeps an earlier run's residue from failing this one.
-session_residue() {
-    find /tmp -maxdepth 1 \
-        \( -name 'glass-wl.*' -o -name 'glass-a11y-*' \) \
-        -newer "$1" 2>/dev/null || true
+# A marker file whose mtime is "now". The caller owns removing it — do NOT trap EXIT in here:
+# callers read this through `$(…)`, whose subshell would fire the trap and delete the marker
+# before it is ever compared against, leaving a scan that finds nothing and passes.
+residue_marker() {
+    mktemp "${TMPDIR:-/tmp}/glass-residue-marker.XXXXXX"
 }
 
-# Run `session_residue`, report to stderr, and echo the exit status the caller should use:
-# $1 marker, $2 the status the suite itself produced.
+# Report session dirs modified since marker $1; non-zero if there were any. The remaining args
+# are the globs this suite can itself produce — matching one it cannot lets a concurrent suite's
+# live scratch read as this one's leak.
+#
+# Six `?` matches `tempfile`'s random suffix and nothing else: `test-a11y.sh` names its own
+# runtime dir `glass-a11y-test-rt.XXXXXX`, which is deliberate scratch rather than residue.
 report_residue() {
-    local marker="$1" status="$2" leaked
-    leaked=$(session_residue "$marker")
-    rm -f "$marker"
-    if [ -n "$leaked" ]; then
-        echo "FAIL: the suite leaked $(printf '%s\n' "$leaked" | wc -l) session(s):" >&2
-        printf '%s\n' "$leaked" >&2
-        echo "Each is a live compositor or a11y bus; a test never stopped its session." >&2
-        status=1
+    local marker="$1" leaked="" glob hits
+    shift
+    for glob in "$@"; do
+        # A failed scan must not read as a clean one — that is how a leak detector goes quiet.
+        if ! hits=$(find "${TMPDIR:-/tmp}" -maxdepth 1 -name "$glob" -newer "$marker"); then
+            echo "FAIL: could not scan for session residue (marker $marker)" >&2
+            return 1
+        fi
+        if [ -n "$hits" ]; then
+            leaked="${leaked}${hits}"$'\n'
+        fi
+    done
+    leaked="${leaked%$'\n'}"
+    if [ -z "$leaked" ]; then
+        return 0
     fi
-    echo "$status"
+    echo "FAIL: the suite leaked $(printf '%s\n' "$leaked" | wc -l) session(s):" >&2
+    printf '%s\n' "$leaked" >&2
+    echo "Each is a live compositor or a11y bus; a test never stopped its session." >&2
+    return 1
 }

--- a/scripts/lib/session-residue.sh
+++ b/scripts/lib/session-residue.sh
@@ -3,15 +3,15 @@
 #
 # A session's private dirs — the compositor's runtime dir and the a11y bus dir — are removed by
 # the same teardown that reaps their processes, so one surviving a run is a live sway or
-# dbus-daemon nobody owns (glass#415, glass#418). The tests pass while it happens, which is why
-# this is checked around a suite rather than asserted inside one.
+# dbus-daemon nobody owns (glass#415, glass#418). The tests pass while it happens, hence a check
+# around the suite rather than an assertion inside one.
 #
-# Both dirs are `tempfile` temp dirs, so they follow `$TMPDIR` exactly as `mktemp` does — scan
-# where they are actually created, or the check silently passes forever.
+# Both dirs follow `$TMPDIR` as `mktemp` does — scan where they are created, or this silently
+# passes forever.
 
-# A marker file whose mtime is "now". The caller owns removing it — do NOT trap EXIT in here:
-# callers read this through `$(…)`, whose subshell would fire the trap and delete the marker
-# before it is ever compared against, leaving a scan that finds nothing and passes.
+# A marker file whose mtime is "now"; the caller removes it. Do NOT trap EXIT in here: callers
+# read this through `$(…)`, whose subshell fires the trap and deletes the marker before it is
+# ever compared against, leaving a scan that finds nothing and passes.
 residue_marker() {
     mktemp "${TMPDIR:-/tmp}/glass-residue-marker.XXXXXX"
 }
@@ -20,8 +20,8 @@ residue_marker() {
 # are the globs this suite can itself produce — matching one it cannot lets a concurrent suite's
 # live scratch read as this one's leak.
 #
-# Six `?` matches `tempfile`'s random suffix and nothing else: `test-a11y.sh` names its own
-# runtime dir `glass-a11y-test-rt.XXXXXX`, which is deliberate scratch rather than residue.
+# Six `?` matches `tempfile`'s random suffix and nothing else: `test-a11y.sh`'s own
+# `glass-a11y-test-rt.XXXXXX` runtime dir is scratch, not residue.
 report_residue() {
     local marker="$1" leaked="" glob hits
     shift

--- a/scripts/lib/session-residue.sh
+++ b/scripts/lib/session-residue.sh
@@ -1,0 +1,33 @@
+# shellcheck shell=bash
+# Detect sessions that never tore down.
+#
+# A session's private dirs — the compositor's runtime dir and the a11y bus dir — are removed by
+# the same teardown that reaps their processes, so one surviving a run is a live sway or
+# dbus-daemon nobody owns (glass#415, glass#418). The tests pass while it happens, which is why
+# this is checked around a suite rather than asserted inside one.
+
+# A file whose mtime is "now". Pass it to `session_residue`, then delete it.
+residue_marker() { mktemp; }
+
+# Print the session dirs created since $1, one per line. Empty means none. Scoping to "newer
+# than the marker" keeps an earlier run's residue from failing this one.
+session_residue() {
+    find /tmp -maxdepth 1 \
+        \( -name 'glass-wl.*' -o -name 'glass-a11y-*' \) \
+        -newer "$1" 2>/dev/null || true
+}
+
+# Run `session_residue`, report to stderr, and echo the exit status the caller should use:
+# $1 marker, $2 the status the suite itself produced.
+report_residue() {
+    local marker="$1" status="$2" leaked
+    leaked=$(session_residue "$marker")
+    rm -f "$marker"
+    if [ -n "$leaked" ]; then
+        echo "FAIL: the suite leaked $(printf '%s\n' "$leaked" | wc -l) session(s):" >&2
+        printf '%s\n' "$leaked" >&2
+        echo "Each is a live compositor or a11y bus; a test never stopped its session." >&2
+        status=1
+    fi
+    echo "$status"
+}

--- a/scripts/test-wayland.sh
+++ b/scripts/test-wayland.sh
@@ -21,7 +21,8 @@ fi
 # --test-threads=1: each test spawns its own sway (and Xwayland); serialize
 # so concurrent compositors don't contend for the display.
 marker="$(residue_marker)"
+trap 'rm -f "$marker"' EXIT
 status=0
 cargo test -p glass-testapp --test wayland --test wayland_ignore_regions_e2e -- --ignored --test-threads=1 "$@" || status=$?
-status=$(report_residue "$marker" "$status")
+report_residue "$marker" 'glass-wl.??????' 'glass-a11y-??????' || status=1
 exit "$status"

--- a/scripts/test-wayland.sh
+++ b/scripts/test-wayland.sh
@@ -13,26 +13,15 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 . scripts/lib/have-sway.sh
+. scripts/lib/session-residue.sh
 if ! have_sway; then
     echo "no glass-discoverable sway >=1.12; build+install via https://github.com/fixed-width/sway-build. Skipping Wayland tests."
     exit 0
 fi
 # --test-threads=1: each test spawns its own sway (and Xwayland); serialize
 # so concurrent compositors don't contend for the display.
-marker="$(mktemp)"
+marker="$(residue_marker)"
 status=0
 cargo test -p glass-testapp --test wayland --test wayland_ignore_regions_e2e -- --ignored --test-threads=1 "$@" || status=$?
-
-# A session's runtime dir is dropped by the same teardown that reaps its compositor, so one left
-# behind is a teardown that never finished — a live sway still holding the app and the session's
-# a11y bus. Newer than the marker only, so an earlier run's residue is not this run's failure.
-# Checked here rather than in a test because the tests pass while it happens (glass#415).
-leaked=$(find /tmp -maxdepth 1 -name 'glass-wl.*' -newer "$marker" 2>/dev/null || true)
-rm -f "$marker"
-if [ -n "$leaked" ]; then
-    echo "FAIL: the suite leaked $(printf '%s\n' "$leaked" | wc -l) compositor session(s):" >&2
-    printf '%s\n' "$leaked" >&2
-    echo "Each is a live sway; the test that started it never stopped its session." >&2
-    status=1
-fi
+status=$(report_residue "$marker" "$status")
 exit "$status"

--- a/scripts/test-x11.sh
+++ b/scripts/test-x11.sh
@@ -21,8 +21,13 @@
 # with a filter (e.g. ./scripts/test-x11.sh network_screenshot_over_http) to skip them.
 set -euo pipefail
 cd "$(dirname "$0")/.."
+. scripts/lib/session-residue.sh
 # host_conformance spawns the glass-mcp *binary* as a stdio child. `cargo test -p glass-testapp`
 # builds glass-mcp only as a library dependency, not its binary, so build the binary explicitly
 # — otherwise the test can't find it in a clean checkout (e.g. CI, which runs only this script).
 cargo build -p glass-mcp --bin glass-mcp
-exec cargo test -p glass-testapp --test integration --test network --test ignore_regions_e2e --test host_conformance --test software_render -- --ignored --test-threads=1 "$@"
+marker="$(residue_marker)"
+status=0
+cargo test -p glass-testapp --test integration --test network --test ignore_regions_e2e --test host_conformance --test software_render -- --ignored --test-threads=1 "$@" || status=$?
+status=$(report_residue "$marker" "$status")
+exit "$status"

--- a/scripts/test-x11.sh
+++ b/scripts/test-x11.sh
@@ -27,7 +27,10 @@ cd "$(dirname "$0")/.."
 # — otherwise the test can't find it in a clean checkout (e.g. CI, which runs only this script).
 cargo build -p glass-mcp --bin glass-mcp
 marker="$(residue_marker)"
+trap 'rm -f "$marker"' EXIT
 status=0
 cargo test -p glass-testapp --test integration --test network --test ignore_regions_e2e --test host_conformance --test software_render -- --ignored --test-threads=1 "$@" || status=$?
-status=$(report_residue "$marker" "$status")
+# No compositor glob: this suite cannot create one, so matching it would only let a concurrent
+# Wayland run read as this suite's leak.
+report_residue "$marker" 'glass-a11y-??????' || status=1
 exit "$status"

--- a/scripts/test-x11.sh
+++ b/scripts/test-x11.sh
@@ -30,7 +30,6 @@ marker="$(residue_marker)"
 trap 'rm -f "$marker"' EXIT
 status=0
 cargo test -p glass-testapp --test integration --test network --test ignore_regions_e2e --test host_conformance --test software_render -- --ignored --test-threads=1 "$@" || status=$?
-# No compositor glob: this suite cannot create one, so matching it would only let a concurrent
-# Wayland run read as this suite's leak.
+# No compositor glob: this suite cannot create one, so it would only catch a concurrent Wayland run.
 report_residue "$marker" 'glass-a11y-??????' || status=1
 exit "$status"


### PR DESCRIPTION
Fixes #418.

`Drop for StdioServer` ended the child glass-mcp with `Child::kill()` — SIGKILL, which cannot be
handled — so the server never reached its own shutdown. The happy path was fine because the test
calls `glass_stop` first; a panic before that left the session running. Now
`glass_proc_linux::reap_graceful` sends SIGTERM, waits, and falls back to SIGKILL only if the
child overstays.

`reap_group` would be wrong here: the child is not spawned as a group leader, so it inherits the
harness's group. Signalling the child alone is right, and glass-mcp's own shutdown reaps its
descendants.

## What actually leaked

Measured by injecting a panic between `glass_start` and the `glass_stop`. The launched app does
**not** survive either way — the test's private Xvfb dies right after and takes it — but the
session's private a11y bus does:

```
PPID 1  dbus-daemon --config-file /tmp/glass-a11y-<x>/session-bus.conf
PPID    dbus-daemon ... --address=unix:path=/tmp/glass-a11y-<x>/at-spi/bus_0
```

plus the `/tmp/glass-a11y-<x>/` dir. After the fix: no dir, no daemons.

## The guard from #417 could not have caught this

It matched `glass-wl.*` only, and this leak is a11y-only. Extracted to
`scripts/lib/session-residue.sh`, extended to both dir kinds, and `test-x11.sh` now runs it too.
Each suite scans only the dir kinds it can itself produce, so a concurrent run of the other one
cannot read as its leak.

Ablated end to end: restore `child.kill()`, add a panic, and `./scripts/test-x11.sh` exits 1 with
`FAIL: the suite leaked 1 session(s): /tmp/glass-a11y-<x>`.

## Review found three defects in the first cut

- **The grace was shorter than the child's own budget.** `REAP_GRACE` is 2s; glass-mcp's
  `run_shutdown` may take the full `TEARDOWN_BUDGET` of 3s. SIGKILL at 2s lands inside a
  legitimate teardown and reinstates the leak — as a required check, that is a flake. The grace
  is now derived from `TEARDOWN_BUDGET`. Suite timings are unchanged (15.51s vs 15.46s), because
  the child exits on SIGTERM promptly.
- **The scan hardcoded `/tmp`** while both the marker and the residue dirs follow `$TMPDIR`. With
  `TMPDIR` set the guard would have found nothing and passed forever. A failed scan also read as
  a clean one; both fixed.
- **`glass-a11y-*` collided with `test-a11y.sh`'s own `glass-a11y-test-rt.XXXXXX`** scratch dir.
  The globs now match `tempfile`'s six-character suffix only.

A fourth, self-inflicted, came out of unit-testing the lib: `residue_marker` trapped EXIT to clean
up after itself, but callers read it through `$(…)`, so the subshell fired the trap and deleted
the marker before it was ever compared — the scan then failed and reported clean. The trap moved
to the callers, and the lib is tested in both directions: it catches a real leak under a custom
`TMPDIR` and ignores both decoy dirs.

## Verification

`cargo test --workspace --locked` (82 targets), clippy `-D warnings`, `cargo fmt --all --check`,
`shellcheck -x`, `./scripts/test-x11.sh` (51 tests) and `./scripts/test-wayland.sh` (25) — both
green with the guard silent, no orphaned compositor or bus after any run.
