### PR TITLE
test(android): fail a device suite run that leaves state behind

### DIFF
--- a/crates/glass-android/tests/a11y_service_loop.rs
+++ b/crates/glass-android/tests/a11y_service_loop.rs
@@ -15,6 +15,8 @@ use glass_core::accessibility::{
 };
 use glass_core::{AppSpec, Platform, SandboxLevel, WindowGeometry};
 
+mod common;
+
 /// Serialize the two tests below: the on-device accessibility service accepts one connection
 /// at a time, and both tests drive whichever activity is currently foreground, so running them
 /// concurrently makes each retarget the other's window. Poison-tolerant so a panicking test
@@ -29,6 +31,7 @@ fn a11y_service_snapshot_and_actions() {
     // Resolve the device the same way production does, and reuse its serial-bound adb (the
     // `resolved_adb()` accessor) — no bespoke test helper. Launch Settings for an active window.
     let agents = AgentRegistry::new();
+    let _stop_agent = common::StopAgent(&agents);
     let mut p = AndroidPlatform::from_env(&EmulatorRegistry::new(), &agents).expect("attach");
     let spec = AppSpec {
         build: None,
@@ -44,6 +47,7 @@ fn a11y_service_snapshot_and_actions() {
     let adb = p.resolved_adb();
 
     let reg = A11yServiceRegistry::new();
+    let _restore = common::RestoreServiceState(&reg);
     let client = reg.ensure(&adb, &apk).expect("install + enable + connect");
     let mut a11y = ServiceA11y::new(client, String::new());
     let ctx = AxContext {
@@ -89,13 +93,9 @@ fn a11y_service_snapshot_and_actions() {
             .expect("set_value via ACTION_SET_TEXT");
     }
 
-    reg.shutdown(); // restores enabled_accessibility_services + removes the forward
     p.stop_app().ok();
-    drop(p);
-    agents.shutdown(); // tear down any agent the platform launched (no leaks)
-
-    // Then the controller condition-polls the device to confirm teardown left no enabled service
-    // and no forward (don't snapshot immediately — the unbind is async, ~1s; mirror the agent_loop leak check).
+    // The guards above restore the service settings and the forwards as they drop, and
+    // scripts/test-android.sh re-reads the device after the suite to confirm they did.
 }
 
 /// Native invoke against the fixture. Ignored; same environment as the test above.
@@ -108,6 +108,7 @@ fn native_invoke_actuates_the_fixture() {
         std::env::var("GLASS_ANDROID_FIXTURE_APK").expect("set GLASS_ANDROID_FIXTURE_APK");
 
     let agents = AgentRegistry::new();
+    let _stop_agent = common::StopAgent(&agents);
     let mut p = AndroidPlatform::from_env(&EmulatorRegistry::new(), &agents).expect("attach");
     let adb = p.resolved_adb();
     adb.run(["install", "-r", "-g", &fixture])
@@ -127,6 +128,7 @@ fn native_invoke_actuates_the_fixture() {
         .expect("launch view fixture");
 
     let reg = A11yServiceRegistry::new();
+    let _restore = common::RestoreServiceState(&reg);
     let client = reg.ensure(&adb, &apk).expect("install + enable + connect");
     let mut a11y = ServiceA11y::new(client, String::new());
     let ctx = AxContext {
@@ -302,11 +304,9 @@ fn native_invoke_actuates_the_fixture() {
         || counter(&mut a11y),
     );
 
-    reg.shutdown();
     p.stop_app().ok();
     drop(p);
     // The fixture is glass's to install and glass's to remove: leaving it installed lets device
     // state accumulate across runs.
     adb.run(["uninstall", "com.fixedwidth.glassfixture"]).ok();
-    agents.shutdown();
 }

--- a/crates/glass-android/tests/a11y_service_loop.rs
+++ b/crates/glass-android/tests/a11y_service_loop.rs
@@ -113,6 +113,9 @@ fn native_invoke_actuates_the_fixture() {
     let adb = p.resolved_adb();
     adb.run(["install", "-r", "-g", &fixture])
         .expect("install fixture");
+    let _uninstall = common::OnDrop(|| {
+        let _ = adb.run(["uninstall", "com.fixedwidth.glassfixture"]);
+    });
 
     let spec = |activity: &str| AppSpec {
         build: None,
@@ -306,7 +309,4 @@ fn native_invoke_actuates_the_fixture() {
 
     p.stop_app().ok();
     drop(p);
-    // The fixture is glass's to install and glass's to remove: leaving it installed lets device
-    // state accumulate across runs.
-    adb.run(["uninstall", "com.fixedwidth.glassfixture"]).ok();
 }

--- a/crates/glass-android/tests/agent_loop.rs
+++ b/crates/glass-android/tests/agent_loop.rs
@@ -9,6 +9,8 @@
 use glass_android::{AgentRegistry, EmulatorRegistry};
 use glass_core::{AppSpec, KeyEvent, MouseButton, Platform, PointerEvent, SandboxLevel};
 
+mod common;
+
 fn settings_spec() -> AppSpec {
     AppSpec {
         build: None,
@@ -29,6 +31,9 @@ fn agent_clipboard_and_input_roundtrip() {
     // tear the agent down explicitly at the end — in production `Glass`'s shutdown hook does
     // this; a test must not leak the process (the registry doesn't kill on drop).
     let agents = AgentRegistry::new();
+    // Before the platform, so the platform's agent connection closes first — and so a
+    // panicking assertion below cannot skip the teardown (glass#423).
+    let _stop_agent = common::StopAgent(&agents);
     let mut p = glass_android::AndroidPlatform::from_env(&EmulatorRegistry::new(), &agents)
         .expect("attach + agent");
     p.start_app(&settings_spec()).expect("launch settings");
@@ -50,6 +55,4 @@ fn agent_clipboard_and_input_roundtrip() {
         .expect("agent text");
 
     p.stop_app().expect("stop");
-    drop(p); // close the platform's agent connection before stopping the agent
-    agents.shutdown(); // kill the launched agent + remove the forward (no leaked process)
 }

--- a/crates/glass-android/tests/common/mod.rs
+++ b/crates/glass-android/tests/common/mod.rs
@@ -2,14 +2,13 @@
 //!
 //! Both registries put state on the device that outlives the process — an `adb forward` each, and
 //! for the companion the secure settings that enable it as an accessibility service — that only
-//! their `shutdown` takes it back off. Neither has a `Drop`, so a test panicking past a trailing
-//! `shutdown()` hands an enabled companion to every later reader on that device (glass#423).
+//! their `shutdown` takes back off. Neither has a `Drop`, so a test panicking past a trailing
+//! `shutdown()` hands an enabled companion to every later reader on that device (glass#423), and
 //! `scripts/test-android.sh` fails a run that ends with any of it still on.
 //!
 //! Declare a guard BEFORE the platform it serves: locals drop in reverse, so the platform's agent
-//! connection closes before the registry that owns the agent. The two registries are independent
-//! of each other — separate forwards, and the a11y one has no process — so their order between
-//! themselves does not matter, and it differs across the suite.
+//! connection closes before the registry that owns the agent. Order between the two registries
+//! does not matter — separate forwards, and the a11y one has no process.
 
 #![allow(dead_code)]
 
@@ -29,10 +28,9 @@ impl Drop for StopAgent<'_> {
 /// Restores the device's accessibility settings — `enabled_accessibility_services`,
 /// `accessibility_enabled` and the `adb forward` — when it drops.
 ///
-/// Covers a `shutdown` that a panic would skip, not one that has nothing to undo: `ensure`
-/// enables the service on the device before it records anything in `state`, so a failure in that
-/// window leaves the companion on and this a no-op (glass#425). `scripts/test-android.sh` is what
-/// catches that.
+/// Covers a `shutdown` a panic would skip, not one with nothing to undo: `ensure` enables the
+/// service before it records anything in `state`, so a failure in that window leaves the
+/// companion on and this a no-op (glass#425).
 pub struct RestoreServiceState<'a>(pub &'a A11yServiceRegistry);
 
 impl Drop for RestoreServiceState<'_> {
@@ -41,10 +39,9 @@ impl Drop for RestoreServiceState<'_> {
     }
 }
 
-/// Runs its closure when it drops — for device cleanup with no registry to hang off, such as the
-/// fixture APK a test installs, which is glass's to remove and which the residue check cannot see.
-/// A closure rather than a typed guard because `glass_android`'s `Adb` is not exported, so nothing
-/// here can name what it has to call.
+/// Runs its closure when it drops — for device cleanup with no registry to hang off, like the
+/// fixture APK a test installs, which the residue check cannot see. A closure, not a typed guard:
+/// `glass_android`'s `Adb` is not exported, so nothing here can name what it calls.
 pub struct OnDrop<F: FnMut()>(pub F);
 
 impl<F: FnMut()> Drop for OnDrop<F> {
@@ -53,9 +50,9 @@ impl<F: FnMut()> Drop for OnDrop<F> {
     }
 }
 
-/// Stops any emulator glass booted itself when it drops; a no-op when it attached to a running
-/// one, and idempotent with an explicit `kill_all` (which takes the list). The leak this catches
-/// is a whole ~2GB VM, so it is worth guarding even where an assertion is unlikely to fail.
+/// Stops any emulator glass booted itself when it drops — a no-op when it attached to a running
+/// one, and idempotent with an explicit `kill_all`, which takes the list. The leak it catches is
+/// a whole ~2GB VM.
 pub struct KillBootedEmulators<'a>(pub &'a EmulatorRegistry);
 
 impl Drop for KillBootedEmulators<'_> {

--- a/crates/glass-android/tests/common/mod.rs
+++ b/crates/glass-android/tests/common/mod.rs
@@ -1,13 +1,15 @@
 //! Teardown guards for the device suites.
 //!
 //! Both registries put state on the device that outlives the process — an `adb forward` each, and
-//! for the companion the secure settings that enable it as an accessibility service — and only
+//! for the companion the secure settings that enable it as an accessibility service — that only
 //! their `shutdown` takes it back off. Neither has a `Drop`, so a test panicking past a trailing
 //! `shutdown()` hands an enabled companion to every later reader on that device (glass#423).
 //! `scripts/test-android.sh` fails a run that ends with any of it still on.
 //!
 //! Declare a guard BEFORE the platform it serves: locals drop in reverse, so the platform's agent
-//! connection closes before the registry that owns the agent.
+//! connection closes before the registry that owns the agent. The two registries are independent
+//! of each other — separate forwards, and the a11y one has no process — so their order between
+//! themselves does not matter, and it differs across the suite.
 
 #![allow(dead_code)]
 
@@ -25,14 +27,29 @@ impl Drop for StopAgent<'_> {
 }
 
 /// Restores the device's accessibility settings — `enabled_accessibility_services`,
-/// `accessibility_enabled` and the `adb forward` — when it drops. `A11yServiceRegistry::ensure`
-/// records the prior values and `shutdown` puts them back, so the only question is whether
-/// `shutdown` is reached.
+/// `accessibility_enabled` and the `adb forward` — when it drops.
+///
+/// Covers a `shutdown` that a panic would skip, not one that has nothing to undo: `ensure`
+/// enables the service on the device before it records anything in `state`, so a failure in that
+/// window leaves the companion on and this a no-op (glass#425). `scripts/test-android.sh` is what
+/// catches that.
 pub struct RestoreServiceState<'a>(pub &'a A11yServiceRegistry);
 
 impl Drop for RestoreServiceState<'_> {
     fn drop(&mut self) {
         self.0.shutdown();
+    }
+}
+
+/// Runs its closure when it drops — for device cleanup with no registry to hang off, such as the
+/// fixture APK a test installs, which is glass's to remove and which the residue check cannot see.
+/// A closure rather than a typed guard because `glass_android`'s `Adb` is not exported, so nothing
+/// here can name what it has to call.
+pub struct OnDrop<F: FnMut()>(pub F);
+
+impl<F: FnMut()> Drop for OnDrop<F> {
+    fn drop(&mut self) {
+        (self.0)();
     }
 }
 

--- a/crates/glass-android/tests/common/mod.rs
+++ b/crates/glass-android/tests/common/mod.rs
@@ -1,0 +1,48 @@
+//! Teardown guards for the device suites.
+//!
+//! Both registries put state on the device that outlives the process — an `adb forward` each, and
+//! for the companion the secure settings that enable it as an accessibility service — and only
+//! their `shutdown` takes it back off. Neither has a `Drop`, so a test panicking past a trailing
+//! `shutdown()` hands an enabled companion to every later reader on that device (glass#423).
+//! `scripts/test-android.sh` fails a run that ends with any of it still on.
+//!
+//! Declare a guard BEFORE the platform it serves: locals drop in reverse, so the platform's agent
+//! connection closes before the registry that owns the agent.
+
+#![allow(dead_code)]
+
+use glass_android::{A11yServiceRegistry, AgentRegistry, EmulatorRegistry};
+
+/// Kills the launched agent and removes its `adb forward` when it drops.
+pub struct StopAgent<'a>(pub &'a AgentRegistry);
+
+impl Drop for StopAgent<'_> {
+    fn drop(&mut self) {
+        // Reached while a panic unwinds, where a second panic aborts the process — nothing here
+        // may assert.
+        self.0.shutdown();
+    }
+}
+
+/// Restores the device's accessibility settings — `enabled_accessibility_services`,
+/// `accessibility_enabled` and the `adb forward` — when it drops. `A11yServiceRegistry::ensure`
+/// records the prior values and `shutdown` puts them back, so the only question is whether
+/// `shutdown` is reached.
+pub struct RestoreServiceState<'a>(pub &'a A11yServiceRegistry);
+
+impl Drop for RestoreServiceState<'_> {
+    fn drop(&mut self) {
+        self.0.shutdown();
+    }
+}
+
+/// Stops any emulator glass booted itself when it drops; a no-op when it attached to a running
+/// one, and idempotent with an explicit `kill_all` (which takes the list). The leak this catches
+/// is a whole ~2GB VM, so it is worth guarding even where an assertion is unlikely to fail.
+pub struct KillBootedEmulators<'a>(pub &'a EmulatorRegistry);
+
+impl Drop for KillBootedEmulators<'_> {
+    fn drop(&mut self) {
+        self.0.kill_all();
+    }
+}

--- a/crates/glass-android/tests/input_loop.rs
+++ b/crates/glass-android/tests/input_loop.rs
@@ -12,6 +12,8 @@ use glass_core::{
 };
 use std::time::{Duration, Instant};
 
+mod common;
+
 fn settings_spec() -> AppSpec {
     AppSpec {
         build: None,
@@ -121,6 +123,9 @@ fn assert_screen_changed(p: &mut glass_android::AndroidPlatform, before: &Frame,
 #[ignore = "requires a booted AVD + GLASS_ANDROID_SERIAL/GLASS_ADB"]
 fn scroll_and_tap_change_the_screen() {
     let agents = glass_android::AgentRegistry::new();
+    // Before the platform, so the platform's agent connection closes first — and so a
+    // panicking assertion below cannot skip the teardown (glass#423).
+    let _stop_agent = common::StopAgent(&agents);
     let mut p =
         glass_android::AndroidPlatform::from_env(&glass_android::EmulatorRegistry::new(), &agents)
             .expect("attach to emulator");
@@ -156,6 +161,4 @@ fn scroll_and_tap_change_the_screen() {
     assert_screen_changed(&mut p, &before, "tap");
 
     p.stop_app().expect("stop");
-    drop(p); // close the platform's agent connection (if any) first
-    agents.shutdown(); // tear down a launched agent — these tests must not leak it
 }

--- a/crates/glass-android/tests/managed_avd.rs
+++ b/crates/glass-android/tests/managed_avd.rs
@@ -9,6 +9,8 @@ use glass_android::EmulatorRegistry;
 use std::process::Command;
 use std::time::{Duration, Instant};
 
+mod common;
+
 fn adb() -> String {
     std::env::var("GLASS_ADB").unwrap_or_else(|_| "adb".into())
 }
@@ -84,9 +86,14 @@ fn boots_reuses_and_cleans_up() {
         "start this test with no emulator running"
     );
     let registry = EmulatorRegistry::new();
+    // `kill_all` below is what this test asserts on, so it stays explicit; this only covers the
+    // path where an assertion between here and there panics, which would otherwise leave a
+    // booted emulator behind. Idempotent — `kill_all` takes the list.
+    let _kill_emulators = common::KillBootedEmulators(&registry);
 
     // First resolve boots the AVD.
     let agents1 = glass_android::AgentRegistry::new();
+    let _stop_agent1 = common::StopAgent(&agents1);
     let mut p1 =
         glass_android::AndroidPlatform::from_env(&registry, &agents1).expect("boot+attach");
     assert_eq!(online_count(), 1, "expected one emulator after boot");
@@ -94,13 +101,16 @@ fn boots_reuses_and_cleans_up() {
 
     // Second resolve attaches to the same emulator — no second boot.
     let agents2 = glass_android::AgentRegistry::new();
+    let _stop_agent2 = common::StopAgent(&agents2);
     let _p2 = glass_android::AndroidPlatform::from_env(&registry, &agents2).expect("attach reuse");
     assert_eq!(online_count(), 1, "reuse must not boot a second emulator");
 
     // Cleanup stops the glass-booted emulator.
     drop(p1);
     drop(_p2);
-    agents1.shutdown(); // tear down any launched agent — these tests must not leak it
+    // Explicit, and before `kill_all`, because this test goes on to assert the emulator went
+    // offline: the guards above only repeat this on the panicking path.
+    agents1.shutdown();
     agents2.shutdown();
     registry.kill_all();
     let w = await_offline();

--- a/crates/glass-android/tests/role_probe.rs
+++ b/crates/glass-android/tests/role_probe.rs
@@ -42,6 +42,8 @@ use glass_core::{
     description_census_report, role_histogram,
 };
 
+mod common;
+
 /// Comma-separated `package/activity` components to probe, e.g.
 /// `com.android.settings/.Settings`. Each element is exactly what `AppSpec::run`'s first
 /// element accepts on this backend. Unset (or set but empty) skips the probe rather than
@@ -210,19 +212,6 @@ fn spec_for(component: &str) -> AppSpec {
     }
 }
 
-/// Restores the device's accessibility settings — `enabled_accessibility_services`,
-/// `accessibility_enabled` and the `adb forward` — when it drops. `A11yServiceRegistry::ensure`
-/// records the prior values and `shutdown` puts them back, so the only question is whether
-/// `shutdown` is reached: a guard reaches it on the panicking path too, which a plain call at
-/// the end of the test does not.
-struct RestoreServiceState<'a>(&'a A11yServiceRegistry);
-
-impl Drop for RestoreServiceState<'_> {
-    fn drop(&mut self) {
-        self.0.shutdown();
-    }
-}
-
 /// The node cap lifted, so a big app's tree is never truncated mid-probe. Depth and per-level
 /// sibling rails keep their generous structural defaults regardless.
 fn uncapped() -> WalkLimits {
@@ -241,6 +230,7 @@ fn uiautomator_role_histogram_probe() {
     };
 
     let agents = AgentRegistry::new();
+    let _stop_agent = common::StopAgent(&agents);
     let mut platform =
         AndroidPlatform::from_env(&EmulatorRegistry::new(), &agents).expect("attach to a device");
     let mut violations = Vec::new();
@@ -277,8 +267,6 @@ fn uiautomator_role_histogram_probe() {
         platform.stop_app().expect("stop_app");
     }
 
-    drop(platform); // close the platform's agent connection (if any) before the registry
-    agents.shutdown(); // never leak a launched agent
     // The census prints without a caveat now that this reader sources the field, so a reader
     // regressed to `description: None` would print a plausible zero for every app and this probe
     // would pass silently. The app list is the caller's, so this is a note, not a failure.
@@ -308,6 +296,7 @@ fn service_role_histogram_probe() {
     };
 
     let agents = AgentRegistry::new();
+    let _stop_agent = common::StopAgent(&agents);
     let mut platform =
         AndroidPlatform::from_env(&EmulatorRegistry::new(), &agents).expect("attach to a device");
     let registry = A11yServiceRegistry::new();
@@ -323,7 +312,7 @@ fn service_role_histogram_probe() {
     // Held for the rest of the run so the settings go back however this probe leaves — a
     // panicking start_app or snapshot mid-loop would otherwise strand the device in exactly
     // the state the hoisted `ensure` above exists to avoid.
-    let _restore = RestoreServiceState(&registry);
+    let _restore = common::RestoreServiceState(&registry);
     let mut a11y = ServiceA11y::new(client, String::new());
     let mut violations = Vec::new();
     let mut described = 0usize;
@@ -360,7 +349,6 @@ fn service_role_histogram_probe() {
     }
 
     drop(platform);
-    agents.shutdown();
     // Same rationale as `uiautomator_role_histogram_probe` above: a silent zero is a note here,
     // not a failure, since the app list is the caller's.
     if described == 0 {

--- a/crates/glass-android/tests/see_loop.rs
+++ b/crates/glass-android/tests/see_loop.rs
@@ -7,6 +7,8 @@
 
 use glass_core::{AppSpec, Platform, SandboxLevel};
 
+mod common;
+
 fn settings_spec() -> AppSpec {
     AppSpec {
         build: None,
@@ -24,6 +26,9 @@ fn settings_spec() -> AppSpec {
 #[ignore = "requires a booted AVD + GLASS_ANDROID_SERIAL"]
 fn see_loop_launches_and_captures_settings() {
     let agents = glass_android::AgentRegistry::new();
+    // Before the platform, so the platform's agent connection closes first — and so a
+    // panicking assertion below cannot skip the teardown (glass#423).
+    let _stop_agent = common::StopAgent(&agents);
     let mut p =
         glass_android::AndroidPlatform::from_env(&glass_android::EmulatorRegistry::new(), &agents)
             .expect("attach to emulator");
@@ -40,6 +45,4 @@ fn see_loop_launches_and_captures_settings() {
     assert!(!logs.is_empty(), "expected some logcat output");
 
     p.stop_app().expect("stop");
-    drop(p); // close the platform's agent connection (if any) first
-    agents.shutdown(); // tear down a launched agent — these tests must not leak it
 }

--- a/crates/glass-android/tests/window_loop.rs
+++ b/crates/glass-android/tests/window_loop.rs
@@ -7,6 +7,8 @@
 
 use glass_core::{AppSpec, Platform, SandboxLevel, WindowId};
 
+mod common;
+
 fn settings_spec() -> AppSpec {
     AppSpec {
         build: None,
@@ -24,6 +26,9 @@ fn settings_spec() -> AppSpec {
 #[ignore = "requires a booted AVD + GLASS_ANDROID_SERIAL/GLASS_ADB"]
 fn lists_and_selects_app_windows() {
     let agents = glass_android::AgentRegistry::new();
+    // Before the platform, so the platform's agent connection closes first — and so a
+    // panicking assertion below cannot skip the teardown (glass#423).
+    let _stop_agent = common::StopAgent(&agents);
     let mut p =
         glass_android::AndroidPlatform::from_env(&glass_android::EmulatorRegistry::new(), &agents)
             .expect("attach");
@@ -47,6 +52,4 @@ fn lists_and_selects_app_windows() {
     ));
 
     p.stop_app().expect("stop");
-    drop(p); // close the platform's agent connection (if any) first
-    agents.shutdown(); // tear down a launched agent — these tests must not leak it
 }

--- a/scripts/lib/device-residue-test.sh
+++ b/scripts/lib/device-residue-test.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Self-test for device-residue.sh, against a stub adb. Needs no device:
+#
+#   ./scripts/lib/device-residue-test.sh
+#
+# A leak detector that is never shown to fail is indistinguishable from one that always passes,
+# and this one has three ways to go quiet that are invisible on a real run: an unreadable device
+# compared against another unreadable device, a clean teardown that normalises `null` to `0`, and
+# a baseline that already carries the leak. Each has a case below.
+set -uo pipefail
+cd "$(dirname "$0")/../.." || exit 1
+. scripts/lib/device-residue.sh
+GLASS_RESIDUE_SETTLE=2
+unset GLASS_ANDROID_SERIAL
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/glass-residue-selftest.XXXXXX")
+trap 'rm -rf "$work"' EXIT
+adb="$work/adb"
+
+# A stub adb driven by $work/state: `services|enabled|forwards`, or `broken`/`silent`.
+cat > "$adb" <<'STUB'
+#!/usr/bin/env bash
+state=$(cat "$(dirname "$0")/state")
+[ "$state" = broken ] && { echo "error: no devices/emulators found" >&2; exit 1; }
+[ "$state" = silent ] && exit 0
+IFS='|' read -r services enabled forwards <<< "$state"
+args=("$@"); [ "${args[0]}" = "-s" ] && args=("${args[@]:2}")
+case "${args[0]}" in
+  forward) [ -n "$forwards" ] && tr ';' '\n' <<< "$forwards" ;;
+  shell)   case "${args[4]}" in
+             enabled_accessibility_services) echo "$services" ;;
+             accessibility_enabled) echo "$enabled" ;;
+           esac ;;
+esac
+exit 0
+STUB
+chmod +x "$adb"
+state() { printf '%s' "$1" > "$work/state"; }
+
+pass=0 fail=0
+check() { # label expected actual
+    if [ "$2" = "$3" ]; then echo "  ok   $1"; pass=$((pass + 1))
+    else echo "  FAIL $1 — expected rc=$2, got rc=$3"; fail=$((fail + 1)); fi
+}
+
+echo "a clean run:"
+state 'null|0|'
+before=$(device_snapshot "$adb"); check "the snapshot reads" 0 $?
+report_device_residue "$adb" "$before" > /dev/null 2>&1; check "no change passes" 0 $?
+
+echo "a leak:"
+state 'null|0|'
+before=$(device_snapshot "$adb")
+state "com.fixedwidth.glassa11y/x|1|emulator-5554 tcp:1 localabstract:glass-agent"
+out=$(report_device_residue "$adb" "$before" 2>&1); check "it fails" 1 $?
+grep -q 'GLASS-RESIDUE: LEAKED' <<< "$out"; check "it prints the greppable marker" 0 $?
+grep -q 'glass-agent' <<< "$out"; check "the diff names the forward" 0 $?
+
+echo "an unreadable device:"
+state 'null|0|'
+before=$(device_snapshot "$adb")
+state broken
+out=$(report_device_residue "$adb" "$before" 2>&1); check "fails rather than passing" 1 $?
+grep -q 'could not read the device' <<< "$out"; check "it says why" 0 $?
+
+echo "adb exiting 0 having printed nothing:"
+state silent
+device_snapshot "$adb" > /dev/null 2>&1; check "an empty reading is not a snapshot" 1 $?
+
+echo "a teardown that normalised null to 0 (not a leak):"
+state 'null|null|'
+before=$(device_snapshot "$adb")
+state 'null|0|'
+report_device_residue "$adb" "$before" > /dev/null 2>&1; check "passes" 0 $?
+
+echo "a device with its own accessibility service (not a leak):"
+state 'com.google.android.marvin.talkback/x|1|'
+before=$(device_snapshot "$adb")
+report_device_residue "$adb" "$before" > /dev/null 2>&1; check "unchanged state passes" 0 $?
+assert_clean_baseline "$before" > /dev/null 2>&1; check "and the baseline is accepted" 0 $?
+
+echo "a baseline already carrying glass's own residue:"
+state 'com.fixedwidth.glassa11y/x|1|'
+before=$(device_snapshot "$adb")
+out=$(assert_clean_baseline "$before" 2>&1); check "is refused" 1 $?
+grep -q 'already enabled' <<< "$out"; check "and says how to clear it" 0 $?
+state 'null|0|emulator-5554 tcp:1 localabstract:glass-a11y'
+out=$(assert_clean_baseline "$(device_snapshot "$adb")" 2>&1); check "a stale forward too" 1 $?
+
+echo "more forwards after than before:"
+state 'null|0|emulator-5554 tcp:1 localabstract:glass-a11y'
+before=$(device_snapshot "$adb")
+state 'null|0|emulator-5554 tcp:1 localabstract:glass-a11y;emulator-5554 tcp:2 localabstract:glass-a11y'
+report_device_residue "$adb" "$before" > /dev/null 2>&1; check "counted, not deduplicated" 1 $?
+
+echo "a bad settle value:"
+state 'null|0|'
+before=$(device_snapshot "$adb")
+GLASS_RESIDUE_SETTLE=30s report_device_residue "$adb" "$before" > /dev/null 2>&1
+check "is refused rather than skipping the check" 1 $?
+GLASS_RESIDUE_SETTLE=08 report_device_residue "$adb" "$before" > /dev/null 2>&1
+check "a zero-padded one is base 10, not octal" 0 $?
+
+echo "passed=$pass failed=$fail"
+[ "$fail" -eq 0 ]

--- a/scripts/lib/device-residue.sh
+++ b/scripts/lib/device-residue.sh
@@ -9,42 +9,144 @@
 #
 # Compared against a snapshot taken BEFORE the run, never against a fixed "clean" value: a dev box
 # may have its own accessibility service enabled, and asserting `null` would fail there forever.
+# The one thing checked absolutely is glass's *own* residue — see `assert_clean_baseline`.
 
-# How long to keep re-reading before calling a difference real. The service unbind is async by
-# about a second, so a single look right after the suite reads a mid-teardown device as a leak.
+# Seconds to keep re-reading before calling a difference real, or an unreadable device dead.
 : "${GLASS_RESIDUE_SETTLE:=15}"
+
+# `SERVICE_PACKAGE` and the two `SOCKET` constants in crates/glass-android/src/{a11y_service,agent}.rs.
+# Duplicated because a shell script cannot read a Rust `const`; `assert_clean_baseline` is what
+# would notice them drifting, by never firing again.
+GLASS_RESIDUE_SERVICE_PKG='com.fixedwidth.glassa11y'
+
+# Run adb against the device the suite drives. `GLASS_ANDROID_SERIAL` is how a host with more than
+# one device online picks it (crates/glass-android/src/adb.rs `build_argv` does the same), and
+# without it every probe here fails on exactly the setup that variable exists for.
+#
+# `timeout` because a wedged device otherwise hangs the probe forever: the Rust side bounds every
+# adb call, and the poll below only checks its deadline between reads.
+_residue_adb() {
+    local adb="$1"
+    shift
+    if [ -n "${GLASS_ANDROID_SERIAL:-}" ]; then
+        timeout 10 "$adb" -s "$GLASS_ANDROID_SERIAL" "$@"
+    else
+        timeout 10 "$adb" "$@"
+    fi
+}
+
+# The `localabstract:glass-*` sockets forwarded for this device, sorted, space-separated.
+_residue_forwards() {
+    local adb="$1" list line
+    local -a names=()
+    list=$(_residue_adb "$adb" forward --list) || return 1
+    while IFS= read -r line; do
+        # `adb forward --list` is global — it ignores `-s` — so another device's forwards would
+        # read as this one's.
+        if [ -n "${GLASS_ANDROID_SERIAL:-}" ]; then
+            case "$line" in "$GLASS_ANDROID_SERIAL "*) ;; *) continue ;; esac
+        fi
+        case "$line" in *" localabstract:glass-"*) names+=("${line##* }") ;; esac
+    done <<< "$list"
+    # Sorted for a stable comparison but NOT deduplicated: four leaked `glass-a11y` forwards are
+    # four leaks, and `sort -u` would report them as the state one leaves.
+    [ "${#names[@]}" -eq 0 ] || printf '%s' "$(printf '%s\n' "${names[@]}" | sort | tr '\n' ' ')"
+}
 
 # Print the device state this guard compares, one `key=value` line each, through the adb in $1.
 # Non-zero if any probe failed — a device that cannot be read must not compare equal to another
 # unreadable one, which is a guard that passes because it looked at nothing.
 device_snapshot() {
     local adb="$1" services enabled forwards
-    services=$("$adb" shell settings get secure enabled_accessibility_services) || return 1
-    enabled=$("$adb" shell settings get secure accessibility_enabled) || return 1
-    forwards=$("$adb" forward --list) || return 1
-    # Only the socket names: the local tcp port is assigned per run, so the raw lines differ
-    # between two equally clean snapshots.
-    forwards=$(printf '%s\n' "$forwards" | grep -o 'localabstract:glass-[a-z0-9-]*' | sort -u) ||
-        [ $? -eq 1 ] || return 1
-    printf 'enabled_accessibility_services=%s\n' "$(printf '%s' "$services" | tr -d '\r')"
-    printf 'accessibility_enabled=%s\n' "$(printf '%s' "$enabled" | tr -d '\r')"
-    printf 'forwards=%s\n' "$(printf '%s' "$forwards" | tr '\n' ' ')"
+    # The `shell` probes first: `adb forward --list` succeeds with no device attached, so leading
+    # with it would let "nothing is connected" read as "nothing is forwarded".
+    services=$(_residue_adb "$adb" shell settings get secure enabled_accessibility_services) || return 1
+    enabled=$(_residue_adb "$adb" shell settings get secure accessibility_enabled) || return 1
+    services=$(printf '%s' "$services" | tr -d '\r\n')
+    enabled=$(printf '%s' "$enabled" | tr -d '\r\n')
+    # A live device answers `settings get` with a value or the literal `null`, so nothing at all
+    # means the probe did not run. `adb shell` does not carry the remote exit status on every
+    # platform-tools version, which makes an empty reading the only sign of it.
+    if [ -z "$services" ] || [ -z "$enabled" ]; then
+        return 1
+    fi
+    # Normalised the way `A11yServiceRegistry::ensure` normalises before recording what to restore
+    # (a11y_service.rs): an unset list becomes "" and an unset flag becomes "0", so a correct
+    # teardown leaves `0` where it found `null` and a raw comparison would call that a leak.
+    case "$services" in null) services="" ;; esac
+    case "$enabled" in null | "") enabled=0 ;; esac
+    forwards=$(_residue_forwards "$adb") || return 1
+
+    printf 'enabled_accessibility_services=%s\n' "$services"
+    printf 'accessibility_enabled=%s\n' "$enabled"
+    printf 'forwards=%s\n' "$forwards"
 }
 
-# Compare the device against the snapshot in $2, polling until it settles. Non-zero, and loud, if
+# Refuse to run against a device that already carries glass's own residue.
+#
+# The before/after comparison cannot see it: `ensure` records the leaked service as the state to
+# restore, puts that same state back, and every run after the first reports clean on a device that
+# never got cleaned. Checked absolutely because these names are glass's own — unlike a dev box's
+# TalkBack, they are never legitimately on before a run.
+assert_clean_baseline() {
+    local snapshot="$1" bad=""
+    case "$snapshot" in
+        *"$GLASS_RESIDUE_SERVICE_PKG"*) bad="the glass companion is already enabled" ;;
+    esac
+    case "$snapshot" in
+        *"forwards=localabstract:glass-"*) bad="${bad:+$bad, and }a glass forward is already open" ;;
+    esac
+    [ -n "$bad" ] || return 0
+    echo "FAIL: $bad before this run started — an earlier run leaked it." >&2
+    printf '%s\n' "$snapshot" >&2
+    echo "Clear it, or this check can never see a new leak:" >&2
+    echo "  adb shell settings delete secure enabled_accessibility_services" >&2
+    echo "  adb shell settings put secure accessibility_enabled 0" >&2
+    echo "  adb forward --remove-all" >&2
+    return 1
+}
+
+# Compare the device against the snapshot in $2, retrying until it settles. Non-zero, and loud, if
 # it has not gone back to $2 within `GLASS_RESIDUE_SETTLE` seconds.
 report_device_residue() {
-    local adb="$1" before="$2" after deadline=$((SECONDS + GLASS_RESIDUE_SETTLE))
-    while :; do
-        if ! after=$(device_snapshot "$adb"); then
-            echo "FAIL: could not read the device state after the suite" >&2
+    local adb="$1" before="$2" after last="" looks=0 started=$SECONDS deadline
+    # Validated rather than trusted: an arithmetic error in the deadline below would skip the
+    # comparison, and the whole run would then pass having checked nothing. `10#` so a
+    # zero-padded `08` is eight seconds rather than a base-8 error.
+    case "$GLASS_RESIDUE_SETTLE" in
+        '' | *[!0-9]*)
+            echo "FAIL: GLASS_RESIDUE_SETTLE must be whole seconds, got '$GLASS_RESIDUE_SETTLE'" >&2
             return 1
+            ;;
+    esac
+    deadline=$((SECONDS + 10#$GLASS_RESIDUE_SETTLE))
+
+    while :; do
+        looks=$((looks + 1))
+        if after=$(device_snapshot "$adb"); then
+            if [ "$after" = "$before" ]; then
+                # Said out loud so a run that skipped the check cannot be mistaken for a clean one.
+                echo "device-residue: clean after $looks look(s), $((SECONDS - started))s" >&2
+                return 0
+            fi
+            last=differs
+        else
+            # Retried, not fatal on the first miss: the suite has just finished hammering the
+            # device, and in CI the emulator is about to be torn down around it.
+            last=unreadable
         fi
-        [ "$after" = "$before" ] && return 0
-        [ "$SECONDS" -ge "$deadline" ] && break
+        [ "$SECONDS" -lt "$deadline" ] || break
         sleep 1
     done
-    echo "FAIL: the suite left device state behind (- before the run, + after):" >&2
+
+    if [ "$last" = unreadable ]; then
+        echo "FAIL: could not read the device for ${GLASS_RESIDUE_SETTLE}s after the suite" >&2
+        return 1
+    fi
+    # A fixed marker, because the exit status is lost when the suite failed too — which is the
+    # case this guard exists for, a test panicking past its own teardown.
+    echo "GLASS-RESIDUE: LEAKED" >&2
+    echo "The suite left device state behind (- before the run, + after):" >&2
     diff <(printf '%s\n' "$before") <(printf '%s\n' "$after") >&2 || true
     echo "A test never reached its registry \`shutdown\`; an enabled companion is in the tree of" >&2
     echo "every later reader on this device." >&2

--- a/scripts/lib/device-residue.sh
+++ b/scripts/lib/device-residue.sh
@@ -14,17 +14,16 @@
 # Seconds to keep re-reading before calling a difference real, or an unreadable device dead.
 : "${GLASS_RESIDUE_SETTLE:=15}"
 
-# `SERVICE_PACKAGE` and the two `SOCKET` constants in crates/glass-android/src/{a11y_service,agent}.rs.
-# Duplicated because a shell script cannot read a Rust `const`; `assert_clean_baseline` is what
-# would notice them drifting, by never firing again.
+# `SERVICE_PACKAGE` in crates/glass-android/src/a11y_service.rs, duplicated because a shell script
+# cannot read a Rust `const`. Drift shows up as `assert_clean_baseline` never firing again.
 GLASS_RESIDUE_SERVICE_PKG='com.fixedwidth.glassa11y'
 
 # Run adb against the device the suite drives. `GLASS_ANDROID_SERIAL` is how a host with more than
 # one device online picks it (crates/glass-android/src/adb.rs `build_argv` does the same), and
 # without it every probe here fails on exactly the setup that variable exists for.
 #
-# `timeout` because a wedged device otherwise hangs the probe forever: the Rust side bounds every
-# adb call, and the poll below only checks its deadline between reads.
+# `timeout` because the poll below only checks its deadline between reads, so a wedged device
+# would hang a probe forever.
 _residue_adb() {
     local adb="$1"
     shift
@@ -110,9 +109,8 @@ assert_clean_baseline() {
 # it has not gone back to $2 within `GLASS_RESIDUE_SETTLE` seconds.
 report_device_residue() {
     local adb="$1" before="$2" after last="" looks=0 started=$SECONDS deadline
-    # Validated rather than trusted: an arithmetic error in the deadline below would skip the
-    # comparison, and the whole run would then pass having checked nothing. `10#` so a
-    # zero-padded `08` is eight seconds rather than a base-8 error.
+    # Validated, because an arithmetic error in the deadline below would skip the comparison and
+    # the run would pass having checked nothing. `10#` so `08` is eight seconds, not a base-8 error.
     case "$GLASS_RESIDUE_SETTLE" in
         '' | *[!0-9]*)
             echo "FAIL: GLASS_RESIDUE_SETTLE must be whole seconds, got '$GLASS_RESIDUE_SETTLE'" >&2

--- a/scripts/lib/device-residue.sh
+++ b/scripts/lib/device-residue.sh
@@ -1,0 +1,52 @@
+# shellcheck shell=bash
+# Detect device state a suite switched on and never switched back off.
+#
+# `A11yServiceRegistry::ensure` enables the companion as an accessibility service and opens an
+# `adb forward`; `AgentRegistry::ensure` opens one too. Only their `shutdown` puts that back, and a
+# test panicking past a trailing `shutdown()` leaves the companion in the tree of every later
+# reader on the device (glass#423). The suite reports green while it happens, hence a check around
+# it rather than an assertion inside one test.
+#
+# Compared against a snapshot taken BEFORE the run, never against a fixed "clean" value: a dev box
+# may have its own accessibility service enabled, and asserting `null` would fail there forever.
+
+# How long to keep re-reading before calling a difference real. The service unbind is async by
+# about a second, so a single look right after the suite reads a mid-teardown device as a leak.
+: "${GLASS_RESIDUE_SETTLE:=15}"
+
+# Print the device state this guard compares, one `key=value` line each, through the adb in $1.
+# Non-zero if any probe failed — a device that cannot be read must not compare equal to another
+# unreadable one, which is a guard that passes because it looked at nothing.
+device_snapshot() {
+    local adb="$1" services enabled forwards
+    services=$("$adb" shell settings get secure enabled_accessibility_services) || return 1
+    enabled=$("$adb" shell settings get secure accessibility_enabled) || return 1
+    forwards=$("$adb" forward --list) || return 1
+    # Only the socket names: the local tcp port is assigned per run, so the raw lines differ
+    # between two equally clean snapshots.
+    forwards=$(printf '%s\n' "$forwards" | grep -o 'localabstract:glass-[a-z0-9-]*' | sort -u) ||
+        [ $? -eq 1 ] || return 1
+    printf 'enabled_accessibility_services=%s\n' "$(printf '%s' "$services" | tr -d '\r')"
+    printf 'accessibility_enabled=%s\n' "$(printf '%s' "$enabled" | tr -d '\r')"
+    printf 'forwards=%s\n' "$(printf '%s' "$forwards" | tr '\n' ' ')"
+}
+
+# Compare the device against the snapshot in $2, polling until it settles. Non-zero, and loud, if
+# it has not gone back to $2 within `GLASS_RESIDUE_SETTLE` seconds.
+report_device_residue() {
+    local adb="$1" before="$2" after deadline=$((SECONDS + GLASS_RESIDUE_SETTLE))
+    while :; do
+        if ! after=$(device_snapshot "$adb"); then
+            echo "FAIL: could not read the device state after the suite" >&2
+            return 1
+        fi
+        [ "$after" = "$before" ] && return 0
+        [ "$SECONDS" -ge "$deadline" ] && break
+        sleep 1
+    done
+    echo "FAIL: the suite left device state behind (- before the run, + after):" >&2
+    diff <(printf '%s\n' "$before") <(printf '%s\n' "$after") >&2 || true
+    echo "A test never reached its registry \`shutdown\`; an enabled companion is in the tree of" >&2
+    echo "every later reader on this device." >&2
+    return 1
+}

--- a/scripts/test-android.sh
+++ b/scripts/test-android.sh
@@ -34,9 +34,11 @@ cd "$(dirname "$0")/.."
 
 adb="${GLASS_ADB:-adb}"
 if ! before="$(device_snapshot "$adb")"; then
-    echo "cannot read the device (GLASS_ADB=${GLASS_ADB:-<unset>}); is one attached?" >&2
+    echo "cannot read the device (GLASS_ADB=${GLASS_ADB:-<unset>}, \
+GLASS_ANDROID_SERIAL=${GLASS_ANDROID_SERIAL:-<unset>}); is one attached?" >&2
     exit 1
 fi
+assert_clean_baseline "$before" || exit 1
 
 # Two invocations, not one `-p glass-android -p glass-mcp`: a `--test` filter applies to every
 # `-p` package, so neither package matches the other's targets and the run exits 0 having tested

--- a/scripts/test-android.sh
+++ b/scripts/test-android.sh
@@ -30,6 +30,13 @@
 # SUBSTRING, so a future test whose name contains the excluded one's would go too, unannounced.
 set -euo pipefail
 cd "$(dirname "$0")/.."
+. scripts/lib/device-residue.sh
+
+adb="${GLASS_ADB:-adb}"
+if ! before="$(device_snapshot "$adb")"; then
+    echo "cannot read the device (GLASS_ADB=${GLASS_ADB:-<unset>}); is one attached?" >&2
+    exit 1
+fi
 
 # Two invocations, not one `-p glass-android -p glass-mcp`: a `--test` filter applies to every
 # `-p` package, so neither package matches the other's targets and the run exits 0 having tested
@@ -52,5 +59,15 @@ cargo test --no-fail-fast -p glass-android \
 cargo test --no-fail-fast -p glass-mcp \
   --test android_session_loop \
   -- --ignored --test-threads=1 "$@" || rc=$?
+
+# After the suite, not per test: the check costs a settle wait, and a test that leaks hands the
+# device to every test after it anyway, so the run is the unit worth reporting on.
+residue=0
+report_device_residue "$adb" "$before" || residue=1
+# Only when the suite itself passed, so a leak does not overwrite cargo's 101 with a 1 and hide
+# which kind of failure this was.
+if [ "$rc" -eq 0 ]; then
+  rc="$residue"
+fi
 
 exit "$rc"


### PR DESCRIPTION
Closes #423.

Two pieces: a guard around the Android device suite, and the teardown conversions it makes
verifiable.

## The guard

`A11yServiceRegistry::ensure` enables the companion as an accessibility service and opens an `adb
forward`; `AgentRegistry::ensure` opens one too. Only their `shutdown` puts that back, and the
suite reported green whether or not it ran — measured before #419, a full local run left the
companion enabled and passed.

`scripts/lib/device-residue.sh` compares the device against a snapshot taken **before** the run
rather than a fixed clean value, so a dev box with its own accessibility service enabled does not
fail forever. The one thing checked absolutely is glass's *own* residue, because a delta cannot
see a device an earlier run already dirtied: `ensure` would record the leaked service as the state
to restore, put it back, and report clean forever. `assert_clean_baseline` refuses to start on one
and says how to clear it.

## Nine sites, not eight

Each ran a long series of `.expect()`s above a bare trailing `shutdown()`. They now declare a
guard before the platform they serve — locals drop in reverse, so the platform's agent connection
closes before the registry that owns the agent, which is the ordering the removed `drop(p)` calls
used to spell out.

`managed_avd.rs` was not in #423's list and is handled differently: its assertions sit above a
`kill_all` whose effect the test then checks, so the explicit calls stay and the guards only repeat
them on the panicking path. The leak it avoids is a whole booted emulator.

## Verified on a device, and against a stub

CI cannot check any of this — `.github/workflows/android.yml` is schedule-only and never runs on
pull requests.

On a booted API 34 pixel_6 AVD:

| | result |
|---|---|
| full suite, `GLASS_ANDROID_SERIAL` set | green, `device-residue: clean after 1 look(s)` |
| `see_loop` reverted to its pre-fix shape, panic injected | red, **and** the guard reported `forwards=` → `forwards=localabstract:glass-agent` |
| same panic, guard restored | red (the injected failure), residue check silent |
| device left dirty before the run | refused to start, naming what to clear |
| fixture-uninstall guard | fixture installed by the test, gone after it |

`scripts/lib/device-residue-test.sh` drives the library against a stub adb with no device at all —
17 cases including every way it could go quiet. **9 of them fail against the version in this
branch's first commit**, one per review finding.

## What the reviews found

Two passes, and between them five defects in the first cut:

- **A clean teardown was reported as a leak.** `ensure` coerces an unset `accessibility_enabled` to
  `"0"` and restores that, so a correct run ends at `0` where it began at `null`. My device runs
  missed it because I had set that key to `0` by hand hours earlier — the fixture was
  pre-conditioned into passing. On the API 34 image it reads `0` even after `settings delete`, so
  this one is demonstrated against the stub rather than on hardware.
- **`GLASS_ANDROID_SERIAL` was ignored**, so a two-device host failed the pre-flight and never ran
  the suite. `adb forward --list` ignores `-s` as well, so it is filtered by serial explicitly.
- **`adb` exiting 0 having printed nothing** counted as a valid reading.
- **`sort -u`** collapsed four leaked forwards into the state one leaves.
- **A non-numeric `GLASS_RESIDUE_SETTLE`** broke the deadline arithmetic. Reported as failing open;
  in my harness the old code failed *closed* (a false red), which is the safe direction — either
  way it is validated now, and `10#` keeps `08` from being a base-8 error.

The clean path also says so out loud now: a guard that never reports looking cannot be caught
having not looked.

## Filed rather than fixed here

**#425** — both registries' `shutdown` can silently no-op, so a guard can run, call it, and change
nothing. `A11yServiceRegistry::ensure` enables the service on the device three lines before it
records anything to restore, and both registries treat a poisoned lock as "nothing to do" while
`ensure` treats it as an error. The guard added here catches both, by reading the device instead of
the registry.

## Other gates

`cargo test --workspace --locked`, `cargo clippy --workspace --all-targets --locked -D warnings`,
`cargo fmt --all --check`, `shellcheck -x` on all three shell files.
