### PR TITLE
refactor: one Deadline type for every bound

### DIFF
--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -6,7 +6,8 @@ use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use glass_core::accessibility::{Accessibility, AxContext, AxDeadline, AxNode, AxTarget, AxTree};
+use glass_core::Deadline;
+use glass_core::accessibility::{Accessibility, AxContext, AxNode, AxTarget, AxTree};
 use glass_core::{
     GlassError, KeyEvent, MouseButton, PointerEvent, Result, TAP_MAY_HAVE_MISSED, WindowGeometry,
     read_back_failed, verify_typed_write,
@@ -71,7 +72,7 @@ type AdbRunner<'a> = dyn FnMut(&[&str], Instant) -> Result<(String, String)> + '
 pub(crate) fn adb_runner(
     adb: &Adb,
 ) -> impl FnMut(&[&str], Instant) -> Result<(String, String)> + '_ {
-    move |argv, deadline| adb.run_streams_until(argv.iter().copied(), deadline)
+    move |argv, deadline| adb.run_streams_until(argv.iter().copied(), Deadline::at(deadline))
 }
 
 /// When one whole dump attempt — the dump, the read of what it wrote, and the removal of the file
@@ -82,7 +83,7 @@ pub(crate) fn adb_runner(
 /// the sum of all three, 50s against the 10s a `glass_wait_for_element` asks for by default and
 /// re-snapshots inside.
 ///
-/// A caller that named a deadline gets [`AxDeadline::cap`] of this instead — see
+/// A caller that named a deadline gets [`Deadline::cap`] of this instead — see
 /// [`dump_until_ready`], which needs both to tell which of them ended an attempt.
 pub(crate) fn attempt_deadline() -> Instant {
     Instant::now() + AdbOp::Dump.budget()
@@ -244,7 +245,7 @@ fn dump_until_ready(
     prefix: &str,
     bound: RetryBound,
     interval: Duration,
-    caller: AxDeadline,
+    caller: Deadline,
 ) -> Result<String> {
     let retry_until = caller.cap(Instant::now() + bound.then_within);
     let mut owed = bound.least.max(1);
@@ -330,7 +331,7 @@ const VERIFY_PHASE_BUDGET_MS: u64 = 20_000;
 /// binding to a device.
 ///
 /// Split out so a host test can see the join: inline, replacing `ctx.deadline` with
-/// [`AxDeadline::UNBOUNDED`] left every non-device test green.
+/// [`Deadline::UNBOUNDED`] left every non-device test green.
 fn snapshot_with_runner(
     run: &mut AdbRunner<'_>,
     ctx: &AxContext,
@@ -365,7 +366,7 @@ pub(crate) enum Warmth {
 ///
 /// The cold wait is not capped here: [`dump_until_ready`] caps every wait by the caller, and this
 /// one must still *owe* the two attempts the accessibility bridge's registration needs.
-fn snapshot_bound(warmth: Warmth, deadline: AxDeadline) -> RetryBound {
+fn snapshot_bound(warmth: Warmth, deadline: Deadline) -> RetryBound {
     if warmth == Warmth::Cold {
         return COLD_BOUND;
     }
@@ -606,9 +607,9 @@ mod tests {
         snapshot_with_runner,
     };
     use crate::adb::{AdbOp, a_failed_call, a_real_spawn_failure, a_real_timeout_hinted};
+    use glass_core::Deadline;
     use glass_core::accessibility::{
-        AxContext, AxDeadline, AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget, AxTree,
-        WalkLimits,
+        AxContext, AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget, AxTree, WalkLimits,
     };
     use glass_core::{BoundKind, GlassError, Result, WindowGeometry};
     use std::collections::HashMap;
@@ -625,7 +626,7 @@ mod tests {
         glass_core::run_bounded_until(
             &mut std::process::Command::new("adb"),
             Duration::from_secs(10),
-            Instant::now(),
+            Deadline::at(Instant::now()),
             "adb:uiautomator dump",
         )
         .expect_err("a spent deadline starts nothing")
@@ -768,7 +769,7 @@ mod tests {
                 then_within: Duration::from_millis(10),
             },
             Duration::ZERO,
-            AxDeadline::UNBOUNDED,
+            Deadline::UNBOUNDED,
         )
         .expect("the second attempt is owed however long the first took");
 
@@ -810,7 +811,7 @@ mod tests {
                 PREFIX,
                 RetryBound::ONCE,
                 Duration::ZERO,
-                AxDeadline::from_millis(50),
+                Deadline::from_millis(50),
             )
             .expect("the dump succeeds");
         }
@@ -872,7 +873,7 @@ mod tests {
                 PREFIX,
                 RetryBound::ONCE,
                 Duration::ZERO,
-                AxDeadline::UNBOUNDED,
+                Deadline::UNBOUNDED,
             )
             .expect("the dump succeeds");
         }
@@ -897,7 +898,7 @@ mod tests {
             PREFIX,
             patient(),
             Duration::ZERO,
-            AxDeadline::from_millis(0),
+            Deadline::from_millis(0),
         )
         .expect_err("the caller had stopped waiting");
 
@@ -912,13 +913,13 @@ mod tests {
     /// nothing else bounded a retry.
     #[test]
     fn a_warmed_reader_retries_only_inside_the_deadline_the_caller_named() {
-        let told = snapshot_bound(Warmth::Warmed, AxDeadline::from_millis(5_000));
+        let told = snapshot_bound(Warmth::Warmed, Deadline::from_millis(5_000));
         assert!(
             told.then_within > Duration::from_secs(4) && told.then_within <= Duration::from_secs(5),
             "the retry window is not the caller's: {told:?}"
         );
 
-        let untold = snapshot_bound(Warmth::Warmed, AxDeadline::UNBOUNDED);
+        let untold = snapshot_bound(Warmth::Warmed, Deadline::UNBOUNDED);
         assert_eq!(
             untold.then_within,
             Duration::ZERO,
@@ -932,7 +933,7 @@ mod tests {
     /// would apply it twice and leave the attempts the bridge's registration needs unasked.
     #[test]
     fn a_cold_reader_is_owed_its_attempts_however_little_the_caller_allowed() {
-        let bound = snapshot_bound(Warmth::Cold, AxDeadline::from_millis(1));
+        let bound = snapshot_bound(Warmth::Cold, Deadline::from_millis(1));
         assert_eq!(bound.least, COLD_BOUND.least, "{bound:?}");
         assert_eq!(bound.then_within, COLD_BOUND.then_within, "{bound:?}");
     }
@@ -961,7 +962,7 @@ mod tests {
             PREFIX,
             patient(),
             Duration::from_secs(5),
-            AxDeadline::from_millis(10),
+            Deadline::from_millis(10),
         )
         .expect_err("the caller's deadline passed during the attempt");
 
@@ -989,7 +990,7 @@ mod tests {
             window_handle: None,
             a11y_bus_addr: None,
             limits: WalkLimits::DEFAULT,
-            deadline: AxDeadline::from_millis(50),
+            deadline: Deadline::from_millis(50),
         };
         {
             let mut run = recording(&mut seen);
@@ -1049,7 +1050,7 @@ mod tests {
             window_handle: None,
             a11y_bus_addr: None,
             limits: WalkLimits::DEFAULT,
-            deadline: AxDeadline::UNBOUNDED,
+            deadline: Deadline::UNBOUNDED,
         }
     }
 
@@ -1068,7 +1069,7 @@ mod tests {
             PREFIX,
             COLD_BOUND,
             Duration::ZERO,
-            AxDeadline::from_millis(5_000),
+            Deadline::from_millis(5_000),
         )
         .expect("the second attempt runs inside the window the caller is still waiting through");
 
@@ -1092,7 +1093,7 @@ mod tests {
             Duration::ZERO,
             // Nearer than `AdbOp::Dump`'s budget, so the caller's bound governs the attempt —
             // which is true of every read a `wait_for_element` makes.
-            AxDeadline::from_millis(5_000),
+            Deadline::from_millis(5_000),
         )
         .expect_err("the device is gone");
 
@@ -1181,7 +1182,7 @@ mod tests {
             PREFIX,
             RetryBound::ONCE,
             Duration::ZERO,
-            AxDeadline::from_millis(5_000),
+            Deadline::from_millis(5_000),
         )
         .expect_err("the device failed");
 
@@ -1216,7 +1217,7 @@ mod tests {
             PREFIX,
             COLD_BOUND,
             Duration::ZERO,
-            AxDeadline::from_millis(10),
+            Deadline::from_millis(10),
         )
         .expect_err("the caller's deadline passed during the first attempt");
 
@@ -1241,7 +1242,7 @@ mod tests {
             PREFIX,
             RetryBound::ONCE,
             Duration::ZERO,
-            AxDeadline::from_millis(20),
+            Deadline::from_millis(20),
         )
         .expect_err("the attempt was abandoned");
         assert!(matches!(e, GlassError::AccessibilityNotReady(_)), "{e}");
@@ -1260,7 +1261,7 @@ mod tests {
             PREFIX,
             RetryBound::ONCE,
             Duration::ZERO,
-            AxDeadline::UNBOUNDED,
+            Deadline::UNBOUNDED,
         )
         .expect_err("the attempt timed out");
         assert_eq!(e.bound(), Some(BoundKind::TimedOut), "{e}");
@@ -1470,7 +1471,7 @@ mod tests {
             PREFIX,
             RetryBound::ONCE,
             Duration::ZERO,
-            AxDeadline::UNBOUNDED,
+            Deadline::UNBOUNDED,
         )
         .unwrap();
 
@@ -1506,7 +1507,7 @@ mod tests {
                 then_within: Duration::from_secs(5),
             },
             Duration::from_millis(1),
-            AxDeadline::UNBOUNDED,
+            Deadline::UNBOUNDED,
         )
         .expect("the second attempt succeeds");
 
@@ -1540,7 +1541,7 @@ mod tests {
             PREFIX,
             bound,
             Duration::from_secs(2),
-            AxDeadline::UNBOUNDED,
+            Deadline::UNBOUNDED,
         )
         .expect_err("a device that never becomes ready");
 
@@ -1577,7 +1578,7 @@ mod tests {
             PREFIX,
             patient(),
             Duration::ZERO,
-            AxDeadline::UNBOUNDED,
+            Deadline::UNBOUNDED,
         )
         .unwrap_err();
 
@@ -1605,7 +1606,7 @@ mod tests {
             PREFIX,
             patient(),
             Duration::ZERO,
-            AxDeadline::UNBOUNDED,
+            Deadline::UNBOUNDED,
         )
         .expect("a device that becomes ready within the budget must produce a tree");
         assert_eq!(xml, XML);
@@ -1619,7 +1620,7 @@ mod tests {
             PREFIX,
             RetryBound::ONCE,
             Duration::ZERO,
-            AxDeadline::UNBOUNDED,
+            Deadline::UNBOUNDED,
         )
         .unwrap_err();
         assert!(e.to_string().contains(NOT_READY), "{e}");
@@ -1654,7 +1655,7 @@ mod tests {
             PREFIX,
             patient(),
             Duration::ZERO,
-            AxDeadline::UNBOUNDED,
+            Deadline::UNBOUNDED,
         )
         .unwrap_err();
         assert!(e.to_string().contains("not found"), "{e}");
@@ -1674,7 +1675,7 @@ mod tests {
             PREFIX,
             patient(),
             Duration::ZERO,
-            AxDeadline::UNBOUNDED,
+            Deadline::UNBOUNDED,
         )
         .expect("a dump that crashed must be retried inside the budget");
         assert_eq!(xml, XML);
@@ -1715,7 +1716,7 @@ mod tests {
                 PREFIX,
                 patient(),
                 Duration::ZERO,
-                AxDeadline::UNBOUNDED,
+                Deadline::UNBOUNDED,
             )
             .expect("the attempt after the crashes dumps");
         }
@@ -1879,7 +1880,7 @@ mod tests {
             window_handle: None,
             a11y_bus_addr: None,
             limits: WalkLimits::DEFAULT,
-            deadline: AxDeadline::from_millis(300),
+            deadline: Deadline::from_millis(300),
         };
 
         let err = reader
@@ -1985,7 +1986,7 @@ mod tests {
             window_handle: None,
             a11y_bus_addr: None,
             limits: WalkLimits::DEFAULT,
-            deadline: AxDeadline::from_millis(30_000),
+            deadline: Deadline::from_millis(30_000),
         };
         // The synthetic Window root is id 0, so the field is id 1.
         let field = AxTarget {
@@ -2043,7 +2044,7 @@ mod tests {
             window_handle: None,
             a11y_bus_addr: None,
             limits: WalkLimits::DEFAULT,
-            deadline: AxDeadline::from_millis(30_000),
+            deadline: Deadline::from_millis(30_000),
         };
         let field = AxTarget {
             id: AxNodeId(1),
@@ -2098,7 +2099,7 @@ mod tests {
             window_handle: None,
             a11y_bus_addr: None,
             limits: WalkLimits::DEFAULT,
-            deadline: AxDeadline::from_millis(30_000),
+            deadline: Deadline::from_millis(30_000),
         };
         let field = AxTarget {
             id: AxNodeId(1),

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -6,9 +6,10 @@ use std::sync::Mutex;
 
 use serde_json::{Value, json};
 
+use glass_core::Deadline;
 use glass_core::accessibility::{
-    Accessibility, AxContext, AxDeadline, AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget,
-    AxTree, Subject, WalkBudget, WalkLimits,
+    Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget, AxTree,
+    Subject, WalkBudget, WalkLimits,
 };
 use glass_core::platform::WindowGeometry;
 use glass_core::{GlassError, Result, read_back_failed, write_took_no_effect};
@@ -262,7 +263,7 @@ impl ServiceClient {
     /// Scoped rather than set-and-leave: the connection outlives any one request, so a bound left
     /// behind would apply to a later call that never agreed to it — and to the *reconnect* path,
     /// where a fresh `Conn` starts from the standing timeout again.
-    fn read_within(&self, deadline: AxDeadline) -> ReadBound<'_> {
+    fn read_within(&self, deadline: Deadline) -> ReadBound<'_> {
         if let Ok(mut conn) = self.conn.lock() {
             conn.read_within(deadline.remaining());
         }
@@ -287,14 +288,14 @@ impl ServiceClient {
     /// Serve the tree for `package` on the connection's standing timeout — the readiness probe and
     /// the tests, neither of which has a caller waiting on a clock.
     fn tree(&self, package: &str) -> Result<TreeReply> {
-        self.tree_within(package, AxDeadline::UNBOUNDED)
+        self.tree_within(package, Deadline::UNBOUNDED)
     }
 
     /// Serve the tree for `package`, blocking no longer than `deadline` allows.
     ///
     /// The bound covers the reconnect-and-re-send too, so one call cannot cost two socket
     /// timeouts against a caller who asked for less than one (glass#338).
-    fn tree_within(&self, package: &str, deadline: AxDeadline) -> Result<TreeReply> {
+    fn tree_within(&self, package: &str, deadline: Deadline) -> Result<TreeReply> {
         let _bound = self.read_within(deadline);
         let r = self
             .call(json!({"op": "tree", "package": package}), None)
@@ -704,7 +705,7 @@ impl A11yServiceRegistry {
             &|step| escalate(adb, apk, &want, step, READY_ATTEMPTS),
             // No deadline: this is the rollback for a failed `ensure` during `glass_start`, not
             // teardown, so each call keeps its own budget and answers to no shared one.
-            &|| restore_a11y(adb, prior, prior_a11y, port, None),
+            &|| restore_a11y(adb, prior, prior_a11y, port, Deadline::UNBOUNDED),
         )?;
         *self.state.lock().unwrap() = Some(Active {
             adb: adb.clone(),
@@ -717,14 +718,10 @@ impl A11yServiceRegistry {
 
     /// Restore the device's prior accessibility state and remove the forward. Best-effort,
     /// idempotent. No process to kill (disabling unbinds the service).
-    pub fn shutdown(&self) {
-        self.shutdown_until(None);
-    }
-
-    /// [`A11yServiceRegistry::shutdown`] under a deadline the rest of teardown shares — the
-    /// process-exit path, where stopping the app has already spent part of
-    /// `glass_core::TEARDOWN_BUDGET` (glass#422).
-    pub fn shutdown_until(&self, deadline: Option<std::time::Instant>) {
+    /// Restore the device and remove the forward by `deadline`, which the rest of teardown shares
+    /// — stopping the app has already spent part of `glass_core::TEARDOWN_BUDGET` (glass#422).
+    /// [`Deadline::UNBOUNDED`] off that path, where each call keeps its own budget.
+    pub fn shutdown(&self, deadline: Deadline) {
         if let Ok(mut g) = self.state.lock()
             && let Some(a) = g.take()
         {
@@ -751,31 +748,22 @@ fn escalate(adb: &Adb, apk: &str, want: &str, step: u32, attempts: u32) -> Resul
 }
 
 fn put_secure(adb: &Adb, key: &str, value: &str) -> Result<()> {
-    put_secure_until(adb, key, value, None).map(|_| ())
+    put_secure_until(adb, key, value, Deadline::UNBOUNDED).map(|_| ())
 }
 
 /// [`put_secure`] under a deadline the caller shares with the rest of its sequence.
-fn put_secure_until(
-    adb: &Adb,
-    key: &str,
-    value: &str,
-    deadline: Option<std::time::Instant>,
-) -> Result<String> {
+fn put_secure_until(adb: &Adb, key: &str, value: &str, deadline: Deadline) -> Result<String> {
     adb.run_until(["shell", "settings", "put", "secure", key, value], deadline)
 }
 
 /// Write `enabled_accessibility_services`. An empty list is a `delete`: `settings put ... ""`
 /// errors ("Bad arguments").
 fn put_enabled_services(adb: &Adb, list: &str) -> Result<()> {
-    put_enabled_services_until(adb, list, None)
+    put_enabled_services_until(adb, list, Deadline::UNBOUNDED)
 }
 
 /// [`put_enabled_services`] under a deadline the caller shares with the rest of its sequence.
-fn put_enabled_services_until(
-    adb: &Adb,
-    list: &str,
-    deadline: Option<std::time::Instant>,
-) -> Result<()> {
+fn put_enabled_services_until(adb: &Adb, list: &str, deadline: Deadline) -> Result<()> {
     if list.is_empty() {
         adb.run_until(
             [
@@ -818,7 +806,7 @@ fn restore_a11y(
     prior_enabled: &str,
     prior_a11y_enabled: &str,
     port: u16,
-    deadline: Option<std::time::Instant>,
+    deadline: Deadline,
 ) {
     let services = put_enabled_services_until(adb, prior_enabled, deadline);
     glass_core::note_if_skipped("restoring enabled_accessibility_services", &services);
@@ -1221,7 +1209,7 @@ fn check_timeout(target: u32, act: &Actuated, want: bool, seen: CheckState) -> G
 #[cfg(test)]
 mod tests {
     use super::*;
-    use glass_core::accessibility::{AxDeadline, AxRole, TruncationLimit};
+    use glass_core::accessibility::{AxRole, TruncationLimit};
     use serde_json::json;
     use std::io::{BufRead, Write};
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -1291,7 +1279,7 @@ mod tests {
         });
 
         let started = Instant::now();
-        reg.shutdown_until(Some(Instant::now() + Duration::from_millis(300)));
+        reg.shutdown(Deadline::at(Instant::now() + Duration::from_millis(300)));
 
         assert!(
             started.elapsed() < Duration::from_secs(2),
@@ -2872,7 +2860,7 @@ mod tests {
             window_handle: None,
             a11y_bus_addr: None,
             limits: WalkLimits::DEFAULT,
-            deadline: AxDeadline::UNBOUNDED,
+            deadline: Deadline::UNBOUNDED,
         }
     }
 
@@ -2891,7 +2879,7 @@ mod tests {
         let (port, ops) = fake_service(vec![compose_like()], OnAction::Ok);
         let mut a11y = reader(port, std::time::Duration::ZERO);
         let mut ctx = ctx();
-        ctx.deadline = AxDeadline::from_millis(0);
+        ctx.deadline = Deadline::from_millis(0);
 
         let e = a11y
             .snapshot(&ctx)
@@ -3135,7 +3123,7 @@ mod tests {
             fake.calls()
         );
 
-        registry.shutdown();
+        registry.shutdown(Deadline::UNBOUNDED);
 
         // An empty list is a `delete`, and the global flag goes back to off rather than to "null".
         assert!(
@@ -3165,7 +3153,7 @@ mod tests {
         registry
             .ensure(fake.adb(), "/opt/glass/glass-a11y.apk")
             .expect("the service comes up");
-        registry.shutdown();
+        registry.shutdown(Deadline::UNBOUNDED);
 
         assert_eq!(
             enabled_list_written(&fake),
@@ -3174,7 +3162,7 @@ mod tests {
         );
 
         let after = fake.calls().len();
-        registry.shutdown();
+        registry.shutdown(Deadline::UNBOUNDED);
         assert_eq!(
             fake.calls().len(),
             after,
@@ -3265,7 +3253,7 @@ mod tests {
         let (port, _ops) = fake_service(vec![compose_like()], OnAction::Ok);
         let mut a = reader(port, std::time::Duration::ZERO);
         let mut bounded = ctx();
-        bounded.deadline = AxDeadline::from_millis(500);
+        bounded.deadline = Deadline::from_millis(500);
         a.snapshot(&bounded).expect("a bounded snapshot");
 
         let left = a

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -643,13 +643,28 @@ pub fn a11y_apk(get: &dyn Fn(&str) -> Option<String>) -> Option<String> {
     )
 }
 
-struct Active {
+pub(crate) struct Active {
     /// The client the service was enabled through, kept rather than resolved again at teardown:
     /// `Adb::from_env` reads the environment as it is *then*, which need not be what set this up.
     adb: Adb,
     port: u16,
     prior_enabled: String,
     prior_a11y_enabled: String,
+}
+
+// Unix-gated with its only consumer, the `FakeAdb`-backed teardown test — that fake is a
+// `/bin/sh` script.
+#[cfg(all(test, unix))]
+impl Active {
+    /// An enabled service to restore, for a test that needs a registry with work to do.
+    pub(crate) fn for_test(adb: Adb, port: u16) -> Self {
+        Self {
+            adb,
+            port,
+            prior_enabled: String::new(),
+            prior_a11y_enabled: "0".to_string(),
+        }
+    }
 }
 
 /// Owns the installed+enabled state so the shutdown hook can restore it. Cloneable (shared
@@ -716,11 +731,18 @@ impl A11yServiceRegistry {
         Ok(client)
     }
 
-    /// Restore the device's prior accessibility state and remove the forward. Best-effort,
-    /// idempotent. No process to kill (disabling unbinds the service).
-    /// Restore the device and remove the forward by `deadline`, which the rest of teardown shares
-    /// — stopping the app has already spent part of `glass_core::TEARDOWN_BUDGET` (glass#422).
-    /// [`Deadline::UNBOUNDED`] off that path, where each call keeps its own budget.
+    /// Plant an active service, for a test that needs a registry with something to restore.
+    #[cfg(all(test, unix))]
+    pub(crate) fn set_active_for_test(&self, active: Active) {
+        *self.state.lock().unwrap() = Some(active);
+    }
+
+    /// Restore the device's prior accessibility state and remove the forward by `deadline`, which
+    /// the rest of teardown shares — stopping the app has already spent part of
+    /// `glass_core::TEARDOWN_BUDGET` (glass#422). [`Deadline::UNBOUNDED`] off that path, where
+    /// each call keeps its own budget.
+    ///
+    /// Best-effort and idempotent. No process to kill: disabling unbinds the service.
     pub fn shutdown(&self, deadline: Deadline) {
         if let Ok(mut g) = self.state.lock()
             && let Some(a) = g.take()

--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -1,7 +1,7 @@
 use std::process::{Command, Output};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
-use glass_core::{BoundKind, GlassError, Result, run_bounded, run_bounded_until};
+use glass_core::{BoundKind, Deadline, GlassError, Result, run_bounded_until};
 
 /// What an adb invocation is doing, which is what decides how long it may take.
 ///
@@ -123,13 +123,13 @@ impl Adb {
     where
         I: IntoIterator<Item = &'a str>,
     {
-        self.run_until(args, None)
+        self.run_until(args, Deadline::UNBOUNDED)
     }
 
     /// [`Adb::run`] under a deadline the whole sequence shares, `None` for a call that answers to
     /// nothing but its own budget. The deadline bounds the run; it does not reserve time for the
     /// calls behind, which is `Glass::shutdown`'s job (glass#422).
-    pub fn run_until<'a, I>(&self, args: I, deadline: Option<Instant>) -> Result<String>
+    pub fn run_until<'a, I>(&self, args: I, deadline: Deadline) -> Result<String>
     where
         I: IntoIterator<Item = &'a str>,
     {
@@ -144,11 +144,11 @@ impl Adb {
     /// from the streams itself. The call gets its operation's budget or what is left of `deadline`,
     /// whichever is nearer, so the steps of one dump cannot together cost the sum of their
     /// budgets.
-    pub fn run_streams_until<'a, I>(&self, args: I, deadline: Instant) -> Result<(String, String)>
+    pub fn run_streams_until<'a, I>(&self, args: I, deadline: Deadline) -> Result<(String, String)>
     where
         I: IntoIterator<Item = &'a str>,
     {
-        let out = self.output(args, Some(deadline))?;
+        let out = self.output(args, deadline)?;
         Ok((
             String::from_utf8_lossy(&out.stdout).into_owned(),
             String::from_utf8_lossy(&out.stderr).into_owned(),
@@ -160,13 +160,13 @@ impl Adb {
     where
         I: IntoIterator<Item = &'a str>,
     {
-        Ok(self.output(args, None)?.stdout)
+        Ok(self.output(args, Deadline::UNBOUNDED)?.stdout)
     }
 
     /// Run adb and return the completed process, erroring on spawn failure or non-zero
     /// exit so every caller reports those two the same way. `deadline` is the outer bound of a
     /// multi-call sequence, where there is one.
-    fn output<'a, I>(&self, args: I, deadline: Option<Instant>) -> Result<Output>
+    fn output<'a, I>(&self, args: I, deadline: Deadline) -> Result<Output>
     where
         I: IntoIterator<Item = &'a str>,
     {
@@ -177,11 +177,8 @@ impl Adb {
         cmd.args(&argv);
         // A wedged adb server answers nothing at all, and the fix is one command — so the remedy
         // rides in the error the caller sees rather than in a log line nobody reads.
-        let out = match deadline {
-            Some(d) => run_bounded_until(&mut cmd, op.budget(), d, op.label()),
-            None => run_bounded(&mut cmd, op.budget(), op.label()),
-        }
-        .map_err(with_adb_hint)?;
+        let out = run_bounded_until(&mut cmd, op.budget(), deadline, op.label())
+            .map_err(with_adb_hint)?;
         if out.status.success() {
             Ok(out)
         } else {
@@ -225,7 +222,7 @@ pub(crate) fn a_real_timeout() -> GlassError {
     #[cfg(windows)]
     let (bin, args): (&str, &[&str]) = ("ping", &["-n", "31", "127.0.0.1"]);
 
-    let e = run_bounded(
+    let e = glass_core::run_bounded(
         Command::new(bin).args(args),
         Duration::from_millis(200),
         "adb:shell",
@@ -451,12 +448,12 @@ impl FakeAdb {
     }
 
     fn wait_until(&self, within: Duration, ready: impl Fn() -> bool) -> bool {
-        let deadline = Instant::now() + within;
+        let deadline = std::time::Instant::now() + within;
         loop {
             if ready() {
                 return true;
             }
-            if Instant::now() >= deadline {
+            if std::time::Instant::now() >= deadline {
                 return false;
             }
             std::thread::sleep(Duration::from_millis(10));
@@ -632,13 +629,15 @@ mod tests {
             bin: "/bin/sh".to_string(),
             serial: None,
         };
+        use glass_core::Deadline;
+
         let started = std::time::Instant::now();
         let err = adb
             .run_streams_until(
                 // `exec` so the bound kills the sleep itself; without it the shell is what dies
                 // and the sleep is orphaned for its full thirty seconds.
                 ["-c", "exec sleep 30"],
-                std::time::Instant::now() + Duration::from_millis(300),
+                Deadline::at(std::time::Instant::now() + Duration::from_millis(300)),
             )
             .expect_err("a step must not outlive the deadline it serves");
 

--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -126,9 +126,9 @@ impl Adb {
         self.run_until(args, Deadline::UNBOUNDED)
     }
 
-    /// [`Adb::run`] under a deadline the whole sequence shares, `None` for a call that answers to
-    /// nothing but its own budget. The deadline bounds the run; it does not reserve time for the
-    /// calls behind, which is `Glass::shutdown`'s job (glass#422).
+    /// [`Adb::run`] under a deadline the whole sequence shares, [`Deadline::UNBOUNDED`] for a call
+    /// that answers to nothing but its own budget. The deadline bounds the run; it does not
+    /// reserve time for the calls behind, which is `Glass::shutdown`'s job (glass#422).
     pub fn run_until<'a, I>(&self, args: I, deadline: Deadline) -> Result<String>
     where
         I: IntoIterator<Item = &'a str>,

--- a/crates/glass-android/src/agent.rs
+++ b/crates/glass-android/src/agent.rs
@@ -7,6 +7,7 @@ use std::process::{Child, Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use glass_core::Deadline;
 use glass_core::{GlassError, Result};
 use serde_json::{Value, json};
 
@@ -326,15 +327,12 @@ impl AgentRegistry {
     }
 
     /// Kill the device agent (via the host child) and remove the forward. Best-effort.
-    pub fn shutdown(&self) {
-        self.shutdown_until(None);
-    }
-
-    /// [`AgentRegistry::shutdown`] under a deadline the rest of teardown shares (glass#422).
+    /// Kill the agent and remove its forward by `deadline`, which the rest of teardown shares
+    /// (glass#422); [`Deadline::UNBOUNDED`] off that path.
     ///
     /// Only the forward removal is under it — dropping `p` then kills and reaps the agent with an
     /// unbounded `wait()`, the gap `AndroidPlatform::stop_app_until` names for logcat.
-    pub fn shutdown_until(&self, deadline: Option<std::time::Instant>) {
+    pub fn shutdown(&self, deadline: Deadline) {
         if let Ok(mut guard) = self.state.lock()
             && let Some(p) = guard.take()
         {
@@ -398,7 +396,7 @@ mod tests {
         });
 
         let started = Instant::now();
-        reg.shutdown_until(Some(Instant::now() + Duration::from_millis(300)));
+        reg.shutdown(Deadline::at(Instant::now() + Duration::from_millis(300)));
 
         assert!(
             started.elapsed() < Duration::from_secs(2),
@@ -610,7 +608,7 @@ mod tests {
         assert!(!child.is_empty(), "the launch should still be running");
         assert!(still_running(&child));
 
-        registry.shutdown();
+        registry.shutdown(Deadline::UNBOUNDED);
         assert!(fake.called("forward --remove"), "{:?}", fake.calls());
         assert!(
             !still_running(&child),

--- a/crates/glass-android/src/agent.rs
+++ b/crates/glass-android/src/agent.rs
@@ -326,12 +326,12 @@ impl AgentRegistry {
         Ok(port)
     }
 
-    /// Kill the device agent (via the host child) and remove the forward. Best-effort.
-    /// Kill the agent and remove its forward by `deadline`, which the rest of teardown shares
-    /// (glass#422); [`Deadline::UNBOUNDED`] off that path.
+    /// Kill the device agent (via the host child) and remove the forward by `deadline`, which the
+    /// rest of teardown shares (glass#422); [`Deadline::UNBOUNDED`] off that path. Best-effort.
     ///
-    /// Only the forward removal is under it — dropping `p` then kills and reaps the agent with an
-    /// unbounded `wait()`, the gap `AndroidPlatform::stop_app_until` names for logcat.
+    /// Only the forward removal is under the deadline — dropping `p` then kills and reaps the
+    /// agent with an unbounded `wait()`, the gap `AndroidPlatform::stop_app_until` names for
+    /// logcat.
     pub fn shutdown(&self, deadline: Deadline) {
         if let Ok(mut guard) = self.state.lock()
             && let Some(p) = guard.take()

--- a/crates/glass-android/src/avd.rs
+++ b/crates/glass-android/src/avd.rs
@@ -185,11 +185,12 @@ impl EmulatorRegistry {
         }
     }
 
-    /// Stop every registered emulator (`adb -s <serial> emu kill`) and clear the list.
-    /// Best-effort: a device already gone is fine.
-    /// Stop every registered emulator by `deadline` — the rest of teardown shares it. `adb emu kill`
-    /// was observed at 2ms — it acknowledges and lets the VM go down on its own time — so this is
-    /// the cheapest step in teardown and the worst one to skip (glass#422).
+    /// Stop every registered emulator (`adb -s <serial> emu kill`) by `deadline` and clear the
+    /// list. Best-effort: a device already gone is fine, and [`Deadline::UNBOUNDED`] off the
+    /// teardown path, where each call keeps its own budget.
+    ///
+    /// `adb emu kill` was observed at 2ms — it acknowledges and lets the VM go down on its own
+    /// time — so this is the cheapest step in teardown and the worst one to skip (glass#422).
     pub fn kill_all(&self, deadline: Deadline) {
         let clients = self
             .booted
@@ -289,7 +290,7 @@ pub fn boot_avd(base: &Adb, get: &dyn Fn(&str) -> Option<String>) -> Result<Stri
     }
 }
 
-/// Deadline for `emulator -list-avds`. It reads the AVD directory and prints names — a fast local
+/// Budget for `emulator -list-avds`. It reads the AVD directory and prints names — a fast local
 /// query — but a broken SDK can wedge the binary, and this runs first on the `glass_start` boot
 /// path, so an unbounded call here hangs a launch before anything else happens.
 pub(crate) const EMULATOR_LIST_BUDGET: Duration = Duration::from_secs(15);

--- a/crates/glass-android/src/avd.rs
+++ b/crates/glass-android/src/avd.rs
@@ -7,6 +7,7 @@ use std::process::Command;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use glass_core::Deadline;
 use glass_core::{GlassError, Result};
 
 use crate::adb::Adb;
@@ -186,14 +187,10 @@ impl EmulatorRegistry {
 
     /// Stop every registered emulator (`adb -s <serial> emu kill`) and clear the list.
     /// Best-effort: a device already gone is fine.
-    pub fn kill_all(&self) {
-        self.kill_all_until(None);
-    }
-
-    /// [`EmulatorRegistry::kill_all`] under a deadline the rest of teardown shares. `adb emu kill`
+    /// Stop every registered emulator by `deadline` — the rest of teardown shares it. `adb emu kill`
     /// was observed at 2ms — it acknowledges and lets the VM go down on its own time — so this is
     /// the cheapest step in teardown and the worst one to skip (glass#422).
-    pub fn kill_all_until(&self, deadline: Option<std::time::Instant>) {
+    pub fn kill_all(&self, deadline: Deadline) {
         let clients = self
             .booted
             .lock()
@@ -421,7 +418,7 @@ mod tests {
         reg.register(fake.adb(), "emulator-5554".into());
 
         let started = Instant::now();
-        reg.kill_all_until(Some(Instant::now() + Duration::from_millis(300)));
+        reg.kill_all(Deadline::at(Instant::now() + Duration::from_millis(300)));
 
         assert!(
             started.elapsed() < Duration::from_secs(2),
@@ -547,7 +544,7 @@ mod tests {
         registry.register(fake.adb(), "emulator-5554".into());
         registry.register(fake.adb(), "emulator-5556".into());
 
-        registry.kill_all();
+        registry.kill_all(Deadline::UNBOUNDED);
 
         assert_eq!(
             fake.calls(),
@@ -555,7 +552,7 @@ mod tests {
         );
         // Cleared, so a second shutdown does not kill a device someone has since started.
         assert!(registry.serials().is_empty());
-        registry.kill_all();
+        registry.kill_all(Deadline::UNBOUNDED);
         assert_eq!(fake.calls().len(), 2);
     }
 

--- a/crates/glass-android/src/doctor.rs
+++ b/crates/glass-android/src/doctor.rs
@@ -4,6 +4,7 @@
 //! Pure `build_checks(&Probe)` over observed state, plus a thin subprocess `probe`.
 //! Reports `Check` statuses; never errors.
 
+use glass_core::Deadline;
 use glass_core::{Check, CheckStatus};
 
 use crate::a11y::{Attempt, adb_runner, attempt_deadline, dump_once};
@@ -145,7 +146,7 @@ fn probe_with(
                 .ensure(&adb.with_serial(serial.clone()), get)
                 .map(|_| ())
                 .map_err(|e| e.to_string());
-            reg.shutdown();
+            reg.shutdown(Deadline::UNBOUNDED);
             Some(r)
         }
         _ => None,
@@ -169,7 +170,7 @@ fn probe_with(
                 .ensure(&adb.with_serial(serial.clone()), apk)
                 .map(|_| ())
                 .map_err(|e| e.to_string());
-            reg.shutdown();
+            reg.shutdown(Deadline::UNBOUNDED);
             Some(r)
         }
         _ => None,

--- a/crates/glass-android/src/lib.rs
+++ b/crates/glass-android/src/lib.rs
@@ -172,6 +172,34 @@ mod teardown_tests {
     use glass_core::Deadline;
     use std::time::{Duration, Instant};
 
+    /// A device that answers gets all three asked, in the order the deadline makes load-bearing.
+    ///
+    /// The wedged case below can only ever see the first, so without this the a11y restore — and
+    /// the seam that plants something for it to restore — could do nothing and stay green.
+    #[test]
+    fn a_device_that_answers_is_asked_for_all_three_in_order() {
+        let fake = FakeAdb::new(&[("*", Answer::Silent)]);
+        let a11y = A11yServiceRegistry::new();
+        a11y.set_active_for_test(Active::for_test(fake.adb().clone(), 1234));
+        let agents = AgentRegistry::new();
+        let emulators = EmulatorRegistry::new();
+        emulators.register(fake.adb(), "emulator-5554".into());
+
+        hand_the_device_back(&a11y, &agents, &emulators, Deadline::UNBOUNDED);
+
+        let calls = fake.calls();
+        assert_eq!(
+            calls,
+            vec![
+                "-s emulator-5554 emu kill",
+                "shell settings delete secure enabled_accessibility_services",
+                "shell settings put secure accessibility_enabled 0",
+                "forward --remove tcp:1234",
+            ],
+            "all three registries, emulator first"
+        );
+    }
+
     /// The join glass-mcp's shutdown hook makes. Each registry has its own wedged-device test;
     /// this one is about the deadline reaching all three, which nothing else can see — before the
     /// `shutdown`/`shutdown_until` pairs collapsed, dropping it meant calling a differently-named

--- a/crates/glass-android/src/lib.rs
+++ b/crates/glass-android/src/lib.rs
@@ -87,6 +87,29 @@ pub(crate) fn unsupported_window_move_resize() -> glass_core::GlassError {
     )
 }
 
+/// Give the device back what glass took: the accessibility companion it enabled, the `adb forward`
+/// it opened, the emulator it booted — all by `deadline`.
+///
+/// `Glass::shutdown` keeps `TEARDOWN_HOOK_RESERVE` back from the sessions so these have time
+/// (glass#422). Between themselves it is first-come-first-served, which makes the order
+/// load-bearing: the emulator goes first, being both the cheapest step (`adb emu kill` measured at
+/// 2ms) and the largest leak. Put it last and a wedged device spends the whole deadline on the
+/// settings restore, leaving a ~2GB VM that was never asked to stop.
+///
+/// One function rather than three calls in glass-mcp's hook, so a test can watch the deadline
+/// reach all three — collapsing each registry's `shutdown`/`shutdown_until` pair made losing it a
+/// one-token edit.
+pub fn hand_the_device_back(
+    a11y: &A11yServiceRegistry,
+    agents: &AgentRegistry,
+    emulators: &EmulatorRegistry,
+    deadline: glass_core::Deadline,
+) {
+    emulators.kill_all(deadline);
+    a11y.shutdown(deadline);
+    agents.shutdown(deadline);
+}
+
 #[cfg(test)]
 mod capability_tests {
     use super::*;
@@ -137,5 +160,51 @@ mod capability_tests {
         assert!(msg.contains("android backend"), "{msg}");
         assert!(msg.contains("full-screen"), "{msg}");
         assert!(msg.contains("glass_capabilities"), "{msg}");
+    }
+}
+
+#[cfg(test)]
+#[cfg(unix)]
+mod teardown_tests {
+    use super::*;
+    use crate::a11y_service::Active;
+    use crate::adb::{Answer, FakeAdb};
+    use glass_core::Deadline;
+    use std::time::{Duration, Instant};
+
+    /// The join glass-mcp's shutdown hook makes. Each registry has its own wedged-device test;
+    /// this one is about the deadline reaching all three, which nothing else can see — before the
+    /// `shutdown`/`shutdown_until` pairs collapsed, dropping it meant calling a differently-named
+    /// method (glass#422).
+    #[test]
+    fn a_device_that_stopped_answering_cannot_spend_more_than_the_deadline_on_all_three() {
+        let fake = FakeAdb::new(&[("*", Answer::Lingers)]);
+        let a11y = A11yServiceRegistry::new();
+        a11y.set_active_for_test(Active::for_test(fake.adb().clone(), 1234));
+        let agents = AgentRegistry::new();
+        let emulators = EmulatorRegistry::new();
+        emulators.register(fake.adb(), "emulator-5554".into());
+
+        let started = Instant::now();
+        hand_the_device_back(
+            &a11y,
+            &agents,
+            &emulators,
+            Deadline::at(Instant::now() + Duration::from_millis(300)),
+        );
+
+        assert!(
+            started.elapsed() < Duration::from_secs(3),
+            "waited {:?} handing the device back — one of the three is running unbounded, and \
+             three AdbOp::Shell budgets is 30s against a 3s teardown",
+            started.elapsed()
+        );
+        // The emulator is asked first, so a wedged device cannot leave a VM running that was
+        // never even asked to stop. The two behind it are starved, which is the trade.
+        assert!(
+            fake.called("emu kill"),
+            "the largest leak must be asked about before the deadline can be spent: {:?}",
+            fake.calls()
+        );
     }
 }

--- a/crates/glass-android/src/platform.rs
+++ b/crates/glass-android/src/platform.rs
@@ -273,10 +273,6 @@ impl Platform for AndroidPlatform {
         Ok(window)
     }
 
-    fn stop_app(&mut self) -> Result<()> {
-        self.stop_app_until(Deadline::UNBOUNDED)
-    }
-
     /// Force-stop measures 101ms median, 267ms worst on an emulator with every core saturated,
     /// against the 3s all of teardown gets — so the deadline is not expected to bind. It is for
     /// the device that stopped answering, which would otherwise run out the 10s `AdbOp::Shell`

--- a/crates/glass-android/src/platform.rs
+++ b/crates/glass-android/src/platform.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use glass_core::Deadline;
 use glass_core::Platform;
 use glass_core::{
     AppSpec, Frame, GlassError, KeyEvent, PointerEvent, Region, Result, Stream, WindowGeometry,
@@ -49,7 +50,7 @@ impl AndroidPlatform {
     ///
     /// The logcat reap comes first and is unbounded, measured at 0-1ms — a kill and reap of a
     /// direct child, which only uninterruptible sleep can hold up.
-    fn stop_app_until(&mut self, deadline: Option<Instant>) -> Result<()> {
+    fn stop_app_until(&mut self, deadline: Deadline) -> Result<()> {
         if let Some(mut app) = self.app.take() {
             if let Some(mut logcat) = app.logcat.take() {
                 logcat.stop();
@@ -273,15 +274,15 @@ impl Platform for AndroidPlatform {
     }
 
     fn stop_app(&mut self) -> Result<()> {
-        self.stop_app_until(None)
+        self.stop_app_until(Deadline::UNBOUNDED)
     }
 
     /// Force-stop measures 101ms median, 267ms worst on an emulator with every core saturated,
     /// against the 3s all of teardown gets — so the deadline is not expected to bind. It is for
     /// the device that stopped answering, which would otherwise run out the 10s `AdbOp::Shell`
     /// budget and leave the hook nothing (glass#422).
-    fn stop_app_by(&mut self, deadline: Instant) -> Result<()> {
-        self.stop_app_until(Some(deadline))
+    fn stop_app_by(&mut self, deadline: Deadline) -> Result<()> {
+        self.stop_app_until(deadline)
     }
 
     fn capture_frame(&mut self, region: Option<&Region>) -> Result<Frame> {
@@ -681,7 +682,7 @@ mod platform_tests {
 
         let started_at = Instant::now();
         platform
-            .stop_app_by(Instant::now() + Duration::from_millis(300))
+            .stop_app_by(Deadline::at(Instant::now() + Duration::from_millis(300)))
             .expect("teardown is best-effort and reports success either way");
         let waited = started_at.elapsed();
 

--- a/crates/glass-android/tests/a11y_loop.rs
+++ b/crates/glass-android/tests/a11y_loop.rs
@@ -12,9 +12,8 @@
 //! says which app it describes; and that a test which fails mid-interaction still hands the
 //! device back launchable.
 
-use glass_core::accessibility::{
-    Accessibility, AxContext, AxDeadline, AxNode, AxTarget, AxTree, WalkLimits,
-};
+use glass_core::Deadline;
+use glass_core::accessibility::{Accessibility, AxContext, AxNode, AxTarget, AxTree, WalkLimits};
 use glass_core::{
     AppSpec, GlassError, MouseButton, Platform, PointerEvent, SandboxLevel, WindowGeometry,
 };
@@ -86,7 +85,7 @@ impl Session {
             window_handle: None,
             a11y_bus_addr: None,
             limits: WalkLimits::DEFAULT,
-            deadline: AxDeadline::UNBOUNDED,
+            deadline: Deadline::UNBOUNDED,
         }
     }
 
@@ -125,9 +124,9 @@ impl Drop for Session {
         if let Some(mut platform) = self.platform.take() {
             let _ = platform.stop_app();
         }
-        self.agents.shutdown();
+        self.agents.shutdown(Deadline::UNBOUNDED);
         if let Some(registry) = &self.a11y_service {
-            registry.shutdown();
+            registry.shutdown(Deadline::UNBOUNDED);
         }
     }
 }
@@ -173,7 +172,7 @@ fn a_read_stops_at_the_deadline_its_caller_named() {
         .expect("the first snapshot warms the reader");
 
     let mut hurried = session.ctx();
-    hurried.deadline = AxDeadline::from_millis(50);
+    hurried.deadline = Deadline::from_millis(50);
     let started = std::time::Instant::now();
     let e = a11y
         .snapshot(&hurried)

--- a/crates/glass-android/tests/a11y_service_loop.rs
+++ b/crates/glass-android/tests/a11y_service_loop.rs
@@ -10,9 +10,8 @@ use std::sync::Mutex;
 use glass_android::{
     A11yServiceRegistry, AgentRegistry, AndroidPlatform, EmulatorRegistry, ServiceA11y,
 };
-use glass_core::accessibility::{
-    Accessibility, AxContext, AxDeadline, AxNode, AxTarget, WalkLimits,
-};
+use glass_core::Deadline;
+use glass_core::accessibility::{Accessibility, AxContext, AxNode, AxTarget, WalkLimits};
 use glass_core::{AppSpec, Platform, SandboxLevel, WindowGeometry};
 
 mod common;
@@ -61,7 +60,7 @@ fn a11y_service_snapshot_and_actions() {
         window_handle: None,
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
-        deadline: AxDeadline::UNBOUNDED,
+        deadline: Deadline::UNBOUNDED,
     };
 
     let mut tree = a11y.snapshot(&ctx).expect("snapshot");
@@ -145,7 +144,7 @@ fn native_invoke_actuates_the_fixture() {
         window_handle: None,
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
-        deadline: AxDeadline::UNBOUNDED,
+        deadline: Deadline::UNBOUNDED,
     };
 
     fn by_desc<'a>(n: &'a AxNode, desc: &str) -> Option<&'a AxNode> {

--- a/crates/glass-android/tests/common/mod.rs
+++ b/crates/glass-android/tests/common/mod.rs
@@ -13,6 +13,7 @@
 #![allow(dead_code)]
 
 use glass_android::{A11yServiceRegistry, AgentRegistry, EmulatorRegistry};
+use glass_core::Deadline;
 
 /// Kills the launched agent and removes its `adb forward` when it drops.
 pub struct StopAgent<'a>(pub &'a AgentRegistry);
@@ -21,7 +22,7 @@ impl Drop for StopAgent<'_> {
     fn drop(&mut self) {
         // Reached while a panic unwinds, where a second panic aborts the process — nothing here
         // may assert.
-        self.0.shutdown();
+        self.0.shutdown(Deadline::UNBOUNDED);
     }
 }
 
@@ -35,7 +36,7 @@ pub struct RestoreServiceState<'a>(pub &'a A11yServiceRegistry);
 
 impl Drop for RestoreServiceState<'_> {
     fn drop(&mut self) {
-        self.0.shutdown();
+        self.0.shutdown(Deadline::UNBOUNDED);
     }
 }
 
@@ -57,6 +58,6 @@ pub struct KillBootedEmulators<'a>(pub &'a EmulatorRegistry);
 
 impl Drop for KillBootedEmulators<'_> {
     fn drop(&mut self) {
-        self.0.kill_all();
+        self.0.kill_all(Deadline::UNBOUNDED);
     }
 }

--- a/crates/glass-android/tests/managed_avd.rs
+++ b/crates/glass-android/tests/managed_avd.rs
@@ -6,6 +6,7 @@
 //! Asserts: boot when none online; reuse on a second resolve (no 2nd boot); cleanup kills it.
 
 use glass_android::EmulatorRegistry;
+use glass_core::Deadline;
 use std::process::Command;
 use std::time::{Duration, Instant};
 
@@ -110,9 +111,9 @@ fn boots_reuses_and_cleans_up() {
     drop(_p2);
     // Explicit, and before `kill_all`, because this test goes on to assert the emulator went
     // offline: the guards above only repeat this on the panicking path.
-    agents1.shutdown();
-    agents2.shutdown();
-    registry.kill_all();
+    agents1.shutdown(Deadline::UNBOUNDED);
+    agents2.shutdown(Deadline::UNBOUNDED);
+    registry.kill_all(Deadline::UNBOUNDED);
     let w = await_offline();
     assert!(
         w.confirmed,

--- a/crates/glass-android/tests/role_probe.rs
+++ b/crates/glass-android/tests/role_probe.rs
@@ -36,7 +36,8 @@ use std::time::Duration;
 use glass_android::{
     A11yServiceRegistry, AgentRegistry, AndroidA11y, AndroidPlatform, EmulatorRegistry, ServiceA11y,
 };
-use glass_core::accessibility::{Accessibility, AxContext, AxDeadline, WalkLimits};
+use glass_core::Deadline;
+use glass_core::accessibility::{Accessibility, AxContext, WalkLimits};
 use glass_core::{
     AppSpec, AxRole, AxTree, DescriptionSourcing, Platform, SandboxLevel,
     description_census_report, role_histogram,
@@ -248,7 +249,7 @@ fn uiautomator_role_histogram_probe() {
             window_handle: None,
             a11y_bus_addr: None,
             limits: uncapped(),
-            deadline: AxDeadline::UNBOUNDED,
+            deadline: Deadline::UNBOUNDED,
         };
         let mut a11y = AndroidA11y::new();
         let mut tree = a11y
@@ -329,7 +330,7 @@ fn service_role_histogram_probe() {
             window_handle: None,
             a11y_bus_addr: None,
             limits: uncapped(),
-            deadline: AxDeadline::UNBOUNDED,
+            deadline: Deadline::UNBOUNDED,
         };
         let mut tree = a11y
             .snapshot(&ctx)

--- a/crates/glass-core/src/a11y_thread.rs
+++ b/crates/glass-core/src/a11y_thread.rs
@@ -16,7 +16,7 @@
 use std::sync::mpsc::{self, RecvTimeoutError};
 use std::time::{Duration, Instant};
 
-use crate::accessibility::AxDeadline;
+use crate::deadline::Deadline;
 use crate::{GlassError, Result};
 
 /// Which bound ended a wait. Decided before the wait, never inferred from its outcome — the
@@ -85,7 +85,7 @@ impl A11yThread {
     /// Both come from one comparison, made before the wait: a call the *caller* cut short is a
     /// spent budget and one that used the whole ceiling is a backend that stopped answering, and
     /// inferring which afterwards is the mistake glass#341 recorded.
-    fn bounded_wait(&self, deadline: AxDeadline) -> (Duration, EndedBy) {
+    fn bounded_wait(&self, deadline: Deadline) -> (Duration, EndedBy) {
         let own = Instant::now() + self.ceiling;
         let ended_by = if deadline.governs(own) {
             EndedBy::Caller
@@ -104,7 +104,7 @@ impl A11yThread {
     /// waiting holds the backend's connection while producing an answer nobody reads.
     pub fn snapshot<T: Send + 'static>(
         &self,
-        deadline: AxDeadline,
+        deadline: Deadline,
         job: impl FnOnce() -> Result<T> + Send + 'static,
     ) -> Result<T> {
         if deadline.has_passed() {
@@ -117,7 +117,7 @@ impl A11yThread {
     /// Write a value, bounded by the ceiling alone.
     ///
     /// No deadline: the seam places the capping obligation on `snapshot`, and the session builds
-    /// both this context and `invoke`'s with [`AxDeadline::UNBOUNDED`], so there is none to honour.
+    /// both this context and `invoke`'s with [`Deadline::UNBOUNDED`], so there is none to honour.
     pub fn set_value(&self, job: impl FnOnce() -> Result<()> + Send + 'static) -> Result<()> {
         self.detached(Op::SetValue, self.ceiling, job, EndedBy::Ceiling)
     }
@@ -229,7 +229,7 @@ mod tests {
     /// detached, so nothing outside it can shorten one that has started.
     #[test]
     fn a_read_is_bounded_by_the_caller_when_that_falls_first() {
-        let (wait, ended_by) = reader().bounded_wait(AxDeadline::from_millis(50));
+        let (wait, ended_by) = reader().bounded_wait(Deadline::from_millis(50));
         assert!(wait <= Duration::from_millis(50), "{wait:?}");
         assert_eq!(ended_by, EndedBy::Caller);
     }
@@ -237,7 +237,7 @@ mod tests {
     /// The other direction: without it the test above passes on a reader that waits for nothing.
     #[test]
     fn a_caller_that_names_no_deadline_leaves_the_read_its_own_ceiling() {
-        let (wait, ended_by) = reader().bounded_wait(AxDeadline::UNBOUNDED);
+        let (wait, ended_by) = reader().bounded_wait(Deadline::UNBOUNDED);
         assert!(wait > CEILING - Duration::from_secs(1), "{wait:?}");
         assert_eq!(ended_by, EndedBy::Ceiling);
     }
@@ -270,7 +270,7 @@ mod tests {
         // a quiet window, which would be a race: refusing drops `job` unrun and its `Sender` with
         // it, where a worker that ran would have sent. No load can turn one into the other.
         let (started, ran) = mpsc::channel();
-        let r: Result<()> = reader().snapshot(AxDeadline::from_millis(0), move || {
+        let r: Result<()> = reader().snapshot(Deadline::from_millis(0), move || {
             let _ = started.send(());
             Ok(())
         });
@@ -287,10 +287,7 @@ mod tests {
 
     #[test]
     fn an_answer_within_the_bound_is_returned() {
-        assert_eq!(
-            reader().snapshot(AxDeadline::UNBOUNDED, || Ok(7)).unwrap(),
-            7
-        );
+        assert_eq!(reader().snapshot(Deadline::UNBOUNDED, || Ok(7)).unwrap(), 7);
     }
 
     #[test]
@@ -327,7 +324,7 @@ mod tests {
     #[test]
     fn a_read_that_timed_out_claims_nothing_about_landing() {
         let e = impatient()
-            .snapshot(AxDeadline::UNBOUNDED, hangs())
+            .snapshot(Deadline::UNBOUNDED, hangs())
             .unwrap_err();
         assert!(e.to_string().contains("snapshot timed out"), "{e}");
         assert!(!e.to_string().contains("may still land"), "{e}");
@@ -338,7 +335,7 @@ mod tests {
     #[test]
     fn a_read_the_caller_ran_out_of_time_for_blames_the_caller_not_the_backend() {
         // A live deadline well inside the ceiling, against a job that will not answer within it.
-        let r: Result<()> = reader().snapshot(AxDeadline::from_millis(30), hangs());
+        let r: Result<()> = reader().snapshot(Deadline::from_millis(30), hangs());
         assert!(
             matches!(r, Err(GlassError::AccessibilityNotReady(_))),
             "{r:?}"
@@ -348,7 +345,7 @@ mod tests {
     #[test]
     fn a_read_that_outruns_the_ceiling_blames_the_backend_not_the_caller() {
         let e = impatient()
-            .snapshot(AxDeadline::UNBOUNDED, hangs())
+            .snapshot(Deadline::UNBOUNDED, hangs())
             .unwrap_err();
         assert!(
             matches!(e, GlassError::AccessibilityUnavailable(_)),
@@ -371,7 +368,7 @@ mod tests {
     #[test]
     fn a_panicking_read_is_never_the_variant_a_wait_polls_through() {
         let e = reader()
-            .snapshot(AxDeadline::from_millis(60_000), || -> Result<()> {
+            .snapshot(Deadline::from_millis(60_000), || -> Result<()> {
                 panic!("the backend crate unwound")
             })
             .unwrap_err();

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -6,6 +6,7 @@
 //! `glass-a11y-linux`) map their native roles/states into the normalized types
 //! here; no OS/AT-SPI/D-Bus types appear in this module.
 
+use crate::deadline::Deadline;
 use crate::error::{GlassError, Result};
 use crate::platform::{Segment, WindowGeometry};
 
@@ -777,67 +778,7 @@ pub struct AxContext {
     /// tree with the same bounds (ids stay resolvable).
     pub limits: WalkLimits,
     /// The time bound for this call, as [`Self::limits`] is its size bound.
-    pub deadline: AxDeadline,
-}
-
-/// When the caller stops waiting for the accessibility call this context belongs to.
-///
-/// A reader cannot be interrupted mid-read — [`crate::Glass::wait_for_element`] re-reads from a
-/// synchronous tick — so a 20s `uiautomator dump` answered a 10s wait until readers took this
-/// (glass#338). The obligation is stated on [`Accessibility::snapshot`], where an implementer
-/// meets it.
-///
-/// [`Self::UNBOUNDED`] leaves the reader its own budget: it is the *widest* value, as `WalkLimits`'
-/// unbounded is, and not a deadline of zero.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[must_use]
-pub struct AxDeadline(Option<std::time::Instant>);
-
-impl AxDeadline {
-    /// The caller named no instant to stop at.
-    pub const UNBOUNDED: Self = Self(None);
-
-    /// Stop `ms` milliseconds from now.
-    pub fn from_millis(ms: u64) -> Self {
-        Self::at(std::time::Instant::now() + std::time::Duration::from_millis(ms))
-    }
-
-    /// Stop at `instant` — for a caller that already holds the moment it stops waiting, and for a
-    /// test that needs the same instant on both sides of a comparison.
-    pub const fn at(instant: std::time::Instant) -> Self {
-        Self(Some(instant))
-    }
-
-    /// `proposed`, or this deadline when it falls first — the bound one step of a call runs under.
-    pub fn cap(self, proposed: std::time::Instant) -> std::time::Instant {
-        match self.0 {
-            Some(d) => proposed.min(d),
-            None => proposed,
-        }
-    }
-
-    /// Whether this deadline falls before `proposed`, so a step that runs out was cut off rather
-    /// than unanswered.
-    ///
-    /// A tie is deliberately not this deadline: reporting a backend that hung for its whole
-    /// ceiling as a spent caller budget hides it.
-    pub fn governs(self, proposed: std::time::Instant) -> bool {
-        self.0.is_some_and(|d| d < proposed)
-    }
-
-    /// How long is left, or `None` when the caller named no instant. Zero once it has passed.
-    pub fn remaining(self) -> Option<std::time::Duration> {
-        self.0
-            .map(|d| d.saturating_duration_since(std::time::Instant::now()))
-    }
-
-    /// Whether the caller named an instant that has passed — work started now cannot be wanted.
-    ///
-    /// `false` for [`Self::UNBOUNDED`] — this asks whether the caller has gone, not whether
-    /// budget remains, and a reader reading it as the latter would retry an untimed call forever.
-    pub fn has_passed(self) -> bool {
-        self.remaining().is_some_and(|left| left.is_zero())
-    }
+    pub deadline: Deadline,
 }
 
 /// A fingerprint identifying the element a value-set targets: its synthetic id
@@ -1373,7 +1314,7 @@ mod tests {
     /// first, in both directions.
     #[test]
     fn a_deadline_caps_a_proposed_instant_only_when_it_falls_first() {
-        let soon = AxDeadline::from_millis(1_000);
+        let soon = Deadline::from_millis(1_000);
         let later = std::time::Instant::now() + std::time::Duration::from_secs(60);
         assert!(soon.cap(later) < later, "the nearer bound did not govern");
 
@@ -1385,14 +1326,14 @@ mod tests {
         );
     }
 
-    /// A caller that named no instant leaves the reader whatever it proposed — [`AxDeadline::UNBOUNDED`]
+    /// A caller that named no instant leaves the reader whatever it proposed — [`Deadline::UNBOUNDED`]
     /// is not a deadline of zero, which would stop every read before it started.
     #[test]
     fn no_deadline_caps_nothing_and_is_never_spent() {
         let proposed = std::time::Instant::now() + std::time::Duration::from_secs(60);
-        assert_eq!(AxDeadline::UNBOUNDED.cap(proposed), proposed);
-        assert_eq!(AxDeadline::UNBOUNDED.remaining(), None);
-        assert!(!AxDeadline::UNBOUNDED.has_passed());
+        assert_eq!(Deadline::UNBOUNDED.cap(proposed), proposed);
+        assert_eq!(Deadline::UNBOUNDED.remaining(), None);
+        assert!(!Deadline::UNBOUNDED.has_passed());
     }
 
     /// The tie-break is load-bearing: a reader blames its own bound when both fall together, so a
@@ -1400,19 +1341,19 @@ mod tests {
     #[test]
     fn a_deadline_governs_a_step_only_when_it_falls_strictly_first() {
         let now = std::time::Instant::now();
-        let soon = AxDeadline::from_millis(1_000);
+        let soon = Deadline::from_millis(1_000);
         assert!(soon.governs(now + std::time::Duration::from_secs(60)));
         assert!(!soon.governs(now));
-        assert!(!AxDeadline::UNBOUNDED.governs(now + std::time::Duration::from_secs(60)));
+        assert!(!Deadline::UNBOUNDED.governs(now + std::time::Duration::from_secs(60)));
         // The tie itself, which only a shared instant can express: `<=` here would blame the
         // caller for a backend that hung for exactly its own ceiling.
-        assert!(!AxDeadline::at(now).governs(now));
+        assert!(!Deadline::at(now).governs(now));
     }
 
     #[test]
     fn a_deadline_has_passed_once_its_instant_has_passed() {
-        assert!(AxDeadline::from_millis(0).has_passed());
-        assert!(!AxDeadline::from_millis(60_000).has_passed());
+        assert!(Deadline::from_millis(0).has_passed());
+        assert!(!Deadline::from_millis(60_000).has_passed());
     }
 
     /// Compile-time guard for [`AxRole::ALL`] — never called, and exists only for its exhaustive
@@ -1521,7 +1462,7 @@ mod tests {
             window_handle: None,
             a11y_bus_addr: None,
             limits: WalkLimits::DEFAULT,
-            deadline: AxDeadline::UNBOUNDED,
+            deadline: Deadline::UNBOUNDED,
         };
         let err = Bare
             .set_value(&ctx, &target, "x")
@@ -3239,7 +3180,7 @@ mod tests {
             window_handle: None,
             a11y_bus_addr: None,
             limits: WalkLimits::DEFAULT,
-            deadline: AxDeadline::UNBOUNDED,
+            deadline: Deadline::UNBOUNDED,
         };
         let target = AxTarget {
             id: AxNodeId(1),

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -1310,52 +1310,6 @@ pub fn element_match<'a>(
 mod tests {
     use super::*;
 
-    /// The two bounds a reader holds — its own and its caller's — resolve to whichever falls
-    /// first, in both directions.
-    #[test]
-    fn a_deadline_caps_a_proposed_instant_only_when_it_falls_first() {
-        let soon = Deadline::from_millis(1_000);
-        let later = std::time::Instant::now() + std::time::Duration::from_secs(60);
-        assert!(soon.cap(later) < later, "the nearer bound did not govern");
-
-        let now = std::time::Instant::now();
-        assert_eq!(
-            soon.cap(now),
-            now,
-            "a reader's own nearer bound was widened"
-        );
-    }
-
-    /// A caller that named no instant leaves the reader whatever it proposed — [`Deadline::UNBOUNDED`]
-    /// is not a deadline of zero, which would stop every read before it started.
-    #[test]
-    fn no_deadline_caps_nothing_and_is_never_spent() {
-        let proposed = std::time::Instant::now() + std::time::Duration::from_secs(60);
-        assert_eq!(Deadline::UNBOUNDED.cap(proposed), proposed);
-        assert_eq!(Deadline::UNBOUNDED.remaining(), None);
-        assert!(!Deadline::UNBOUNDED.has_passed());
-    }
-
-    /// The tie-break is load-bearing: a reader blames its own bound when both fall together, so a
-    /// backend that hung for its whole ceiling is never reported as a caller who ran out of time.
-    #[test]
-    fn a_deadline_governs_a_step_only_when_it_falls_strictly_first() {
-        let now = std::time::Instant::now();
-        let soon = Deadline::from_millis(1_000);
-        assert!(soon.governs(now + std::time::Duration::from_secs(60)));
-        assert!(!soon.governs(now));
-        assert!(!Deadline::UNBOUNDED.governs(now + std::time::Duration::from_secs(60)));
-        // The tie itself, which only a shared instant can express: `<=` here would blame the
-        // caller for a backend that hung for exactly its own ceiling.
-        assert!(!Deadline::at(now).governs(now));
-    }
-
-    #[test]
-    fn a_deadline_has_passed_once_its_instant_has_passed() {
-        assert!(Deadline::from_millis(0).has_passed());
-        assert!(!Deadline::from_millis(60_000).has_passed());
-    }
-
     /// Compile-time guard for [`AxRole::ALL`] — never called, and exists only for its exhaustive
     /// match. The role-parity tests and [`crate::role_support::ROLE_SUPPORT`] quantify their
     /// completeness claims over `ALL`, so a new variant missing from it would silently weaken

--- a/crates/glass-core/src/bounded.rs
+++ b/crates/glass-core/src/bounded.rs
@@ -13,6 +13,7 @@ use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
+use crate::deadline::Deadline;
 use crate::{BoundKind, GlassError, Result};
 
 /// The phrase a timeout error carries, for a reader of the message. What a *caller* keys on is
@@ -59,7 +60,7 @@ const MAX_CAPTURE: usize = 64 * 1024 * 1024;
 /// Both pipes are drained on their own threads: a child that fills a pipe buffer while the parent
 /// waits blocks in `write` and never exits, putting the deadline itself out of reach.
 pub fn run_bounded(cmd: &mut Command, budget: Duration, op: &str) -> Result<Output> {
-    run_bounded_inner(cmd, budget, op, None)
+    run_bounded_until(cmd, budget, Deadline::UNBOUNDED, op)
 }
 
 /// [`run_bounded`], but waiting no later than `deadline` — the bound of the larger call this one
@@ -72,10 +73,10 @@ pub fn run_bounded(cmd: &mut Command, budget: Duration, op: &str) -> Result<Outp
 pub fn run_bounded_until(
     cmd: &mut Command,
     budget: Duration,
-    deadline: Instant,
+    deadline: Deadline,
     op: &str,
 ) -> Result<Output> {
-    let budget = budget_within(budget, deadline, Instant::now());
+    let budget = deadline.within(budget, Instant::now());
     if budget.is_zero() {
         return Err(GlassError::Bounded {
             kind: BoundKind::NotStarted,
@@ -334,12 +335,6 @@ fn next_wait(previous: Duration) -> Duration {
 /// Whether appending `n` more bytes to a buffer of `len` would pass [`MAX_CAPTURE`].
 fn would_exceed_capture(len: usize, n: usize) -> bool {
     len + n > MAX_CAPTURE
-}
-
-/// The budget a call actually gets: its own, or what is left of the deadline it serves, whichever
-/// is nearer. Its own function so the rule is pinned by a test, which a timing test cannot do.
-fn budget_within(budget: Duration, deadline: Instant, now: Instant) -> Duration {
-    budget.min(deadline.saturating_duration_since(now))
 }
 
 /// Whether `deadline` has arrived. Its own function so the boundary — a deadline exactly reached
@@ -773,29 +768,6 @@ mod tests {
     }
 
     #[test]
-    fn a_call_gets_the_nearer_of_its_own_budget_and_the_deadline_it_serves() {
-        // The rule the deadline-taking runner exists for, pinned where no timing test can reach it.
-        let now = Instant::now();
-        assert_eq!(
-            budget_within(Duration::from_secs(20), now + Duration::from_secs(5), now),
-            Duration::from_secs(5)
-        );
-        assert_eq!(
-            budget_within(Duration::from_secs(3), now + Duration::from_secs(5), now),
-            Duration::from_secs(3)
-        );
-        assert_eq!(
-            budget_within(Duration::from_secs(20), now, now),
-            Duration::ZERO
-        );
-        let past = now.checked_sub(Duration::from_secs(1)).unwrap_or(now);
-        assert_eq!(
-            budget_within(Duration::from_secs(20), past, now),
-            Duration::ZERO
-        );
-    }
-
-    #[test]
     #[cfg(unix)]
     fn a_call_dies_at_the_deadline_it_serves_rather_than_at_its_own_budget() {
         // A step of a longer sequence gets what is left of the sequence's deadline, not the sum of
@@ -804,7 +776,7 @@ mod tests {
         let err = run_bounded_until(
             Command::new("/bin/sh").args(["-c", "sleep 30"]),
             Duration::from_secs(20),
-            Instant::now() + Duration::from_millis(300),
+            Deadline::at(Instant::now() + Duration::from_millis(300)),
             "test:outer-deadline",
         )
         .expect_err("must not wait out its own budget past the deadline it serves");
@@ -824,7 +796,7 @@ mod tests {
         let err = run_bounded_until(
             Command::new("/bin/sh").args(["-c", "sleep 30"]),
             Duration::from_millis(300),
-            Instant::now() + Duration::from_secs(60),
+            Deadline::at(Instant::now() + Duration::from_secs(60)),
             "test:own-budget",
         )
         .expect_err("must time out");
@@ -840,7 +812,7 @@ mod tests {
         let err = run_bounded_until(
             Command::new("/bin/sh").args(["-c", "sleep 30"]),
             Duration::from_secs(20),
-            Instant::now(),
+            Deadline::at(Instant::now()),
             "test:spent-deadline",
         )
         .expect_err("a call with no time left must fail rather than run");
@@ -865,7 +837,7 @@ mod tests {
         let out = run_bounded_until(
             Command::new("/bin/sh").args(["-c", "printf ready; exit 3"]),
             Duration::from_secs(10),
-            Instant::now() + Duration::from_secs(10),
+            Deadline::at(Instant::now() + Duration::from_secs(10)),
             "test:until-fast",
         )
         .expect("a fast command yields its Output");
@@ -895,7 +867,7 @@ mod tests {
         let spent = run_bounded_until(
             &mut Command::new("/nonexistent/glass-test-binary"),
             Duration::from_secs(20),
-            Instant::now(),
+            Deadline::at(Instant::now()),
             "test:kind-not-started",
         )
         .expect_err("a call with no time left must fail rather than run");

--- a/crates/glass-core/src/bounded.rs
+++ b/crates/glass-core/src/bounded.rs
@@ -59,6 +59,9 @@ const MAX_CAPTURE: usize = 64 * 1024 * 1024;
 ///
 /// Both pipes are drained on their own threads: a child that fills a pipe buffer while the parent
 /// waits blocks in `write` and never exits, putting the deadline itself out of reach.
+///
+/// A zero `budget` is [`BoundKind::NotStarted`] — the command is not spawned at all, rather than
+/// spawned and killed at once.
 pub fn run_bounded(cmd: &mut Command, budget: Duration, op: &str) -> Result<Output> {
     run_bounded_until(cmd, budget, Deadline::UNBOUNDED, op)
 }

--- a/crates/glass-core/src/deadline.rs
+++ b/crates/glass-core/src/deadline.rs
@@ -1,0 +1,141 @@
+//! One type for "when the caller stops waiting", shared by every bound in glass.
+//!
+//! It began as the accessibility readers' `AxDeadline`. Teardown then grew its own spellings — a
+//! bare `Instant` in one place and an `Option<Instant>` in another, fifteen lines apart in `Adb`
+//! — and `None` reads as "zero" as readily as "unbounded", which is the direction that fails
+//! quietly: a call given zero is not run at all (glass#430).
+//!
+//! Where a bound is *required*, a plain `Instant` is still right and is left alone — `poll_until`,
+//! the wayland clipboard transfer, `wait_for_agent_until`. This type is for the boundaries where a
+//! caller may have no bound to give, so "none" has a name rather than being an empty `Option`.
+
+/// When the caller stops waiting.
+///
+/// An accessibility reader cannot be interrupted mid-read — [`crate::Glass::wait_for_element`]
+/// re-reads from a synchronous tick — so a 20s `uiautomator dump` answered a 10s wait until
+/// readers took this (glass#338). The obligation is stated on
+/// [`crate::Accessibility::snapshot`], where an implementer meets it; teardown's is on
+/// [`crate::Platform::stop_app_by`].
+///
+/// [`Self::UNBOUNDED`] leaves the callee its own budget: it is the *widest* value, as `WalkLimits`'
+/// unbounded is, and not a deadline of zero.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[must_use]
+pub struct Deadline(Option<std::time::Instant>);
+
+impl Deadline {
+    /// The caller named no instant to stop at.
+    pub const UNBOUNDED: Self = Self(None);
+
+    /// Stop `ms` milliseconds from now.
+    pub fn from_millis(ms: u64) -> Self {
+        Self::at(std::time::Instant::now() + std::time::Duration::from_millis(ms))
+    }
+
+    /// Stop at `instant` — for a caller that already holds the moment it stops waiting, and for a
+    /// test that needs the same instant on both sides of a comparison.
+    pub const fn at(instant: std::time::Instant) -> Self {
+        Self(Some(instant))
+    }
+
+    /// `proposed`, or this deadline when it falls first — the bound one step of a call runs under.
+    pub fn cap(self, proposed: std::time::Instant) -> std::time::Instant {
+        match self.0 {
+            Some(d) => proposed.min(d),
+            None => proposed,
+        }
+    }
+
+    /// Whether this deadline falls before `proposed`, so a step that runs out was cut off rather
+    /// than unanswered.
+    ///
+    /// A tie is deliberately not this deadline: reporting a backend that hung for its whole
+    /// ceiling as a spent caller budget hides it.
+    pub fn governs(self, proposed: std::time::Instant) -> bool {
+        self.0.is_some_and(|d| d < proposed)
+    }
+
+    /// How long is left, or `None` when the caller named no instant. Zero once it has passed.
+    pub fn remaining(self) -> Option<std::time::Duration> {
+        self.0
+            .map(|d| d.saturating_duration_since(std::time::Instant::now()))
+    }
+
+    /// The budget a call actually gets: its own, or what is left of this deadline at `now`,
+    /// whichever is nearer — zero once it has passed, since the caller is gone.
+    ///
+    /// `now` is a parameter rather than read here so an exact test can pin the rule.
+    pub fn within(
+        self,
+        budget: std::time::Duration,
+        now: std::time::Instant,
+    ) -> std::time::Duration {
+        match self.0 {
+            Some(d) => budget.min(d.saturating_duration_since(now)),
+            None => budget,
+        }
+    }
+
+    /// This deadline brought `earlier` forward — for splitting one budget between steps that run
+    /// in sequence. [`Self::UNBOUNDED`] stays unbounded: there is nothing to take a share of.
+    pub fn less(self, earlier: std::time::Duration) -> Self {
+        Self(self.0.map(|d| d - earlier))
+    }
+
+    /// Whether the caller named an instant that has passed — work started now cannot be wanted.
+    ///
+    /// `false` for [`Self::UNBOUNDED`] — this asks whether the caller has gone, not whether
+    /// budget remains, and a reader reading it as the latter would retry an untimed call forever.
+    pub fn has_passed(self) -> bool {
+        self.remaining().is_some_and(|left| left.is_zero())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    /// The rule the deadline-taking runner exists for, pinned where no timing test can reach it.
+    #[test]
+    fn a_call_gets_the_nearer_of_its_own_budget_and_the_deadline_it_serves() {
+        let now = Instant::now();
+        assert_eq!(
+            Deadline::at(now + Duration::from_secs(5)).within(Duration::from_secs(20), now),
+            Duration::from_secs(5)
+        );
+        assert_eq!(
+            Deadline::at(now + Duration::from_secs(5)).within(Duration::from_secs(3), now),
+            Duration::from_secs(3)
+        );
+        assert_eq!(
+            Deadline::at(now).within(Duration::from_secs(20), now),
+            Duration::ZERO
+        );
+        let past = now.checked_sub(Duration::from_secs(1)).unwrap_or(now);
+        assert_eq!(
+            Deadline::at(past).within(Duration::from_secs(20), now),
+            Duration::ZERO
+        );
+        // No deadline is the widest value, not a budget of zero.
+        assert_eq!(
+            Deadline::UNBOUNDED.within(Duration::from_secs(20), now),
+            Duration::from_secs(20)
+        );
+    }
+
+    /// A share taken out of one budget, so two steps in sequence cannot each spend the whole.
+    #[test]
+    fn less_takes_a_share_and_leaves_unbounded_unbounded() {
+        let now = Instant::now();
+        let left = Deadline::at(now + Duration::from_secs(3))
+            .less(Duration::from_secs(1))
+            .remaining()
+            .expect("still bounded");
+        assert!(left <= Duration::from_secs(2) && left > Duration::from_millis(1900));
+        assert_eq!(
+            Deadline::UNBOUNDED.less(Duration::from_secs(1)),
+            Deadline::UNBOUNDED
+        );
+    }
+}

--- a/crates/glass-core/src/deadline.rs
+++ b/crates/glass-core/src/deadline.rs
@@ -1,13 +1,14 @@
 //! One type for "when the caller stops waiting", shared by every bound in glass.
 //!
-//! It began as the accessibility readers' `AxDeadline`. Teardown then grew its own spellings — a
-//! bare `Instant` in one place and an `Option<Instant>` in another, fifteen lines apart in `Adb`
-//! — and `None` reads as "zero" as readily as "unbounded", which is the direction that fails
-//! quietly: a call given zero is not run at all (glass#430).
+//! It began as the accessibility readers' `AxDeadline`. `Adb` then grew two more spellings fifteen
+//! lines apart — a bare `Instant` for the dump sequence (glass#312) and an `Option<Instant>` for
+//! teardown (glass#431) — and `None` reads as "zero" as readily as "unbounded", which is the
+//! direction that fails quietly: a call given zero is not run at all (glass#430).
 //!
-//! Where a bound is *required*, a plain `Instant` is still right and is left alone — `poll_until`,
-//! the wayland clipboard transfer, `wait_for_agent_until`. This type is for the boundaries where a
-//! caller may have no bound to give, so "none" has a name rather than being an empty `Option`.
+//! Where a bound is *required*, a plain `Instant` is still right and is left alone — the wayland
+//! clipboard transfer, `wait_for_agent_until`, `bounded`'s own `poll_until`. This type is for the
+//! boundaries where a caller may have no bound to give, so "none" has a name rather than being an
+//! empty `Option`.
 
 /// When the caller stops waiting.
 ///
@@ -76,10 +77,17 @@ impl Deadline {
         }
     }
 
-    /// This deadline brought `earlier` forward — for splitting one budget between steps that run
-    /// in sequence. [`Self::UNBOUNDED`] stays unbounded: there is nothing to take a share of.
-    pub fn less(self, earlier: std::time::Duration) -> Self {
-        Self(self.0.map(|d| d - earlier))
+    /// This deadline pulled in by `reserve`, but never by more than half of what is left — for
+    /// splitting one budget between steps that run in sequence, where a reserve larger than the
+    /// budget would otherwise starve the first step entirely.
+    ///
+    /// [`Self::UNBOUNDED`] stays unbounded: there is nothing to take a share of. Never lands
+    /// before now, so it cannot underflow the monotonic clock the way a bare subtraction can.
+    pub fn reserving(self, reserve: std::time::Duration) -> Self {
+        Self(self.0.map(|d| {
+            let left = d.saturating_duration_since(std::time::Instant::now());
+            d - reserve.min(left / 2)
+        }))
     }
 
     /// Whether the caller named an instant that has passed — work started now cannot be wanted.
@@ -96,7 +104,53 @@ mod tests {
     use super::*;
     use std::time::{Duration, Instant};
 
-    /// The rule the deadline-taking runner exists for, pinned where no timing test can reach it.
+    /// The two bounds a callee holds — its own and its caller's — resolve to whichever falls
+    /// first, in both directions.
+    #[test]
+    fn a_deadline_caps_a_proposed_instant_only_when_it_falls_first() {
+        let soon = Deadline::from_millis(1_000);
+        let later = std::time::Instant::now() + std::time::Duration::from_secs(60);
+        assert!(soon.cap(later) < later, "the nearer bound did not govern");
+
+        let now = std::time::Instant::now();
+        assert_eq!(
+            soon.cap(now),
+            now,
+            "a reader's own nearer bound was widened"
+        );
+    }
+
+    /// A caller that named no instant leaves the callee whatever it proposed — `UNBOUNDED` is not a
+    /// deadline of zero, which would stop every call before it started.
+    #[test]
+    fn no_deadline_caps_nothing_and_is_never_spent() {
+        let proposed = std::time::Instant::now() + std::time::Duration::from_secs(60);
+        assert_eq!(Deadline::UNBOUNDED.cap(proposed), proposed);
+        assert_eq!(Deadline::UNBOUNDED.remaining(), None);
+        assert!(!Deadline::UNBOUNDED.has_passed());
+    }
+
+    /// The tie-break is load-bearing: a callee blames its own bound when both fall together, so a
+    /// backend that hung for exactly its ceiling is never reported as a caller who ran out of time.
+    #[test]
+    fn a_deadline_governs_a_step_only_when_it_falls_strictly_first() {
+        let now = std::time::Instant::now();
+        let soon = Deadline::from_millis(1_000);
+        assert!(soon.governs(now + std::time::Duration::from_secs(60)));
+        assert!(!soon.governs(now));
+        assert!(!Deadline::UNBOUNDED.governs(now + std::time::Duration::from_secs(60)));
+        // The tie itself, which only a shared instant can express: `<=` here would blame the
+        // caller for a backend that hung for exactly its own ceiling.
+        assert!(!Deadline::at(now).governs(now));
+    }
+
+    #[test]
+    fn a_deadline_has_passed_once_its_instant_has_passed() {
+        assert!(Deadline::from_millis(0).has_passed());
+        assert!(!Deadline::from_millis(60_000).has_passed());
+    }
+
+    /// The rule [`crate::run_bounded_until`] exists for, pinned where no timing test can reach it.
     #[test]
     fn a_call_gets_the_nearer_of_its_own_budget_and_the_deadline_it_serves() {
         let now = Instant::now();
@@ -126,16 +180,32 @@ mod tests {
 
     /// A share taken out of one budget, so two steps in sequence cannot each spend the whole.
     #[test]
-    fn less_takes_a_share_and_leaves_unbounded_unbounded() {
-        let now = Instant::now();
-        let left = Deadline::at(now + Duration::from_secs(3))
-            .less(Duration::from_secs(1))
+    fn reserving_takes_a_share_and_leaves_unbounded_unbounded() {
+        let left = Deadline::at(Instant::now() + Duration::from_secs(3))
+            .reserving(Duration::from_secs(1))
             .remaining()
             .expect("still bounded");
-        assert!(left <= Duration::from_secs(2) && left > Duration::from_millis(1900));
+        assert!(
+            left <= Duration::from_secs(2) && left > Duration::from_millis(1900),
+            "{left:?}"
+        );
         assert_eq!(
-            Deadline::UNBOUNDED.less(Duration::from_secs(1)),
+            Deadline::UNBOUNDED.reserving(Duration::from_secs(1)),
             Deadline::UNBOUNDED
+        );
+    }
+
+    /// The clamp: a reserve bigger than what is left must not take everything, or the step it was
+    /// held back from gets a deadline already in the past and is skipped rather than run.
+    #[test]
+    fn a_reserve_larger_than_the_budget_takes_only_half() {
+        let left = Deadline::at(Instant::now() + Duration::from_millis(100))
+            .reserving(Duration::from_secs(30))
+            .remaining()
+            .expect("still bounded");
+        assert!(
+            left > Duration::from_millis(30) && left <= Duration::from_millis(50),
+            "a 30s reserve out of 100ms should leave about half, left {left:?}"
         );
     }
 }

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -80,12 +80,15 @@ pub use platform::{
     WindowGeometry, WindowHint, WindowId, WindowInfo, WindowOp,
 };
 
+pub mod deadline;
+pub use deadline::Deadline;
+
 pub mod accessibility;
 pub use accessibility::{
-    Accessibility, AxContext, AxDeadline, AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget,
-    AxTree, ChangeSignal, ChangeWait, ClickMethod, ElementCondition, ElementInfo, ElementMatch,
-    MAX_DEPTH, MAX_NODES, MAX_SIBLINGS, Subject, Truncation, TruncationLimit, WalkBudget,
-    WalkLimits, element_match, normalize_description,
+    Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget, AxTree,
+    ChangeSignal, ChangeWait, ClickMethod, ElementCondition, ElementInfo, ElementMatch, MAX_DEPTH,
+    MAX_NODES, MAX_SIBLINGS, Subject, Truncation, TruncationLimit, WalkBudget, WalkLimits,
+    element_match, normalize_description,
 };
 
 pub mod marks;

--- a/crates/glass-core/src/platform.rs
+++ b/crates/glass-core/src/platform.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use crate::error::{GlassError, Result};
 use crate::frame::{Frame, Region};
@@ -267,7 +267,7 @@ pub trait Platform {
     /// residual its own comment names). A backend that tears down over a link to a device has one
     /// tool invocation per step, each with its own budget and no sum to assert, so it overrides
     /// this and spends the shared deadline (glass#422, glass#427).
-    fn stop_app_by(&mut self, _deadline: Instant) -> Result<()> {
+    fn stop_app_by(&mut self, _deadline: crate::Deadline) -> Result<()> {
         self.stop_app()
     }
 
@@ -563,8 +563,10 @@ mod tests {
         let mut p = CountingPlatform(0);
         // A deadline already gone: the default must stop the app regardless, since it does not
         // spend one.
-        p.stop_app_by(Instant::now() - Duration::from_secs(1))
-            .expect("the default delegates to stop_app");
+        p.stop_app_by(crate::Deadline::at(
+            std::time::Instant::now() - Duration::from_secs(1),
+        ))
+        .expect("the default delegates to stop_app");
         assert_eq!(p.0, 1);
     }
 

--- a/crates/glass-core/src/platform.rs
+++ b/crates/glass-core/src/platform.rs
@@ -530,18 +530,18 @@ mod tests {
         assert_eq!(MinimalPlatform.app_pid(), None);
     }
 
-    /// The default is what the four constant-bounded backends rely on, and it is reached only on
-    /// the exit path — where a body of `Ok(())` would mean they quietly stopped stopping their
-    /// app, with every existing test still green.
+    /// `stop_app` is now the provided half of the pair, so a body of `Ok(())` would mean the tool
+    /// path quietly stopped stopping the app — with every backend still compiling, since they
+    /// implement the other one.
     #[test]
-    fn default_stop_app_by_stops_the_app_and_ignores_the_deadline() {
-        struct CountingPlatform(u32);
+    fn the_default_stop_app_reaches_stop_app_by_with_no_bound() {
+        struct CountingPlatform(Option<crate::Deadline>);
         impl Platform for CountingPlatform {
             fn start_app(&mut self, _spec: &AppSpec) -> Result<WindowGeometry> {
                 Ok(WindowGeometry::default())
             }
-            fn stop_app_by(&mut self, _deadline: crate::Deadline) -> Result<()> {
-                self.0 += 1;
+            fn stop_app_by(&mut self, deadline: crate::Deadline) -> Result<()> {
+                self.0 = Some(deadline);
                 Ok(())
             }
             fn capture_frame(&mut self, _region: Option<&Region>) -> Result<Frame> {
@@ -567,14 +567,13 @@ mod tests {
             }
         }
 
-        let mut p = CountingPlatform(0);
-        // A deadline already gone: the default must stop the app regardless, since it does not
-        // spend one.
-        p.stop_app_by(crate::Deadline::at(
-            std::time::Instant::now() - Duration::from_secs(1),
-        ))
-        .expect("the default delegates to stop_app");
-        assert_eq!(p.0, 1);
+        let mut p = CountingPlatform(None);
+        p.stop_app().expect("the default delegates");
+        assert_eq!(
+            p.0,
+            Some(crate::Deadline::UNBOUNDED),
+            "the tool path must reach the backend, and with no bound"
+        );
     }
 
     #[test]

--- a/crates/glass-core/src/platform.rs
+++ b/crates/glass-core/src/platform.rs
@@ -256,19 +256,26 @@ pub trait Platform {
     /// return the window's geometry.
     fn start_app(&mut self, spec: &AppSpec) -> Result<WindowGeometry>;
 
-    /// Terminate the running app (idempotent).
-    fn stop_app(&mut self) -> Result<()>;
-
-    /// [`Platform::stop_app`] on the process-exit path, where the whole of teardown shares
-    /// [`TEARDOWN_BUDGET`] and `deadline` is this step's share of it.
+    /// Terminate the running app (idempotent), giving up by `deadline`.
     ///
-    /// The default ignores it, which is what a signal ladder over local processes already asserts
-    /// against [`TEARDOWN_BUDGET`] at compile time (x11, wayland, windows, macos — each with the
-    /// residual its own comment names). A backend that tears down over a link to a device has one
-    /// tool invocation per step, each with its own budget and no sum to assert, so it overrides
-    /// this and spends the shared deadline (glass#422, glass#427).
-    fn stop_app_by(&mut self, _deadline: crate::Deadline) -> Result<()> {
-        self.stop_app()
+    /// **Cap every wait of your own by it.** On the process-exit path the whole of teardown shares
+    /// [`TEARDOWN_BUDGET`], and a step that overruns is not merely late — it spends what the steps
+    /// behind it needed, and they are skipped rather than slowed (glass#422, glass#427).
+    ///
+    /// A backend whose teardown is a signal ladder over local processes may ignore it — those
+    /// ladders already assert their own constants against [`TEARDOWN_BUDGET`] at compile time
+    /// (x11, wayland, windows, macos, each with the residual its own comment names). One that
+    /// tears down over a link to a device has a tool invocation per step, each with its own budget
+    /// and no sum to assert, so it has nothing but this deadline.
+    ///
+    /// Required rather than defaulted, so a new device-linked backend cannot inherit an unbounded
+    /// teardown in silence — which is how both device backends came to need glass#422/#427.
+    fn stop_app_by(&mut self, deadline: crate::Deadline) -> Result<()>;
+
+    /// [`Platform::stop_app_by`] with no bound — the tool path, where `glass_stop` waits as long
+    /// as the backend needs.
+    fn stop_app(&mut self) -> Result<()> {
+        self.stop_app_by(crate::Deadline::UNBOUNDED)
     }
 
     /// Capture the current window contents as an RGBA frame. `region` (if set,
@@ -447,7 +454,7 @@ mod tests {
         fn start_app(&mut self, _spec: &AppSpec) -> Result<WindowGeometry> {
             Ok(WindowGeometry::default())
         }
-        fn stop_app(&mut self) -> Result<()> {
+        fn stop_app_by(&mut self, _deadline: crate::Deadline) -> Result<()> {
             Ok(())
         }
         fn capture_frame(&mut self, _region: Option<&Region>) -> Result<Frame> {
@@ -483,7 +490,7 @@ mod tests {
         fn start_app(&mut self, _spec: &AppSpec) -> Result<WindowGeometry> {
             unimplemented!()
         }
-        fn stop_app(&mut self) -> Result<()> {
+        fn stop_app_by(&mut self, _deadline: crate::Deadline) -> Result<()> {
             unimplemented!()
         }
         fn capture_frame(&mut self, _region: Option<&Region>) -> Result<Frame> {
@@ -533,7 +540,7 @@ mod tests {
             fn start_app(&mut self, _spec: &AppSpec) -> Result<WindowGeometry> {
                 Ok(WindowGeometry::default())
             }
-            fn stop_app(&mut self) -> Result<()> {
+            fn stop_app_by(&mut self, _deadline: crate::Deadline) -> Result<()> {
                 self.0 += 1;
                 Ok(())
             }

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -34,7 +34,7 @@ impl Glass {
             crate::accessibility::WalkLimits::from_max_nodes(max_nodes);
         // The tool takes no timeout, so the reader keeps its own budget. Inventing one here would
         // cap a plain snapshot at a number no caller asked for.
-        self.snapshot_at_current_limits(AxDeadline::UNBOUNDED)
+        self.snapshot_at_current_limits(Deadline::UNBOUNDED)
     }
 
     /// Subscribe to the backend's change notifications for the active app, if it has any.
@@ -48,7 +48,7 @@ impl Glass {
     /// bound their own registration — so today it only travels.
     pub(crate) fn subscribe_a11y_changes(
         &mut self,
-        deadline: AxDeadline,
+        deadline: Deadline,
     ) -> Option<Box<dyn ChangeSignal>> {
         let s = self.active_mut().ok()?;
         // Reader check first: the accessors below are platform round-trips (`app_pids` shells
@@ -72,16 +72,16 @@ impl Glass {
     /// and the scroll/combo/toggle loops) so an agent working in a raised-cap tree keeps that
     /// id-space instead of silently reverting to the default cap on the next internal snapshot.
     ///
-    /// `deadline` is the enclosing operation's bound, not this walk's — see [`AxDeadline`]. A
-    /// caller with no timeout of its own passes [`AxDeadline::UNBOUNDED`].
-    pub fn a11y_resnapshot(&mut self, deadline: AxDeadline) -> Result<AxTree> {
+    /// `deadline` is the enclosing operation's bound, not this walk's — see [`Deadline`]. A
+    /// caller with no timeout of its own passes [`Deadline::UNBOUNDED`].
+    pub fn a11y_resnapshot(&mut self, deadline: Deadline) -> Result<AxTree> {
         self.snapshot_at_current_limits(deadline)
     }
 
     /// The snapshot worker: walks the active window's tree bounded by the session's current
     /// `a11y_limits` and caches it. Callers set `a11y_limits` first (or reuse it) — see
     /// [`Glass::a11y_snapshot`] / [`Glass::a11y_resnapshot`].
-    fn snapshot_at_current_limits(&mut self, deadline: AxDeadline) -> Result<AxTree> {
+    fn snapshot_at_current_limits(&mut self, deadline: Deadline) -> Result<AxTree> {
         let s = self.active_mut()?;
         let limits = s.a11y_limits;
         // Reader-presence check up front (mirrors set_value_inner) so `AxUnsupported` keeps
@@ -119,7 +119,7 @@ impl Glass {
     /// Caches the snapshot, so `click_element` resolves a mark's id afterward.
     pub fn a11y_marks(&mut self) -> Result<(Frame, Vec<Mark>)> {
         let frame = self.screenshot(None, None)?;
-        let tree = self.a11y_resnapshot(AxDeadline::UNBOUNDED)?;
+        let tree = self.a11y_resnapshot(Deadline::UNBOUNDED)?;
         Ok(crate::marks::render(&frame, &tree))
     }
 
@@ -305,7 +305,7 @@ impl Glass {
                 window_handle: s.platform.active_window_handle(),
                 a11y_bus_addr: s.platform.a11y_bus_addr(),
                 limits: s.a11y_limits,
-                deadline: AxDeadline::UNBOUNDED,
+                deadline: Deadline::UNBOUNDED,
             };
             (target, ctx)
         };
@@ -370,7 +370,7 @@ impl Glass {
                 window_handle: s.platform.active_window_handle(),
                 a11y_bus_addr: s.platform.a11y_bus_addr(),
                 limits: s.a11y_limits,
-                deadline: AxDeadline::UNBOUNDED,
+                deadline: Deadline::UNBOUNDED,
             };
             (target, ctx)
         };
@@ -416,7 +416,7 @@ impl Glass {
             // holds the tree that observed the toggle.
             self.click_element_inner(id)?; // the toggle actuation (a swipe for a row-shaped control)
             // Not event-gated: this branch runs only on iOS, whose reader has no event stream.
-            // No deadline either: `AxDeadline` carries the *caller's* bound, and
+            // No deadline either: `Deadline` carries the *caller's* bound, and
             // `TOGGLE_VERIFY_TIMEOUT_MS` is glass's own.
             // Kept as the poll runs, not re-read afterwards — a read taken after the bound elapsed
             // could catch a state that arrived late and contradict the verdict.
@@ -425,7 +425,7 @@ impl Glass {
                 TOGGLE_VERIFY_INTERVAL_MS,
                 TOGGLE_VERIFY_TIMEOUT_MS,
                 || {
-                    let tree = self.a11y_resnapshot(AxDeadline::UNBOUNDED)?;
+                    let tree = self.a11y_resnapshot(Deadline::UNBOUNDED)?;
                     seen = find_checkable_near(&tree.root, target.bounds.as_ref())
                         .map(|n| n.states.checked);
                     Ok((seen == Some(want)).then_some(()))
@@ -497,7 +497,7 @@ impl Glass {
         self.settle_for_popup();
         // Ids don't survive a re-snapshot, so match the open (`expanded`) combo, else the one
         // nearest the target's bounds.
-        let tree = self.a11y_resnapshot(AxDeadline::UNBOUNDED)?;
+        let tree = self.a11y_resnapshot(Deadline::UNBOUNDED)?;
         let combo = find_expanded_combo(&tree.root)
             .or_else(|| find_combo_near(&tree.root, target.bounds.as_ref()))
             .ok_or(GlassError::AxElementChanged(id.0))?;
@@ -535,7 +535,7 @@ impl Glass {
         self.settle_for_popup();
         // Verify the model actually committed — the *target* combo (matched by bounds,
         // now closed so nothing is `expanded`) must read the wanted label.
-        let tree = self.a11y_resnapshot(AxDeadline::UNBOUNDED)?;
+        let tree = self.a11y_resnapshot(Deadline::UNBOUNDED)?;
         let shows =
             find_combo_near(&tree.root, target.bounds.as_ref()).and_then(|c| c.name.clone());
         if shows
@@ -3070,7 +3070,7 @@ mod tests {
                 .as_ref()
                 .expect("snapshot recorded its ctx")
                 .deadline,
-            AxDeadline::UNBOUNDED,
+            Deadline::UNBOUNDED,
         );
     }
 

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -416,7 +416,7 @@ impl Glass {
             // holds the tree that observed the toggle.
             self.click_element_inner(id)?; // the toggle actuation (a swipe for a row-shaped control)
             // Not event-gated: this branch runs only on iOS, whose reader has no event stream.
-            // No deadline either: `Deadline` carries the *caller's* bound, and
+            // Unbounded here too: a `Deadline` carries the *caller's* bound, and
             // `TOGGLE_VERIFY_TIMEOUT_MS` is glass's own.
             // Kept as the poll runs, not re-read afterwards — a read taken after the bound elapsed
             // could catch a state that arrived late and contradict the verdict.

--- a/crates/glass-core/src/session/lifecycle.rs
+++ b/crates/glass-core/src/session/lifecycle.rs
@@ -1,5 +1,5 @@
 //! `Glass` session lifecycle: start/stop/shutdown and geometry.
-use std::time::Instant;
+use std::time::Duration;
 
 use super::*;
 
@@ -95,13 +95,14 @@ impl Glass {
     /// Written to drain the session set so the future multi-session registry (a
     /// `HashMap` instead of this `Option`) reuses it unchanged — it becomes a `for`
     /// loop with no other change.
-    pub fn shutdown(&mut self, deadline: Instant) {
+    pub fn shutdown(&mut self, deadline: Deadline) {
         // Never more than half, or a caller whose budget is smaller than the reserve — a test,
         // a host that shortens it — starves the sessions instead of the hook.
-        let remaining = deadline.saturating_duration_since(Instant::now());
-        let reserve = crate::TEARDOWN_HOOK_RESERVE.min(remaining / 2);
+        let reserve = deadline.remaining().map_or(Duration::ZERO, |left| {
+            crate::TEARDOWN_HOOK_RESERVE.min(left / 2)
+        });
         if let Some(mut s) = self.active.take() {
-            let _ = s.platform.stop_app_by(deadline - reserve);
+            let _ = s.platform.stop_app_by(deadline.less(reserve));
             // `s` drops here: the backend (Xvfb/sway/Job) is torn down.
         }
         if let Some(hook) = self.shutdown_hook.take() {
@@ -153,8 +154,8 @@ mod tests {
 
     /// A deadline far enough out that nothing in these tests is bounded by it — they are about
     /// what `shutdown` calls, not about what a spent budget does.
-    fn soon() -> std::time::Instant {
-        std::time::Instant::now() + crate::TEARDOWN_BUDGET
+    fn soon() -> Deadline {
+        Deadline::at(std::time::Instant::now() + crate::TEARDOWN_BUDGET)
     }
 
     #[test]
@@ -256,8 +257,9 @@ mod tests {
             .lock()
             .unwrap()
             .expect("the backend must be stopped through `stop_app_by`, not `stop_app`");
+        // Both read now, so the difference between them is the reserve.
         assert!(
-            at_stop < deadline,
+            at_stop.remaining().expect("a bounded share") < deadline.remaining().unwrap(),
             "the session's share must stop short of the hook's, or the reserve is not held back"
         );
         assert_eq!(
@@ -285,13 +287,15 @@ mod tests {
         // A fifth of the reserve, so an unclamped subtraction lands well in the past.
         let budget = crate::TEARDOWN_HOOK_RESERVE / 5;
         let started = std::time::Instant::now();
-        g.shutdown(started + budget);
+        g.shutdown(Deadline::at(started + budget));
 
         let given = at_stop
             .lock()
             .unwrap()
             .expect("the backend was stopped")
-            .saturating_duration_since(started);
+            .remaining()
+            .expect("a bounded share");
+        let _ = started;
         assert!(
             given >= budget / 3,
             "the sessions were given {given:?} of a {budget:?} budget — the reserve was taken \
@@ -313,14 +317,13 @@ mod tests {
         let recorded = left.clone();
         let mut g = glass_with_factory(factory);
         g.set_shutdown_hook(Box::new(move |d| {
-            *recorded.lock().unwrap() =
-                Some(d.saturating_duration_since(std::time::Instant::now()));
+            *recorded.lock().unwrap() = d.remaining();
         }));
         g.start(&spec()).unwrap();
 
         // A tenth of the real budget, so the test costs what it measures rather than 3s.
         let budget = crate::TEARDOWN_BUDGET / 10;
-        g.shutdown(std::time::Instant::now() + budget);
+        g.shutdown(Deadline::at(std::time::Instant::now() + budget));
 
         let left = left.lock().unwrap().expect("the hook ran at all");
         assert!(

--- a/crates/glass-core/src/session/lifecycle.rs
+++ b/crates/glass-core/src/session/lifecycle.rs
@@ -1,6 +1,4 @@
 //! `Glass` session lifecycle: start/stop/shutdown and geometry.
-use std::time::Duration;
-
 use super::*;
 
 impl Glass {
@@ -96,13 +94,10 @@ impl Glass {
     /// `HashMap` instead of this `Option`) reuses it unchanged — it becomes a `for`
     /// loop with no other change.
     pub fn shutdown(&mut self, deadline: Deadline) {
-        // Never more than half, or a caller whose budget is smaller than the reserve — a test,
-        // a host that shortens it — starves the sessions instead of the hook.
-        let reserve = deadline.remaining().map_or(Duration::ZERO, |left| {
-            crate::TEARDOWN_HOOK_RESERVE.min(left / 2)
-        });
         if let Some(mut s) = self.active.take() {
-            let _ = s.platform.stop_app_by(deadline.less(reserve));
+            let _ = s
+                .platform
+                .stop_app_by(deadline.reserving(crate::TEARDOWN_HOOK_RESERVE));
             // `s` drops here: the backend (Xvfb/sway/Job) is torn down.
         }
         if let Some(hook) = self.shutdown_hook.take() {
@@ -257,7 +252,8 @@ mod tests {
             .lock()
             .unwrap()
             .expect("the backend must be stopped through `stop_app_by`, not `stop_app`");
-        // Both read now, so the difference between them is the reserve.
+        // Each `remaining()` reads its own now, microseconds apart, so comparing them compares
+        // the instants they hold.
         assert!(
             at_stop.remaining().expect("a bounded share") < deadline.remaining().unwrap(),
             "the session's share must stop short of the hook's, or the reserve is not held back"
@@ -269,7 +265,6 @@ mod tests {
         );
     }
 
-    /// The property this whole split exists for (glass#422): a session that spends everything it
     /// The other half of the split: the reserve is a fixed 750ms, so without the clamp a caller
     /// whose whole budget is smaller hands the sessions a deadline already in the past.
     #[test]
@@ -289,13 +284,13 @@ mod tests {
         let started = std::time::Instant::now();
         g.shutdown(Deadline::at(started + budget));
 
+        // Measured from `started`, not from now: `remaining()` here would subtract whatever the
+        // test itself has since spent, and the margin is only tens of milliseconds.
         let given = at_stop
             .lock()
             .unwrap()
             .expect("the backend was stopped")
-            .remaining()
-            .expect("a bounded share");
-        let _ = started;
+            .within(std::time::Duration::MAX, started);
         assert!(
             given >= budget / 3,
             "the sessions were given {given:?} of a {budget:?} budget — the reserve was taken \
@@ -303,9 +298,10 @@ mod tests {
         );
     }
 
-    /// is given must still leave the hook enough to run. Without the reserve the hook is reached
-    /// with a spent deadline, and `run_bounded_until` does not start a command it has no time for
-    /// — so every step behind it is skipped rather than merely slow.
+    /// The property this whole split exists for (glass#422): a session that spends everything it is
+    /// given must still leave the hook enough to run. Without the reserve the hook is reached with
+    /// a spent deadline, and `run_bounded_until` does not start a command it has no time for — so
+    /// every step behind it is skipped rather than merely slow.
     #[test]
     fn a_session_that_burns_its_deadline_still_leaves_the_hook_time_to_run() {
         let factory: PlatformFactory = Box::new(move |_backend| {

--- a/crates/glass-core/src/session/mod.rs
+++ b/crates/glass-core/src/session/mod.rs
@@ -2,11 +2,12 @@
 //! its operations are grouped into submodules (each adds an `impl Glass` block).
 
 use crate::accessibility::{
-    Accessibility, AxContext, AxDeadline, AxNode, AxNodeId, AxRect, AxRole, AxTarget, AxTree,
-    ChangeSignal, ChangeWait, ClickMethod, ElementCondition, ElementInfo, ElementMatch, WalkLimits,
+    Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxTarget, AxTree, ChangeSignal,
+    ChangeWait, ClickMethod, ElementCondition, ElementInfo, ElementMatch, WalkLimits,
     element_match,
 };
 use crate::baseline::BaselineStore;
+use crate::deadline::Deadline;
 use crate::diff::{
     BBox, DiffResult, IgnoreMask, RegionUntil, diff_perceptual_with_mask, diff_with_mask,
     region_satisfied,
@@ -94,7 +95,7 @@ pub struct Glass {
     log_capacity: usize,
     active: Option<ActiveSession>,
     audit: Option<Box<dyn crate::audit::AuditSink>>,
-    shutdown_hook: Option<Box<dyn FnOnce(std::time::Instant) + Send>>,
+    shutdown_hook: Option<Box<dyn FnOnce(Deadline) + Send>>,
 }
 
 impl Glass {
@@ -127,7 +128,7 @@ impl Glass {
     /// [`crate::TEARDOWN_HOOK_RESERVE`] short so this still has time. A hook whose cleanup is
     /// local can ignore it; one that talks to a device spends it, and gets
     /// `BoundKind::NotStarted` for whatever it reaches with nothing left.
-    pub fn set_shutdown_hook(&mut self, hook: Box<dyn FnOnce(std::time::Instant) + Send>) {
+    pub fn set_shutdown_hook(&mut self, hook: Box<dyn FnOnce(Deadline) + Send>) {
         self.shutdown_hook = Some(hook);
     }
 

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -62,7 +62,7 @@ pub(crate) struct FakePlatform {
     resized_to: VecDeque<WindowGeometry>,
     /// The deadline `stop_app_by` was handed, when it was the entry point — `None` after a plain
     /// `stop_app`, which is how a test tells the two apart.
-    stop_deadline: Option<Arc<Mutex<Option<std::time::Instant>>>>,
+    stop_deadline: Option<Arc<Mutex<Option<crate::Deadline>>>>,
     /// Makes `stop_app_by` spend its whole deadline, standing in for a device that stopped
     /// answering.
     stop_burns_deadline: bool,
@@ -124,7 +124,7 @@ impl FakePlatform {
     }
     pub(crate) fn recording_stop_deadline(
         mut self,
-        at: Arc<Mutex<Option<std::time::Instant>>>,
+        at: Arc<Mutex<Option<crate::Deadline>>>,
     ) -> Self {
         self.stop_deadline = Some(at);
         self
@@ -183,12 +183,12 @@ impl Platform for FakePlatform {
         }
         Ok(())
     }
-    fn stop_app_by(&mut self, deadline: std::time::Instant) -> Result<()> {
+    fn stop_app_by(&mut self, deadline: crate::Deadline) -> Result<()> {
         if let Some(at) = &self.stop_deadline {
             *at.lock().unwrap() = Some(deadline);
         }
         if self.stop_burns_deadline {
-            std::thread::sleep(deadline.saturating_duration_since(std::time::Instant::now()));
+            std::thread::sleep(deadline.remaining().unwrap_or_default());
         }
         self.stop_app()
     }
@@ -988,7 +988,7 @@ impl Accessibility for NotReadyThenTree {
 }
 
 /// A reader that answers while the caller's deadline has time and gives up once it is spent —
-/// what a backend honouring [`AxDeadline`] does on the tick that ends a wait.
+/// what a backend honouring [`Deadline`] does on the tick that ends a wait.
 ///
 /// Every other fake here ignores `ctx.deadline`, so none of them can reach the case a wait's own
 /// deadline creates.

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -900,7 +900,7 @@ impl Platform for BareMinPlatform {
     fn start_app(&mut self, _spec: &AppSpec) -> Result<WindowGeometry> {
         Ok(WindowGeometry::default())
     }
-    fn stop_app(&mut self) -> Result<()> {
+    fn stop_app_by(&mut self, _deadline: crate::Deadline) -> Result<()> {
         Ok(())
     }
     fn capture_frame(&mut self, _region: Option<&crate::frame::Region>) -> Result<Frame> {

--- a/crates/glass-core/src/session/wait.rs
+++ b/crates/glass-core/src/session/wait.rs
@@ -387,7 +387,7 @@ impl Glass {
         let started = std::time::Instant::now();
         // Every read this wait makes carries when the wait stops: the tick is synchronous, so the
         // loop cannot take back a read a reader has started (glass#338).
-        let deadline = AxDeadline::from_millis(params.timeout_ms);
+        let deadline = Deadline::from_millis(params.timeout_ms);
         // Before the first walk, not after: a change landing in that gap is announced to nobody,
         // and the wait then burns its whole budget on a condition that already holds.
         //
@@ -446,7 +446,7 @@ impl Glass {
                 let bound = if looked {
                     deadline
                 } else {
-                    AxDeadline::UNBOUNDED
+                    Deadline::UNBOUNDED
                 };
                 looked = true;
                 let tree = match self.a11y_resnapshot(bound) {
@@ -620,7 +620,7 @@ impl Glass {
         // No deadline, though the sweep has a `timeout_ms`: this read propagates its error with
         // `?`, so a reader giving up at the deadline would turn the sweep's soft `{matched:false}`
         // into an error.
-        let tree = self.a11y_resnapshot(AxDeadline::UNBOUNDED)?;
+        let tree = self.a11y_resnapshot(Deadline::UNBOUNDED)?;
         let found = match element_match(
             &tree,
             params.name.as_deref(),
@@ -1361,7 +1361,7 @@ mod tests {
                 .as_ref()
                 .expect("the sweep read the tree")
                 .deadline,
-            AxDeadline::UNBOUNDED,
+            Deadline::UNBOUNDED,
         );
     }
 

--- a/crates/glass-ios/src/doctor.rs
+++ b/crates/glass-ios/src/doctor.rs
@@ -177,7 +177,7 @@ fn device_check(p: &Probe) -> Check {
     }
 }
 
-/// Deadline for each doctor probe. Doctor reports on the host rather than driving it, so every
+/// Budget for each doctor probe. Doctor reports on the host rather than driving it, so every
 /// probe here is a fast query; a tool that does not answer in this long is itself the finding.
 const PROBE_BUDGET: Duration = Duration::from_secs(10);
 

--- a/crates/glass-ios/src/idb/client.rs
+++ b/crates/glass-ios/src/idb/client.rs
@@ -16,9 +16,9 @@ use tonic::transport::{Channel, Endpoint, Uri};
 use super::proto;
 use proto::companion_service_client::CompanionServiceClient;
 
-/// Deadline for establishing the connection (dial + HTTP/2 handshake).
+/// Budget for establishing the connection (dial + HTTP/2 handshake).
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
-/// Deadline for a single RPC. 30s mirrors glass-android's socket timeout.
+/// Budget for a single RPC. 30s mirrors glass-android's socket timeout.
 const RPC_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Blocking handle to `idb_companion`'s gRPC service.
@@ -41,7 +41,7 @@ pub struct IdbClient {
     client: CompanionServiceClient<Channel>,
 }
 
-/// Deadline for one `hid` stream. A `HidSwipe`/`HidDelay`/`HidPinch` plays out over
+/// Budget for one `hid` stream. A `HidSwipe`/`HidDelay`/`HidPinch` plays out over
 /// its `duration` seconds on the device and holds the streaming RPC open at least
 /// that long, so a flat [`RPC_TIMEOUT`] aborts any gesture longer than it mid-stream
 /// (issue #116). Budget the summed event durations plus [`RPC_TIMEOUT`] of margin: a

--- a/crates/glass-ios/src/platform.rs
+++ b/crates/glass-ios/src/platform.rs
@@ -4,6 +4,7 @@
 use std::process::Command;
 use std::time::{Duration, Instant};
 
+use glass_core::Deadline;
 use glass_core::{
     AppSpec, Frame, GlassError, KeyEvent, Platform, PointerEvent, Region, Result, Stream,
     WindowGeometry, WindowId, WindowInfo, WindowOp,
@@ -284,7 +285,7 @@ pub(crate) fn bundle_id_from_run(run: &[String]) -> Result<(Option<String>, Stri
 
 impl IosPlatform {
     /// Terminate the app, under `deadline` when the caller has one to share.
-    fn stop_app_until(&mut self, deadline: Option<Instant>) -> Result<()> {
+    fn stop_app_until(&mut self, deadline: Deadline) -> Result<()> {
         if let Some(app) = self.app.take() {
             // Best-effort teardown: the app may already be gone (it crashed, or a prior
             // launch's `--terminate-running-process` killed it), so a failing `terminate`
@@ -601,15 +602,15 @@ impl Platform for IosPlatform {
     }
 
     fn stop_app(&mut self) -> Result<()> {
-        self.stop_app_until(None)
+        self.stop_app_until(Deadline::UNBOUNDED)
     }
 
     /// `terminate` measures ~101ms against the 3s all of teardown gets, so the deadline is not
     /// expected to bind. It is for the simulator that stopped answering, which would otherwise run
     /// out the 10s `SimctlOp::Query` budget and leave nothing for the hook behind it
     /// (glass#427).
-    fn stop_app_by(&mut self, deadline: Instant) -> Result<()> {
-        self.stop_app_until(Some(deadline))
+    fn stop_app_by(&mut self, deadline: Deadline) -> Result<()> {
+        self.stop_app_until(deadline)
     }
 
     fn capture_frame(&mut self, region: Option<&Region>) -> Result<Frame> {
@@ -1331,8 +1332,10 @@ mod teardown_tests {
         let mut p = platform(&fake, true);
 
         let started = std::time::Instant::now();
-        p.stop_app_by(std::time::Instant::now() + std::time::Duration::from_millis(300))
-            .expect("teardown is best-effort and reports success either way");
+        p.stop_app_by(Deadline::at(
+            std::time::Instant::now() + std::time::Duration::from_millis(300),
+        ))
+        .expect("teardown is best-effort and reports success either way");
         let waited = started.elapsed();
 
         assert!(

--- a/crates/glass-ios/src/platform.rs
+++ b/crates/glass-ios/src/platform.rs
@@ -601,10 +601,6 @@ impl Platform for IosPlatform {
         self.app.as_ref().and_then(|a| a.pid)
     }
 
-    fn stop_app(&mut self) -> Result<()> {
-        self.stop_app_until(Deadline::UNBOUNDED)
-    }
-
     /// `terminate` measures ~101ms against the 3s all of teardown gets, so the deadline is not
     /// expected to bind. It is for the simulator that stopped answering, which would otherwise run
     /// out the 10s `SimctlOp::Query` budget and leave nothing for the hook behind it

--- a/crates/glass-ios/src/simctl.rs
+++ b/crates/glass-ios/src/simctl.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
-use glass_core::{GlassError, Result, run_bounded, run_bounded_until};
+use glass_core::{Deadline, GlassError, Result, run_bounded_until};
 
 /// What a `simctl` invocation is doing, which is what decides how long it may take.
 ///
@@ -115,13 +115,13 @@ impl Simctl {
 
     /// Run `xcrun simctl <sub...>` and return captured stdout as lossy UTF-8 text.
     pub fn run(&self, sub: &[&str]) -> Result<String> {
-        self.run_until(sub, None)
+        self.run_until(sub, Deadline::UNBOUNDED)
     }
 
     /// [`Simctl::run`] under a deadline the whole sequence shares, `None` for a call that answers
     /// to nothing but its own budget. The deadline bounds the run; it does not reserve time for
     /// the calls behind, which is `Glass::shutdown`'s job (glass#427).
-    pub fn run_until(&self, sub: &[&str], deadline: Option<Instant>) -> Result<String> {
+    pub fn run_until(&self, sub: &[&str], deadline: Deadline) -> Result<String> {
         let out = self.output(sub, deadline)?;
         Ok(String::from_utf8_lossy(&out).into_owned())
     }
@@ -143,14 +143,11 @@ impl Simctl {
         cmd.spawn()
     }
 
-    fn output(&self, sub: &[&str], deadline: Option<Instant>) -> Result<Vec<u8>> {
+    fn output(&self, sub: &[&str], deadline: Deadline) -> Result<Vec<u8>> {
         let op = SimctlOp::for_sub(sub);
         let mut cmd = Command::new(self.program());
         cmd.args(self.full_args(sub));
-        let out = match deadline {
-            Some(d) => run_bounded_until(&mut cmd, op.budget(), d, op.label())?,
-            None => run_bounded(&mut cmd, op.budget(), op.label())?,
-        };
+        let out = run_bounded_until(&mut cmd, op.budget(), deadline, op.label())?;
         if !out.status.success() {
             return Err(GlassError::Backend(format!(
                 "simctl {:?} failed: {}",

--- a/crates/glass-ios/src/simctl.rs
+++ b/crates/glass-ios/src/simctl.rs
@@ -118,8 +118,8 @@ impl Simctl {
         self.run_until(sub, Deadline::UNBOUNDED)
     }
 
-    /// [`Simctl::run`] under a deadline the whole sequence shares, `None` for a call that answers
-    /// to nothing but its own budget. The deadline bounds the run; it does not reserve time for
+    /// [`Simctl::run`] under a deadline the whole sequence shares, [`Deadline::UNBOUNDED`] for a
+    /// call that answers to nothing but its own budget. The deadline bounds the run; it does not reserve time for
     /// the calls behind, which is `Glass::shutdown`'s job (glass#427).
     pub fn run_until(&self, sub: &[&str], deadline: Deadline) -> Result<String> {
         let out = self.output(sub, deadline)?;

--- a/crates/glass-ios/tests/drive_integration.rs
+++ b/crates/glass-ios/tests/drive_integration.rs
@@ -30,9 +30,8 @@
 
 use std::time::Duration;
 
-use glass_core::accessibility::{
-    Accessibility, AxContext, AxDeadline, AxNode, AxTarget, AxTree, WalkLimits,
-};
+use glass_core::Deadline;
+use glass_core::accessibility::{Accessibility, AxContext, AxNode, AxTarget, AxTree, WalkLimits};
 use glass_core::{AppSpec, KeyEvent, MouseButton, Platform, PointerEvent, SandboxLevel};
 use glass_ios::{IosA11y, IosPlatform, SimulatorRegistry};
 
@@ -136,7 +135,7 @@ fn drive_fixture_snapshot_tap_and_type_end_to_end() {
         window_handle: None,
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
-        deadline: AxDeadline::UNBOUNDED,
+        deadline: Deadline::UNBOUNDED,
     };
 
     // 1) Snapshot: the fixture's elements must appear, and the status starts at READY. The

--- a/crates/glass-ios/tests/launch_args_integration.rs
+++ b/crates/glass-ios/tests/launch_args_integration.rs
@@ -22,7 +22,8 @@
 
 #![cfg(unix)]
 
-use glass_core::accessibility::{Accessibility, AxContext, AxDeadline, AxNode, AxTree, WalkLimits};
+use glass_core::Deadline;
+use glass_core::accessibility::{Accessibility, AxContext, AxNode, AxTree, WalkLimits};
 use glass_core::{AppSpec, Platform, SandboxLevel};
 use glass_ios::{IosPlatform, SimulatorRegistry};
 
@@ -73,7 +74,7 @@ fn screen_of(spec: &AppSpec) -> AxTree {
         window_handle: None,
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
-        deadline: AxDeadline::UNBOUNDED,
+        deadline: Deadline::UNBOUNDED,
     };
     // UIKit keeps building the hierarchy for a beat after the app is up, so a tree read straight
     // after `start_app` can be half-drawn — which would fail here as "the argument did not

--- a/crates/glass-ios/tests/role_probe.rs
+++ b/crates/glass-ios/tests/role_probe.rs
@@ -30,7 +30,8 @@
 use std::time::Duration;
 
 use glass_core::Accessibility; // the trait must be in scope to call `snapshot` on the boxed reader
-use glass_core::accessibility::{AxContext, AxDeadline, WalkLimits};
+use glass_core::Deadline;
+use glass_core::accessibility::{AxContext, WalkLimits};
 use glass_core::{
     AppSpec, AxRole, AxTree, DescriptionSourcing, Platform, SandboxLevel,
     description_census_report, role_histogram,
@@ -225,7 +226,7 @@ fn role_histogram_probe() {
             // The node cap lifted, so a big app's tree is never truncated mid-probe. Depth
             // and per-level sibling rails keep their generous structural defaults regardless.
             limits: WalkLimits::from_max_nodes(Some(0)),
-            deadline: AxDeadline::UNBOUNDED,
+            deadline: Deadline::UNBOUNDED,
         };
         let mut tree = a11y
             .snapshot(&ctx)

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -684,7 +684,8 @@ impl Platform for MacosPlatform {
     /// first, per the `adopted` field's doc. This then falls through to the child/pasteboard
     /// cleanup rather than returning early: a session is `adopted` XOR `child`-backed, so the
     /// fall-through is a no-op, and it keeps `stop_app` and `Drop` structurally identical.
-    fn stop_app(&mut self) -> Result<()> {
+    /// Ignores the deadline: this teardown is an ask-then-signal ladder, already asserted against TEARDOWN_BUDGET.
+    fn stop_app_by(&mut self, _deadline: glass_core::Deadline) -> Result<()> {
         if let Some(a) = self.adopted.take() {
             a.reap();
         }

--- a/crates/glass-macos/tests/a11y.rs
+++ b/crates/glass-macos/tests/a11y.rs
@@ -62,7 +62,7 @@ mod macos_main {
 
     use glass_core::platform::{MouseButton, PointerEvent};
     use glass_core::{
-        Accessibility, AppSpec, AxContext, AxDeadline, AxNode, AxRole, AxTarget, GlassError,
+        Accessibility, AppSpec, AxContext, AxNode, AxRole, AxTarget, Deadline, GlassError,
         Platform, SandboxLevel, Stream, WalkLimits,
     };
     use glass_macos::MacosPlatform;
@@ -153,7 +153,7 @@ mod macos_main {
             window_handle: None,
             a11y_bus_addr: None,
             limits: WalkLimits::DEFAULT,
-            deadline: AxDeadline::UNBOUNDED,
+            deadline: Deadline::UNBOUNDED,
         };
 
         let mut a11y = glass_a11y_macos::MacosA11y::new();

--- a/crates/glass-macos/tests/bundle_launch.rs
+++ b/crates/glass-macos/tests/bundle_launch.rs
@@ -70,7 +70,7 @@ mod macos_main {
     use glass_a11y_macos::MacosA11y;
     use glass_core::platform::{MouseButton, PointerEvent};
     use glass_core::{
-        Accessibility, AppSpec, AxContext, AxDeadline, GlassError, Platform, SandboxLevel, Stream,
+        Accessibility, AppSpec, AxContext, Deadline, GlassError, Platform, SandboxLevel, Stream,
         WalkLimits,
     };
     use glass_macos::MacosPlatform;
@@ -352,7 +352,7 @@ mod macos_main {
                 window_handle: None,
                 a11y_bus_addr: None,
                 limits: WalkLimits::DEFAULT,
-                deadline: AxDeadline::UNBOUNDED,
+                deadline: Deadline::UNBOUNDED,
             };
             let mut a11y = MacosA11y::new();
             let mut tree = try_expect(a11y.snapshot(&ctx), "a11y snapshot(TextEdit)")?;

--- a/crates/glass-macos/tests/role_probe.rs
+++ b/crates/glass-macos/tests/role_probe.rs
@@ -45,9 +45,8 @@ mod macos_main {
 
     use glass_a11y_macos::MacosA11y;
     use glass_core::{
-        Accessibility, AppSpec, AxContext, AxDeadline, AxRole, AxTree, DescriptionSourcing,
-        Platform, SandboxLevel, WalkLimits, description_census, description_census_report,
-        role_histogram,
+        Accessibility, AppSpec, AxContext, AxRole, AxTree, Deadline, DescriptionSourcing, Platform,
+        SandboxLevel, WalkLimits, description_census, description_census_report, role_histogram,
     };
     use glass_macos::MacosPlatform;
 
@@ -229,7 +228,7 @@ mod macos_main {
                 window_handle: None,
                 a11y_bus_addr: None,
                 limits: WalkLimits::from_max_nodes(Some(0)),
-                deadline: AxDeadline::UNBOUNDED,
+                deadline: Deadline::UNBOUNDED,
             };
             let mut a11y = MacosA11y::new();
             let mut tree = a11y

--- a/crates/glass-macos/tests/window_adopt_probe.rs
+++ b/crates/glass-macos/tests/window_adopt_probe.rs
@@ -59,7 +59,7 @@ mod macos_main {
 
     use glass_a11y_macos::MacosA11y;
     use glass_core::{
-        Accessibility, AppSpec, AxContext, AxDeadline, Platform, SandboxLevel, WalkLimits,
+        Accessibility, AppSpec, AxContext, Deadline, Platform, SandboxLevel, WalkLimits,
         WindowGeometry, WindowInfo, WindowOp,
     };
     use glass_macos::MacosPlatform;
@@ -273,7 +273,7 @@ mod macos_main {
                 // Only Ok/Err is read below, and that outcome turns on root window resolution,
                 // not tree size — cap at 1 node instead of paying for the full tree.
                 limits: WalkLimits::from_max_nodes(Some(1)),
-                deadline: AxDeadline::UNBOUNDED,
+                deadline: Deadline::UNBOUNDED,
             };
             let snapshot_ok = match MacosA11y::new().snapshot(&ctx) {
                 Ok(_) => {

--- a/crates/glass-mcp/src/lib.rs
+++ b/crates/glass-mcp/src/lib.rs
@@ -359,9 +359,9 @@ pub fn boot(audit: Option<Box<dyn glass_core::AuditSink>>) -> Glass {
         // time (glass#422). Between themselves it is first-come-first-served, which holds because
         // at most one of the first three has real work: `kill_all` is empty unless glass booted
         // the emulator, and if it did, the a11y settings restored before it die with the VM.
-        a11y.shutdown_until(Some(deadline));
-        agents.shutdown_until(Some(deadline));
-        registry.kill_all_until(Some(deadline));
+        a11y.shutdown(deadline);
+        agents.shutdown(deadline);
+        registry.kill_all(deadline);
         // Not under the deadline: it does not wait (see `shutdown_all`).
         #[cfg(target_os = "macos")]
         sim_registry.request_shutdown_all();

--- a/crates/glass-mcp/src/lib.rs
+++ b/crates/glass-mcp/src/lib.rs
@@ -355,14 +355,8 @@ pub fn boot(audit: Option<Box<dyn glass_core::AuditSink>>) -> Glass {
         Box::new(move |b| make_platform(b, &reg_factory, &agents_factory, &a11y_factory));
     let mut glass = Glass::new(platform_factory, default, baselines, 10_000);
     glass.set_shutdown_hook(Box::new(move |deadline| {
-        // `Glass::shutdown` keeps `TEARDOWN_HOOK_RESERVE` back from the sessions so these have
-        // time (glass#422). Between themselves it is first-come-first-served, which holds because
-        // at most one of the first three has real work: `kill_all` is empty unless glass booted
-        // the emulator, and if it did, the a11y settings restored before it die with the VM.
-        a11y.shutdown(deadline);
-        agents.shutdown(deadline);
-        registry.kill_all(deadline);
-        // Not under the deadline: it does not wait (see `shutdown_all`).
+        glass_android::hand_the_device_back(&a11y, &agents, &registry, deadline);
+        // Not under the deadline: it does not wait (see `request_shutdown_all`).
         #[cfg(target_os = "macos")]
         sim_registry.request_shutdown_all();
     }));

--- a/crates/glass-mcp/src/shutdown.rs
+++ b/crates/glass-mcp/src/shutdown.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use glass_core::Glass;
+use glass_core::{Deadline, Glass};
 use tokio::sync::Mutex;
 
 /// How long a tool call may hold the session before teardown says so.
@@ -37,7 +37,9 @@ pub async fn run_shutdown(sessions: Arc<Mutex<Glass>>, budget: Duration) {
         if waited > LOCK_WAIT_WORTH_SAYING {
             eprintln!("glass: a tool call held the session for {waited:?} before teardown started");
         }
-        glass.shutdown(Instant::now() + budget - glass_core::TEARDOWN_REAP_HEADROOM);
+        glass.shutdown(Deadline::at(
+            Instant::now() + budget - glass_core::TEARDOWN_REAP_HEADROOM,
+        ));
     });
     match tokio::time::timeout(budget, task).await {
         Ok(Ok(())) => {}
@@ -171,8 +173,8 @@ mod tests {
             fn stop_app(&mut self) -> Result<()> {
                 Ok(())
             }
-            fn stop_app_by(&mut self, deadline: Instant) -> Result<()> {
-                *self.0.lock().unwrap() = Some(deadline.saturating_duration_since(Instant::now()));
+            fn stop_app_by(&mut self, deadline: glass_core::Deadline) -> Result<()> {
+                *self.0.lock().unwrap() = deadline.remaining();
                 Ok(())
             }
             fn capture_frame(&mut self, _r: Option<&Region>) -> Result<Frame> {

--- a/crates/glass-mcp/src/shutdown.rs
+++ b/crates/glass-mcp/src/shutdown.rs
@@ -101,7 +101,7 @@ mod tests {
                 height: 10,
             })
         }
-        fn stop_app(&mut self) -> Result<()> {
+        fn stop_app_by(&mut self, _deadline: glass_core::Deadline) -> Result<()> {
             // 2s >> the 200ms budget below — long enough to prove `run_shutdown`
             // returns on the timeout rather than waiting for stop_app, but short
             // enough that the runtime's wait for this detached blocking thread at

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -578,7 +578,7 @@ pub(crate) mod testutil {
             self.started = true;
             Ok(self.geometry.clone())
         }
-        fn stop_app(&mut self) -> Result<()> {
+        fn stop_app_by(&mut self, _deadline: glass_core::Deadline) -> Result<()> {
             self.started = false;
             Ok(())
         }

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -387,7 +387,7 @@ fn resolve_return(
             // Reuse the session's current limits so a fold after a raised/unbounded snapshot
             // isn't silently re-truncated to the default cap.
             let tree = glass
-                .a11y_resnapshot(glass_core::AxDeadline::UNBOUNDED)
+                .a11y_resnapshot(glass_core::Deadline::UNBOUNDED)
                 .map_err(|e| e.to_string())?;
             // Same shape as `a11y_snapshot`: the app-derived outline stays untrusted-wrapped;
             // glass's own steers are separate trusted blocks, not baked into that body.

--- a/crates/glass-mcp/tests/android_session_loop.rs
+++ b/crates/glass-mcp/tests/android_session_loop.rs
@@ -8,6 +8,7 @@
 //!     cargo test -p glass-mcp --test android_session_loop -- --ignored --nocapture
 
 use glass_android::{A11yServiceRegistry, AgentRegistry, AndroidPlatform, EmulatorRegistry};
+use glass_core::Deadline;
 use glass_core::accessibility::{AxNode, AxTree, ClickMethod};
 use glass_core::{AppSpec, BaselineStore, Glass, PlatformFactory, SandboxLevel};
 
@@ -33,10 +34,10 @@ impl Drop for Companions {
     fn drop(&mut self) {
         // Reached while a panic unwinds, where a second panic aborts the process — nothing here
         // may assert.
-        self.agents.shutdown();
-        self.a11y.shutdown();
+        self.agents.shutdown(Deadline::UNBOUNDED);
+        self.a11y.shutdown(Deadline::UNBOUNDED);
         // A no-op unless glass booted the emulator rather than attaching to one.
-        self.emulators.kill_all();
+        self.emulators.kill_all(Deadline::UNBOUNDED);
     }
 }
 

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -1687,7 +1687,8 @@ impl Platform for WaylandPlatform {
         Err(last_err)
     }
 
-    fn stop_app(&mut self) -> Result<()> {
+    /// Ignores the deadline: this teardown is a signal ladder over local processes, already asserted against TEARDOWN_BUDGET.
+    fn stop_app_by(&mut self, _deadline: glass_core::Deadline) -> Result<()> {
         self.kill_session();
         Ok(())
     }

--- a/crates/glass-windows/src/lib.rs
+++ b/crates/glass-windows/src/lib.rs
@@ -253,7 +253,8 @@ mod backend {
             }
         }
 
-        fn stop_app(&mut self) -> Result<()> {
+        /// Ignores the deadline: this teardown is a Job object close, already asserted against TEARDOWN_BUDGET.
+        fn stop_app_by(&mut self, _deadline: glass_core::Deadline) -> Result<()> {
             if let Some(app) = self.app.take() {
                 crate::process::disclose_teardown(app.kill());
             }

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -14,8 +14,8 @@ use std::time::{Duration, Instant};
 
 use glass_a11y_windows::WindowsA11y;
 use glass_core::{
-    Accessibility, AppSpec, AxContext, AxDeadline, AxNode, AxRole, AxTarget, AxTree, Backend,
-    BaselineStore, ChangeSignal, DescriptionSourcing, Glass, GlassError, KeyEvent, Modifier,
+    Accessibility, AppSpec, AxContext, AxNode, AxRole, AxTarget, AxTree, Backend, BaselineStore,
+    ChangeSignal, Deadline, DescriptionSourcing, Glass, GlassError, KeyEvent, Modifier,
     MouseButton, Platform, PlatformFactory, PointerEvent, WalkLimits, WindowGeometry, WindowHint,
     WindowOp, description_census, description_census_report, role_histogram,
 };
@@ -640,7 +640,7 @@ fn onbox_modifier_click() {
         window_handle: p.active_window_handle(),
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
-        deadline: AxDeadline::UNBOUNDED,
+        deadline: Deadline::UNBOUNDED,
     };
     let tree = a11y.snapshot(&ctx).expect("a11y snapshot");
     let mut hit = None;
@@ -762,7 +762,7 @@ fn onbox_a11y_set_value() {
         window_handle: p.active_window_handle(),
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
-        deadline: AxDeadline::UNBOUNDED,
+        deadline: Deadline::UNBOUNDED,
     };
     let tree = a11y.snapshot(&ctx).expect("a11y snapshot");
 
@@ -831,7 +831,7 @@ fn onbox_egui_set_value_honesty() {
         window_handle: p.active_window_handle(),
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
-        deadline: AxDeadline::UNBOUNDED,
+        deadline: Deadline::UNBOUNDED,
     };
     let tree = a11y
         .snapshot(&ctx)
@@ -1017,7 +1017,7 @@ fn onbox_a11y_edge_multiprocess() {
         window_handle: p.active_window_handle(),
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
-        deadline: AxDeadline::UNBOUNDED,
+        deadline: Deadline::UNBOUNDED,
     };
     let tree = a11y
         .snapshot(&ctx)
@@ -1282,7 +1282,7 @@ fn probe_role_histogram(label: &str, spec: &AppSpec, report: &mut String) -> Pro
         window_handle: p.active_window_handle(),
         a11y_bus_addr: None,
         limits: WalkLimits::from_max_nodes(Some(0)),
-        deadline: AxDeadline::UNBOUNDED,
+        deadline: Deadline::UNBOUNDED,
     };
     let tree = a11y
         .snapshot(&ctx)
@@ -1455,7 +1455,7 @@ fn onbox_a11y_subscription_reports_a_real_change() {
         window_handle: p.active_window_handle(),
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
-        deadline: AxDeadline::UNBOUNDED,
+        deadline: Deadline::UNBOUNDED,
     };
 
     // Before the first read, as the seam requires: a change landing between a read and the
@@ -1517,7 +1517,7 @@ fn onbox_a11y_subscription_is_quiet_on_an_idle_app() {
         window_handle: p.active_window_handle(),
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
-        deadline: AxDeadline::UNBOUNDED,
+        deadline: Deadline::UNBOUNDED,
     };
     let mut signal = a11y
         .subscribe_changes(&ctx)
@@ -1870,7 +1870,7 @@ fn independent_ctx(handle: i64) -> AxContext {
         window_handle: Some(handle),
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
-        deadline: AxDeadline::UNBOUNDED,
+        deadline: Deadline::UNBOUNDED,
     }
 }
 

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -1051,7 +1051,8 @@ impl Platform for X11Platform {
         }
     }
 
-    fn stop_app(&mut self) -> Result<()> {
+    /// Ignores the deadline: this teardown is a signal ladder over local processes, already asserted against TEARDOWN_BUDGET.
+    fn stop_app_by(&mut self, _deadline: glass_core::Deadline) -> Result<()> {
         self.kill_child();
         Ok(())
     }


### PR DESCRIPTION
Closes #430.

`AxDeadline`, `Option<Instant>` and a bare `Instant` all meant "when the caller stops waiting" —
the last two fifteen lines apart in `Adb`. `None` reads as "zero" as readily as "unbounded", and a
call given zero is never spawned, so that ambiguity fails in the quiet direction.

`AxDeadline` moves to `glass_core::deadline::Deadline` and is what every boundary that can be
unbounded now takes: `run_bounded_until`, `Adb::run_until` and `run_streams_until`,
`Simctl::run_until`, `Platform::stop_app_by`, `Glass::shutdown` and its hook, and the three Android
registries — whose `shutdown()`/`shutdown_until()` pairs collapse into one method each.

A *required* bound stays a plain `Instant` — the wayland clipboard transfer, `wait_for_agent_until`,
`bounded`'s own `poll_until`. The module doc says so, or the next reader finishes the job and makes
unboundedness representable where an infinite block is the result.

## Two things that came out better than a rename

`budget_within` was a private function whose comment said it existed so "the rule is pinned by a
test, which a timing test cannot do". Moving it onto the type broke that — reading the clock
internally made the exact test fail by 264ns. It keeps `now` as a parameter, and the test stayed
exact.

`Deadline::reserving` replaces both the hand-rolled `deadline - reserve` in `Glass::shutdown` and
the half-clamp that lived beside it. The rule is now in one tested place, `shutdown` is one line,
and the bare `Instant - Duration` — which panics on Windows, where `Instant` is a duration since
boot — is gone.

## What the review changed

Four lenses. The one real hole was mine: collapsing each registry's pair **removed a naming guard
and put nothing in its place**. On master, losing a deadline meant calling a differently-named
method; afterwards it was one argument value. Setting all three hook arguments to `UNBOUNDED` left
**314 glass-mcp tests green** — a wedged device costing 3×10s against a 3s budget, silently.

The join now lives in `glass_android::hand_the_device_back`, where `FakeAdb` lives and a test can
watch the deadline reach all three. **That test then failed for a reason I had not seen**: with the
a11y restore first, a wedged device spends the whole deadline before `emu kill` is even asked — the
largest leak starved by the smallest, while my comment claimed that could not matter. The emulator
goes first now, and the ordering is pinned by ablation.

`Platform::stop_app_by` became the required method and `stop_app` the provided one, so a new
device-linked backend cannot inherit an unbounded teardown in silence — the bug class that produced
#422 and #427. Eight impls, no call sites.

**Docs the `sed` broke, or that were wrong before it:**

- The history claim was false. The bare `Instant` came from the a11y dump path (#312), not
  teardown — so teardown grew one spelling, not two. I had already fixed this paragraph once for
  telling a tidier story than what happened, and it was still doing it.
- `poll_until` was the wrong example for "a required bound keeps its `Instant`": there are three,
  and the public re-exported one takes no `Instant` at all.
- Both `run_until` docs still told callers to pass `None`.
- The three collapsed registry docs kept *both* lead sentences, so each rendered as a run-on saying
  the same thing twice.
- Two test docs in `lifecycle.rs` were spliced into each other by my own #431 edit — and I spliced
  a third the same way in this round while adding a test seam, which is why the pattern is worth
  naming rather than just fixing.

## Verified

Behaviour-preservation was checked exhaustively rather than assumed: all ~40 introduced
`UNBOUNDED`s map 1:1 to a former `None` or `AxDeadline::UNBOUNDED`, `Deadline::within`'s body is
character-for-character the old `budget_within`, and `run_streams_until`'s single production caller
still wraps with `Deadline::at`. No real deadline became unbounded anywhere.

Every behavioural claim was ablated: the `within` UNBOUNDED arm (13 further failures if it returns
zero), `reserving` in both direction and amount, `run_bounded`'s delegation, and each of the five
teardown call sites, each failing on its own ablation and no other.

Three targets, since this touched macOS and Windows code that does not compile here: Linux,
`x86_64-pc-windows-gnu`, and `x86_64-apple-darwin` including glass-macos/glass-ios all-targets. The
Windows leg earned its keep twice — it caught an import used only under `cfg(unix)`, and then a
test seam that was dead there.

## Filed, not fixed

`cap` and `governs` are an atomic pair: both consumers call them on the same instant, nine lines
apart, and the glass#341 "which bound ended this" invariant rests entirely on that sameness. A
`resolve(own) -> (Instant, Whose)` would make it structural. That is a new safety property in the
a11y path, not a spelling cleanup, so it gets its own issue.
