### PR TITLE
fix(ios): terminate the app on drop, and reap a launch that failed on the way up

### DIFF
--- a/crates/glass-ios/src/logs.rs
+++ b/crates/glass-ios/src/logs.rs
@@ -8,6 +8,8 @@ use std::time::Duration;
 
 use glass_core::Stream;
 
+use crate::simctl::Simctl;
+
 /// Does `line` look like a real `log stream --style compact` entry, as opposed to the tool's
 /// own startup output? Compact entries begin with an ISO-ish timestamp (`2026-07-11 ...`), so a
 /// leading ASCII digit distinguishes them from the `Timestamp  Ty Process[PID:TID]` column
@@ -107,14 +109,16 @@ impl LogStream {
     /// Best-effort: if `xcrun` fails to spawn, `child` is `None` and `drain` simply
     /// yields nothing, matching the sibling Android backend's behavior when `adb` is
     /// unavailable.
-    pub fn spawn(udid: &str) -> Self {
+    ///
+    /// Spawned through the caller's [`Simctl`] rather than a literal `xcrun`, so a unit test's
+    /// stand-in covers this too — a hardcoded one here spawned the real tool against a fake
+    /// UDID on every macOS test run.
+    pub fn spawn(simctl: &Simctl, udid: &str) -> Self {
         let buf = SharedLog::default();
         // Take the piped stdout before storing `child` — reading `child.stdout` after
         // moving `child` into `Self` would not borrow-check.
-        let mut child = Command::new("xcrun")
-            .args([
-                "simctl", "spawn", udid, "log", "stream", "--style", "compact",
-            ])
+        let mut child = Command::new(simctl.program())
+            .args(simctl.full_args(&["spawn", udid, "log", "stream", "--style", "compact"]))
             .stdout(Stdio::piped())
             .stderr(Stdio::null())
             .spawn()

--- a/crates/glass-ios/src/logs.rs
+++ b/crates/glass-ios/src/logs.rs
@@ -106,23 +106,35 @@ impl LogStream {
     /// Stream the device's unified log. `log stream` prints all system logs; that is
     /// noisy but honest — callers filter.
     ///
-    /// Best-effort: if `xcrun` fails to spawn, `child` is `None` and `drain` simply
+    /// Best-effort: if the tool fails to spawn, `child` is `None` and `drain` simply
     /// yields nothing, matching the sibling Android backend's behavior when `adb` is
     /// unavailable.
     ///
-    /// Spawned through the caller's [`Simctl`] rather than a literal `xcrun`, so a unit test's
-    /// stand-in covers this too — a hardcoded one here spawned the real tool against a fake
-    /// UDID on every macOS test run.
+    /// Spawned through the caller's [`Simctl`], not a literal `xcrun`: a hardcoded one here
+    /// spawned the real tool against a fake UDID on every macOS test run.
     pub fn spawn(simctl: &Simctl, udid: &str) -> Self {
         let buf = SharedLog::default();
         // Take the piped stdout before storing `child` — reading `child.stdout` after
         // moving `child` into `Self` would not borrow-check.
-        let mut child = Command::new(simctl.program())
+        let mut child = match Command::new(simctl.program())
             .args(simctl.full_args(&["spawn", udid, "log", "stream", "--style", "compact"]))
             .stdout(Stdio::piped())
             .stderr(Stdio::null())
             .spawn()
-            .ok();
+        {
+            Ok(child) => Some(child),
+            Err(e) => {
+                // The caller's "stream not confirmed live" line cannot tell a quiet two seconds
+                // from a stream that will never exist, which leaves `glass_logs` empty for the
+                // whole session — indistinguishable from an app that logged nothing.
+                eprintln!(
+                    "glass-ios: could not start the unified-log stream ({}: {e}); glass_logs \
+                     will return nothing for this session",
+                    simctl.program()
+                );
+                None
+            }
+        };
         let out = child.as_mut().and_then(|c| c.stdout.take());
         if let Some(out) = out {
             let sink = buf.clone();

--- a/crates/glass-ios/src/platform.rs
+++ b/crates/glass-ios/src/platform.rs
@@ -166,8 +166,19 @@ fn launch_stderr_tail(simctl: &Simctl, udid: &str) -> Option<String> {
 /// Terminate a launch that failed after `simctl launch` had already put the app on the screen, and
 /// hand its error back — `start_app` records `self.app` only on success, so neither `stop_app` nor
 /// the `Drop` below reaps one that failed on the way up (glass#421).
+///
+/// The caller's error is returned, not the reap's — the caller needs the failure that stopped the
+/// launch.
 fn reap_failed_launch(simctl: &Simctl, udid: &str, bundle_id: &str, e: GlassError) -> GlassError {
-    let _ = simctl.run(&["terminate", udid, bundle_id]);
+    if let Err(reap) = simctl.run(&["terminate", udid, bundle_id]) {
+        // A reap usually fails for the same reason the launch did, and says so in plainer words
+        // than the error being returned — a simulator that shut down under us reads there as a
+        // screenshot that could not be decoded.
+        eprintln!(
+            "glass-ios: {bundle_id} launched but failed on the way up, and could not then be \
+             terminated on {udid}: {reap}"
+        );
+    }
     e
 }
 
@@ -395,6 +406,11 @@ impl Platform for IosPlatform {
     }
 
     fn start_app(&mut self, spec: &AppSpec) -> Result<WindowGeometry> {
+        // `self.app` is overwritten below, so an app still recorded here is one nothing would
+        // reap again, `Drop` included. A no-op on the path `Glass` takes — a platform per
+        // session.
+        self.stop_app()?;
+
         if let Some(build) = &spec.build {
             let mut cmd = Command::new("sh");
             cmd.arg("-c").arg(build);
@@ -446,18 +462,31 @@ impl Platform for IosPlatform {
         for (k, v) in &spec.env {
             launch.env(format!("SIMCTL_CHILD_{k}"), v);
         }
+        // The app can be on the screen from here on, while `self.app` is not set until the end,
+        // so every failure below reaps for itself.
+        //
         // Bounded like every other simctl call, but spelled out here because this one cannot go
         // through `Simctl::run`: it needs `SIMCTL_CHILD_*` in the child's environment.
         let out = glass_core::run_bounded(
             &mut launch,
             crate::simctl::SimctlOp::Lifecycle.budget(),
             "simctl:launch",
-        )?;
+        )
+        // A timeout kills the `xcrun` client, not the app — `launchd_sim` launched that — so a
+        // simulator that answered late leaves it running with nothing holding it.
+        .map_err(|e| reap_failed_launch(self.target.simctl(), udid, &bundle_id, e))?;
         if !out.status.success() {
-            return Err(GlassError::Backend(format!(
-                "simctl launch failed: {}",
-                String::from_utf8_lossy(&out.stderr).trim()
-            )));
+            // Usually nothing launched — but `simctl launch` reports enough kinds of failure
+            // that "usually" is not worth leaving an app running on.
+            return Err(reap_failed_launch(
+                self.target.simctl(),
+                udid,
+                &bundle_id,
+                GlassError::Backend(format!(
+                    "simctl launch failed: {}",
+                    String::from_utf8_lossy(&out.stderr).trim()
+                )),
+            ));
         }
         // `simctl launch` returns as soon as launchd has spawned the process, so a zero exit says
         // the app started, not that it is still running: an app that aborts on a bad launch
@@ -476,23 +505,11 @@ impl Platform for IosPlatform {
             );
         }
 
-        // The app is on the screen from here, but `self.app` is not set until the end, so each
-        // failure below has to reap for itself.
-        //
         // Capture once, purely to learn the device's pixel dimensions for the geometry we
         // report. These are device *pixels* (the screenshot's raw resolution), not UIKit
         // points — the two differ by the device's point-to-pixel scale factor.
-        let frame = match screenshot(self.target.simctl(), udid) {
-            Ok(frame) => frame,
-            Err(e) => {
-                return Err(reap_failed_launch(
-                    self.target.simctl(),
-                    udid,
-                    &bundle_id,
-                    e,
-                ));
-            }
-        };
+        let frame = screenshot(self.target.simctl(), udid)
+            .map_err(|e| reap_failed_launch(self.target.simctl(), udid, &bundle_id, e))?;
         let geometry = WindowGeometry {
             x: 0,
             y: 0,
@@ -506,17 +523,9 @@ impl Platform for IosPlatform {
         // no injector — input is unsupported — but geometry is still reported so
         // capture/logs/clipboard work.
         let injector = match &self.driver {
-            Some(driver) => match discover_scale(&driver.client) {
-                Ok(scale) => Some(IdbInjector::new(scale)),
-                Err(e) => {
-                    return Err(reap_failed_launch(
-                        self.target.simctl(),
-                        udid,
-                        &bundle_id,
-                        e,
-                    ));
-                }
-            },
+            Some(driver) => Some(IdbInjector::new(discover_scale(&driver.client).map_err(
+                |e| reap_failed_launch(self.target.simctl(), udid, &bundle_id, e),
+            )?)),
             None => None,
         };
         // Everything above would look identical for an app that died on launch: `simctl launch`
@@ -536,6 +545,9 @@ impl Platform for IosPlatform {
                 std::thread::sleep(remaining);
             }
             if !pid_is_running(pid) {
+                // The one failure below the launch that does not reap: `pid_is_running` fails
+                // open, so reaching here is evidence the app is already gone.
+                //
                 // What the app itself said travels in the message rather than being left for
                 // `glass_logs`: this return drops the `LogStream` and never registers a session,
                 // so a caller sent to that tool would be told there is no active session. The
@@ -683,10 +695,16 @@ impl Platform for IosPlatform {
 
 impl Drop for IosPlatform {
     /// Terminate the app on drop, for a platform dropped without an explicit `stop_app()` —
-    /// parity with the other backends, iOS having been the last without one. The Simulator
-    /// outlives the process, so the app would otherwise still be in the foreground for the next
-    /// run (glass#421). `stop_app` takes `self.app`, so this is a no-op once it has run, which
-    /// every path through `Glass` does.
+    /// parity with the other backends. The Simulator outlives the process, so the app would
+    /// otherwise still be in the foreground for the next run (glass#421).
+    ///
+    /// Not a guarantee, as the X11 and Wayland drops also note: glass-mcp bounds teardown by
+    /// `glass_core::TEARDOWN_BUDGET` and exits regardless, and this backend's `terminate` carries
+    /// a longer budget than that (glass#427).
+    ///
+    /// `stop_app` takes `self.app`, so this is a no-op after it — and `Glass::stop`,
+    /// `Glass::shutdown` and a session replacement all call it. The path they do not reach is a
+    /// launch that failed on the way up, which is [`reap_failed_launch`]'s.
     fn drop(&mut self) {
         let _ = self.stop_app();
     }
@@ -1191,9 +1209,9 @@ mod pid_liveness_tests {
     }
 }
 
-/// Teardown: what reaches the Simulator when a session ends, however it ends. Each builds the
-/// platform over a `FakeSimctl` and asserts on the argv it recorded — a `terminate` that never
-/// ran and one that ran are otherwise the same green test.
+/// Teardown: what reaches the Simulator when a session ends, however it ends. Each asserts on the
+/// argv a `FakeSimctl` recorded — a `terminate` that never ran and one that did are otherwise the
+/// same green test.
 #[cfg(test)]
 mod teardown_tests {
     use super::*;
@@ -1202,18 +1220,12 @@ mod teardown_tests {
 
     const BUNDLE: &str = "tech.fixedwidth.demo";
 
-    /// An observe-only platform (no companion, so no RPC is reachable) holding `app`.
-    fn platform(fake: &FakeSimctl, app: Option<RunningApp>) -> IosPlatform {
-        IosPlatform {
-            target: SimTarget::for_test_at(fake.program()),
-            app,
-            driver: None,
-            driver_error: Some("no companion in this test".into()),
-        }
-    }
-
-    fn running_app(fake: &FakeSimctl) -> RunningApp {
-        RunningApp {
+    /// An observe-only platform (no companion, so no RPC is reachable), holding a running app or
+    /// nothing. One `SimTarget` throughout — a call escaping the fake is one the assertions
+    /// cannot see.
+    fn platform(fake: &FakeSimctl, running: bool) -> IosPlatform {
+        let target = SimTarget::for_test_at(fake.program());
+        let app = running.then(|| RunningApp {
             bundle_id: BUNDLE.into(),
             pid: None,
             geometry: WindowGeometry {
@@ -1222,15 +1234,25 @@ mod teardown_tests {
                 width: 390,
                 height: 844,
             },
-            logs: LogStream::spawn(&Simctl::at(fake.program()), "test-udid"),
+            logs: LogStream::spawn(target.simctl(), target.udid()),
             injector: None,
+        });
+        IosPlatform {
+            target,
+            app,
+            driver: None,
+            driver_error: Some("no companion in this test".into()),
         }
     }
 
     fn spec() -> AppSpec {
+        spec_for(BUNDLE)
+    }
+
+    fn spec_for(bundle: &str) -> AppSpec {
         AppSpec {
             build: None,
-            run: vec![BUNDLE.to_string()],
+            run: vec![bundle.to_string()],
             cwd: None,
             env: vec![],
             window_hint: None,
@@ -1252,7 +1274,7 @@ mod teardown_tests {
     #[test]
     fn dropping_a_platform_that_still_holds_an_app_terminates_it() {
         let fake = FakeSimctl::new();
-        drop(platform(&fake, Some(running_app(&fake))));
+        drop(platform(&fake, true));
 
         assert_eq!(
             terminations(&fake),
@@ -1263,17 +1285,23 @@ mod teardown_tests {
     }
 
     #[test]
-    fn a_platform_that_never_started_an_app_terminates_nothing_on_drop() {
+    fn a_platform_that_never_started_an_app_runs_nothing_at_all_on_drop() {
         let fake = FakeSimctl::new();
-        drop(platform(&fake, None));
+        drop(platform(&fake, false));
 
-        assert!(terminations(&fake).is_empty(), "{:?}", fake.calls());
+        // The whole list, not just the terminates — a drop that reached for anything else, a
+        // `shutdown` of the simulator itself say, is as wrong as one that terminates nothing.
+        assert!(fake.calls().is_empty(), "{:?}", fake.calls());
     }
 
+    /// Named for the mechanism it can actually see: with the `Drop` deleted the count is still
+    /// one, so what this discriminates is `stop_app` taking the session.
     #[test]
-    fn an_explicit_stop_is_not_repeated_by_the_drop_behind_it() {
+    fn stop_app_takes_the_session_so_the_drop_behind_it_repeats_nothing() {
         let fake = FakeSimctl::new();
-        let mut p = platform(&fake, Some(running_app(&fake)));
+        let mut p = platform(&fake, true);
+        // Best-effort by construction today; when that changes (glass#428) this line changes with
+        // it.
         p.stop_app().expect("stop is best-effort and cannot fail");
         drop(p);
 
@@ -1294,10 +1322,13 @@ mod teardown_tests {
 
     /// The leak the `Drop` alone does not cover: `start_app` records `self.app` on its last
     /// statement, so an app that launched and then failed to come up is held by nothing.
+    ///
+    /// Named for the terminate, not the app — the fake runs no app, so these tests see the call,
+    /// never its effect.
     #[test]
-    fn a_launch_that_fails_after_the_app_is_up_does_not_leave_it_running() {
+    fn a_launch_that_fails_after_the_app_is_up_terminates_it_before_returning() {
         let fake = FakeSimctl::new();
-        let mut p = platform(&fake, None);
+        let mut p = platform(&fake, false);
 
         // The fake exits 0 having written no PNG, so the launch succeeds and the screenshot
         // taken for the window geometry is what fails.
@@ -1316,19 +1347,84 @@ mod teardown_tests {
             "all calls: {:?}",
             fake.calls()
         );
+        // The log stream goes through the same runner — hardcoding `xcrun` there is silent on a
+        // host without it, and reaches the real tool with a fake UDID on macOS.
+        assert!(
+            fake.called("spawn test-udid log stream"),
+            "all calls: {:?}",
+            fake.calls()
+        );
+    }
+
+    /// A reap is best-effort, but it must not swallow the failure it was called about.
+    #[test]
+    fn a_reap_that_itself_fails_still_returns_the_launch_failure() {
+        let fake = FakeSimctl::new();
+        fake.fails("terminate");
+        let mut p = platform(&fake, false);
+
+        let err = p
+            .start_app(&spec())
+            .expect_err("the screenshot still fails");
+
+        assert!(
+            matches!(err, GlassError::CaptureFailed(_)),
+            "a failed reap must not replace the error it was reaping for: {err}"
+        );
+        assert_eq!(terminations(&fake).len(), 1, "{:?}", fake.calls());
+    }
+
+    /// `simctl launch` reporting failure usually means nothing launched — but not always, and the
+    /// launch whose result this backend never sees is the one that leaves an app up.
+    #[test]
+    fn a_launch_simctl_reported_as_failed_is_reaped_too() {
+        let fake = FakeSimctl::new();
+        fake.fails("launch");
+        let mut p = platform(&fake, false);
+
+        p.start_app(&spec()).expect_err("the launch itself fails");
+
+        assert_eq!(
+            terminations(&fake),
+            vec![format!("simctl terminate test-udid {BUNDLE}")],
+            "all calls: {:?}",
+            fake.calls()
+        );
+    }
+
+    /// Starting a second app overwrites `self.app`, leaving the first running with nothing able
+    /// to reap it — the failed-launch leak from the other end. Not reachable through `Glass`,
+    /// which builds a platform per session.
+    #[test]
+    fn starting_a_second_app_terminates_the_one_the_platform_was_holding() {
+        let fake = FakeSimctl::new();
+        let mut p = platform(&fake, true);
+
+        p.start_app(&spec_for("tech.fixedwidth.other"))
+            .expect_err("the screenshot fails, as ever with this fake");
+
+        assert_eq!(
+            terminations(&fake),
+            vec![
+                format!("simctl terminate test-udid {BUNDLE}"),
+                "simctl terminate test-udid tech.fixedwidth.other".to_string(),
+            ],
+            "the old app first, then the reap of the new one: {:?}",
+            fake.calls()
+        );
     }
 
     /// The same leak one step later, on the path a real device takes: capture succeeds and it is
     /// the companion's scale RPC that fails, so the app is up with no session to hold it.
     #[test]
-    fn a_launch_whose_scale_never_resolves_does_not_leave_the_app_running() {
+    fn a_launch_whose_scale_never_resolves_terminates_the_app_before_returning() {
         let fake = FakeSimctl::new();
         fake.writes_screenshot(&png(2, 3));
         let mut p = IosPlatform {
             target: SimTarget::for_test_at(fake.program()),
             app: None,
-            // The stub client dials a socket nothing serves, which is what a companion that died
-            // between spawn and launch looks like from here.
+            // The stub client dials its own dead endpoint — what a companion that died between
+            // spawn and launch looks like from here.
             driver: Some(IdbDriver::for_test()),
             driver_error: None,
         };
@@ -1338,8 +1434,13 @@ mod teardown_tests {
             .expect_err("a scale that never resolved must not report a started app");
 
         assert!(
-            !matches!(err, GlassError::CaptureFailed(_)),
-            "capture was answered; the failure must be the scale RPC: {err}"
+            err.to_string().contains("idb describe"),
+            "the failure must be the scale RPC, not something before it: {err}"
+        );
+        assert!(
+            fake.called("io test-udid screenshot"),
+            "capture must have been reached and answered: {:?}",
+            fake.calls()
         );
         assert!(p.app.is_none(), "no session may be registered");
         assert_eq!(

--- a/crates/glass-ios/src/platform.rs
+++ b/crates/glass-ios/src/platform.rs
@@ -163,6 +163,14 @@ fn launch_stderr_tail(simctl: &Simctl, udid: &str) -> Option<String> {
     Some(tail.into_iter().rev().collect::<Vec<_>>().join(" | "))
 }
 
+/// Terminate a launch that failed after `simctl launch` had already put the app on the screen, and
+/// hand its error back — `start_app` records `self.app` only on success, so neither `stop_app` nor
+/// the `Drop` below reaps one that failed on the way up (glass#421).
+fn reap_failed_launch(simctl: &Simctl, udid: &str, bundle_id: &str, e: GlassError) -> GlassError {
+    let _ = simctl.run(&["terminate", udid, bundle_id]);
+    e
+}
+
 /// Whether `pid` is still running, asked of the host: a Simulator app is an ordinary host
 /// process, so `ps` answers for it without this crate taking a `libc` dependency for one probe.
 ///
@@ -417,7 +425,7 @@ impl Platform for IosPlatform {
         // confirmed-live stream closes that race. Logs stay best-effort: a stream that never
         // comes up does not fail the launch — it only means a launch-time line may be missed,
         // which is noted rather than swallowed.
-        let logs = LogStream::spawn(udid);
+        let logs = LogStream::spawn(self.target.simctl(), udid);
         if !logs.wait_until_ready(LOG_STREAM_READY_TIMEOUT) {
             eprintln!(
                 "glass-ios: unified-log stream not confirmed live before launch; a \
@@ -468,10 +476,23 @@ impl Platform for IosPlatform {
             );
         }
 
+        // The app is on the screen from here, but `self.app` is not set until the end, so each
+        // failure below has to reap for itself.
+        //
         // Capture once, purely to learn the device's pixel dimensions for the geometry we
         // report. These are device *pixels* (the screenshot's raw resolution), not UIKit
         // points — the two differ by the device's point-to-pixel scale factor.
-        let frame = screenshot(self.target.simctl(), udid)?;
+        let frame = match screenshot(self.target.simctl(), udid) {
+            Ok(frame) => frame,
+            Err(e) => {
+                return Err(reap_failed_launch(
+                    self.target.simctl(),
+                    udid,
+                    &bundle_id,
+                    e,
+                ));
+            }
+        };
         let geometry = WindowGeometry {
             x: 0,
             y: 0,
@@ -485,7 +506,17 @@ impl Platform for IosPlatform {
         // no injector — input is unsupported — but geometry is still reported so
         // capture/logs/clipboard work.
         let injector = match &self.driver {
-            Some(driver) => Some(IdbInjector::new(discover_scale(&driver.client)?)),
+            Some(driver) => match discover_scale(&driver.client) {
+                Ok(scale) => Some(IdbInjector::new(scale)),
+                Err(e) => {
+                    return Err(reap_failed_launch(
+                        self.target.simctl(),
+                        udid,
+                        &bundle_id,
+                        e,
+                    ));
+                }
+            },
             None => None,
         };
         // Everything above would look identical for an app that died on launch: `simctl launch`
@@ -650,6 +681,17 @@ impl Platform for IosPlatform {
     }
 }
 
+impl Drop for IosPlatform {
+    /// Terminate the app on drop, for a platform dropped without an explicit `stop_app()` —
+    /// parity with the other backends, iOS having been the last without one. The Simulator
+    /// outlives the process, so the app would otherwise still be in the foreground for the next
+    /// run (glass#421). `stop_app` takes `self.app`, so this is a no-op once it has run, which
+    /// every path through `Glass` does.
+    fn drop(&mut self) {
+        let _ = self.stop_app();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -704,9 +746,11 @@ mod tests {
 
 /// State-machine tests: `IosPlatform` built directly (bypassing `from_env`) with a fake
 /// `RunningApp` (or none) and a stub driver (or none), so none of these touch a real
-/// simulator or `idb_companion` — `xcrun` is never invoked and no RPC is made, only the
-/// pure in-memory branching (session guards, driver presence, the `Move`-is-a-noop
-/// short-circuit, the input-error surface).
+/// simulator or `idb_companion` — no RPC is made, only the pure in-memory branching (session
+/// guards, driver presence, the `Move`-is-a-noop short-circuit, the input-error surface).
+///
+/// Every `simctl` call a fixture does make — the log stream, and the `terminate` each platform
+/// now issues as it drops — goes to `SimTarget::for_test`'s stand-in program, not to `xcrun`.
 #[cfg(test)]
 mod state_machine_tests {
     use super::*;
@@ -724,15 +768,16 @@ mod state_machine_tests {
     /// A running app with a driver present: input reaches the injector (its RPC would fail,
     /// but these tests only exercise events that error or short-circuit before any RPC).
     fn running_platform() -> IosPlatform {
+        let target = SimTarget::for_test();
         IosPlatform {
-            target: SimTarget::for_test(),
             app: Some(RunningApp {
                 bundle_id: "tech.fixedwidth.demo".into(),
                 pid: None,
                 geometry: geometry(),
-                logs: LogStream::spawn("fake"),
+                logs: LogStream::spawn(target.simctl(), "fake"),
                 injector: Some(IdbInjector::new(1.0)),
             }),
+            target,
             driver: Some(IdbDriver::for_test()),
             driver_error: None,
         }
@@ -751,15 +796,16 @@ mod state_machine_tests {
     /// Observe-only: no companion, so a running app has no injector. Capture/logs/clipboard
     /// would work; input and the accessibility reader degrade.
     fn observe_only_platform() -> IosPlatform {
+        let target = SimTarget::for_test();
         IosPlatform {
-            target: SimTarget::for_test(),
             app: Some(RunningApp {
                 bundle_id: "tech.fixedwidth.demo".into(),
                 pid: None,
                 geometry: geometry(),
-                logs: LogStream::spawn("fake"),
+                logs: LogStream::spawn(target.simctl(), "fake"),
                 injector: None,
             }),
+            target,
             driver: None,
             driver_error: Some(
                 "idb_companion not found (install: brew install idb-companion)".into(),
@@ -1142,5 +1188,165 @@ mod pid_liveness_tests {
         let pid = child.id();
         child.wait().expect("reap it");
         assert!(!pid_is_running(pid));
+    }
+}
+
+/// Teardown: what reaches the Simulator when a session ends, however it ends. Each builds the
+/// platform over a `FakeSimctl` and asserts on the argv it recorded — a `terminate` that never
+/// ran and one that ran are otherwise the same green test.
+#[cfg(test)]
+mod teardown_tests {
+    use super::*;
+    use crate::simctl::FakeSimctl;
+    use glass_core::SandboxLevel;
+
+    const BUNDLE: &str = "tech.fixedwidth.demo";
+
+    /// An observe-only platform (no companion, so no RPC is reachable) holding `app`.
+    fn platform(fake: &FakeSimctl, app: Option<RunningApp>) -> IosPlatform {
+        IosPlatform {
+            target: SimTarget::for_test_at(fake.program()),
+            app,
+            driver: None,
+            driver_error: Some("no companion in this test".into()),
+        }
+    }
+
+    fn running_app(fake: &FakeSimctl) -> RunningApp {
+        RunningApp {
+            bundle_id: BUNDLE.into(),
+            pid: None,
+            geometry: WindowGeometry {
+                x: 0,
+                y: 0,
+                width: 390,
+                height: 844,
+            },
+            logs: LogStream::spawn(&Simctl::at(fake.program()), "test-udid"),
+            injector: None,
+        }
+    }
+
+    fn spec() -> AppSpec {
+        AppSpec {
+            build: None,
+            run: vec![BUNDLE.to_string()],
+            cwd: None,
+            env: vec![],
+            window_hint: None,
+            timeout_ms: 2_000,
+            sandbox: SandboxLevel::Off,
+            a11y: false,
+        }
+    }
+
+    /// The `terminate` calls, matched on the verb in argv position — `launch` carries
+    /// `--terminate-running-process`, which a bare substring test counts as a teardown.
+    fn terminations(fake: &FakeSimctl) -> Vec<String> {
+        fake.calls()
+            .into_iter()
+            .filter(|c| c.starts_with("simctl terminate "))
+            .collect()
+    }
+
+    #[test]
+    fn dropping_a_platform_that_still_holds_an_app_terminates_it() {
+        let fake = FakeSimctl::new();
+        drop(platform(&fake, Some(running_app(&fake))));
+
+        assert_eq!(
+            terminations(&fake),
+            vec![format!("simctl terminate test-udid {BUNDLE}")],
+            "all calls: {:?}",
+            fake.calls()
+        );
+    }
+
+    #[test]
+    fn a_platform_that_never_started_an_app_terminates_nothing_on_drop() {
+        let fake = FakeSimctl::new();
+        drop(platform(&fake, None));
+
+        assert!(terminations(&fake).is_empty(), "{:?}", fake.calls());
+    }
+
+    #[test]
+    fn an_explicit_stop_is_not_repeated_by_the_drop_behind_it() {
+        let fake = FakeSimctl::new();
+        let mut p = platform(&fake, Some(running_app(&fake)));
+        p.stop_app().expect("stop is best-effort and cannot fail");
+        drop(p);
+
+        assert_eq!(terminations(&fake).len(), 1, "{:?}", fake.calls());
+    }
+
+    /// A `w`x`h` opaque PNG, as `simctl io screenshot` writes one.
+    fn png(w: u32, h: u32) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        image::RgbaImage::from_pixel(w, h, image::Rgba([0, 0, 0, 255]))
+            .write_to(
+                &mut std::io::Cursor::new(&mut bytes),
+                image::ImageFormat::Png,
+            )
+            .expect("encode a PNG");
+        bytes
+    }
+
+    /// The leak the `Drop` alone does not cover: `start_app` records `self.app` on its last
+    /// statement, so an app that launched and then failed to come up is held by nothing.
+    #[test]
+    fn a_launch_that_fails_after_the_app_is_up_does_not_leave_it_running() {
+        let fake = FakeSimctl::new();
+        let mut p = platform(&fake, None);
+
+        // The fake exits 0 having written no PNG, so the launch succeeds and the screenshot
+        // taken for the window geometry is what fails.
+        let err = p
+            .start_app(&spec())
+            .expect_err("a screenshot that decodes to nothing must not report a started app");
+
+        assert!(
+            matches!(err, GlassError::CaptureFailed(_)),
+            "the launch failure must survive the reap: {err}"
+        );
+        assert!(p.app.is_none(), "no session may be registered");
+        assert_eq!(
+            terminations(&fake),
+            vec![format!("simctl terminate test-udid {BUNDLE}")],
+            "all calls: {:?}",
+            fake.calls()
+        );
+    }
+
+    /// The same leak one step later, on the path a real device takes: capture succeeds and it is
+    /// the companion's scale RPC that fails, so the app is up with no session to hold it.
+    #[test]
+    fn a_launch_whose_scale_never_resolves_does_not_leave_the_app_running() {
+        let fake = FakeSimctl::new();
+        fake.writes_screenshot(&png(2, 3));
+        let mut p = IosPlatform {
+            target: SimTarget::for_test_at(fake.program()),
+            app: None,
+            // The stub client dials a socket nothing serves, which is what a companion that died
+            // between spawn and launch looks like from here.
+            driver: Some(IdbDriver::for_test()),
+            driver_error: None,
+        };
+
+        let err = p
+            .start_app(&spec())
+            .expect_err("a scale that never resolved must not report a started app");
+
+        assert!(
+            !matches!(err, GlassError::CaptureFailed(_)),
+            "capture was answered; the failure must be the scale RPC: {err}"
+        );
+        assert!(p.app.is_none(), "no session may be registered");
+        assert_eq!(
+            terminations(&fake),
+            vec![format!("simctl terminate test-udid {BUNDLE}")],
+            "all calls: {:?}",
+            fake.calls()
+        );
     }
 }

--- a/crates/glass-ios/src/simctl.rs
+++ b/crates/glass-ios/src/simctl.rs
@@ -66,10 +66,8 @@ impl SimctlOp {
 /// positionally in `sub` (matching how `simctl` itself takes it), so this holds no per-device
 /// state.
 ///
-/// The program is a field rather than a literal so a unit test can point it at a stand-in, the
-/// way `glass-android`'s `Adb` carries its `bin`. Nothing in production sets it: an installed
-/// Xcode is what `xcrun` resolves against, and a second way to name the tool would be a second
-/// thing to diagnose.
+/// The program is a field so a unit test can point it at a stand-in, as `glass-android`'s `Adb`
+/// carries its `bin` — but unlike `Adb`, there is deliberately no production override.
 #[derive(Clone, Debug)]
 pub struct Simctl {
     program: String,
@@ -89,8 +87,8 @@ impl Simctl {
         }
     }
 
-    /// A runner that invokes `program` where the real one invokes `xcrun` — the seam every
-    /// stand-in in this crate's tests goes through, so no unit test reaches CoreSimulator.
+    /// A runner that invokes `program` in place of `xcrun` — the seam every stand-in in this
+    /// crate's tests goes through, so no unit test loads CoreSimulator.
     #[cfg(test)]
     pub(crate) fn at(program: impl Into<String>) -> Self {
         Self {
@@ -131,16 +129,14 @@ impl Simctl {
     }
 }
 
-/// An `xcrun` that is a shell script rather than the real tool: it records every invocation and
-/// exits 0 saying nothing.
+/// An `xcrun` that is a shell script rather than the real tool: it records every invocation and,
+/// unless told otherwise, exits 0 saying nothing.
 ///
 /// Records the argv because a teardown stubbed to do nothing is otherwise indistinguishable from
-/// one that ran — which is the whole question a `Drop` test asks. Deliberately thinner than
-/// `glass-android`'s `FakeAdb`: nothing here needs a canned answer, because every call these
-/// tests make is one whose *result* the code discards.
+/// one that ran — the whole question a `Drop` test asks.
 #[cfg(test)]
 pub(crate) struct FakeSimctl {
-    dir: std::path::PathBuf,
+    dir: tempfile::TempDir,
 }
 
 #[cfg(test)]
@@ -150,10 +146,15 @@ const FAKE_SIMCTL_SCRIPT: &str = "\
 [ \"$1\" = --glass-probe ] && exit 0
 dir=$(dirname \"$0\")
 printf '%s\\n' \"$*\" >> \"$dir/calls\"
+# `$2` is the simctl verb, since `$1` is always `simctl`.
+if [ -f \"$dir/fail-$2\" ]; then
+    printf 'the fake xcrun was told to fail %s\\n' \"$2\" >&2
+    exit 1
+fi
 case \"$*\" in
     *screenshot*)
-        # `io <udid> screenshot ... <path>` writes a file the caller then decodes, so a planted
-        # PNG is the only way past capture. Its destination is the last argument.
+        # A planted PNG is the only way past capture — the caller decodes the file this writes.
+        # Its destination is the last argument.
         if [ -f \"$dir/screenshot.png\" ]; then
             for last in \"$@\"; do :; done
             cp \"$dir/screenshot.png\" \"$last\"
@@ -165,26 +166,23 @@ exit 0
 
 #[cfg(test)]
 impl FakeSimctl {
-    pub(crate) fn new() -> FakeSimctl {
+    pub(crate) fn new() -> Self {
         use std::os::unix::fs::PermissionsExt;
-        use std::sync::atomic::{AtomicU32, Ordering};
-        static NEXT: AtomicU32 = AtomicU32::new(0);
 
-        let dir = std::env::temp_dir().join(format!(
-            "glass-fake-simctl-{}-{}",
-            std::process::id(),
-            NEXT.fetch_add(1, Ordering::Relaxed)
-        ));
-        std::fs::create_dir_all(&dir).expect("create the fake xcrun's directory");
-        let path = dir.join("xcrun");
+        // A `TempDir`, not a pid-derived name — a pid the OS has since reused would hand this
+        // fake an earlier run's recorded calls.
+        let dir = tempfile::Builder::new()
+            .prefix("glass-fake-simctl")
+            .tempdir()
+            .expect("create the fake xcrun's directory");
+        let path = dir.path().join("xcrun");
         std::fs::write(&path, FAKE_SIMCTL_SCRIPT).expect("write the fake xcrun");
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
             .expect("make the fake xcrun executable");
 
-        // Proven runnable before it is handed out, because a parallel test's fork can still be
-        // holding an inherited write fd, which raises `ETXTBSY` on exec. `glass-android`'s
-        // `write_executable` documents the same hazard; `--glass-probe` is the argument this
-        // script answers by exiting before it records anything.
+        // Proven runnable before it is handed out: a parallel test's fork can be holding an
+        // inherited write fd, which raises `ETXTBSY` on exec (`glass-android`'s
+        // `write_executable`, same hazard). `--glass-probe` exits before recording anything.
         for _ in 0..100 {
             match Command::new(&path).arg("--glass-probe").status() {
                 Ok(_) => return FakeSimctl { dir },
@@ -199,18 +197,32 @@ impl FakeSimctl {
 
     /// The path to hand [`Simctl::at`].
     pub(crate) fn program(&self) -> String {
-        self.dir.join("xcrun").to_string_lossy().into_owned()
+        self.dir.path().join("xcrun").to_string_lossy().into_owned()
     }
 
     /// Answer `io … screenshot` with these PNG bytes, for a test that needs to get *past*
-    /// capture. Without this the fake writes nothing and the caller fails to decode.
+    /// capture — without one the fake writes no file and the caller fails to decode.
     pub(crate) fn writes_screenshot(&self, png: &[u8]) {
-        std::fs::write(self.dir.join("screenshot.png"), png).expect("plant the fake's screenshot");
+        std::fs::write(self.dir.path().join("screenshot.png"), png)
+            .expect("plant the fake's screenshot");
+    }
+
+    /// Make every `simctl <verb>` call exit non-zero, for a test that asks what the caller does
+    /// when the Simulator refuses.
+    pub(crate) fn fails(&self, verb: &str) {
+        std::fs::write(self.dir.path().join(format!("fail-{verb}")), "")
+            .expect("tell the fake to fail");
     }
 
     /// The argv of every invocation so far, in order, joined by spaces.
     pub(crate) fn calls(&self) -> Vec<String> {
-        std::fs::read_to_string(self.dir.join("calls"))
+        // An unreadable `calls` is "nothing run yet" only while the directory is there; gone,
+        // every assertion built on this silently reads as "no calls".
+        assert!(
+            self.dir.path().exists(),
+            "the fake xcrun's directory is gone; it was dropped before what it recorded was read"
+        );
+        std::fs::read_to_string(self.dir.path().join("calls"))
             .unwrap_or_default()
             .lines()
             .map(str::to_string)
@@ -220,13 +232,6 @@ impl FakeSimctl {
     /// Whether any invocation's argv contains `needle`.
     pub(crate) fn called(&self, needle: &str) -> bool {
         self.calls().iter().any(|c| c.contains(needle))
-    }
-}
-
-#[cfg(test)]
-impl Drop for FakeSimctl {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_dir_all(&self.dir);
     }
 }
 
@@ -317,23 +322,42 @@ mod tests {
     fn program_is_xcrun_with_simctl_first_arg() {
         let s = Simctl::new();
         assert_eq!(s.program(), "xcrun");
+        // `Default` is hand-written and public API — a derived one would hand back an empty
+        // program.
+        assert_eq!(Simctl::default().program(), "xcrun");
         assert_eq!(
             s.full_args(&["help"]),
             vec!["simctl".to_string(), "help".to_string()]
         );
     }
 
-    /// The fake is load-bearing for every teardown test, which asserts on what it recorded — so
-    /// prove it records, or those tests pass against a stand-in that does nothing.
+    /// The fake is load-bearing for every teardown test — prove it records, or those tests pass
+    /// against a stand-in that does nothing.
     #[test]
     fn the_fake_xcrun_records_what_it_was_asked_and_the_real_one_is_not_run() {
         let fake = FakeSimctl::new();
         let simctl = Simctl::at(fake.program());
+        // A real `xcrun simctl terminate UDID app.id` could not answer `Ok("")`.
         assert_eq!(simctl.run(&["terminate", "UDID", "app.id"]).unwrap(), "");
+        // Two calls: a fake that recorded only the first would satisfy every assertion a single
+        // call can make.
+        simctl.run(&["list", "devices"]).unwrap();
 
-        assert_eq!(fake.calls(), vec!["simctl terminate UDID app.id"]);
-        assert!(fake.called("terminate UDID"));
+        assert_eq!(
+            fake.calls(),
+            vec!["simctl terminate UDID app.id", "simctl list devices"]
+        );
         assert!(!fake.called("boot"), "{:?}", fake.calls());
+    }
+
+    #[test]
+    fn a_fake_told_to_fail_a_verb_fails_that_verb_and_no_other() {
+        let fake = FakeSimctl::new();
+        let simctl = Simctl::at(fake.program());
+        fake.fails("terminate");
+
+        assert!(simctl.run(&["terminate", "UDID", "app.id"]).is_err());
+        assert!(simctl.run(&["shutdown", "UDID"]).is_ok());
     }
 
     #[test]

--- a/crates/glass-ios/src/simctl.rs
+++ b/crates/glass-ios/src/simctl.rs
@@ -65,17 +65,41 @@ impl SimctlOp {
 /// A stateless `xcrun simctl <argv>` runner. Every call site passes the target device's UDID
 /// positionally in `sub` (matching how `simctl` itself takes it), so this holds no per-device
 /// state.
-#[derive(Clone, Debug, Default)]
-pub struct Simctl;
+///
+/// The program is a field rather than a literal so a unit test can point it at a stand-in, the
+/// way `glass-android`'s `Adb` carries its `bin`. Nothing in production sets it: an installed
+/// Xcode is what `xcrun` resolves against, and a second way to name the tool would be a second
+/// thing to diagnose.
+#[derive(Clone, Debug)]
+pub struct Simctl {
+    program: String,
+}
+
+impl Default for Simctl {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl Simctl {
-    /// A new runner. There is nothing to configure — `Simctl` is stateless.
+    /// A runner over the real `xcrun`.
     pub fn new() -> Self {
-        Self
+        Self {
+            program: "xcrun".to_string(),
+        }
     }
 
-    pub(crate) fn program(&self) -> &'static str {
-        "xcrun"
+    /// A runner that invokes `program` where the real one invokes `xcrun` — the seam every
+    /// stand-in in this crate's tests goes through, so no unit test reaches CoreSimulator.
+    #[cfg(test)]
+    pub(crate) fn at(program: impl Into<String>) -> Self {
+        Self {
+            program: program.into(),
+        }
+    }
+
+    pub(crate) fn program(&self) -> &str {
+        &self.program
     }
 
     /// Full argv passed to `xcrun`: `simctl <sub...>`.
@@ -104,6 +128,105 @@ impl Simctl {
             )));
         }
         Ok(out.stdout)
+    }
+}
+
+/// An `xcrun` that is a shell script rather than the real tool: it records every invocation and
+/// exits 0 saying nothing.
+///
+/// Records the argv because a teardown stubbed to do nothing is otherwise indistinguishable from
+/// one that ran — which is the whole question a `Drop` test asks. Deliberately thinner than
+/// `glass-android`'s `FakeAdb`: nothing here needs a canned answer, because every call these
+/// tests make is one whose *result* the code discards.
+#[cfg(test)]
+pub(crate) struct FakeSimctl {
+    dir: std::path::PathBuf,
+}
+
+#[cfg(test)]
+const FAKE_SIMCTL_SCRIPT: &str = "\
+#!/bin/sh
+# Stand-in for xcrun; see FakeSimctl in simctl.rs.
+[ \"$1\" = --glass-probe ] && exit 0
+dir=$(dirname \"$0\")
+printf '%s\\n' \"$*\" >> \"$dir/calls\"
+case \"$*\" in
+    *screenshot*)
+        # `io <udid> screenshot ... <path>` writes a file the caller then decodes, so a planted
+        # PNG is the only way past capture. Its destination is the last argument.
+        if [ -f \"$dir/screenshot.png\" ]; then
+            for last in \"$@\"; do :; done
+            cp \"$dir/screenshot.png\" \"$last\"
+        fi
+        ;;
+esac
+exit 0
+";
+
+#[cfg(test)]
+impl FakeSimctl {
+    pub(crate) fn new() -> FakeSimctl {
+        use std::os::unix::fs::PermissionsExt;
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static NEXT: AtomicU32 = AtomicU32::new(0);
+
+        let dir = std::env::temp_dir().join(format!(
+            "glass-fake-simctl-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&dir).expect("create the fake xcrun's directory");
+        let path = dir.join("xcrun");
+        std::fs::write(&path, FAKE_SIMCTL_SCRIPT).expect("write the fake xcrun");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+            .expect("make the fake xcrun executable");
+
+        // Proven runnable before it is handed out, because a parallel test's fork can still be
+        // holding an inherited write fd, which raises `ETXTBSY` on exec. `glass-android`'s
+        // `write_executable` documents the same hazard; `--glass-probe` is the argument this
+        // script answers by exiting before it records anything.
+        for _ in 0..100 {
+            match Command::new(&path).arg("--glass-probe").status() {
+                Ok(_) => return FakeSimctl { dir },
+                Err(e) if e.kind() == std::io::ErrorKind::ExecutableFileBusy => {
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                Err(e) => panic!("the fake xcrun is not runnable: {e}"),
+            }
+        }
+        panic!("the fake xcrun was still ETXTBSY after 100 retries");
+    }
+
+    /// The path to hand [`Simctl::at`].
+    pub(crate) fn program(&self) -> String {
+        self.dir.join("xcrun").to_string_lossy().into_owned()
+    }
+
+    /// Answer `io … screenshot` with these PNG bytes, for a test that needs to get *past*
+    /// capture. Without this the fake writes nothing and the caller fails to decode.
+    pub(crate) fn writes_screenshot(&self, png: &[u8]) {
+        std::fs::write(self.dir.join("screenshot.png"), png).expect("plant the fake's screenshot");
+    }
+
+    /// The argv of every invocation so far, in order, joined by spaces.
+    pub(crate) fn calls(&self) -> Vec<String> {
+        std::fs::read_to_string(self.dir.join("calls"))
+            .unwrap_or_default()
+            .lines()
+            .map(str::to_string)
+            .collect()
+    }
+
+    /// Whether any invocation's argv contains `needle`.
+    pub(crate) fn called(&self, needle: &str) -> bool {
+        self.calls().iter().any(|c| c.contains(needle))
+    }
+}
+
+#[cfg(test)]
+impl Drop for FakeSimctl {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.dir);
     }
 }
 
@@ -198,5 +321,27 @@ mod tests {
             s.full_args(&["help"]),
             vec!["simctl".to_string(), "help".to_string()]
         );
+    }
+
+    /// The fake is load-bearing for every teardown test, which asserts on what it recorded — so
+    /// prove it records, or those tests pass against a stand-in that does nothing.
+    #[test]
+    fn the_fake_xcrun_records_what_it_was_asked_and_the_real_one_is_not_run() {
+        let fake = FakeSimctl::new();
+        let simctl = Simctl::at(fake.program());
+        assert_eq!(simctl.run(&["terminate", "UDID", "app.id"]).unwrap(), "");
+
+        assert_eq!(fake.calls(), vec!["simctl terminate UDID app.id"]);
+        assert!(fake.called("terminate UDID"));
+        assert!(!fake.called("boot"), "{:?}", fake.calls());
+    }
+
+    #[test]
+    fn a_fake_removes_its_directory_when_it_drops() {
+        let path = {
+            let fake = FakeSimctl::new();
+            std::path::PathBuf::from(fake.program())
+        };
+        assert!(!path.exists(), "{} outlived its fake", path.display());
     }
 }

--- a/crates/glass-ios/src/target.rs
+++ b/crates/glass-ios/src/target.rs
@@ -19,11 +19,22 @@ use crate::simctl::Simctl;
 #[derive(Clone, Default)]
 pub struct SimulatorRegistry {
     booted: Arc<Mutex<Vec<String>>>,
+    /// The runner `shutdown_all` uses, held so a test can point it at a stand-in — one built
+    /// inside `shutdown_all` put a real `xcrun simctl shutdown` in a unit test.
+    simctl: Simctl,
 }
 
 impl SimulatorRegistry {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    #[cfg(test)]
+    fn at(program: &str) -> Self {
+        Self {
+            booted: Arc::default(),
+            simctl: Simctl::at(program),
+        }
     }
 
     /// Record a simulator UDID glass booted.
@@ -42,9 +53,8 @@ impl SimulatorRegistry {
             .lock()
             .map(|mut g| std::mem::take(&mut *g))
             .unwrap_or_default();
-        let s = Simctl::new();
         for udid in udids {
-            let _ = s.run(&["shutdown", &udid]);
+            let _ = self.simctl.run(&["shutdown", &udid]);
         }
     }
 
@@ -111,16 +121,16 @@ impl SimTarget {
     }
 
     /// A `SimTarget` for `IosPlatform` unit tests, whose `simctl` runs `true` instead of
-    /// `xcrun`. A stand-in rather than the real tool because the platform now terminates its
-    /// app on drop: a real `Simctl` here would have every test holding a fake `RunningApp`
-    /// reach CoreSimulator with a bogus UDID as it dropped.
+    /// `xcrun`. Both ends of a fixture's life reach `simctl` — the log stream it spawns as it is
+    /// built, the `terminate` it issues as it drops — so a real one sends both into
+    /// CoreSimulator against a bogus UDID.
     #[cfg(test)]
     pub(crate) fn for_test() -> Self {
         Self::for_test_at("true")
     }
 
-    /// [`SimTarget::for_test`] against a named stand-in program — a `FakeSimctl`, for a test
-    /// that asserts on which calls were made rather than only that none escaped.
+    /// [`SimTarget::for_test`] against a named stand-in — a `FakeSimctl`, for a test that
+    /// asserts which calls were made rather than only that none escaped.
     #[cfg(test)]
     pub(crate) fn for_test_at(program: impl Into<String>) -> Self {
         Self {
@@ -167,13 +177,38 @@ mod tests {
         assert_eq!(r.udids(), vec!["AAA".to_string(), "BBB".to_string()]);
     }
 
+    /// Pinned because losing it is invisible here: with no `xcrun` on the host every escaped
+    /// call fails silently, while on a macOS runner the ~20 fixtures built from this reach
+    /// CoreSimulator with a bogus UDID, twice each.
     #[test]
-    fn shutdown_all_clears_the_registry() {
-        let r = SimulatorRegistry::new();
+    fn the_test_target_never_names_the_real_tool() {
+        assert_ne!(SimTarget::for_test().simctl().program(), "xcrun");
+    }
+
+    #[test]
+    fn shutdown_all_shuts_down_what_it_recorded_and_clears_the_registry() {
+        let fake = crate::simctl::FakeSimctl::new();
+        let r = SimulatorRegistry::at(&fake.program());
         r.register("AAA".into());
-        // Best-effort: `xcrun simctl shutdown` may fail in a CI sandbox with no real
-        // simulator, but the registry is cleared regardless.
+
         r.shutdown_all();
+
+        assert_eq!(fake.calls(), vec!["simctl shutdown AAA"]);
+        assert!(r.udids().is_empty());
+    }
+
+    /// Shutdown is best-effort — a simulator already stopped answers non-zero — but the registry
+    /// must still be cleared, or a second `shutdown_all` retries a device that is already gone.
+    #[test]
+    fn a_shutdown_that_fails_still_clears_the_registry() {
+        let fake = crate::simctl::FakeSimctl::new();
+        fake.fails("shutdown");
+        let r = SimulatorRegistry::at(&fake.program());
+        r.register("AAA".into());
+
+        r.shutdown_all();
+
+        assert!(fake.called("shutdown AAA"), "{:?}", fake.calls());
         assert!(r.udids().is_empty());
     }
 }

--- a/crates/glass-ios/src/target.rs
+++ b/crates/glass-ios/src/target.rs
@@ -110,12 +110,21 @@ impl SimTarget {
         &self.udid
     }
 
-    /// A `SimTarget` for `IosPlatform` unit tests that never touch a real simulator (a
-    /// `NoActiveSession`/state-machine guard fires before `target` is used).
+    /// A `SimTarget` for `IosPlatform` unit tests, whose `simctl` runs `true` instead of
+    /// `xcrun`. A stand-in rather than the real tool because the platform now terminates its
+    /// app on drop: a real `Simctl` here would have every test holding a fake `RunningApp`
+    /// reach CoreSimulator with a bogus UDID as it dropped.
     #[cfg(test)]
     pub(crate) fn for_test() -> Self {
+        Self::for_test_at("true")
+    }
+
+    /// [`SimTarget::for_test`] against a named stand-in program — a `FakeSimctl`, for a test
+    /// that asserts on which calls were made rather than only that none escaped.
+    #[cfg(test)]
+    pub(crate) fn for_test_at(program: impl Into<String>) -> Self {
         Self {
-            simctl: Simctl::new(),
+            simctl: Simctl::at(program),
             udid: "test-udid".to_string(),
         }
     }


### PR DESCRIPTION
Closes #421.

`IosPlatform` had no `Drop`, so a platform dropped without an explicit `stop_app()` left the app in
the Simulator's foreground for whatever ran next. iOS was the last backend without one.

## The seam that was blocking it

The issue named the reason this was not done alongside the Android fix: `SimTarget::for_test`
carried a real `Simctl`, whose `program()` was a hardcoded `"xcrun"`, so a `Drop` would have every
state-machine test holding a fake `RunningApp` shell out as it dropped — on the macOS CI job, into
CoreSimulator with a bogus UDID.

`Simctl` now carries its program the way `glass-android`'s `Adb` carries its `bin`. Two other
places needed it, both of which were *already* reaching the real tool from a unit test:

- `LogStream::spawn` hardcoded `Command::new("xcrun")`, and the state-machine fixtures call it. On
  `macos-14`, `cargo test --workspace --lib` really did fork `xcrun simctl spawn fake log stream`
  about a dozen times per run. The module's doc claimed "`xcrun` is never invoked".
- `SimulatorRegistry::shutdown_all` built its own `Simctl`, so `shutdown_all_clears_the_registry`
  ran `xcrun simctl shutdown AAA`. Its own comment admitted the shell-out, assuming no simulator
  would be there — which the macOS job contradicts.

## The leaks the `Drop` does not cover

`start_app` records `self.app` on its last statement, so an app that launched and then failed on
the way up is held by nothing: `stop_app` has nothing to take and the `Drop` reaps nothing. Four
paths, all now reaped before the error returns:

| failure | why the app can still be up |
|---|---|
| `simctl launch` times out | the bound kills the `xcrun` client; `launchd_sim` launched the app |
| `simctl launch` exits non-zero | usually nothing launched — but not always |
| the geometry screenshot fails | the app is on screen |
| the companion's scale RPC fails | same, one step later |

The liveness check is the one failure below the launch that deliberately does **not** reap:
`pid_is_running` fails open, so reaching it is evidence the app is already gone.

Also here, same defect class from the other end: `start_app` overwrote `self.app` without stopping
the app it was already holding, which the `Drop` then could not reach. Not reachable through
`Glass`, which builds a platform per session.

## Verified

Every mechanism was ablated and shown to fail — emptying `Drop::drop`, reverting each of the four
reaps to `?`, reverting `LogStream::spawn` to its hardcoded `xcrun`, pointing `SimTarget::for_test`
back at the real tool, and dropping the second-start stop. Each reddens its own test and no other.

The one path covered by inspection only is the `simctl launch` **timeout**: its budget is 60s, so a
test would have to spend it. Its sibling branch — a launch simctl reports as failed — is tested,
and both go through the same helper.

`cargo test --workspace --locked` green (208 in glass-ios), `cargo clippy --workspace --all-targets
--locked -D warnings` clean, `cargo fmt --all --check` clean. Nothing here needs a Simulator: the
tests drive a `FakeSimctl` stand-in that records argv, can be told to fail a verb, and refuses to
answer once its directory is gone.

## Filed rather than fixed

- **#427** — iOS teardown can exceed `TEARDOWN_BUDGET`: `terminate` falls to `SimctlOp::Query`'s
  10s against a 3s budget, the log stream's reap is unbounded, and glass-ios is the one backend
  with no compile-time assert. Pre-existing; the new `Drop` documents the limit rather than
  claiming a guarantee it cannot make.
- **#428** — `stop_app` returns `Ok(())` when `terminate` failed, so `glass_stop` and the audit log
  record a stop that may not have happened. `glass-android` has the identical defect. Fixing it
  means classifying real tool stderr, which needs a captured string from each.
