### PR TITLE
fix(android): reap the app on drop, and hand the device back clean

### DIFF
--- a/crates/glass-android/src/platform.rs
+++ b/crates/glass-android/src/platform.rs
@@ -203,6 +203,14 @@ fn visible_window_region(win: &WindowGeometry, disp_w: u32, disp_h: u32) -> Resu
     })
 }
 
+/// Force-stop a launch that failed after `am start` had already put the app on the device, and
+/// hand its error back. The X11 backend reaps the same case; here nothing else would, because
+/// `start_app` records `self.app` only once the launch has fully succeeded.
+fn reap_failed_launch(adb: &Adb, package: &str, e: GlassError) -> GlassError {
+    let _ = adb.run(force_stop_args(package).iter().map(String::as_str));
+    e
+}
+
 impl Platform for AndroidPlatform {
     fn start_app(&mut self, spec: &AppSpec) -> Result<WindowGeometry> {
         run_build(spec, &self.logs)?;
@@ -217,14 +225,22 @@ impl Platform for AndroidPlatform {
         let started = adb.run(launch_args(&target.component).iter().map(String::as_str))?;
         check_am_start(&started)?;
 
-        let (active_id, window) = self.discover_window(&target.package, spec.timeout_ms)?;
+        // Past this point the app is on the device while `self.app` — the only thing `stop_app`
+        // and the drop reap — is still `None`, so every failure below has to reap for itself.
+        let (active_id, window) = match self.discover_window(&target.package, spec.timeout_ms) {
+            Ok(found) => found,
+            Err(e) => return Err(reap_failed_launch(&adb, &target.package, e)),
+        };
 
         let pidof = adb
             .run(["shell", "pidof", &target.package])
             .unwrap_or_default();
         let pid = parse_pid(&pidof);
         let logcat = match pid {
-            Some(pid) => Some(LogcatStream::spawn(&adb, pid, self.logs.clone())?),
+            Some(pid) => match LogcatStream::spawn(&adb, pid, self.logs.clone()) {
+                Ok(stream) => Some(stream),
+                Err(e) => return Err(reap_failed_launch(&adb, &target.package, e)),
+            },
             None => None,
         };
 
@@ -381,14 +397,11 @@ impl Platform for AndroidPlatform {
 }
 
 impl Drop for AndroidPlatform {
-    /// Force-stop a still-running app on drop — parity with the X11/Wayland/Windows/macOS
-    /// backends, so a platform dropped without an explicit `stop_app()` (panic-unwind, or the
-    /// process-exit backstop) does not leave the app on the device for the next run (glass#419).
-    /// `stop_app` takes `self.app`, so this is a no-op once it has run.
-    ///
-    /// Not a guarantee where the drop is not on the caller's own thread: glass-mcp drops on a
-    /// detached thread nothing joins, so a process exiting right after kills this partway
-    /// (glass#415). The one bounded `am force-stop` here keeps that window short.
+    /// Force-stop the app on drop — parity with the X11/Wayland/Windows/macOS backends, for a
+    /// platform dropped without an explicit `stop_app()`: a panic unwinding past it, or an owner
+    /// that simply drops it. The device outlives the process, so the app would otherwise still be
+    /// there for the next run (glass#419). `stop_app` takes `self.app`, so this is a no-op once
+    /// it has run — which every path through `Glass` takes first.
     fn drop(&mut self) {
         let _ = self.stop_app();
     }
@@ -587,6 +600,34 @@ mod platform_tests {
             platform.window(&WindowOp::Geometry),
             Err(GlassError::NoActiveSession)
         ));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_launch_whose_window_never_appears_does_not_leave_the_app_running() {
+        let empty = Answer::says("");
+        let started = Answer::says("Starting: Intent {...}\nStatus: ok\n");
+        let fake = FakeAdb::scripted(&[
+            ("shell am start *", vec![&started]),
+            ("shell dumpsys window windows", vec![&empty]),
+            ("*", vec![&Answer::Silent]),
+        ]);
+
+        let mut platform = platform_over(&fake);
+        let mut spec = spec();
+        spec.timeout_ms = 300;
+
+        platform
+            .start_app(&spec)
+            .expect_err("a launch whose window never appears fails");
+
+        // `am start` put it on the device and the failure left `self.app` unset, so this is the
+        // only reap it will ever get — the drop below passes over it.
+        assert!(
+            fake.called("am force-stop com.example.app"),
+            "{:?}",
+            fake.calls()
+        );
     }
 
     #[test]

--- a/crates/glass-android/src/platform.rs
+++ b/crates/glass-android/src/platform.rs
@@ -380,6 +380,20 @@ impl Platform for AndroidPlatform {
     }
 }
 
+impl Drop for AndroidPlatform {
+    /// Force-stop a still-running app on drop — parity with the X11/Wayland/Windows/macOS
+    /// backends, so a platform dropped without an explicit `stop_app()` (panic-unwind, or the
+    /// process-exit backstop) does not leave the app on the device for the next run (glass#419).
+    /// `stop_app` takes `self.app`, so this is a no-op once it has run.
+    ///
+    /// Not a guarantee where the drop is not on the caller's own thread: glass-mcp drops on a
+    /// detached thread nothing joins, so a process exiting right after kills this partway
+    /// (glass#415). The one bounded `am force-stop` here keeps that window short.
+    fn drop(&mut self) {
+        let _ = self.stop_app();
+    }
+}
+
 // Unix-gated as a whole: `FakeAdb` is a `/bin/sh` script, so this import breaks the Windows
 // build without it.
 #[cfg(test)]
@@ -573,6 +587,20 @@ mod platform_tests {
             platform.window(&WindowOp::Geometry),
             Err(GlassError::NoActiveSession)
         ));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn dropping_a_platform_that_still_holds_an_app_force_stops_it() {
+        let fake = launchable();
+
+        drop(started(&fake));
+
+        assert!(
+            fake.called("am force-stop com.example.app"),
+            "{:?}",
+            fake.calls()
+        );
     }
 
     #[test]

--- a/crates/glass-android/src/platform.rs
+++ b/crates/glass-android/src/platform.rs
@@ -204,8 +204,7 @@ fn visible_window_region(win: &WindowGeometry, disp_w: u32, disp_h: u32) -> Resu
 }
 
 /// Force-stop a launch that failed after `am start` had already put the app on the device, and
-/// hand its error back. The X11 backend reaps the same case; here nothing else would, because
-/// `start_app` records `self.app` only once the launch has fully succeeded.
+/// hand its error back — `start_app` records `self.app` only on success, so nothing else reaps it.
 fn reap_failed_launch(adb: &Adb, package: &str, e: GlassError) -> GlassError {
     let _ = adb.run(force_stop_args(package).iter().map(String::as_str));
     e
@@ -225,8 +224,8 @@ impl Platform for AndroidPlatform {
         let started = adb.run(launch_args(&target.component).iter().map(String::as_str))?;
         check_am_start(&started)?;
 
-        // Past this point the app is on the device while `self.app` — the only thing `stop_app`
-        // and the drop reap — is still `None`, so every failure below has to reap for itself.
+        // The app is on the device from here, but `self.app` is not set until the end, so each
+        // failure below has to reap for itself.
         let (active_id, window) = match self.discover_window(&target.package, spec.timeout_ms) {
             Ok(found) => found,
             Err(e) => return Err(reap_failed_launch(&adb, &target.package, e)),
@@ -397,11 +396,10 @@ impl Platform for AndroidPlatform {
 }
 
 impl Drop for AndroidPlatform {
-    /// Force-stop the app on drop — parity with the X11/Wayland/Windows/macOS backends, for a
-    /// platform dropped without an explicit `stop_app()`: a panic unwinding past it, or an owner
-    /// that simply drops it. The device outlives the process, so the app would otherwise still be
-    /// there for the next run (glass#419). `stop_app` takes `self.app`, so this is a no-op once
-    /// it has run — which every path through `Glass` takes first.
+    /// Force-stop the app on drop, for a platform dropped without an explicit `stop_app()` —
+    /// parity with the X11/Wayland/Windows/macOS backends. The device outlives the process, so
+    /// the app would otherwise still be there for the next run (glass#419). `stop_app` takes
+    /// `self.app`, so this is a no-op once it has run, which every path through `Glass` does.
     fn drop(&mut self) {
         let _ = self.stop_app();
     }
@@ -621,8 +619,8 @@ mod platform_tests {
             .start_app(&spec)
             .expect_err("a launch whose window never appears fails");
 
-        // `am start` put it on the device and the failure left `self.app` unset, so this is the
-        // only reap it will ever get — the drop below passes over it.
+        // `am start` put it on the device and the failure left `self.app` unset, so the drop
+        // below passes over it.
         assert!(
             fake.called("am force-stop com.example.app"),
             "{:?}",

--- a/crates/glass-mcp/tests/android_session_loop.rs
+++ b/crates/glass-mcp/tests/android_session_loop.rs
@@ -16,6 +16,31 @@ use glass_core::{AppSpec, BaselineStore, Glass, PlatformFactory, SandboxLevel};
 const AWAIT_DEADLINE: std::time::Duration = std::time::Duration::from_secs(5);
 const AWAIT_INTERVAL: std::time::Duration = std::time::Duration::from_millis(150);
 
+/// The registries whose `ensure` switches something on for the whole device, put back when this
+/// goes out of scope — a panic unwinds through it, where a trailing `shutdown()` is skipped.
+///
+/// A guard rather than a block around the assertions, because the state is already on by then:
+/// `Glass::start` runs the factory before `start_app`, and the factory enables the companion. A
+/// launch that fails — the likeliest failure here — panics with it enabled, and only `shutdown`
+/// restores the secure settings and removes the `adb forward` each registry opened. The APK
+/// itself is left installed, as glass owns that package (glass#419).
+struct Companions {
+    agents: AgentRegistry,
+    a11y: A11yServiceRegistry,
+    emulators: EmulatorRegistry,
+}
+
+impl Drop for Companions {
+    fn drop(&mut self) {
+        // Reached while a panic unwinds, where a second panic aborts the process — nothing here
+        // may assert.
+        self.agents.shutdown();
+        self.a11y.shutdown();
+        // A no-op unless glass booted the emulator rather than attaching to one.
+        self.emulators.kill_all();
+    }
+}
+
 /// glass#287: the glass-android device tests build `ServiceA11y` by hand, so none of them can see
 /// which reader a session would have picked — and picking the uiautomator one makes every click a
 /// pointer tap that still reports `Ok`.
@@ -28,36 +53,45 @@ fn a_session_click_reports_the_native_accessibility_action() {
     let fixture =
         std::env::var("GLASS_ANDROID_FIXTURE_APK").expect("set GLASS_ANDROID_FIXTURE_APK");
 
-    // Under the default attach-or-boot lifecycle a second `EmulatorRegistry` with no device
-    // attached boots a second emulator, so the install below and the factory share one.
-    let registry = EmulatorRegistry::new();
-    // `Arc` only so the teardown below can still reach them: the factory closure takes what it
-    // captures. Both leave state on the *device* that outliving the process does not clear —
-    // an `adb forward`, and the companion installed and enabled as an accessibility service —
-    // and neither registry has a `Drop`, so only `shutdown` takes it back off.
-    let agents = std::sync::Arc::new(AgentRegistry::new());
-    let a11y = std::sync::Arc::new(A11yServiceRegistry::new());
+    // First, so it drops last: the app has to be force-stopped before the companion reading it
+    // goes away. Under the default attach-or-boot lifecycle a second `EmulatorRegistry` with no
+    // device attached boots a second emulator, so the install below and the factory share one.
+    let device = Companions {
+        agents: AgentRegistry::new(),
+        a11y: A11yServiceRegistry::new(),
+        emulators: EmulatorRegistry::new(),
+    };
 
     {
-        let p = AndroidPlatform::from_env(&registry, &agents).expect("attach to a device");
+        let p = AndroidPlatform::from_env(&device.emulators, &device.agents)
+            .expect("attach to a device");
         p.resolved_adb()
             .run(["install", "-r", "-g", &fixture])
             .expect("install the fixture APK");
     }
 
     // The two shapes of `boot`'s own factory closure — `make_platform` takes the iOS Simulator
-    // registry on macOS only.
+    // registry on macOS only. Each registry is a handle to shared state, so the clones the
+    // closure moves are the same registries `device` shuts down.
     #[cfg(target_os = "macos")]
     let sim = glass_ios::SimulatorRegistry::new();
     #[cfg(target_os = "macos")]
     let factory: PlatformFactory = {
-        let (agents, a11y) = (agents.clone(), a11y.clone());
-        Box::new(move |b| glass_mcp::make_platform(b, &registry, &agents, &a11y, &sim))
+        let (emulators, agents, a11y) = (
+            device.emulators.clone(),
+            device.agents.clone(),
+            device.a11y.clone(),
+        );
+        Box::new(move |b| glass_mcp::make_platform(b, &emulators, &agents, &a11y, &sim))
     };
     #[cfg(not(target_os = "macos"))]
     let factory: PlatformFactory = {
-        let (agents, a11y) = (agents.clone(), a11y.clone());
-        Box::new(move |b| glass_mcp::make_platform(b, &registry, &agents, &a11y))
+        let (emulators, agents, a11y) = (
+            device.emulators.clone(),
+            device.agents.clone(),
+            device.a11y.clone(),
+        );
+        Box::new(move |b| glass_mcp::make_platform(b, &emulators, &agents, &a11y))
     };
 
     let baselines = tempfile::tempdir().expect("a temp dir for the baseline store");
@@ -80,39 +114,26 @@ fn a_session_click_reports_the_native_accessibility_action() {
         })
         .expect("launch the view fixture");
 
-    let asserted = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let tree = glass.a11y_snapshot(None).expect("snapshot");
-        let before = counter(&tree);
-        let save = find(&tree.root, "SaveBtn").expect("the fixture's SaveBtn is present");
-        let method = glass.click_element(save.id).expect("click SaveBtn");
+    let tree = glass.a11y_snapshot(None).expect("snapshot");
+    let before = counter(&tree);
+    let save = find(&tree.root, "SaveBtn").expect("the fixture's SaveBtn is present");
+    let method = glass.click_element(save.id).expect("click SaveBtn");
 
-        // `Pointer`'s `native_fallback` names the error that sent the click down the synthetic
-        // path.
-        assert!(
-            matches!(method, ClickMethod::NativeAction { .. }),
-            "a session click on an enabled button must fire the native action, got {method:?}"
-        );
+    // `Pointer`'s `native_fallback` names the error that sent the click down the synthetic path.
+    assert!(
+        matches!(method, ClickMethod::NativeAction { .. }),
+        "a session click on an enabled button must fire the native action, got {method:?}"
+    );
 
-        // `NativeAction` is the session's claim about which path it took; the counter is the
-        // fixture's report that something actuated.
-        await_change("SaveBtn's click to register", &before, || {
-            counter(&glass.a11y_snapshot(None).expect("snapshot"))
-        });
-    }));
+    // `NativeAction` is the session's claim about which path it took; the counter is the
+    // fixture's report that something actuated.
+    await_change("SaveBtn's click to register", &before, || {
+        counter(&glass.a11y_snapshot(None).expect("snapshot"))
+    });
 
-    // Caught rather than left to unwind, because the device outlives this process and every
-    // line below is what hands it back clean (glass#419). The session alone would survive a
-    // panic — `AndroidPlatform` force-stops on drop — but the registries have no `Drop`, so an
-    // unwind past them leaves the companion enabled for every later reader on this device.
-    let stopped = glass.stop();
-    agents.shutdown();
-    a11y.shutdown();
-
-    // The assertion's own failure first: a teardown error must not displace what it explains.
-    if let Err(payload) = asserted {
-        std::panic::resume_unwind(payload);
-    }
-    stopped.expect("stop the session");
+    // The path a user takes. An assertion above panics past it, and the drops then do the same
+    // work: `AndroidPlatform` force-stops the app, `Companions` puts the device settings back.
+    glass.stop().expect("stop the session");
 }
 
 /// The fixture's click counter, as the a11y tree reports it.

--- a/crates/glass-mcp/tests/android_session_loop.rs
+++ b/crates/glass-mcp/tests/android_session_loop.rs
@@ -31,8 +31,12 @@ fn a_session_click_reports_the_native_accessibility_action() {
     // Under the default attach-or-boot lifecycle a second `EmulatorRegistry` with no device
     // attached boots a second emulator, so the install below and the factory share one.
     let registry = EmulatorRegistry::new();
-    let agents = AgentRegistry::new();
-    let a11y = A11yServiceRegistry::new();
+    // `Arc` only so the teardown below can still reach them: the factory closure takes what it
+    // captures. Both leave state on the *device* that outliving the process does not clear —
+    // an `adb forward`, and the companion installed and enabled as an accessibility service —
+    // and neither registry has a `Drop`, so only `shutdown` takes it back off.
+    let agents = std::sync::Arc::new(AgentRegistry::new());
+    let a11y = std::sync::Arc::new(A11yServiceRegistry::new());
 
     {
         let p = AndroidPlatform::from_env(&registry, &agents).expect("attach to a device");
@@ -46,11 +50,15 @@ fn a_session_click_reports_the_native_accessibility_action() {
     #[cfg(target_os = "macos")]
     let sim = glass_ios::SimulatorRegistry::new();
     #[cfg(target_os = "macos")]
-    let factory: PlatformFactory =
-        Box::new(move |b| glass_mcp::make_platform(b, &registry, &agents, &a11y, &sim));
+    let factory: PlatformFactory = {
+        let (agents, a11y) = (agents.clone(), a11y.clone());
+        Box::new(move |b| glass_mcp::make_platform(b, &registry, &agents, &a11y, &sim))
+    };
     #[cfg(not(target_os = "macos"))]
-    let factory: PlatformFactory =
-        Box::new(move |b| glass_mcp::make_platform(b, &registry, &agents, &a11y));
+    let factory: PlatformFactory = {
+        let (agents, a11y) = (agents.clone(), a11y.clone());
+        Box::new(move |b| glass_mcp::make_platform(b, &registry, &agents, &a11y))
+    };
 
     let baselines = tempfile::tempdir().expect("a temp dir for the baseline store");
     let mut glass = Glass::new(
@@ -72,22 +80,39 @@ fn a_session_click_reports_the_native_accessibility_action() {
         })
         .expect("launch the view fixture");
 
-    let tree = glass.a11y_snapshot(None).expect("snapshot");
-    let before = counter(&tree);
-    let save = find(&tree.root, "SaveBtn").expect("the fixture's SaveBtn is present");
-    let method = glass.click_element(save.id).expect("click SaveBtn");
+    let asserted = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let tree = glass.a11y_snapshot(None).expect("snapshot");
+        let before = counter(&tree);
+        let save = find(&tree.root, "SaveBtn").expect("the fixture's SaveBtn is present");
+        let method = glass.click_element(save.id).expect("click SaveBtn");
 
-    // `Pointer`'s `native_fallback` names the error that sent the click down the synthetic path.
-    assert!(
-        matches!(method, ClickMethod::NativeAction { .. }),
-        "a session click on an enabled button must fire the native action, got {method:?}"
-    );
+        // `Pointer`'s `native_fallback` names the error that sent the click down the synthetic
+        // path.
+        assert!(
+            matches!(method, ClickMethod::NativeAction { .. }),
+            "a session click on an enabled button must fire the native action, got {method:?}"
+        );
 
-    // `NativeAction` is the session's claim about which path it took; the counter is the
-    // fixture's report that something actuated.
-    await_change("SaveBtn's click to register", &before, || {
-        counter(&glass.a11y_snapshot(None).expect("snapshot"))
-    });
+        // `NativeAction` is the session's claim about which path it took; the counter is the
+        // fixture's report that something actuated.
+        await_change("SaveBtn's click to register", &before, || {
+            counter(&glass.a11y_snapshot(None).expect("snapshot"))
+        });
+    }));
+
+    // Caught rather than left to unwind, because the device outlives this process and every
+    // line below is what hands it back clean (glass#419). The session alone would survive a
+    // panic — `AndroidPlatform` force-stops on drop — but the registries have no `Drop`, so an
+    // unwind past them leaves the companion enabled for every later reader on this device.
+    let stopped = glass.stop();
+    agents.shutdown();
+    a11y.shutdown();
+
+    // The assertion's own failure first: a teardown error must not displace what it explains.
+    if let Err(payload) = asserted {
+        std::panic::resume_unwind(payload);
+    }
+    stopped.expect("stop the session");
 }
 
 /// The fixture's click counter, as the a11y tree reports it.

--- a/crates/glass-mcp/tests/android_session_loop.rs
+++ b/crates/glass-mcp/tests/android_session_loop.rs
@@ -17,13 +17,12 @@ const AWAIT_DEADLINE: std::time::Duration = std::time::Duration::from_secs(5);
 const AWAIT_INTERVAL: std::time::Duration = std::time::Duration::from_millis(150);
 
 /// The registries whose `ensure` switches something on for the whole device, put back when this
-/// goes out of scope — a panic unwinds through it, where a trailing `shutdown()` is skipped.
+/// goes out of scope — a trailing `shutdown()` is skipped by a panic. Only `shutdown` restores
+/// the secure settings and removes the `adb forward` each one opened; the APK stays installed,
+/// as glass owns that package (glass#419).
 ///
-/// A guard rather than a block around the assertions, because the state is already on by then:
-/// `Glass::start` runs the factory before `start_app`, and the factory enables the companion. A
-/// launch that fails — the likeliest failure here — panics with it enabled, and only `shutdown`
-/// restores the secure settings and removes the `adb forward` each registry opened. The APK
-/// itself is left installed, as glass owns that package (glass#419).
+/// A guard, not a block around the assertions: `Glass::start` runs the factory — which enables
+/// the companion — before `start_app`, so a failing launch panics with the state already on.
 struct Companions {
     agents: AgentRegistry,
     a11y: A11yServiceRegistry,
@@ -71,8 +70,8 @@ fn a_session_click_reports_the_native_accessibility_action() {
     }
 
     // The two shapes of `boot`'s own factory closure — `make_platform` takes the iOS Simulator
-    // registry on macOS only. Each registry is a handle to shared state, so the clones the
-    // closure moves are the same registries `device` shuts down.
+    // registry on macOS only. The registries are handles to shared state, so the closure's
+    // clones are the ones `device` shuts down.
     #[cfg(target_os = "macos")]
     let sim = glass_ios::SimulatorRegistry::new();
     #[cfg(target_os = "macos")]
@@ -131,8 +130,8 @@ fn a_session_click_reports_the_native_accessibility_action() {
         counter(&glass.a11y_snapshot(None).expect("snapshot"))
     });
 
-    // The path a user takes. An assertion above panics past it, and the drops then do the same
-    // work: `AndroidPlatform` force-stops the app, `Companions` puts the device settings back.
+    // The user's own path; a panic above skips it and the drops do the same work —
+    // `AndroidPlatform` force-stops the app, `Companions` puts the settings back.
     glass.stop().expect("stop the session");
 }
 


### PR DESCRIPTION
Fixes #419.

`AndroidPlatform` had no `impl Drop` at all, unlike X11, Wayland, Windows and macOS, which all
reap. `am force-stop` ran only from `stop_app`, so a platform dropped without one left the app
running on a device that outlives the process. The new drop delegates to `stop_app`, which takes
`self.app` and is therefore a no-op once it has run.

## Two things the issue did not describe

**A failed launch leaks the app too, and the new drop does not catch it.** `start_app` records
`self.app` on its *last* statement, so a launch that got past `am start` and then failed at
`discover_window` — the window-never-appeared case of #338 — left the app running with nothing
keyed to reap it. The X11 backend already reaps this (`glass-x11/src/platform.rs:1046-1050`);
Android now does too, via `reap_failed_launch`. Without it the drop's parity claim is false on
what is plausibly the more common trigger.

**The test leaves more than a session behind.** Running it against a real AVD showed it also
leaves, every run: two `adb forward` entries, and the a11y companion **enabled** —
`enabled_accessibility_services` naming `…GlassA11yService`, `accessibility_enabled=1`. Attributed
by resetting the device, running this test alone, and re-reading the settings. An enabled
accessibility service is the worse of the two: it is in the tree of every later reader on that
device.

So teardown has to survive a panicking assertion. It is a `Companions` guard rather than a block
around the assertions, because a block around the assertions is in the wrong place: `Glass::start`
runs the factory *before* `start_app`, and the factory is what enables the companion — so the
likeliest failure, a launch that does not come up, panics with the state already on. `Companions`
is declared before any of it and drops after `glass`, so the app is force-stopped before the
companion reading it goes away. It also carries `EmulatorRegistry`, which was moved into the
factory and never killed.

## Verified on a device

CI cannot check any of this: `.github/workflows/android.yml` is schedule-only and explicitly never
runs on pull requests. Verified against a booted API 34 pixel_6 AVD, resetting the settings, the
installed companion and the forwards to a known baseline before each run:

| run | result |
|---|---|
| fixed | green; forwards empty, a11y setting `null`, flag 0, no fixture process |
| no stop, drop ablated to empty | green, **and** fixture pid live with `InvokeViewFixtureActivity` still `topResumedActivity` |
| drop only, explicit stop removed | green; device clean — the backstop works through `Box<dyn Platform>` |
| launch made to fail, guard in place | red; device clean — **the case the earlier `catch_unwind` was blind to** |
| launch made to fail, guard ablated | red; both forwards leaked and the companion left enabled |

Both new unit tests were ablated too: emptying the drop body reddens one, and stubbing out
`reap_failed_launch` reddens the other.

The full Android device suite (`./scripts/test-android.sh`, 14 tests across 8 binaries) is green,
including `set_value_reports_whether_the_write_landed` and
`a_panicking_test_leaves_the_device_launchable_for_the_next_one`. After the whole suite the device
is now clean; before this change it kept the companion enabled. The emulator was shut down
afterwards.

## Filed rather than fixed here

- **#421** — iOS has the same missing `Drop` and is now the only backend without one. Adding it
  makes `glass-ios`'s own `state_machine_tests` shell out to `xcrun`: they build platforms over a
  real `Simctl` with no injection seam, and the module documents that it never invokes it. Needs
  the seam first.
- **#422** — Android teardown can exceed `TEARDOWN_BUDGET`: `am force-stop` classifies as
  `AdbOp::Shell` (10s) against a 3s budget, `logcat.stop()`'s `wait()` is unbounded, and
  glass-android carries none of the compile-time assert the other three backends do — while
  `AdbOp`'s own doc claims force-stop "must keep the short deadline".
- **#423** — eight sibling device tests still skip their registry teardown on a panic, and the
  Android suite has no residue guard equivalent to the one #417/#418 added for X11 and Wayland.

## Other gates

`cargo test --workspace --locked` (exit 0), `cargo clippy --workspace --all-targets --locked -D
warnings`, `cargo fmt --all --check`, and `cargo clippy --target x86_64-apple-darwin -p glass-mcp
--all-targets` to type-check the `cfg(target_os = "macos")` factory arm.
