### PR TITLE
fix: teardown fits its budget — stop waiting on the simulator, and divide the deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,19 @@ internal refactors, CI, or test-only changes.
   so a lowercase value can come back capitalized. It happens intermittently, depending on whether
   the field had finished emptying when the first key arrived, and it read as an unexplained "did
   not take" before.
+- On macOS, glass no longer waits for a Simulator it booted to finish shutting down before it
+  exits. Shutting one down takes about 3.3 seconds — longer than the whole budget glass allows
+  teardown — so it used to overrun that budget and be abandoned partway on every exit. The request
+  is made and glass leaves; CoreSimulator completes it afterwards, which means a Simulator can
+  still read as Booted for a few seconds after glass has gone.
 
 ### Fixed
+- Teardown at process exit now divides its budget instead of letting the first slow step consume
+  it. A device that stopped answering while the app was being stopped could leave glass no time to
+  hand it back: the accessibility companion stayed enabled, the `adb forward` stayed open, and an
+  emulator glass had booted stayed running — silently, because a step skipped for want of time
+  said nothing. Steps that are skipped now say so on stderr, and a tool call still holding the
+  session when the signal arrives is reported rather than quietly consuming the budget.
 - An accessibility reader that crashes on a particular app's tree now says so, instead of reporting
   that the backend stopped responding. On Linux and Windows the reader runs each call on its own
   worker thread; a crash there was indistinguishable from a call that never came back, so a read

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -702,6 +702,8 @@ impl A11yServiceRegistry {
             READY_ATTEMPT,
             READY_ATTEMPTS,
             &|step| escalate(adb, apk, &want, step, READY_ATTEMPTS),
+            // No deadline: this is the rollback for a failed `ensure` during `glass_start`, not
+            // teardown, so each call keeps its own budget and answers to no shared one.
             &|| restore_a11y(adb, prior, prior_a11y, port, None),
         )?;
         *self.state.lock().unwrap() = Some(Active {
@@ -720,8 +722,8 @@ impl A11yServiceRegistry {
     }
 
     /// [`A11yServiceRegistry::shutdown`] under a deadline the rest of teardown shares — the
-    /// process-exit path, where what is left of `glass_core::TEARDOWN_BUDGET` has already paid for
-    /// stopping the app (glass#422).
+    /// process-exit path, where stopping the app has already spent part of
+    /// `glass_core::TEARDOWN_BUDGET` (glass#422).
     pub fn shutdown_until(&self, deadline: Option<std::time::Instant>) {
         if let Ok(mut g) = self.state.lock()
             && let Some(a) = g.take()
@@ -749,8 +751,17 @@ fn escalate(adb: &Adb, apk: &str, want: &str, step: u32, attempts: u32) -> Resul
 }
 
 fn put_secure(adb: &Adb, key: &str, value: &str) -> Result<()> {
-    adb.run(["shell", "settings", "put", "secure", key, value])
-        .map(|_| ())
+    put_secure_until(adb, key, value, None).map(|_| ())
+}
+
+/// [`put_secure`] under a deadline the caller shares with the rest of its sequence.
+fn put_secure_until(
+    adb: &Adb,
+    key: &str,
+    value: &str,
+    deadline: Option<std::time::Instant>,
+) -> Result<String> {
+    adb.run_until(["shell", "settings", "put", "secure", key, value], deadline)
 }
 
 /// Write `enabled_accessibility_services`. An empty list is a `delete`: `settings put ... ""`
@@ -778,18 +789,7 @@ fn put_enabled_services_until(
         )
         .map(|_| ())
     } else {
-        adb.run_until(
-            [
-                "shell",
-                "settings",
-                "put",
-                "secure",
-                "enabled_accessibility_services",
-                list,
-            ],
-            deadline,
-        )
-        .map(|_| ())
+        put_secure_until(adb, "enabled_accessibility_services", list, deadline).map(|_| ())
     }
 }
 
@@ -820,19 +820,12 @@ fn restore_a11y(
     port: u16,
     deadline: Option<std::time::Instant>,
 ) {
-    let _ = put_enabled_services_until(adb, prior_enabled, deadline);
-    let _ = adb.run_until(
-        [
-            "shell",
-            "settings",
-            "put",
-            "secure",
-            "accessibility_enabled",
-            prior_a11y_enabled,
-        ],
-        deadline,
-    );
-    let _ = adb.run_until(["forward", "--remove", &format!("tcp:{port}")], deadline);
+    let services = put_enabled_services_until(adb, prior_enabled, deadline);
+    glass_core::note_if_skipped("restoring enabled_accessibility_services", &services);
+    let enabled = put_secure_until(adb, "accessibility_enabled", prior_a11y_enabled, deadline);
+    glass_core::note_if_skipped("restoring accessibility_enabled", &enabled);
+    let forward = adb.run_until(["forward", "--remove", &format!("tcp:{port}")], deadline);
+    glass_core::note_if_skipped("removing the a11y service's adb forward", &forward);
 }
 
 /// How long ONE readiness attempt polls for a served window. On a cold-booted device readiness

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -1273,6 +1273,39 @@ mod tests {
         .expect("maps")
     }
 
+    /// The restore hands the device back — service disabled, forward removed — and runs after the
+    /// app was stopped, so a wedge earlier in teardown is what would starve it (glass#422).
+    #[test]
+    #[cfg(unix)]
+    fn a_restore_that_never_answers_gives_up_at_the_shared_deadline() {
+        use crate::adb::{Answer, FakeAdb};
+        use std::time::{Duration, Instant};
+
+        let fake = FakeAdb::new(&[("*", Answer::Lingers)]);
+        let reg = A11yServiceRegistry::new();
+        *reg.state.lock().unwrap() = Some(Active {
+            adb: fake.adb().clone(),
+            port: 1234,
+            prior_enabled: String::new(),
+            prior_a11y_enabled: "0".to_string(),
+        });
+
+        let started = Instant::now();
+        reg.shutdown_until(Some(Instant::now() + Duration::from_millis(300)));
+
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "waited {:?} on a device that never answers — three unbounded calls at 10s each is \
+             what the deadline exists to prevent",
+            started.elapsed()
+        );
+        assert!(
+            fake.called("settings"),
+            "the first step still has to be attempted: {:?}",
+            fake.calls()
+        );
+    }
+
     #[test]
     fn signature_mismatch_detected() {
         let failed = |said: &str| {

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -702,7 +702,7 @@ impl A11yServiceRegistry {
             READY_ATTEMPT,
             READY_ATTEMPTS,
             &|step| escalate(adb, apk, &want, step, READY_ATTEMPTS),
-            &|| restore_a11y(adb, prior, prior_a11y, port),
+            &|| restore_a11y(adb, prior, prior_a11y, port, None),
         )?;
         *self.state.lock().unwrap() = Some(Active {
             adb: adb.clone(),
@@ -716,10 +716,23 @@ impl A11yServiceRegistry {
     /// Restore the device's prior accessibility state and remove the forward. Best-effort,
     /// idempotent. No process to kill (disabling unbinds the service).
     pub fn shutdown(&self) {
+        self.shutdown_until(None);
+    }
+
+    /// [`A11yServiceRegistry::shutdown`] under a deadline the rest of teardown shares — the
+    /// process-exit path, where what is left of `glass_core::TEARDOWN_BUDGET` has already paid for
+    /// stopping the app (glass#422).
+    pub fn shutdown_until(&self, deadline: Option<std::time::Instant>) {
         if let Ok(mut g) = self.state.lock()
             && let Some(a) = g.take()
         {
-            restore_a11y(&a.adb, &a.prior_enabled, &a.prior_a11y_enabled, a.port);
+            restore_a11y(
+                &a.adb,
+                &a.prior_enabled,
+                &a.prior_a11y_enabled,
+                a.port,
+                deadline,
+            );
         }
     }
 }
@@ -743,17 +756,40 @@ fn put_secure(adb: &Adb, key: &str, value: &str) -> Result<()> {
 /// Write `enabled_accessibility_services`. An empty list is a `delete`: `settings put ... ""`
 /// errors ("Bad arguments").
 fn put_enabled_services(adb: &Adb, list: &str) -> Result<()> {
+    put_enabled_services_until(adb, list, None)
+}
+
+/// [`put_enabled_services`] under a deadline the caller shares with the rest of its sequence.
+fn put_enabled_services_until(
+    adb: &Adb,
+    list: &str,
+    deadline: Option<std::time::Instant>,
+) -> Result<()> {
     if list.is_empty() {
-        adb.run([
-            "shell",
-            "settings",
-            "delete",
-            "secure",
-            "enabled_accessibility_services",
-        ])
+        adb.run_until(
+            [
+                "shell",
+                "settings",
+                "delete",
+                "secure",
+                "enabled_accessibility_services",
+            ],
+            deadline,
+        )
         .map(|_| ())
     } else {
-        put_secure(adb, "enabled_accessibility_services", list)
+        adb.run_until(
+            [
+                "shell",
+                "settings",
+                "put",
+                "secure",
+                "enabled_accessibility_services",
+                list,
+            ],
+            deadline,
+        )
+        .map(|_| ())
     }
 }
 
@@ -777,10 +813,26 @@ fn force_rebind(adb: &Adb, enabled: &str) -> Result<()> {
 
 /// Restore `enabled_accessibility_services` + `accessibility_enabled` to their prior values and
 /// remove the forwarded port. Shared by `shutdown` and the failed-`ensure` rollback. Best-effort.
-fn restore_a11y(adb: &Adb, prior_enabled: &str, prior_a11y_enabled: &str, port: u16) {
-    let _ = put_enabled_services(adb, prior_enabled);
-    let _ = put_secure(adb, "accessibility_enabled", prior_a11y_enabled);
-    let _ = adb.run(["forward", "--remove", &format!("tcp:{port}")]);
+fn restore_a11y(
+    adb: &Adb,
+    prior_enabled: &str,
+    prior_a11y_enabled: &str,
+    port: u16,
+    deadline: Option<std::time::Instant>,
+) {
+    let _ = put_enabled_services_until(adb, prior_enabled, deadline);
+    let _ = adb.run_until(
+        [
+            "shell",
+            "settings",
+            "put",
+            "secure",
+            "accessibility_enabled",
+            prior_a11y_enabled,
+        ],
+        deadline,
+    );
+    let _ = adb.run_until(["forward", "--remove", &format!("tcp:{port}")], deadline);
 }
 
 /// How long ONE readiness attempt polls for a served window. On a cold-booted device readiness

--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -24,8 +24,13 @@ pub enum AdbOp {
     Transfer,
     /// `am start -W`, which blocks until the activity is up. A first launch after an install pays
     /// for ART compiling and a cold page cache, so it is nothing like the tap it would otherwise
-    /// share a budget with. `am` alone is NOT this: `am force-stop` runs during teardown, inside
-    /// `glass_core::TEARDOWN_BUDGET`, and must keep the short deadline.
+    /// share a budget with. `am` alone is NOT this: `am force-stop` runs during teardown, where
+    /// the 60s a launch gets would outlast `glass_core::TEARDOWN_BUDGET` several times over.
+    ///
+    /// [`AdbOp::Shell`]'s 10s is not what force-stop is expected to cost either — measured at
+    /// 101ms median, 267ms worst over 25 runs on a four-core emulator with every core saturated.
+    /// It is the bound on a device that has stopped answering; what keeps the teardown *sequence*
+    /// inside its budget is the deadline [`Adb::run_until`] carries, not this number.
     Launch,
     /// Everything else: `input`, `dumpsys`, `devices`, `forward`, `getprop`, `pidof`.
     Shell,
@@ -118,7 +123,21 @@ impl Adb {
     where
         I: IntoIterator<Item = &'a str>,
     {
-        let out = self.output(args, None)?;
+        self.run_until(args, None)
+    }
+
+    /// [`Adb::run`] under a deadline the whole sequence shares, `None` for a call that answers to
+    /// nothing but its own budget.
+    ///
+    /// Teardown is what needs it: `stop_app` and the registry shutdowns behind it are a run of
+    /// separate calls, and glass-mcp abandons the lot at [`glass_core::TEARDOWN_BUDGET`] — so
+    /// without a shared deadline one wedged call spends what the calls behind it needed
+    /// (glass#422).
+    pub fn run_until<'a, I>(&self, args: I, deadline: Option<Instant>) -> Result<String>
+    where
+        I: IntoIterator<Item = &'a str>,
+    {
+        let out = self.output(args, deadline)?;
         Ok(String::from_utf8_lossy(&out.stdout).into_owned())
     }
 
@@ -749,8 +768,8 @@ mod tests {
                 vec!["shell", "rm", "-f", "/sdcard/glass_dump_1_2_0.xml"],
                 AdbOp::Shell,
             ),
-            // `am` alone is not a launch: force-stop runs during teardown, inside
-            // TEARDOWN_BUDGET, and a 60s deadline there would outlast the budget that calls it.
+            // `am` alone is not a launch: force-stop runs during teardown, where a 60s deadline
+            // would outlast the whole budget that calls it.
             (
                 vec!["shell", "am", "force-stop", "com.example.app"],
                 AdbOp::Shell,

--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -127,12 +127,8 @@ impl Adb {
     }
 
     /// [`Adb::run`] under a deadline the whole sequence shares, `None` for a call that answers to
-    /// nothing but its own budget.
-    ///
-    /// Teardown is what needs it: `stop_app` and the registry shutdowns behind it are a run of
-    /// separate calls, and glass-mcp abandons the lot at [`glass_core::TEARDOWN_BUDGET`] — so
-    /// without a shared deadline one wedged call spends what the calls behind it needed
-    /// (glass#422).
+    /// nothing but its own budget. The deadline bounds the run; it does not reserve time for the
+    /// calls behind, which is `Glass::shutdown`'s job (glass#422).
     pub fn run_until<'a, I>(&self, args: I, deadline: Option<Instant>) -> Result<String>
     where
         I: IntoIterator<Item = &'a str>,

--- a/crates/glass-android/src/agent.rs
+++ b/crates/glass-android/src/agent.rs
@@ -327,12 +327,18 @@ impl AgentRegistry {
 
     /// Kill the device agent (via the host child) and remove the forward. Best-effort.
     pub fn shutdown(&self) {
+        self.shutdown_until(None);
+    }
+
+    /// [`AgentRegistry::shutdown`] under a deadline the rest of teardown shares (glass#422).
+    pub fn shutdown_until(&self, deadline: Option<std::time::Instant>) {
         if let Ok(mut guard) = self.state.lock()
             && let Some(p) = guard.take()
         {
-            let _ = p
-                .adb
-                .run(["forward", "--remove", &format!("tcp:{}", p.port)]);
+            let _ = p.adb.run_until(
+                ["forward", "--remove", &format!("tcp:{}", p.port)],
+                deadline,
+            );
             // p drops here → Drop kills + reaps the child
         }
     }

--- a/crates/glass-android/src/agent.rs
+++ b/crates/glass-android/src/agent.rs
@@ -331,14 +331,18 @@ impl AgentRegistry {
     }
 
     /// [`AgentRegistry::shutdown`] under a deadline the rest of teardown shares (glass#422).
+    ///
+    /// Only the forward removal is under it — dropping `p` then kills and reaps the agent with an
+    /// unbounded `wait()`, the gap `AndroidPlatform::stop_app_until` names for logcat.
     pub fn shutdown_until(&self, deadline: Option<std::time::Instant>) {
         if let Ok(mut guard) = self.state.lock()
             && let Some(p) = guard.take()
         {
-            let _ = p.adb.run_until(
+            let removed = p.adb.run_until(
                 ["forward", "--remove", &format!("tcp:{}", p.port)],
                 deadline,
             );
+            glass_core::note_if_skipped("removing the agent's adb forward", &removed);
             // p drops here → Drop kills + reaps the child
         }
     }

--- a/crates/glass-android/src/agent.rs
+++ b/crates/glass-android/src/agent.rs
@@ -377,6 +377,40 @@ fn wait_for_agent_until(port: u16, deadline: Instant) -> Result<AgentClient> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The deadline-bearing half of the agent's teardown — without it a wedged device leaks an
+    /// `adb forward` into a server that outlives glass (glass#422).
+    #[test]
+    #[cfg(unix)]
+    fn a_forward_removal_that_never_answers_gives_up_at_the_shared_deadline() {
+        use crate::adb::{Answer, FakeAdb};
+        use std::time::{Duration, Instant};
+
+        let fake = FakeAdb::new(&[("*", Answer::Lingers)]);
+        let reg = AgentRegistry::new();
+        *reg.state.lock().unwrap() = Some(AgentProc {
+            child: std::process::Command::new("sleep")
+                .arg("30")
+                .spawn()
+                .expect("a child to stand in for the agent"),
+            port: 1234,
+            adb: fake.adb().clone(),
+        });
+
+        let started = Instant::now();
+        reg.shutdown_until(Some(Instant::now() + Duration::from_millis(300)));
+
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "waited {:?} on a device that never answers",
+            started.elapsed()
+        );
+        assert!(
+            fake.called("forward --remove"),
+            "it still has to ask: {:?}",
+            fake.calls()
+        );
+    }
     use std::io::Write;
     use std::net::TcpListener;
 

--- a/crates/glass-android/src/avd.rs
+++ b/crates/glass-android/src/avd.rs
@@ -408,6 +408,34 @@ mod tests {
         );
     }
 
+    /// The deadline has to reach here, or a wedge earlier in teardown leaves a whole emulator
+    /// running — the cheapest step to make, the worst to skip (glass#422).
+    #[test]
+    #[cfg(unix)]
+    fn a_kill_that_never_answers_gives_up_at_the_shared_deadline() {
+        use crate::adb::{Answer, FakeAdb};
+        use std::time::{Duration, Instant};
+
+        let fake = FakeAdb::new(&[("*", Answer::Lingers)]);
+        let reg = EmulatorRegistry::new();
+        reg.register(fake.adb(), "emulator-5554".into());
+
+        let started = Instant::now();
+        reg.kill_all_until(Some(Instant::now() + Duration::from_millis(300)));
+
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "waited {:?} on an emulator that never answers — the 10s AdbOp budget was used \
+             instead of the deadline",
+            started.elapsed()
+        );
+        assert!(
+            fake.called("emu kill"),
+            "it still has to ask: {:?}",
+            fake.calls()
+        );
+    }
+
     #[test]
     fn list_avds_parses_names_only() {
         let out = "INFO | Storing crashdata\nPixel_6\nglass\n";

--- a/crates/glass-android/src/avd.rs
+++ b/crates/glass-android/src/avd.rs
@@ -190,8 +190,9 @@ impl EmulatorRegistry {
         self.kill_all_until(None);
     }
 
-    /// [`EmulatorRegistry::kill_all`] under a deadline the rest of teardown shares. Measured at
-    /// 2ms: `adb emu kill` acknowledges and lets the VM go down on its own time (glass#422).
+    /// [`EmulatorRegistry::kill_all`] under a deadline the rest of teardown shares. `adb emu kill`
+    /// was observed at 2ms — it acknowledges and lets the VM go down on its own time — so this is
+    /// the cheapest step in teardown and the worst one to skip (glass#422).
     pub fn kill_all_until(&self, deadline: Option<std::time::Instant>) {
         let clients = self
             .booted
@@ -199,7 +200,8 @@ impl EmulatorRegistry {
             .map(|mut g| std::mem::take(&mut *g))
             .unwrap_or_default();
         for adb in clients {
-            let _ = adb.run_until(["emu", "kill"], deadline);
+            let killed = adb.run_until(["emu", "kill"], deadline);
+            glass_core::note_if_skipped("killing a glass-booted emulator", &killed);
         }
     }
 

--- a/crates/glass-android/src/avd.rs
+++ b/crates/glass-android/src/avd.rs
@@ -187,13 +187,19 @@ impl EmulatorRegistry {
     /// Stop every registered emulator (`adb -s <serial> emu kill`) and clear the list.
     /// Best-effort: a device already gone is fine.
     pub fn kill_all(&self) {
+        self.kill_all_until(None);
+    }
+
+    /// [`EmulatorRegistry::kill_all`] under a deadline the rest of teardown shares. Measured at
+    /// 2ms: `adb emu kill` acknowledges and lets the VM go down on its own time (glass#422).
+    pub fn kill_all_until(&self, deadline: Option<std::time::Instant>) {
         let clients = self
             .booted
             .lock()
             .map(|mut g| std::mem::take(&mut *g))
             .unwrap_or_default();
         for adb in clients {
-            let _ = adb.run(["emu", "kill"]);
+            let _ = adb.run_until(["emu", "kill"], deadline);
         }
     }
 

--- a/crates/glass-android/src/platform.rs
+++ b/crates/glass-android/src/platform.rs
@@ -45,6 +45,24 @@ pub struct AndroidPlatform {
 }
 
 impl AndroidPlatform {
+    /// Stop the app, under `deadline` when the caller has one to share.
+    ///
+    /// The logcat reap comes first and is unbounded, which measurement says costs 0-1ms: it is a
+    /// `SIGKILL` to a direct child, so only that child sitting in uninterruptible sleep can hold
+    /// it up.
+    fn stop_app_until(&mut self, deadline: Option<Instant>) -> Result<()> {
+        if let Some(mut app) = self.app.take() {
+            if let Some(mut logcat) = app.logcat.take() {
+                logcat.stop();
+            }
+            let _ = self.adb().run_until(
+                force_stop_args(&app.package).iter().map(String::as_str),
+                deadline,
+            );
+        }
+        Ok(())
+    }
+
     /// Attach to (or boot) an emulator, and connect the on-device agent if enabled.
     pub fn from_env(
         emulators: &crate::avd::EmulatorRegistry,
@@ -255,15 +273,14 @@ impl Platform for AndroidPlatform {
     }
 
     fn stop_app(&mut self) -> Result<()> {
-        if let Some(mut app) = self.app.take() {
-            if let Some(mut logcat) = app.logcat.take() {
-                logcat.stop();
-            }
-            let _ = self
-                .adb()
-                .run(force_stop_args(&app.package).iter().map(String::as_str));
-        }
-        Ok(())
+        self.stop_app_until(None)
+    }
+
+    /// Measured at ~0.1s on a loaded emulator against the 3s the whole of teardown gets, so the
+    /// deadline is not expected to bind — it is what keeps a device that has stopped answering
+    /// from spending the shutdown hook's turn as well as its own (glass#422).
+    fn stop_app_by(&mut self, deadline: Instant) -> Result<()> {
+        self.stop_app_until(Some(deadline))
     }
 
     fn capture_frame(&mut self, region: Option<&Region>) -> Result<Frame> {
@@ -638,6 +655,43 @@ mod platform_tests {
         assert!(
             fake.called("am force-stop com.example.app"),
             "{:?}",
+            fake.calls()
+        );
+    }
+
+    /// The composition guarantee (glass#422): a force-stop that never answers must not spend the
+    /// budget the shutdown hook's own steps need. `Lingers` is a device that stopped answering.
+    #[test]
+    #[cfg(unix)]
+    fn a_force_stop_that_never_answers_gives_up_at_the_shared_deadline() {
+        // `launchable`'s rules, with a force-stop that never returns in front of them.
+        let fake = FakeAdb::new(&[
+            ("shell am force-stop *", Answer::Lingers),
+            (
+                "shell am start *",
+                Answer::says("Starting: Intent {...}\nStatus: ok\n"),
+            ),
+            ("shell dumpsys window windows", Answer::says(WINDOWS)),
+            ("shell pidof *", Answer::says("4321\n")),
+            ("exec-out screencap", Answer::says(frame_bytes(1080, 2400))),
+            ("*", Answer::Silent),
+        ]);
+        let mut platform = started(&fake);
+
+        let started_at = Instant::now();
+        platform
+            .stop_app_by(Instant::now() + Duration::from_millis(300))
+            .expect("teardown is best-effort and reports success either way");
+        let waited = started_at.elapsed();
+
+        assert!(
+            waited < Duration::from_secs(2),
+            "waited {waited:?} on a force-stop that never answers — the AdbOp budget (10s) was \
+             used instead of the deadline, and the hook behind this gets nothing"
+        );
+        assert!(
+            fake.called("am force-stop com.example.app"),
+            "it still has to have asked: {:?}",
             fake.calls()
         );
     }

--- a/crates/glass-android/src/platform.rs
+++ b/crates/glass-android/src/platform.rs
@@ -47,18 +47,18 @@ pub struct AndroidPlatform {
 impl AndroidPlatform {
     /// Stop the app, under `deadline` when the caller has one to share.
     ///
-    /// The logcat reap comes first and is unbounded, which measurement says costs 0-1ms: it is a
-    /// `SIGKILL` to a direct child, so only that child sitting in uninterruptible sleep can hold
-    /// it up.
+    /// The logcat reap comes first and is unbounded, measured at 0-1ms — a kill and reap of a
+    /// direct child, which only uninterruptible sleep can hold up.
     fn stop_app_until(&mut self, deadline: Option<Instant>) -> Result<()> {
         if let Some(mut app) = self.app.take() {
             if let Some(mut logcat) = app.logcat.take() {
                 logcat.stop();
             }
-            let _ = self.adb().run_until(
+            let stopped = self.adb().run_until(
                 force_stop_args(&app.package).iter().map(String::as_str),
                 deadline,
             );
+            glass_core::note_if_skipped("the app force-stop", &stopped);
         }
         Ok(())
     }
@@ -276,9 +276,10 @@ impl Platform for AndroidPlatform {
         self.stop_app_until(None)
     }
 
-    /// Measured at ~0.1s on a loaded emulator against the 3s the whole of teardown gets, so the
-    /// deadline is not expected to bind — it is what keeps a device that has stopped answering
-    /// from spending the shutdown hook's turn as well as its own (glass#422).
+    /// Force-stop measures 101ms median, 267ms worst on an emulator with every core saturated,
+    /// against the 3s all of teardown gets — so the deadline is not expected to bind. It is for
+    /// the device that stopped answering, which would otherwise run out the 10s `AdbOp::Shell`
+    /// budget and leave the hook nothing (glass#422).
     fn stop_app_by(&mut self, deadline: Instant) -> Result<()> {
         self.stop_app_until(Some(deadline))
     }

--- a/crates/glass-core/src/bounded.rs
+++ b/crates/glass-core/src/bounded.rs
@@ -42,7 +42,7 @@ const DRAIN_SETTLE: Duration = Duration::from_millis(200);
 /// `wait()`: SIGKILL only lands when the child next leaves the kernel, so a process stuck in an
 /// uninterruptible syscall — the very failure this module exists for — would otherwise strand a
 /// caller who has already spent their whole budget. A stray zombie is the cheaper outcome.
-const KILL_REAP: Duration = Duration::from_millis(500);
+pub const KILL_REAP: Duration = Duration::from_millis(500);
 
 /// Most output ONE PIPE may buffer, so a drain thread left reading a pipe something else still
 /// holds cannot grow without bound. Far past any real one-shot's output: measured on the dogfood
@@ -86,6 +86,21 @@ pub fn run_bounded_until(
         });
     }
     run_bounded_inner(cmd, budget, op, None)
+}
+
+/// Say on stderr that a teardown step never ran, when that is what `outcome` reports.
+///
+/// [`BoundKind::NotStarted`] means the deadline was spent before the command was spawned at all,
+/// which every teardown caller discards — nothing can be done about it while the process exits.
+/// Left at that it is invisible: the companion stays enabled, the `adb forward` stays open in a
+/// server that outlives glass, the emulator stays up, and the exit looks clean.
+pub fn note_if_skipped<T>(step: &str, outcome: &Result<T>) {
+    if outcome.as_ref().err().and_then(GlassError::bound) == Some(BoundKind::NotStarted) {
+        eprintln!(
+            "glass: teardown skipped {step} — the deadline was spent before it could run, so the \
+             device still carries it"
+        );
+    }
 }
 
 /// [`run_bounded`], but writing `stdin` to the child first.

--- a/crates/glass-core/src/bounded.rs
+++ b/crates/glass-core/src/bounded.rs
@@ -94,13 +94,15 @@ pub fn run_bounded_until(
 /// which every teardown caller discards — nothing can be done about it while the process exits.
 /// Left at that it is invisible: the companion stays enabled, the `adb forward` stays open in a
 /// server that outlives glass, the emulator stays up, and the exit looks clean.
-pub fn note_if_skipped<T>(step: &str, outcome: &Result<T>) {
-    if outcome.as_ref().err().and_then(GlassError::bound) == Some(BoundKind::NotStarted) {
-        eprintln!(
-            "glass: teardown skipped {step} — the deadline was spent before it could run, so the \
-             device still carries it"
-        );
+pub fn note_if_skipped<T>(step: &str, outcome: &Result<T>) -> bool {
+    if outcome.as_ref().err().and_then(GlassError::bound) != Some(BoundKind::NotStarted) {
+        return false;
     }
+    eprintln!(
+        "glass: teardown skipped {step} — the deadline was spent before it could run, so the \
+         device still carries it"
+    );
+    true
 }
 
 /// [`run_bounded`], but writing `stdin` to the child first.
@@ -415,6 +417,27 @@ mod tests {
     //! hardcoded `/bin/sh` there fails with "the system cannot find the path specified" rather than
     //! testing anything. What stays portable is everything that needs no process: the capture cap,
     //! the deadline boundary, the backoff, and the pipe-drain behaviour, which takes any `Read`.
+
+    /// The only signal that a teardown step never ran, so it reports that and nothing else: a
+    /// failure that did run says so through its own error.
+    #[test]
+    fn only_a_step_that_never_started_is_reported_as_skipped() {
+        let skipped: Result<()> = Err(GlassError::Bounded {
+            kind: BoundKind::NotStarted,
+            message: "spent".into(),
+        });
+        let timed_out: Result<()> = Err(GlassError::Bounded {
+            kind: BoundKind::TimedOut,
+            message: "ran, then gave up".into(),
+        });
+        assert!(note_if_skipped("a step", &skipped));
+        assert!(!note_if_skipped("a step", &timed_out));
+        assert!(!note_if_skipped("a step", &Ok(())));
+        assert!(!note_if_skipped(
+            "a step",
+            &Err::<(), _>(GlassError::Backend("plain".into()))
+        ));
+    }
 
     use super::*;
     #[cfg(unix)]

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -13,7 +13,7 @@ pub mod toolpath;
 pub use toolpath::tool_path;
 
 pub mod bounded;
-pub use bounded::{run_bounded, run_bounded_until, run_bounded_with_stdin};
+pub use bounded::{note_if_skipped, run_bounded, run_bounded_until, run_bounded_with_stdin};
 
 pub mod a11y_thread;
 pub use a11y_thread::A11yThread;
@@ -76,8 +76,8 @@ pub use logbuf::{LogBuffer, LogLine, Stream};
 pub mod platform;
 pub use platform::{
     A11yBind, AppSpec, KeyEvent, MAX_GESTURE_POINTERS, MouseButton, Platform, PointerEvent,
-    SandboxLevel, Segment, TEARDOWN_BUDGET, WindowGeometry, WindowHint, WindowId, WindowInfo,
-    WindowOp,
+    SandboxLevel, Segment, TEARDOWN_BUDGET, TEARDOWN_HOOK_RESERVE, TEARDOWN_REAP_HEADROOM,
+    WindowGeometry, WindowHint, WindowId, WindowInfo, WindowOp,
 };
 
 pub mod accessibility;

--- a/crates/glass-core/src/platform.rs
+++ b/crates/glass-core/src/platform.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::error::{GlassError, Result};
 use crate::frame::{Frame, Region};
@@ -226,6 +226,18 @@ pub trait Platform {
 
     /// Terminate the running app (idempotent).
     fn stop_app(&mut self) -> Result<()>;
+
+    /// [`Platform::stop_app`] on the process-exit path, where the whole of teardown shares
+    /// [`TEARDOWN_BUDGET`] and `deadline` is what is left of it.
+    ///
+    /// The default ignores it, which is right for a backend whose teardown is a wait on a local
+    /// child it can bound with its own constants. A backend that tears down over a link to a
+    /// device — one tool invocation per step, each with a budget of its own — has no such sum to
+    /// assert, and overrides this so a step that wedges cannot spend the steps behind it
+    /// (glass#422, glass#427).
+    fn stop_app_by(&mut self, _deadline: Instant) -> Result<()> {
+        self.stop_app()
+    }
 
     /// Capture the current window contents as an RGBA frame. `region` (if set,
     /// window-relative) captures only that sub-rectangle; `None` captures the

--- a/crates/glass-core/src/platform.rs
+++ b/crates/glass-core/src/platform.rs
@@ -18,6 +18,38 @@ use crate::logbuf::Stream;
 /// asserts its own budget against it at compile time; grep for `TEARDOWN_BUDGET` to find them.
 pub const TEARDOWN_BUDGET: Duration = Duration::from_secs(3);
 
+/// How much of [`TEARDOWN_BUDGET`] is held back from the deadline the steps are given.
+///
+/// Killing a step that hit its deadline costs up to [`crate::bounded::KILL_REAP`] *after* that
+/// deadline, so without headroom the case this exists for — one step wedges, is cut off, the rest
+/// still run — is itself what overruns the budget.
+pub const TEARDOWN_REAP_HEADROOM: Duration = Duration::from_millis(750);
+
+/// How much of [`TEARDOWN_BUDGET`] is reserved for the host's shutdown hook, so stopping the
+/// sessions cannot spend all of it.
+///
+/// A shared deadline bounds a sequence; it does not divide one. Without a reserve, a device that
+/// stops answering during `stop_app` leaves the hook nothing — and `run_bounded_until` does not
+/// start a command with no time left, so its steps are skipped rather than slowed. On Android the
+/// hook is what hands the device back: the companion it enabled, the `adb forward` it opened, the
+/// emulator it booted.
+///
+/// Five adb calls, the slowest measured at 52ms on an emulator with every core saturated
+/// (glass#422).
+pub const TEARDOWN_HOOK_RESERVE: Duration = Duration::from_millis(750);
+
+// The three have to fit, or the split is a slower way of running out of time. The sessions get
+// what is left — 1.5s, against the ~270ms the slowest measured backend teardown needs.
+const _: () = assert!(
+    TEARDOWN_REAP_HEADROOM.as_millis() + TEARDOWN_HOOK_RESERVE.as_millis()
+        < TEARDOWN_BUDGET.as_millis(),
+    "the reap headroom and the hook's reserve must leave the sessions something to stop with"
+);
+const _: () = assert!(
+    crate::bounded::KILL_REAP.as_millis() < TEARDOWN_REAP_HEADROOM.as_millis(),
+    "the headroom must cover a killed step's reap, or the kill itself overruns the budget"
+);
+
 /// How aggressively to contain the process tree a backend launches. Platform-agnostic
 /// *policy*; the Linux mechanism (bubblewrap) lives in the `glass-sandbox-linux` crate.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -228,13 +260,13 @@ pub trait Platform {
     fn stop_app(&mut self) -> Result<()>;
 
     /// [`Platform::stop_app`] on the process-exit path, where the whole of teardown shares
-    /// [`TEARDOWN_BUDGET`] and `deadline` is what is left of it.
+    /// [`TEARDOWN_BUDGET`] and `deadline` is this step's share of it.
     ///
-    /// The default ignores it, which is right for a backend whose teardown is a wait on a local
-    /// child it can bound with its own constants. A backend that tears down over a link to a
-    /// device — one tool invocation per step, each with a budget of its own — has no such sum to
-    /// assert, and overrides this so a step that wedges cannot spend the steps behind it
-    /// (glass#422, glass#427).
+    /// The default ignores it, which is what a signal ladder over local processes already asserts
+    /// against [`TEARDOWN_BUDGET`] at compile time (x11, wayland, windows, macos — each with the
+    /// residual its own comment names). A backend that tears down over a link to a device has one
+    /// tool invocation per step, each with its own budget and no sum to assert, so it overrides
+    /// this and spends the shared deadline (glass#422, glass#427).
     fn stop_app_by(&mut self, _deadline: Instant) -> Result<()> {
         self.stop_app()
     }
@@ -489,6 +521,51 @@ mod tests {
     #[test]
     fn default_app_pid_is_unknown() {
         assert_eq!(MinimalPlatform.app_pid(), None);
+    }
+
+    /// The default is what the four constant-bounded backends rely on, and it is reached only on
+    /// the exit path — where a body of `Ok(())` would mean they quietly stopped stopping their
+    /// app, with every existing test still green.
+    #[test]
+    fn default_stop_app_by_stops_the_app_and_ignores_the_deadline() {
+        struct CountingPlatform(u32);
+        impl Platform for CountingPlatform {
+            fn start_app(&mut self, _spec: &AppSpec) -> Result<WindowGeometry> {
+                Ok(WindowGeometry::default())
+            }
+            fn stop_app(&mut self) -> Result<()> {
+                self.0 += 1;
+                Ok(())
+            }
+            fn capture_frame(&mut self, _region: Option<&Region>) -> Result<Frame> {
+                unimplemented!()
+            }
+            fn send_pointer(&mut self, _event: &PointerEvent) -> Result<()> {
+                unimplemented!()
+            }
+            fn send_key(&mut self, _event: &KeyEvent) -> Result<()> {
+                unimplemented!()
+            }
+            fn window(&mut self, _op: &WindowOp) -> Result<WindowGeometry> {
+                unimplemented!()
+            }
+            fn list_windows(&mut self) -> Result<Vec<WindowInfo>> {
+                unimplemented!()
+            }
+            fn select_window(&mut self, _id: WindowId) -> Result<WindowGeometry> {
+                unimplemented!()
+            }
+            fn drain_logs(&mut self) -> Vec<(Stream, String)> {
+                vec![]
+            }
+        }
+
+        let mut p = CountingPlatform(0);
+        // A deadline already gone: the default must stop the app regardless, since it does not
+        // spend one.
+        p.stop_app_by(Instant::now() - Duration::from_secs(1))
+            .expect("the default delegates to stop_app");
+        assert_eq!(p.0, 1);
     }
 
     #[test]

--- a/crates/glass-core/src/session/lifecycle.rs
+++ b/crates/glass-core/src/session/lifecycle.rs
@@ -268,6 +268,37 @@ mod tests {
     }
 
     /// The property this whole split exists for (glass#422): a session that spends everything it
+    /// The other half of the split: the reserve is a fixed 750ms, so without the clamp a caller
+    /// whose whole budget is smaller hands the sessions a deadline already in the past.
+    #[test]
+    fn a_budget_smaller_than_the_reserve_still_leaves_the_sessions_time() {
+        let at_stop = Arc::new(Mutex::new(None));
+        let recorded = at_stop.clone();
+        let factory: PlatformFactory = Box::new(move |_backend| {
+            Ok(Backend::display_only(Box::new(
+                FakePlatform::new(10, 10).recording_stop_deadline(recorded.clone()),
+            )))
+        });
+        let mut g = glass_with_factory(factory);
+        g.start(&spec()).unwrap();
+
+        // A fifth of the reserve, so an unclamped subtraction lands well in the past.
+        let budget = crate::TEARDOWN_HOOK_RESERVE / 5;
+        let started = std::time::Instant::now();
+        g.shutdown(started + budget);
+
+        let given = at_stop
+            .lock()
+            .unwrap()
+            .expect("the backend was stopped")
+            .saturating_duration_since(started);
+        assert!(
+            given >= budget / 3,
+            "the sessions were given {given:?} of a {budget:?} budget — the reserve was taken \
+             whole from a budget too small to pay it"
+        );
+    }
+
     /// is given must still leave the hook enough to run. Without the reserve the hook is reached
     /// with a spent deadline, and `run_bounded_until` does not start a command it has no time for
     /// — so every step behind it is skipped rather than merely slow.

--- a/crates/glass-core/src/session/lifecycle.rs
+++ b/crates/glass-core/src/session/lifecycle.rs
@@ -1,4 +1,6 @@
 //! `Glass` session lifecycle: start/stop/shutdown and geometry.
+use std::time::Instant;
+
 use super::*;
 
 impl Glass {
@@ -82,16 +84,20 @@ impl Glass {
     /// failed `stop_app` must not prevent releasing the rest (the OS reaps anything
     /// left). Distinct from `stop()`, which reports errors to a tool caller.
     ///
+    /// `deadline` is when the caller stops waiting, and it is passed to both halves rather than
+    /// enforced here: the point is that the hook still gets its turn after a session that tore
+    /// down slowly, which only the steps themselves can arrange (glass#422).
+    ///
     /// Written to drain the session set so the future multi-session registry (a
     /// `HashMap` instead of this `Option`) reuses it unchanged — it becomes a `for`
     /// loop with no other change.
-    pub fn shutdown(&mut self) {
+    pub fn shutdown(&mut self, deadline: Instant) {
         if let Some(mut s) = self.active.take() {
-            let _ = s.platform.stop_app();
+            let _ = s.platform.stop_app_by(deadline);
             // `s` drops here: the backend (Xvfb/sway/Job) is torn down.
         }
         if let Some(hook) = self.shutdown_hook.take() {
-            hook();
+            hook(deadline);
         }
     }
 
@@ -137,6 +143,12 @@ mod tests {
         assert_eq!(lines[0].text, "ready");
     }
 
+    /// A deadline far enough out that nothing in these tests is bounded by it — they are about
+    /// what `shutdown` calls, not about what a spent budget does.
+    fn soon() -> std::time::Instant {
+        std::time::Instant::now() + crate::TEARDOWN_BUDGET
+    }
+
     #[test]
     fn shutdown_runs_the_hook() {
         use std::sync::Arc;
@@ -145,8 +157,8 @@ mod tests {
         let f = fired.clone();
         let mut g =
             glass_with_factory(Box::new(|_b| Err(GlassError::Backend("no backend".into()))));
-        g.set_shutdown_hook(Box::new(move || f.store(true, Ordering::SeqCst)));
-        g.shutdown();
+        g.set_shutdown_hook(Box::new(move |_| f.store(true, Ordering::SeqCst)));
+        g.shutdown(soon());
         assert!(
             fired.load(Ordering::SeqCst),
             "shutdown should invoke the hook"
@@ -193,7 +205,7 @@ mod tests {
         });
         let mut g = glass_with_factory(factory);
         g.start(&spec()).unwrap();
-        g.shutdown();
+        g.shutdown(soon());
         assert_eq!(
             *stops.lock().unwrap(),
             1,
@@ -204,7 +216,7 @@ mod tests {
             "the session is cleared after shutdown"
         );
         // Idempotent: a second shutdown with nothing active is a harmless no-op.
-        g.shutdown();
+        g.shutdown(soon());
         assert_eq!(
             *stops.lock().unwrap(),
             1,
@@ -212,9 +224,37 @@ mod tests {
         );
     }
 
+    /// The budget is only useful if it reaches the code that spends it: a backend that tears down
+    /// over a link, and a hook that does the same for the host's own resources.
+    #[test]
+    fn shutdown_hands_its_deadline_to_both_the_backend_and_the_hook() {
+        let at_stop = Arc::new(Mutex::new(None));
+        let recorded = at_stop.clone();
+        let factory: PlatformFactory = Box::new(move |_backend| {
+            Ok(Backend::display_only(Box::new(
+                FakePlatform::new(10, 10).recording_stop_deadline(recorded.clone()),
+            )))
+        });
+        let at_hook = Arc::new(Mutex::new(None));
+        let hooked = at_hook.clone();
+        let mut g = glass_with_factory(factory);
+        g.set_shutdown_hook(Box::new(move |d| *hooked.lock().unwrap() = Some(d)));
+        g.start(&spec()).unwrap();
+
+        let deadline = soon();
+        g.shutdown(deadline);
+
+        assert_eq!(
+            *at_stop.lock().unwrap(),
+            Some(deadline),
+            "the backend must be stopped through `stop_app_by`, not `stop_app`"
+        );
+        assert_eq!(*at_hook.lock().unwrap(), Some(deadline));
+    }
+
     #[test]
     fn shutdown_without_active_session_is_noop() {
         let mut g = glass_with(FakePlatform::new(10, 10));
-        g.shutdown(); // must not panic and must not error
+        g.shutdown(soon()); // must not panic and must not error
     }
 }

--- a/crates/glass-core/src/session/lifecycle.rs
+++ b/crates/glass-core/src/session/lifecycle.rs
@@ -84,16 +84,24 @@ impl Glass {
     /// failed `stop_app` must not prevent releasing the rest (the OS reaps anything
     /// left). Distinct from `stop()`, which reports errors to a tool caller.
     ///
-    /// `deadline` is when the caller stops waiting, and it is passed to both halves rather than
-    /// enforced here: the point is that the hook still gets its turn after a session that tore
-    /// down slowly, which only the steps themselves can arrange (glass#422).
+    /// `deadline` is when teardown is expected to be done. Stopping the sessions is held
+    /// [`crate::TEARDOWN_HOOK_RESERVE`] short of it: a shared deadline bounds a sequence without
+    /// dividing one, so a device that stops answering during `stop_app` would otherwise leave the
+    /// hook with nothing, and a step with no time left is not run at all (glass#422).
+    ///
+    /// A third step between them is bounded by neither — dropping the session reaps the backend
+    /// (Xvfb, sway, a Job object) and the log-stream children, each an unbounded `wait()`.
     ///
     /// Written to drain the session set so the future multi-session registry (a
     /// `HashMap` instead of this `Option`) reuses it unchanged — it becomes a `for`
     /// loop with no other change.
     pub fn shutdown(&mut self, deadline: Instant) {
+        // Never more than half, or a caller whose budget is smaller than the reserve — a test,
+        // a host that shortens it — starves the sessions instead of the hook.
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let reserve = crate::TEARDOWN_HOOK_RESERVE.min(remaining / 2);
         if let Some(mut s) = self.active.take() {
-            let _ = s.platform.stop_app_by(deadline);
+            let _ = s.platform.stop_app_by(deadline - reserve);
             // `s` drops here: the backend (Xvfb/sway/Job) is torn down.
         }
         if let Some(hook) = self.shutdown_hook.take() {
@@ -244,12 +252,50 @@ mod tests {
         let deadline = soon();
         g.shutdown(deadline);
 
-        assert_eq!(
-            *at_stop.lock().unwrap(),
-            Some(deadline),
-            "the backend must be stopped through `stop_app_by`, not `stop_app`"
+        let at_stop = at_stop
+            .lock()
+            .unwrap()
+            .expect("the backend must be stopped through `stop_app_by`, not `stop_app`");
+        assert!(
+            at_stop < deadline,
+            "the session's share must stop short of the hook's, or the reserve is not held back"
         );
-        assert_eq!(*at_hook.lock().unwrap(), Some(deadline));
+        assert_eq!(
+            *at_hook.lock().unwrap(),
+            Some(deadline),
+            "the hook gets the whole deadline; the reserve is what the session gave up"
+        );
+    }
+
+    /// The property this whole split exists for (glass#422): a session that spends everything it
+    /// is given must still leave the hook enough to run. Without the reserve the hook is reached
+    /// with a spent deadline, and `run_bounded_until` does not start a command it has no time for
+    /// — so every step behind it is skipped rather than merely slow.
+    #[test]
+    fn a_session_that_burns_its_deadline_still_leaves_the_hook_time_to_run() {
+        let factory: PlatformFactory = Box::new(move |_backend| {
+            Ok(Backend::display_only(Box::new(
+                FakePlatform::new(10, 10).burning_its_deadline(),
+            )))
+        });
+        let left = Arc::new(Mutex::new(None));
+        let recorded = left.clone();
+        let mut g = glass_with_factory(factory);
+        g.set_shutdown_hook(Box::new(move |d| {
+            *recorded.lock().unwrap() =
+                Some(d.saturating_duration_since(std::time::Instant::now()));
+        }));
+        g.start(&spec()).unwrap();
+
+        // A tenth of the real budget, so the test costs what it measures rather than 3s.
+        let budget = crate::TEARDOWN_BUDGET / 10;
+        g.shutdown(std::time::Instant::now() + budget);
+
+        let left = left.lock().unwrap().expect("the hook ran at all");
+        assert!(
+            left > std::time::Duration::ZERO,
+            "the hook was handed a spent deadline, so every step behind the session is skipped"
+        );
     }
 
     #[test]

--- a/crates/glass-core/src/session/mod.rs
+++ b/crates/glass-core/src/session/mod.rs
@@ -94,7 +94,7 @@ pub struct Glass {
     log_capacity: usize,
     active: Option<ActiveSession>,
     audit: Option<Box<dyn crate::audit::AuditSink>>,
-    shutdown_hook: Option<Box<dyn FnOnce() + Send>>,
+    shutdown_hook: Option<Box<dyn FnOnce(std::time::Instant) + Send>>,
 }
 
 impl Glass {
@@ -122,7 +122,12 @@ impl Glass {
 
     /// Install a teardown callback run once at the end of `shutdown()` — used by the host
     /// (glass-mcp) for resource cleanup it owns (e.g. stopping a glass-booted emulator).
-    pub fn set_shutdown_hook(&mut self, hook: Box<dyn FnOnce() + Send>) {
+    ///
+    /// It is handed the same deadline `shutdown` was given, which is what is left of
+    /// [`crate::TEARDOWN_BUDGET`] after the sessions stopped. A hook whose cleanup is local can
+    /// ignore it; one that talks to a device cannot, or the last step spends a budget the first
+    /// step already used.
+    pub fn set_shutdown_hook(&mut self, hook: Box<dyn FnOnce(std::time::Instant) + Send>) {
         self.shutdown_hook = Some(hook);
     }
 

--- a/crates/glass-core/src/session/mod.rs
+++ b/crates/glass-core/src/session/mod.rs
@@ -123,10 +123,10 @@ impl Glass {
     /// Install a teardown callback run once at the end of `shutdown()` — used by the host
     /// (glass-mcp) for resource cleanup it owns (e.g. stopping a glass-booted emulator).
     ///
-    /// It is handed the same deadline `shutdown` was given, which is what is left of
-    /// [`crate::TEARDOWN_BUDGET`] after the sessions stopped. A hook whose cleanup is local can
-    /// ignore it; one that talks to a device cannot, or the last step spends a budget the first
-    /// step already used.
+    /// It gets the whole deadline, the sessions before it having been held
+    /// [`crate::TEARDOWN_HOOK_RESERVE`] short so this still has time. A hook whose cleanup is
+    /// local can ignore it; one that talks to a device spends it, and gets
+    /// `BoundKind::NotStarted` for whatever it reaches with nothing left.
     pub fn set_shutdown_hook(&mut self, hook: Box<dyn FnOnce(std::time::Instant) + Send>) {
         self.shutdown_hook = Some(hook);
     }

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -60,6 +60,9 @@ pub(crate) struct FakePlatform {
     /// `glass_window` op, so the session's cached geometry is stale until something re-reads
     /// it. Empty means "report the current geometry unchanged".
     resized_to: VecDeque<WindowGeometry>,
+    /// The deadline `stop_app_by` was handed, when it was the entry point — `None` after a plain
+    /// `stop_app`, which is how a test tells the two apart.
+    stop_deadline: Option<Arc<Mutex<Option<std::time::Instant>>>>,
 }
 
 impl FakePlatform {
@@ -106,6 +109,15 @@ impl FakePlatform {
     }
     pub(crate) fn counting_stops(mut self, c: Arc<Mutex<u32>>) -> Self {
         self.stop_count = Some(c);
+        self
+    }
+    /// Record the deadline `stop_app_by` receives, for proving the teardown budget reaches the
+    /// backend rather than stopping at `Glass`.
+    pub(crate) fn recording_stop_deadline(
+        mut self,
+        at: Arc<Mutex<Option<std::time::Instant>>>,
+    ) -> Self {
+        self.stop_deadline = Some(at);
         self
     }
     pub(crate) fn with_logs(mut self, logs: Vec<(Stream, &str)>) -> Self {
@@ -161,6 +173,12 @@ impl Platform for FakePlatform {
             *c.lock().unwrap() += 1;
         }
         Ok(())
+    }
+    fn stop_app_by(&mut self, deadline: std::time::Instant) -> Result<()> {
+        if let Some(at) = &self.stop_deadline {
+            *at.lock().unwrap() = Some(deadline);
+        }
+        self.stop_app()
     }
     fn capture_frame(&mut self, region: Option<&Region>) -> Result<Frame> {
         self.capture_log.lock().unwrap().push(region.copied());

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -63,6 +63,9 @@ pub(crate) struct FakePlatform {
     /// The deadline `stop_app_by` was handed, when it was the entry point — `None` after a plain
     /// `stop_app`, which is how a test tells the two apart.
     stop_deadline: Option<Arc<Mutex<Option<std::time::Instant>>>>,
+    /// Makes `stop_app_by` spend its whole deadline, standing in for a device that stopped
+    /// answering.
+    stop_burns_deadline: bool,
 }
 
 impl FakePlatform {
@@ -113,6 +116,12 @@ impl FakePlatform {
     }
     /// Record the deadline `stop_app_by` receives, for proving the teardown budget reaches the
     /// backend rather than stopping at `Glass`.
+    /// Spend the whole deadline in `stop_app_by`, so a test can ask what is left for the step
+    /// behind it.
+    pub(crate) fn burning_its_deadline(mut self) -> Self {
+        self.stop_burns_deadline = true;
+        self
+    }
     pub(crate) fn recording_stop_deadline(
         mut self,
         at: Arc<Mutex<Option<std::time::Instant>>>,
@@ -177,6 +186,9 @@ impl Platform for FakePlatform {
     fn stop_app_by(&mut self, deadline: std::time::Instant) -> Result<()> {
         if let Some(at) = &self.stop_deadline {
             *at.lock().unwrap() = Some(deadline);
+        }
+        if self.stop_burns_deadline {
+            std::thread::sleep(deadline.saturating_duration_since(std::time::Instant::now()));
         }
         self.stop_app()
     }

--- a/crates/glass-ios/src/platform.rs
+++ b/crates/glass-ios/src/platform.rs
@@ -283,6 +283,20 @@ pub(crate) fn bundle_id_from_run(run: &[String]) -> Result<(Option<String>, Stri
 }
 
 impl IosPlatform {
+    /// Terminate the app, under `deadline` when the caller has one to share.
+    fn stop_app_until(&mut self, deadline: Option<Instant>) -> Result<()> {
+        if let Some(app) = self.app.take() {
+            // Best-effort teardown: the app may already be gone (it crashed, or a prior
+            // launch's `--terminate-running-process` killed it), so a failing `terminate`
+            // is not an error — dropping the session is the goal, and it is idempotent.
+            let _ = self
+                .target
+                .simctl()
+                .run_until(&["terminate", self.target.udid(), &app.bundle_id], deadline);
+        }
+        Ok(())
+    }
+
     /// Resolve (attaching to or booting) a simulator per the `GLASS_IOS_*` env vars, then
     /// try to start its `idb_companion` input/accessibility driver.
     ///
@@ -586,16 +600,14 @@ impl Platform for IosPlatform {
     }
 
     fn stop_app(&mut self) -> Result<()> {
-        if let Some(app) = self.app.take() {
-            // Best-effort teardown: the app may already be gone (it crashed, or a prior
-            // launch's `--terminate-running-process` killed it), so a failing `terminate`
-            // is not an error — dropping the session is the goal, and it is idempotent.
-            let _ = self
-                .target
-                .simctl()
-                .run(&["terminate", self.target.udid(), &app.bundle_id]);
-        }
-        Ok(())
+        self.stop_app_until(None)
+    }
+
+    /// Measured at ~0.1s against the 3s the whole of teardown gets, so the deadline is not
+    /// expected to bind — it is what keeps a simulator that has stopped answering from spending
+    /// the shutdown hook's turn as well as its own (glass#427).
+    fn stop_app_by(&mut self, deadline: Instant) -> Result<()> {
+        self.stop_app_until(Some(deadline))
     }
 
     fn capture_frame(&mut self, region: Option<&Region>) -> Result<Frame> {

--- a/crates/glass-ios/src/platform.rs
+++ b/crates/glass-ios/src/platform.rs
@@ -289,10 +289,11 @@ impl IosPlatform {
             // Best-effort teardown: the app may already be gone (it crashed, or a prior
             // launch's `--terminate-running-process` killed it), so a failing `terminate`
             // is not an error — dropping the session is the goal, and it is idempotent.
-            let _ = self
+            let stopped = self
                 .target
                 .simctl()
                 .run_until(&["terminate", self.target.udid(), &app.bundle_id], deadline);
+            glass_core::note_if_skipped("terminating the app", &stopped);
         }
         Ok(())
     }
@@ -603,9 +604,10 @@ impl Platform for IosPlatform {
         self.stop_app_until(None)
     }
 
-    /// Measured at ~0.1s against the 3s the whole of teardown gets, so the deadline is not
-    /// expected to bind — it is what keeps a simulator that has stopped answering from spending
-    /// the shutdown hook's turn as well as its own (glass#427).
+    /// `terminate` measures ~101ms against the 3s all of teardown gets, so the deadline is not
+    /// expected to bind. It is for the simulator that stopped answering, which would otherwise run
+    /// out the 10s `SimctlOp::Query` budget and leave nothing for the hook behind it
+    /// (glass#427).
     fn stop_app_by(&mut self, deadline: Instant) -> Result<()> {
         self.stop_app_until(Some(deadline))
     }

--- a/crates/glass-ios/src/platform.rs
+++ b/crates/glass-ios/src/platform.rs
@@ -1322,6 +1322,31 @@ mod teardown_tests {
         assert_eq!(terminations(&fake).len(), 1, "{:?}", fake.calls());
     }
 
+    /// The iOS half of the composition guarantee: a `terminate` that never answers must not spend
+    /// what the hook behind it needs (glass#427).
+    #[test]
+    fn a_terminate_that_never_answers_gives_up_at_the_shared_deadline() {
+        let fake = FakeSimctl::new();
+        fake.slow("terminate", 5);
+        let mut p = platform(&fake, true);
+
+        let started = std::time::Instant::now();
+        p.stop_app_by(std::time::Instant::now() + std::time::Duration::from_millis(300))
+            .expect("teardown is best-effort and reports success either way");
+        let waited = started.elapsed();
+
+        assert!(
+            waited < std::time::Duration::from_secs(2),
+            "waited {waited:?} on a terminate that never answers — the 10s SimctlOp budget was \
+             used instead of the deadline"
+        );
+        assert!(
+            fake.called("terminate test-udid"),
+            "it still has to ask: {:?}",
+            fake.calls()
+        );
+    }
+
     /// A `w`x`h` opaque PNG, as `simctl io screenshot` writes one.
     fn png(w: u32, h: u32) -> Vec<u8> {
         let mut bytes = Vec::new();

--- a/crates/glass-ios/src/simctl.rs
+++ b/crates/glass-ios/src/simctl.rs
@@ -178,6 +178,8 @@ const FAKE_SIMCTL_SCRIPT: &str = "\
 # Stand-in for xcrun; see FakeSimctl in simctl.rs.
 [ \"$1\" = --glass-probe ] && exit 0
 dir=$(dirname \"$0\")
+# Before the argv line, so a test that waits for the call can then read this without racing it.
+printf '%s' \"$(ps -o pgid= -p $$ | tr -d ' ')\" > \"$dir/pgid\"
 printf '%s\\n' \"$*\" >> \"$dir/calls\"
 # `$2` is the simctl verb, since `$1` is always `simctl`.
 # Recorded before sleeping, so a test can see the call while this one is still running.
@@ -277,6 +279,11 @@ impl FakeSimctl {
     /// Whether any invocation's argv contains `needle`.
     pub(crate) fn called(&self, needle: &str) -> bool {
         self.calls().iter().any(|c| c.contains(needle))
+    }
+
+    /// The process group the last invocation ran in, as it saw it.
+    pub(crate) fn pgid(&self) -> String {
+        std::fs::read_to_string(self.dir.path().join("pgid")).unwrap_or_default()
     }
 
     /// [`FakeSimctl::called`], waiting up to `within` for the call to arrive — for a caller that
@@ -408,6 +415,27 @@ mod tests {
             vec!["simctl terminate UDID app.id", "simctl list devices"]
         );
         assert!(!fake.called("boot"), "{:?}", fake.calls());
+    }
+
+    /// `slow` is what lets every "does it wait?" test fail: without the sleep landing, a caller
+    /// that waits looks exactly like one that does not.
+    #[test]
+    fn a_fake_told_to_be_slow_actually_takes_that_long() {
+        let fake = FakeSimctl::new();
+        let simctl = Simctl::at(fake.program());
+        fake.slow("terminate", 1);
+
+        let started = std::time::Instant::now();
+        simctl.run(&["terminate", "UDID", "app.id"]).unwrap();
+        let slept = started.elapsed();
+        assert!(slept >= Duration::from_millis(900), "returned in {slept:?}");
+
+        let started = std::time::Instant::now();
+        simctl.run(&["list", "devices"]).unwrap();
+        assert!(
+            started.elapsed() < Duration::from_millis(500),
+            "an unmarked verb must not be slowed too"
+        );
     }
 
     #[test]

--- a/crates/glass-ios/src/simctl.rs
+++ b/crates/glass-ios/src/simctl.rs
@@ -10,10 +10,10 @@ use glass_core::{GlassError, Result, run_bounded, run_bounded_until};
 /// than left unbounded, because a boot that never completes must still end as an error.
 ///
 /// Budgets are ~4x the slowest healthy run measured on the dogfood simulator, floored at 10s — a
-/// bound on a simulator that has stopped answering, not what a call is expected to cost. Measured
-/// over 25 runs: `terminate` 101ms median, `io screenshot` well inside its own budget. The
-/// exception is `shutdown` at ~3.3s, which is why nothing waits on one during teardown (glass#427,
-/// `SimulatorRegistry::shutdown_all`).
+/// bound on a simulator that has stopped answering, not what a call is expected to cost:
+/// `terminate` measured 101ms median over 25 runs. `shutdown` is the one verb whose *expected*
+/// cost (~3.3s) exceeds `glass_core::TEARDOWN_BUDGET`, which is why nothing waits on one during
+/// teardown (glass#427, `SimulatorRegistry::request_shutdown_all`).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SimctlOp {
     /// `bootstatus -b` — waits out the whole boot.
@@ -25,9 +25,9 @@ pub enum SimctlOp {
     Install,
     /// `io <udid> screenshot` — encodes a frame.
     Screenshot,
-    /// Everything else: `list`, `pbcopy`, `pbpaste`, `terminate`, `spawn`. `terminate` is a
-    /// teardown call and measures ~101ms, so the 10s here is headroom for a wedged simulator; the
-    /// teardown *sequence* is bounded by the deadline [`Simctl::run_until`] carries instead.
+    /// Everything else: `list`, `pbcopy`, `pbpaste`, `terminate`, `spawn`. `terminate` measures
+    /// ~101ms, so the 10s here is headroom for a wedged simulator; a teardown *sequence* is
+    /// bounded by the deadline [`Simctl::run_until`] carries instead.
     Query,
 }
 
@@ -119,14 +119,28 @@ impl Simctl {
     }
 
     /// [`Simctl::run`] under a deadline the whole sequence shares, `None` for a call that answers
-    /// to nothing but its own budget.
-    ///
-    /// Teardown is what needs it: glass-mcp abandons the whole of it at
-    /// [`glass_core::TEARDOWN_BUDGET`], so a call that wedges would otherwise spend what the calls
-    /// behind it needed (glass#427).
+    /// to nothing but its own budget. The deadline bounds the run; it does not reserve time for
+    /// the calls behind, which is `Glass::shutdown`'s job (glass#427).
     pub fn run_until(&self, sub: &[&str], deadline: Option<Instant>) -> Result<String> {
         let out = self.output(sub, deadline)?;
         Ok(String::from_utf8_lossy(&out).into_owned())
+    }
+
+    /// Start `xcrun simctl <sub...>` and hand back the child unwaited, in a process group of its
+    /// own so a signal to glass's group does not take it too.
+    ///
+    /// For the one call costing more than its caller's whole budget (`shutdown`, ~3.3s against a
+    /// 3s teardown), where waiting only delays the exit. stdout is closed rather than inherited —
+    /// on stdio an inherited one corrupts the MCP stream.
+    pub fn spawn_detached(&self, sub: &[&str]) -> std::io::Result<std::process::Child> {
+        let mut cmd = Command::new(self.program());
+        cmd.args(self.full_args(sub))
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped());
+        #[cfg(unix)]
+        std::os::unix::process::CommandExt::process_group(&mut cmd, 0);
+        cmd.spawn()
     }
 
     fn output(&self, sub: &[&str], deadline: Option<Instant>) -> Result<Vec<u8>> {

--- a/crates/glass-ios/src/simctl.rs
+++ b/crates/glass-ios/src/simctl.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
-use glass_core::{GlassError, Result, run_bounded};
+use glass_core::{GlassError, Result, run_bounded, run_bounded_until};
 
 /// What a `simctl` invocation is doing, which is what decides how long it may take.
 ///
@@ -9,7 +9,11 @@ use glass_core::{GlassError, Result, run_bounded};
 /// simulator finishes booting — minutes on a cold machine — so it is bounded generously rather
 /// than left unbounded, because a boot that never completes must still end as an error.
 ///
-/// Budgets are ~4x the slowest healthy run measured on the dogfood simulator, floored at 10s.
+/// Budgets are ~4x the slowest healthy run measured on the dogfood simulator, floored at 10s — a
+/// bound on a simulator that has stopped answering, not what a call is expected to cost. Measured
+/// over 25 runs: `terminate` 101ms median, `io screenshot` well inside its own budget. The
+/// exception is `shutdown` at ~3.3s, which is why nothing waits on one during teardown (glass#427,
+/// `SimulatorRegistry::shutdown_all`).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SimctlOp {
     /// `bootstatus -b` — waits out the whole boot.
@@ -21,7 +25,9 @@ pub enum SimctlOp {
     Install,
     /// `io <udid> screenshot` — encodes a frame.
     Screenshot,
-    /// Everything else: `list`, `pbcopy`, `pbpaste`, `terminate`, `spawn`.
+    /// Everything else: `list`, `pbcopy`, `pbpaste`, `terminate`, `spawn`. `terminate` is a
+    /// teardown call and measures ~101ms, so the 10s here is headroom for a wedged simulator; the
+    /// teardown *sequence* is bounded by the deadline [`Simctl::run_until`] carries instead.
     Query,
 }
 
@@ -109,15 +115,28 @@ impl Simctl {
 
     /// Run `xcrun simctl <sub...>` and return captured stdout as lossy UTF-8 text.
     pub fn run(&self, sub: &[&str]) -> Result<String> {
-        let out = self.output(sub)?;
+        self.run_until(sub, None)
+    }
+
+    /// [`Simctl::run`] under a deadline the whole sequence shares, `None` for a call that answers
+    /// to nothing but its own budget.
+    ///
+    /// Teardown is what needs it: glass-mcp abandons the whole of it at
+    /// [`glass_core::TEARDOWN_BUDGET`], so a call that wedges would otherwise spend what the calls
+    /// behind it needed (glass#427).
+    pub fn run_until(&self, sub: &[&str], deadline: Option<Instant>) -> Result<String> {
+        let out = self.output(sub, deadline)?;
         Ok(String::from_utf8_lossy(&out).into_owned())
     }
 
-    fn output(&self, sub: &[&str]) -> Result<Vec<u8>> {
+    fn output(&self, sub: &[&str], deadline: Option<Instant>) -> Result<Vec<u8>> {
         let op = SimctlOp::for_sub(sub);
         let mut cmd = Command::new(self.program());
         cmd.args(self.full_args(sub));
-        let out = run_bounded(&mut cmd, op.budget(), op.label())?;
+        let out = match deadline {
+            Some(d) => run_bounded_until(&mut cmd, op.budget(), d, op.label())?,
+            None => run_bounded(&mut cmd, op.budget(), op.label())?,
+        };
         if !out.status.success() {
             return Err(GlassError::Backend(format!(
                 "simctl {:?} failed: {}",
@@ -147,6 +166,8 @@ const FAKE_SIMCTL_SCRIPT: &str = "\
 dir=$(dirname \"$0\")
 printf '%s\\n' \"$*\" >> \"$dir/calls\"
 # `$2` is the simctl verb, since `$1` is always `simctl`.
+# Recorded before sleeping, so a test can see the call while this one is still running.
+[ -f \"$dir/slow-$2\" ] && sleep \"$(cat \"$dir/slow-$2\")\"
 if [ -f \"$dir/fail-$2\" ]; then
     printf 'the fake xcrun was told to fail %s\\n' \"$2\" >&2
     exit 1
@@ -214,6 +235,16 @@ impl FakeSimctl {
             .expect("tell the fake to fail");
     }
 
+    /// Make every `simctl <verb>` call take `seconds`, for a test about whether the caller waits.
+    /// The call is recorded before the sleep starts.
+    pub(crate) fn slow(&self, verb: &str, seconds: u32) {
+        std::fs::write(
+            self.dir.path().join(format!("slow-{verb}")),
+            seconds.to_string(),
+        )
+        .expect("tell the fake to be slow");
+    }
+
     /// The argv of every invocation so far, in order, joined by spaces.
     pub(crate) fn calls(&self) -> Vec<String> {
         // An unreadable `calls` is "nothing run yet" only while the directory is there; gone,
@@ -232,6 +263,21 @@ impl FakeSimctl {
     /// Whether any invocation's argv contains `needle`.
     pub(crate) fn called(&self, needle: &str) -> bool {
         self.calls().iter().any(|c| c.contains(needle))
+    }
+
+    /// [`FakeSimctl::called`], waiting up to `within` for the call to arrive — for a caller that
+    /// spawns rather than waits, where the argv lands after the call under test has returned.
+    pub(crate) fn wait_called(&self, needle: &str, within: Duration) -> bool {
+        let deadline = std::time::Instant::now() + within;
+        loop {
+            if self.called(needle) {
+                return true;
+            }
+            if std::time::Instant::now() >= deadline {
+                return false;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
     }
 }
 

--- a/crates/glass-ios/src/target.rs
+++ b/crates/glass-ios/src/target.rs
@@ -227,26 +227,40 @@ mod tests {
             "{:?}",
             fake.calls()
         );
+        // The whole list, not a substring — asking twice is as wrong as not asking.
+        assert_eq!(fake.calls(), vec!["simctl shutdown AAA"]);
         assert!(r.udids().is_empty());
     }
 
-    /// Shutdown is best-effort — a simulator already stopped answers non-zero — but the registry
-    /// must still be cleared, or a second `shutdown_all` retries a device that is already gone.
+    /// Killing the client at spawn leaves the device Booted 30s later (measured), so a Ctrl-C
+    /// reaching glass's group inside that window would strand the simulator.
     #[test]
-    fn a_shutdown_that_fails_still_clears_the_registry() {
+    fn the_shutdown_it_asks_for_runs_in_its_own_process_group() {
         let fake = crate::simctl::FakeSimctl::new();
-        fake.fails("shutdown");
         let r = SimulatorRegistry::at(&fake.program());
         r.register("AAA".into());
 
         r.request_shutdown_all();
+        assert!(fake.wait_called("shutdown AAA", Duration::from_secs(5)));
 
-        assert!(
-            fake.wait_called("shutdown AAA", Duration::from_secs(5)),
-            "{:?}",
-            fake.calls()
+        let ours = std::process::id().to_string();
+        let theirs = fake.pgid();
+        assert!(!theirs.is_empty(), "the fake recorded no process group");
+        assert_ne!(
+            theirs,
+            unsafe_pgid_of_self(),
+            "the child shares glass's process group, so a group-directed signal takes it too"
         );
-        assert!(r.udids().is_empty());
+        let _ = ours;
+    }
+
+    /// This process's group id, read the way the fake reads its own.
+    fn unsafe_pgid_of_self() -> String {
+        let out = std::process::Command::new("ps")
+            .args(["-o", "pgid=", "-p", &std::process::id().to_string()])
+            .output()
+            .expect("ps answers for this process");
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
     }
 
     /// The measured defect (glass#427): a real `simctl shutdown` takes ~3.3s, which is over the

--- a/crates/glass-ios/src/target.rs
+++ b/crates/glass-ios/src/target.rs
@@ -3,7 +3,6 @@
 //! one piece of I/O this crate performs proactively — running `bootstatus -b` to boot and
 //! wait for a device this crate chose to start.
 
-use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex};
 
 use glass_core::{GlassError, Result};
@@ -48,37 +47,36 @@ impl SimulatorRegistry {
     /// Ask every registered simulator to shut down (`xcrun simctl shutdown <udid>`) and clear the
     /// list, without waiting for CoreSimulator to finish.
     ///
-    /// **Measured at 3.26-3.40s per device** on an M4 mini shutting down a freshly booted, idle
-    /// simulator — over `glass_core::TEARDOWN_BUDGET` (3s) by itself, before stopping the app is
-    /// counted. This is the process-exit path's last step, so waiting it out meant every exit that
-    /// had booted a simulator overran the budget and was abandoned anyway (glass#427).
+    /// **Measured at 3.26-3.40s over three rounds on one device** (M4 mini, freshly booted idle
+    /// simulator) — over `glass_core::TEARDOWN_BUDGET` on its own, before stopping the app is
+    /// counted, so waiting it out overran the budget on every exit with a simulator to shut down
+    /// (glass#427).
     ///
-    /// So it is a request, not a wait: the work happens in CoreSimulator, which outlives this
-    /// process and finishes on its own. Android's counterpart already behaves this way —
-    /// `adb emu kill` returns in 2ms and lets the VM go down after it.
+    /// The request survives this process only once made: killing the client at spawn leaves the
+    /// device Booted 30s later, killing it 0.2s in still shuts down. Hence the child's own process
+    /// group — a Ctrl-C to glass's group would otherwise take it inside that window.
     ///
-    /// Best-effort in both directions: a simulator already stopped, or a host with no simulator
-    /// support at all, is fine. What it costs is the report — nothing here can know whether the
-    /// shutdown succeeded, where waiting would have.
-    pub fn shutdown_all(&self) {
+    /// Nothing waits for the result, so the reaper thread reports it.
+    pub fn request_shutdown_all(&self) {
         let udids = self
             .booted
             .lock()
             .map(|mut g| std::mem::take(&mut *g))
             .unwrap_or_default();
         for udid in udids {
-            let mut cmd = Command::new(self.simctl.program());
-            cmd.args(self.simctl.full_args(&["shutdown", &udid]));
-            cmd.stdin(Stdio::null())
-                .stdout(Stdio::null())
-                .stderr(Stdio::null());
-            // Reaped on a thread of its own so a caller that does NOT exit — a test, or a future
-            // host that keeps running — leaves no zombie behind. The thread outliving this
-            // process is the point, not an oversight: the shutdown it is waiting on does too.
-            match cmd.spawn() {
-                Ok(mut child) => {
-                    std::thread::spawn(move || {
-                        let _ = child.wait();
+            match self.simctl.spawn_detached(&["shutdown", &udid]) {
+                Ok(child) => {
+                    // Reaped on its own thread so a caller that does not exit leaves no zombie.
+                    // On process exit the thread goes too and the child is reparented to launchd,
+                    // which is the point.
+                    std::thread::spawn(move || match child.wait_with_output() {
+                        Ok(out) if !out.status.success() => eprintln!(
+                            "glass-ios: {udid} refused to shut down ({}): {}",
+                            out.status,
+                            String::from_utf8_lossy(&out.stderr).trim()
+                        ),
+                        Err(e) => eprintln!("glass-ios: lost track of {udid}'s shutdown: {e}"),
+                        _ => {}
                     });
                 }
                 Err(e) => eprintln!("glass-ios: could not ask {udid} to shut down: {e}"),
@@ -222,7 +220,7 @@ mod tests {
         let r = SimulatorRegistry::at(&fake.program());
         r.register("AAA".into());
 
-        r.shutdown_all();
+        r.request_shutdown_all();
 
         assert!(
             fake.wait_called("shutdown AAA", Duration::from_secs(5)),
@@ -241,7 +239,7 @@ mod tests {
         let r = SimulatorRegistry::at(&fake.program());
         r.register("AAA".into());
 
-        r.shutdown_all();
+        r.request_shutdown_all();
 
         assert!(
             fake.wait_called("shutdown AAA", Duration::from_secs(5)),
@@ -252,21 +250,23 @@ mod tests {
     }
 
     /// The measured defect (glass#427): a real `simctl shutdown` takes ~3.3s, which is over the
-    /// whole teardown budget on its own, so process exit must not wait for it.
+    /// whole teardown budget on its own, so process exit must not wait for it. The fake sleeps 1s
+    /// rather than 3 so the test does not end with its own `TempDir` deleted under a running
+    /// script.
     #[test]
     fn shutdown_all_returns_without_waiting_for_the_simulator_to_go_down() {
         let fake = crate::simctl::FakeSimctl::new();
-        fake.slow("shutdown", 3);
+        fake.slow("shutdown", 1);
         let r = SimulatorRegistry::at(&fake.program());
         r.register("AAA".into());
 
         let started = Instant::now();
-        r.shutdown_all();
+        r.request_shutdown_all();
         let waited = started.elapsed();
 
         assert!(
-            waited < Duration::from_secs(1),
-            "waited {waited:?} for a shutdown that takes 3s — process exit is blocked on \
+            waited < Duration::from_millis(500),
+            "waited {waited:?} for a shutdown that takes 1s — process exit is blocked on \
              CoreSimulator"
         );
         // And it really did ask, rather than returning fast by doing nothing.

--- a/crates/glass-ios/src/target.rs
+++ b/crates/glass-ios/src/target.rs
@@ -3,6 +3,7 @@
 //! one piece of I/O this crate performs proactively — running `bootstatus -b` to boot and
 //! wait for a device this crate chose to start.
 
+use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex};
 
 use glass_core::{GlassError, Result};
@@ -44,9 +45,21 @@ impl SimulatorRegistry {
         }
     }
 
-    /// Shut down every registered simulator (`xcrun simctl shutdown <udid>`) and clear the
-    /// list. Best-effort: a simulator already stopped, or a host with no simulator support at
-    /// all, is fine — each shutdown's result is discarded.
+    /// Ask every registered simulator to shut down (`xcrun simctl shutdown <udid>`) and clear the
+    /// list, without waiting for CoreSimulator to finish.
+    ///
+    /// **Measured at 3.26-3.40s per device** on an M4 mini shutting down a freshly booted, idle
+    /// simulator — over `glass_core::TEARDOWN_BUDGET` (3s) by itself, before stopping the app is
+    /// counted. This is the process-exit path's last step, so waiting it out meant every exit that
+    /// had booted a simulator overran the budget and was abandoned anyway (glass#427).
+    ///
+    /// So it is a request, not a wait: the work happens in CoreSimulator, which outlives this
+    /// process and finishes on its own. Android's counterpart already behaves this way —
+    /// `adb emu kill` returns in 2ms and lets the VM go down after it.
+    ///
+    /// Best-effort in both directions: a simulator already stopped, or a host with no simulator
+    /// support at all, is fine. What it costs is the report — nothing here can know whether the
+    /// shutdown succeeded, where waiting would have.
     pub fn shutdown_all(&self) {
         let udids = self
             .booted
@@ -54,7 +67,22 @@ impl SimulatorRegistry {
             .map(|mut g| std::mem::take(&mut *g))
             .unwrap_or_default();
         for udid in udids {
-            let _ = self.simctl.run(&["shutdown", &udid]);
+            let mut cmd = Command::new(self.simctl.program());
+            cmd.args(self.simctl.full_args(&["shutdown", &udid]));
+            cmd.stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null());
+            // Reaped on a thread of its own so a caller that does NOT exit — a test, or a future
+            // host that keeps running — leaves no zombie behind. The thread outliving this
+            // process is the point, not an oversight: the shutdown it is waiting on does too.
+            match cmd.spawn() {
+                Ok(mut child) => {
+                    std::thread::spawn(move || {
+                        let _ = child.wait();
+                    });
+                }
+                Err(e) => eprintln!("glass-ios: could not ask {udid} to shut down: {e}"),
+            }
         }
     }
 
@@ -144,6 +172,7 @@ impl SimTarget {
 mod tests {
     use super::*;
     use std::collections::HashMap;
+    use std::time::{Duration, Instant};
 
     fn getter(m: HashMap<&'static str, &'static str>) -> impl Fn(&str) -> Option<String> {
         move |k: &str| m.get(k).map(|s| s.to_string())
@@ -185,6 +214,8 @@ mod tests {
         assert_ne!(SimTarget::for_test().simctl().program(), "xcrun");
     }
 
+    /// Waited for, not read straight away: `shutdown_all` spawns and returns, so the argv lands
+    /// after it.
     #[test]
     fn shutdown_all_shuts_down_what_it_recorded_and_clears_the_registry() {
         let fake = crate::simctl::FakeSimctl::new();
@@ -193,7 +224,11 @@ mod tests {
 
         r.shutdown_all();
 
-        assert_eq!(fake.calls(), vec!["simctl shutdown AAA"]);
+        assert!(
+            fake.wait_called("shutdown AAA", Duration::from_secs(5)),
+            "{:?}",
+            fake.calls()
+        );
         assert!(r.udids().is_empty());
     }
 
@@ -208,7 +243,37 @@ mod tests {
 
         r.shutdown_all();
 
-        assert!(fake.called("shutdown AAA"), "{:?}", fake.calls());
+        assert!(
+            fake.wait_called("shutdown AAA", Duration::from_secs(5)),
+            "{:?}",
+            fake.calls()
+        );
         assert!(r.udids().is_empty());
+    }
+
+    /// The measured defect (glass#427): a real `simctl shutdown` takes ~3.3s, which is over the
+    /// whole teardown budget on its own, so process exit must not wait for it.
+    #[test]
+    fn shutdown_all_returns_without_waiting_for_the_simulator_to_go_down() {
+        let fake = crate::simctl::FakeSimctl::new();
+        fake.slow("shutdown", 3);
+        let r = SimulatorRegistry::at(&fake.program());
+        r.register("AAA".into());
+
+        let started = Instant::now();
+        r.shutdown_all();
+        let waited = started.elapsed();
+
+        assert!(
+            waited < Duration::from_secs(1),
+            "waited {waited:?} for a shutdown that takes 3s — process exit is blocked on \
+             CoreSimulator"
+        );
+        // And it really did ask, rather than returning fast by doing nothing.
+        assert!(
+            fake.wait_called("shutdown AAA", Duration::from_secs(10)),
+            "{:?}",
+            fake.calls()
+        );
     }
 }

--- a/crates/glass-mcp/src/lib.rs
+++ b/crates/glass-mcp/src/lib.rs
@@ -354,10 +354,14 @@ pub fn boot(audit: Option<Box<dyn glass_core::AuditSink>>) -> Glass {
     let platform_factory: glass_core::PlatformFactory =
         Box::new(move |b| make_platform(b, &reg_factory, &agents_factory, &a11y_factory));
     let mut glass = Glass::new(platform_factory, default, baselines, 10_000);
-    glass.set_shutdown_hook(Box::new(move || {
-        a11y.shutdown();
-        agents.shutdown();
-        registry.kill_all();
+    glass.set_shutdown_hook(Box::new(move |deadline| {
+        // Under the deadline the sessions did not use, so a device that stopped answering during
+        // `stop_app` cannot also spend the restore that hands it back clean (glass#422). The
+        // a11y restore goes first for that reason: of these, it is the one whose omission is
+        // visible on the device afterwards.
+        a11y.shutdown_until(Some(deadline));
+        agents.shutdown_until(Some(deadline));
+        registry.kill_all_until(Some(deadline));
         #[cfg(target_os = "macos")]
         sim_registry.shutdown_all();
     }));

--- a/crates/glass-mcp/src/lib.rs
+++ b/crates/glass-mcp/src/lib.rs
@@ -355,15 +355,16 @@ pub fn boot(audit: Option<Box<dyn glass_core::AuditSink>>) -> Glass {
         Box::new(move |b| make_platform(b, &reg_factory, &agents_factory, &a11y_factory));
     let mut glass = Glass::new(platform_factory, default, baselines, 10_000);
     glass.set_shutdown_hook(Box::new(move |deadline| {
-        // Under the deadline the sessions did not use, so a device that stopped answering during
-        // `stop_app` cannot also spend the restore that hands it back clean (glass#422). The
-        // a11y restore goes first for that reason: of these, it is the one whose omission is
-        // visible on the device afterwards.
+        // `Glass::shutdown` keeps `TEARDOWN_HOOK_RESERVE` back from the sessions so these have
+        // time (glass#422). Between themselves it is first-come-first-served, which holds because
+        // at most one of the first three has real work: `kill_all` is empty unless glass booted
+        // the emulator, and if it did, the a11y settings restored before it die with the VM.
         a11y.shutdown_until(Some(deadline));
         agents.shutdown_until(Some(deadline));
         registry.kill_all_until(Some(deadline));
+        // Not under the deadline: it does not wait (see `shutdown_all`).
         #[cfg(target_os = "macos")]
-        sim_registry.shutdown_all();
+        sim_registry.request_shutdown_all();
     }));
     if let Some(sink) = audit {
         glass.set_audit_sink(sink);

--- a/crates/glass-mcp/src/shutdown.rs
+++ b/crates/glass-mcp/src/shutdown.rs
@@ -7,32 +7,44 @@ use std::time::{Duration, Instant};
 use glass_core::Glass;
 use tokio::sync::Mutex;
 
-/// How much longer this waits than the deadline it gives `Glass::shutdown`.
+/// How long a tool call may hold the session before teardown says so.
 ///
-/// The two bounds are for different failures. Teardown's own deadline is what the steps divide
-/// between them, so they finish deliberately and the last one still gets a turn. This timeout is
-/// the backstop for a step that ignores a deadline it was given — the process is exiting either
-/// way, and abandoning a `spawn_blocking` thread mid-call orphans whatever it was running. The
-/// grace is what keeps the ordinary case from racing its own backstop and reporting an overrun on
-/// every clean exit.
-const ABANDON_GRACE: Duration = Duration::from_millis(500);
+/// The lock is held for a whole tool body and some legitimately outlast the budget — `am start`
+/// gets 60s — which is a different failure from a step that ran and overran, and reads the same
+/// without a line of its own.
+const LOCK_WAIT_WORTH_SAYING: Duration = Duration::from_millis(250);
 
 /// Best-effort, time-bounded teardown of all sessions for process exit. The backend
 /// teardown blocks (it waits on the child), so it runs off the async reactor via
 /// `spawn_blocking`; after `budget` we stop waiting and let the OS reap whatever is
 /// left — we are exiting regardless.
+///
+/// Two bounds, for two failures. `Glass::shutdown`'s deadline is what its steps spend, held
+/// [`glass_core::TEARDOWN_REAP_HEADROOM`] short of `budget` so killing a wedged step — up to
+/// `bounded::KILL_REAP` past its deadline — still lands inside. This `timeout` is the backstop for
+/// a step that ignores the deadline: a `spawn_blocking` task cannot be cancelled, so that step is
+/// still running when the process exits, and its child is orphaned.
 pub async fn run_shutdown(sessions: Arc<Mutex<Glass>>, budget: Duration) {
-    let deadline = Instant::now() + budget;
     let task = tokio::task::spawn_blocking(move || {
+        // Started after the lock: a tool call in flight holds the session, and a deadline
+        // measured across that wait arrives spent — reported downstream as every step skipped,
+        // when what happened is that teardown never got to start.
+        let waiting = Instant::now();
         // On a `spawn_blocking` thread, `blocking_lock` is allowed (it would panic on
         // a reactor worker thread).
-        sessions.blocking_lock().shutdown(deadline);
+        let mut glass = sessions.blocking_lock();
+        let waited = waiting.elapsed();
+        if waited > LOCK_WAIT_WORTH_SAYING {
+            eprintln!("glass: a tool call held the session for {waited:?} before teardown started");
+        }
+        glass.shutdown(Instant::now() + budget - glass_core::TEARDOWN_REAP_HEADROOM);
     });
-    if tokio::time::timeout(budget + ABANDON_GRACE, task)
-        .await
-        .is_err()
-    {
-        eprintln!("glass: shutdown exceeded {budget:?}; exiting anyway");
+    match tokio::time::timeout(budget, task).await {
+        Ok(Ok(())) => {}
+        // A panic inside teardown: the steps behind it did not run, and the process is about to
+        // exit past it.
+        Ok(Err(e)) => eprintln!("glass: teardown panicked ({e}); exiting anyway"),
+        Err(_) => eprintln!("glass: shutdown exceeded {budget:?}; exiting anyway"),
     }
 }
 

--- a/crates/glass-mcp/src/shutdown.rs
+++ b/crates/glass-mcp/src/shutdown.rs
@@ -154,6 +154,79 @@ mod tests {
         }
     }
 
+    /// Nothing else checks that `run_shutdown` subtracts the headroom that pays for killing a
+    /// wedged step — up to `KILL_REAP` past its deadline.
+    #[tokio::test]
+    async fn the_deadline_the_backend_gets_leaves_room_to_kill_a_wedged_step() {
+        struct RecordingBackend(Arc<std::sync::Mutex<Option<Duration>>>);
+        impl Platform for RecordingBackend {
+            fn start_app(&mut self, _s: &AppSpec) -> Result<WindowGeometry> {
+                Ok(WindowGeometry {
+                    x: 0,
+                    y: 0,
+                    width: 10,
+                    height: 10,
+                })
+            }
+            fn stop_app(&mut self) -> Result<()> {
+                Ok(())
+            }
+            fn stop_app_by(&mut self, deadline: Instant) -> Result<()> {
+                *self.0.lock().unwrap() = Some(deadline.saturating_duration_since(Instant::now()));
+                Ok(())
+            }
+            fn capture_frame(&mut self, _r: Option<&Region>) -> Result<Frame> {
+                unimplemented!()
+            }
+            fn send_pointer(&mut self, _e: &PointerEvent) -> Result<()> {
+                unimplemented!()
+            }
+            fn send_key(&mut self, _e: &KeyEvent) -> Result<()> {
+                unimplemented!()
+            }
+            fn window(&mut self, _o: &WindowOp) -> Result<WindowGeometry> {
+                unimplemented!()
+            }
+            fn list_windows(&mut self) -> Result<Vec<WindowInfo>> {
+                Ok(vec![])
+            }
+            fn select_window(&mut self, _id: WindowId) -> Result<WindowGeometry> {
+                unimplemented!()
+            }
+            fn drain_logs(&mut self) -> Vec<(Stream, String)> {
+                vec![]
+            }
+        }
+
+        let seen = Arc::new(std::sync::Mutex::new(None));
+        let recorded = seen.clone();
+        let dir = tempfile::tempdir().unwrap();
+        let factory: PlatformFactory = Box::new(move |_b| {
+            Ok(Backend::display_only(Box::new(RecordingBackend(
+                recorded.clone(),
+            ))))
+        });
+        let mut glass = Glass::new(
+            factory,
+            "x11".into(),
+            BaselineStore::new(dir.path().join("baselines")),
+            100,
+        );
+        glass.start(&spec()).unwrap();
+
+        let budget = Duration::from_secs(3);
+        run_shutdown(Arc::new(Mutex::new(glass)), budget).await;
+
+        let got = seen.lock().unwrap().expect("the backend was stopped");
+        // With a margin: without the subtraction the backend still comes up a few microseconds
+        // short of the budget, which a bare `<` would read as headroom.
+        assert!(
+            got + Duration::from_millis(100) < budget - glass_core::TEARDOWN_REAP_HEADROOM,
+            "the backend was handed {got:?} of a {budget:?} budget — the headroom that pays for \
+             killing a wedged step was not subtracted"
+        );
+    }
+
     #[tokio::test]
     async fn run_shutdown_is_bounded_when_teardown_blocks() {
         let mut glass = glass_with_blocking_backend();

--- a/crates/glass-mcp/src/shutdown.rs
+++ b/crates/glass-mcp/src/shutdown.rs
@@ -2,22 +2,36 @@
 //! best-effort `Glass::shutdown()`, plus a cross-platform termination signal.
 
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use glass_core::Glass;
 use tokio::sync::Mutex;
+
+/// How much longer this waits than the deadline it gives `Glass::shutdown`.
+///
+/// The two bounds are for different failures. Teardown's own deadline is what the steps divide
+/// between them, so they finish deliberately and the last one still gets a turn. This timeout is
+/// the backstop for a step that ignores a deadline it was given — the process is exiting either
+/// way, and abandoning a `spawn_blocking` thread mid-call orphans whatever it was running. The
+/// grace is what keeps the ordinary case from racing its own backstop and reporting an overrun on
+/// every clean exit.
+const ABANDON_GRACE: Duration = Duration::from_millis(500);
 
 /// Best-effort, time-bounded teardown of all sessions for process exit. The backend
 /// teardown blocks (it waits on the child), so it runs off the async reactor via
 /// `spawn_blocking`; after `budget` we stop waiting and let the OS reap whatever is
 /// left — we are exiting regardless.
 pub async fn run_shutdown(sessions: Arc<Mutex<Glass>>, budget: Duration) {
+    let deadline = Instant::now() + budget;
     let task = tokio::task::spawn_blocking(move || {
         // On a `spawn_blocking` thread, `blocking_lock` is allowed (it would panic on
         // a reactor worker thread).
-        sessions.blocking_lock().shutdown();
+        sessions.blocking_lock().shutdown(deadline);
     });
-    if tokio::time::timeout(budget, task).await.is_err() {
+    if tokio::time::timeout(budget + ABANDON_GRACE, task)
+        .await
+        .is_err()
+    {
         eprintln!("glass: shutdown exceeded {budget:?}; exiting anyway");
     }
 }

--- a/docs/how-to/setup-ios.md
+++ b/docs/how-to/setup-ios.md
@@ -46,8 +46,9 @@ xcrun simctl create "iPhone glass" "iPhone 17"
 ## Attach-or-boot
 
 Like the Android backend, glass prefers to attach: if a Simulator is already booted it uses it;
-otherwise it boots the newest available iPhone simulator itself and shuts it down again on
-shutdown.
+otherwise it boots the newest available iPhone simulator itself and asks it to shut down again
+when glass exits. The request is handed to CoreSimulator, which takes a few seconds and finishes
+after glass has gone — so `xcrun simctl list devices` can still show it Booted for a moment.
 
 - `GLASS_IOS_UDID` — drive an exact device by UDID (see `xcrun simctl list devices`).
 - `GLASS_IOS_DEVICE` — boot a device by name, e.g. `"iPhone 17"` or `"iPad Pro 13-inch"`, when


### PR DESCRIPTION
Closes #422. Closes #427.

Measured both backends on hardware before writing any code; the numbers are in the issue comments
and they inverted what the issues assumed.

| step | measured | its budget |
|---|---|---|
| `am force-stop`, 4-core emulator, all cores saturated | 101ms median, 267ms worst | 10s |
| the three `restore_a11y` calls | ~35ms each, 52ms worst | 10s each |
| `adb emu kill` | 2ms, and the VM goes down after | 10s |
| logcat `kill` + `wait` | 0-1ms | unbounded |
| `simctl terminate` | ~101ms | 10s |
| **`simctl shutdown`** | **3.26-3.40s** | 60s |

Android's whole teardown is ~370ms against a 3s budget — 8x headroom, and no number worth
changing. iOS's `simctl shutdown` is over the entire budget on its own, so every process exit with
a simulator to shut down overran it and was abandoned.

## What changed

**The simulator shutdown is asked for, not waited on.** It only runs from the process-exit hook,
and its Android counterpart already behaves this way. A second measurement decided how: killing the
`simctl` client at spawn leaves the device Booted 30s later, while killing it 0.2s in still shuts
down — so the child gets a process group of its own, or a Ctrl-C to glass's group would take it
inside that window.

**Teardown carries one deadline.** `Glass::shutdown(deadline)` hands it to `Platform::stop_app_by`
— a new default method delegating to `stop_app`, so the four backends that bound a local child with
their own constants are untouched — and to the shutdown hook. The device backends spend it per step
through `Adb::run_until` and `Simctl::run_until`.

A shared deadline bounds a sequence without dividing one, so the sessions are held
`TEARDOWN_HOOK_RESERVE` short of it: `run_bounded_until` does not start a command with no time
left, so without a reserve a wedged `stop_app` leaves the hook's steps *skipped*, not slowed. The
reserve is clamped to half the remaining budget, so a caller with a small budget starves the
sessions rather than the hook.

**A skipped step says so.** `note_if_skipped` puts one line on stderr per step that never ran. An
accessibility service left enabled, an `adb forward` left open in a server that outlives glass, an
emulator left running — all of that used to be indistinguishable from a clean exit.

**The budget comments now carry the numbers.** They said teardown keeps a short deadline *because
of* `TEARDOWN_BUDGET`; the budgets are wedge detectors at ~40x and ~100x measured cost, and they say
that instead.

## What the review changed

Five lenses, two Criticals, both mine and both found independently by more than one reviewer:

- **The deadline reserved nothing.** Nine comments across six files claimed a wedged step could not
  spend the steps behind it. The code had no reservation — it does now, and the composition
  property has a test that fails without it.
- **The deadline was taken before the session lock.** A signal arriving during any in-flight tool
  call spent the whole budget waiting for the mutex, then skipped everything — silently, and
  faster than the backstop, so nothing printed.

Also corrected: `ABANDON_GRACE` was exactly `KILL_REAP`, so the case the deadline exists for landed
precisely on its own backstop (the headroom now comes out of the budget, leaving 3s the one real
ceiling — which keeps `host_conformance`'s derivation true); a panic in teardown was swallowed by
`is_err()`; "a thread outliving this process is the point" — threads die with the process, the
child is what survives; and a claim that `io screenshot` was measured, which it never was.

## Verified

Every mechanism was reverted and the suite watched go red. That took two passes: the first left six
behaviours pinned by nothing, including **the three Android registry shutdowns** — the largest part
of the diff and the substance of #422 — which could all be reverted to unbounded calls with the
suite still green.

The sharpest of the six: `FakeSimctl::slow` was an unvalidated fixture, and the iOS teardown tests
can only fail while its sleep actually lands. With the sleep deleted *and* the simulator shutdown
reverted to the blocking form, the #427 regression walked through green. That fixture is validated
now, as `fails` and the argv recording already were.

One of the new tests passed its own ablation on the first attempt — the backend came up
microseconds short of the full budget, which a bare `<` read as headroom. It carries a margin now.

`cargo test --workspace --locked` green, clippy and `cargo fmt --all --check` clean.

Not covered by a test: the `simctl launch` timeout branch (a 60s budget makes it impractical), and
the orphan behaviour above, which is a measurement rather than a test.

## Declined, with reasons

- **A `Deadline` newtype.** `AxDeadline` already exists with `UNBOUNDED`/`cap`/`has_passed`, and
  this diff adds a third spelling (`Option<Instant>`) beside it and `run_bounded_until`'s bare
  `Instant`. Worth unifying, but not inside a fix for two teardown issues — filed instead.
- **Making `stop_app_by` a required method.** It would make the silent-default failure impossible,
  at 11 call sites across six backends and their doubles. The default is now pinned by a test,
  which closes the hole this branch actually found.
- **#428** (`stop_app` reports `Ok(())` for a stop that did not happen) is untouched and now
  covers one more case: a stop that was never issued. Noted on the issue.
