### PR TITLE
fix(a11y): resolve the bound and its blame in one comparison

### DIFF
--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -6,8 +6,8 @@ use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use glass_core::Deadline;
 use glass_core::accessibility::{Accessibility, AxContext, AxNode, AxTarget, AxTree};
+use glass_core::{Deadline, Whose};
 use glass_core::{
     GlassError, KeyEvent, MouseButton, PointerEvent, Result, TAP_MAY_HAVE_MISSED, WindowGeometry,
     read_back_failed, verify_typed_write,
@@ -247,7 +247,8 @@ fn dump_until_ready(
     interval: Duration,
     caller: Deadline,
 ) -> Result<String> {
-    let retry_until = caller.cap(Instant::now() + bound.then_within);
+    // `.0`: a retry window is not a step, so there is no bound to blame — only the instant.
+    let retry_until = caller.resolve(Instant::now() + bound.then_within).0;
     let mut owed = bound.least.max(1);
     // Kept so a spent caller deadline can name what the device last said, not just the budget.
     let mut unready: Option<GlassError> = None;
@@ -258,17 +259,16 @@ fn dump_until_ready(
         if caller.has_passed() {
             return Err(out_of_time(unready.as_ref()));
         }
-        let own = attempt_deadline();
-        let ends = caller.cap(own);
+        let (ends, whose) = caller.resolve(attempt_deadline());
         match dump_once(run, prefix, ends) {
             Attempt::Dumped(xml) => return Ok(xml),
-            // An attempt the *caller's* deadline cut short is not a device that failed. Which
-            // bound governs is settled before the attempt, not read off its error (glass#341).
+            // An attempt the *caller's* deadline cut short is not a device that failed. Whose
+            // bound ends it is settled before the attempt, not read off its error (glass#341).
             //
             // The abandoned attempt's own error is carried, not dropped: a wedged adb reaches
             // here too — it cannot be told apart from a slow one at the moment the budget ends —
             // and its message is the only place glass names the `adb kill-server` remedy.
-            Attempt::Fatal(e) if caller.governs(own) && bound_fired(&e) => {
+            Attempt::Fatal(e) if whose == Whose::Caller && bound_fired(&e) => {
                 return Err(out_of_time(Some(&e)));
             }
             Attempt::Fatal(e) => return Err(e),
@@ -1091,7 +1091,7 @@ mod tests {
             PREFIX,
             RetryBound::ONCE,
             Duration::ZERO,
-            // Nearer than `AdbOp::Dump`'s budget, so the caller's bound governs the attempt —
+            // Nearer than `AdbOp::Dump`'s budget, so the attempt resolves to `Whose::Caller` —
             // which is true of every read a `wait_for_element` makes.
             Deadline::from_millis(5_000),
         )

--- a/crates/glass-core/src/a11y_thread.rs
+++ b/crates/glass-core/src/a11y_thread.rs
@@ -74,9 +74,8 @@ impl A11yThread {
     /// (glass#341, glass#432).
     ///
     /// One clock read, so the ceiling branch is exactly `ceiling` rather than `ceiling` minus
-    /// whatever fell between two reads. It trades the other way on the caller branch, where the
-    /// wait now expires a read later than the deadline instead of a read earlier; both are
-    /// nanoseconds against a wait the thread spawn below already dominates.
+    /// whatever fell between two reads. It trades the other way by the same nanoseconds on the
+    /// caller branch, where the wait now expires a read after the deadline instead of before.
     fn bounded_wait(&self, deadline: Deadline) -> (Duration, Whose) {
         let now = Instant::now();
         let (ends, whose) = deadline.resolve(now + self.ceiling);
@@ -219,9 +218,8 @@ mod tests {
         assert!(wait <= Duration::from_millis(50), "{wait:?}");
         assert_eq!(ended_by, Whose::Caller);
 
-        // And it is the caller's whole bound, not zero: a Caller branch that waits for nothing
-        // spawns a worker, gives up before it can answer, and reports every read in the window as
-        // the caller running out of time.
+        // And the whole bound, not zero: a Caller branch that waits for nothing spawns a worker,
+        // then reports every read in the window as the caller running out of time.
         let (wait, _) = reader().bounded_wait(Deadline::from_millis(5_000));
         assert!(wait > Duration::from_secs(4), "{wait:?}");
     }
@@ -230,8 +228,8 @@ mod tests {
     #[test]
     fn a_caller_that_names_no_deadline_leaves_the_read_its_own_ceiling() {
         let (wait, ended_by) = reader().bounded_wait(Deadline::UNBOUNDED);
-        // Exactly, not approximately: one clock read makes this branch deterministic, and the
-        // two-read shape it replaced came up short by whatever fell between them.
+        // One clock read makes this branch deterministic; the two-read shape it replaced came up
+        // short by whatever fell between them.
         assert_eq!(wait, CEILING, "{wait:?}");
         assert_eq!(ended_by, Whose::Callee);
     }

--- a/crates/glass-core/src/a11y_thread.rs
+++ b/crates/glass-core/src/a11y_thread.rs
@@ -16,18 +16,8 @@
 use std::sync::mpsc::{self, RecvTimeoutError};
 use std::time::{Duration, Instant};
 
-use crate::deadline::Deadline;
+use crate::deadline::{Deadline, Whose};
 use crate::{GlassError, Result};
-
-/// Which bound ended a wait. Decided before the wait, never inferred from its outcome — the
-/// mistake glass#341 recorded.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-enum EndedBy {
-    /// The caller's own deadline fell first: a spent budget, not a fault.
-    Caller,
-    /// The reader's ceiling ran out: the backend stopped answering.
-    Ceiling,
-}
 
 /// The bounded calls one accessibility backend makes on its detached worker thread.
 ///
@@ -80,22 +70,17 @@ impl A11yThread {
         A11yThread { backend, ceiling }
     }
 
-    /// How long a call may block, and which bound ends it.
+    /// How long a call may block, and which bound ends it — one comparison, made before the wait
+    /// (glass#341, glass#432).
     ///
-    /// Both come from one comparison, made before the wait: a call the *caller* cut short is a
-    /// spent budget and one that used the whole ceiling is a backend that stopped answering, and
-    /// inferring which afterwards is the mistake glass#341 recorded.
-    fn bounded_wait(&self, deadline: Deadline) -> (Duration, EndedBy) {
-        let own = Instant::now() + self.ceiling;
-        let ended_by = if deadline.governs(own) {
-            EndedBy::Caller
-        } else {
-            EndedBy::Ceiling
-        };
-        (
-            deadline.cap(own).saturating_duration_since(Instant::now()),
-            ended_by,
-        )
+    /// One clock read, so the ceiling branch is exactly `ceiling` rather than `ceiling` minus
+    /// whatever fell between two reads. It trades the other way on the caller branch, where the
+    /// wait now expires a read later than the deadline instead of a read earlier; both are
+    /// nanoseconds against a wait the thread spawn below already dominates.
+    fn bounded_wait(&self, deadline: Deadline) -> (Duration, Whose) {
+        let now = Instant::now();
+        let (ends, whose) = deadline.resolve(now + self.ceiling);
+        (ends.saturating_duration_since(now), whose)
     }
 
     /// Read the tree, bounded by whichever of the caller's deadline and the ceiling falls first.
@@ -108,7 +93,7 @@ impl A11yThread {
         job: impl FnOnce() -> Result<T> + Send + 'static,
     ) -> Result<T> {
         if deadline.has_passed() {
-            return Err(self.never_answered(EndedBy::Caller));
+            return Err(self.never_answered(Whose::Caller));
         }
         let (wait, ended_by) = self.bounded_wait(deadline);
         self.detached(Op::Snapshot, wait, job, ended_by)
@@ -119,7 +104,7 @@ impl A11yThread {
     /// No deadline: the seam places the capping obligation on `snapshot`, and the session builds
     /// both this context and `invoke`'s with [`Deadline::UNBOUNDED`], so there is none to honour.
     pub fn set_value(&self, job: impl FnOnce() -> Result<()> + Send + 'static) -> Result<()> {
-        self.detached(Op::SetValue, self.ceiling, job, EndedBy::Ceiling)
+        self.detached(Op::SetValue, self.ceiling, job, Whose::Callee)
     }
 
     /// Actuate the element, bounded by the ceiling alone.
@@ -128,18 +113,18 @@ impl A11yThread {
     /// [`GlassError::invoke_fallback_eligible`] excludes — so no pointer click is layered on top of
     /// an action that may be about to fire.
     pub fn invoke(&self, job: impl FnOnce() -> Result<()> + Send + 'static) -> Result<()> {
-        self.detached(Op::Invoke, self.ceiling, job, EndedBy::Ceiling)
+        self.detached(Op::Invoke, self.ceiling, job, Whose::Callee)
     }
 
     /// The verdict for a read that never answered. The caller's own deadline ending it is
     /// `AccessibilityNotReady`, which [`crate::Glass::wait_for_element`] polls through, where the
     /// backend going quiet for a whole ceiling is not.
-    fn never_answered(&self, ended_by: EndedBy) -> GlassError {
+    fn never_answered(&self, ended_by: Whose) -> GlassError {
         match ended_by {
-            EndedBy::Caller => GlassError::AccessibilityNotReady(
+            Whose::Caller => GlassError::AccessibilityNotReady(
                 "no accessibility tree within the time this call allowed".into(),
             ),
-            EndedBy::Ceiling => self.timed_out(Op::Snapshot),
+            Whose::Callee => self.timed_out(Op::Snapshot),
         }
     }
 
@@ -170,7 +155,7 @@ impl A11yThread {
         op: Op,
         wait: Duration,
         job: impl FnOnce() -> Result<T> + Send + 'static,
-        ended_by: EndedBy,
+        ended_by: Whose,
     ) -> Result<T> {
         let (tx, rx) = mpsc::channel();
         // Named and fallible, unlike a bare `spawn`: a timed-out worker outlives its wait holding
@@ -231,7 +216,7 @@ mod tests {
     fn a_read_is_bounded_by_the_caller_when_that_falls_first() {
         let (wait, ended_by) = reader().bounded_wait(Deadline::from_millis(50));
         assert!(wait <= Duration::from_millis(50), "{wait:?}");
-        assert_eq!(ended_by, EndedBy::Caller);
+        assert_eq!(ended_by, Whose::Caller);
     }
 
     /// The other direction: without it the test above passes on a reader that waits for nothing.
@@ -239,7 +224,7 @@ mod tests {
     fn a_caller_that_names_no_deadline_leaves_the_read_its_own_ceiling() {
         let (wait, ended_by) = reader().bounded_wait(Deadline::UNBOUNDED);
         assert!(wait > CEILING - Duration::from_secs(1), "{wait:?}");
-        assert_eq!(ended_by, EndedBy::Ceiling);
+        assert_eq!(ended_by, Whose::Callee);
     }
 
     /// The variant decides whether a wait polls on or fails, so the two causes must not collapse:
@@ -248,18 +233,18 @@ mod tests {
     #[test]
     fn a_read_the_caller_cut_short_reads_as_not_ready_where_a_quiet_backend_does_not() {
         assert!(matches!(
-            reader().never_answered(EndedBy::Caller),
+            reader().never_answered(Whose::Caller),
             GlassError::AccessibilityNotReady(_)
         ));
         assert!(matches!(
-            reader().never_answered(EndedBy::Ceiling),
+            reader().never_answered(Whose::Callee),
             GlassError::AccessibilityUnavailable(_)
         ));
     }
 
     #[test]
     fn a_timeout_names_the_backend_that_stopped_answering() {
-        let e = A11yThread::new("UIA", CEILING).never_answered(EndedBy::Ceiling);
+        let e = A11yThread::new("UIA", CEILING).never_answered(Whose::Callee);
         assert!(e.to_string().contains("UIA not responding"), "{e}");
     }
 

--- a/crates/glass-core/src/a11y_thread.rs
+++ b/crates/glass-core/src/a11y_thread.rs
@@ -96,7 +96,7 @@ impl A11yThread {
             return Err(self.never_answered(Whose::Caller));
         }
         let (wait, ended_by) = self.bounded_wait(deadline);
-        self.detached(Op::Snapshot, wait, job, ended_by)
+        self.detached(Op::Snapshot, wait, job, || self.never_answered(ended_by))
     }
 
     /// Write a value, bounded by the ceiling alone.
@@ -104,7 +104,9 @@ impl A11yThread {
     /// No deadline: the seam places the capping obligation on `snapshot`, and the session builds
     /// both this context and `invoke`'s with [`Deadline::UNBOUNDED`], so there is none to honour.
     pub fn set_value(&self, job: impl FnOnce() -> Result<()> + Send + 'static) -> Result<()> {
-        self.detached(Op::SetValue, self.ceiling, job, Whose::Callee)
+        self.detached(Op::SetValue, self.ceiling, job, || {
+            self.timed_out(Op::SetValue)
+        })
     }
 
     /// Actuate the element, bounded by the ceiling alone.
@@ -113,7 +115,7 @@ impl A11yThread {
     /// [`GlassError::invoke_fallback_eligible`] excludes — so no pointer click is layered on top of
     /// an action that may be about to fire.
     pub fn invoke(&self, job: impl FnOnce() -> Result<()> + Send + 'static) -> Result<()> {
-        self.detached(Op::Invoke, self.ceiling, job, Whose::Callee)
+        self.detached(Op::Invoke, self.ceiling, job, || self.timed_out(Op::Invoke))
     }
 
     /// The verdict for a read that never answered. The caller's own deadline ending it is
@@ -150,12 +152,14 @@ impl A11yThread {
         ))
     }
 
+    /// `on_timeout` rather than a `Whose`: only a snapshot has two bounds to choose between, and
+    /// handing the other two a verdict this never read let them pass a wrong one unnoticed.
     fn detached<T: Send + 'static>(
         &self,
         op: Op,
         wait: Duration,
         job: impl FnOnce() -> Result<T> + Send + 'static,
-        ended_by: Whose,
+        on_timeout: impl FnOnce() -> GlassError,
     ) -> Result<T> {
         let (tx, rx) = mpsc::channel();
         // Named and fallible, unlike a bare `spawn`: a timed-out worker outlives its wait holding
@@ -174,10 +178,7 @@ impl A11yThread {
             })?;
         match rx.recv_timeout(wait) {
             Ok(r) => r,
-            Err(RecvTimeoutError::Timeout) => Err(match op {
-                Op::Snapshot => self.never_answered(ended_by),
-                _ => self.timed_out(op),
-            }),
+            Err(RecvTimeoutError::Timeout) => Err(on_timeout()),
             // The sender drops unsent only when the worker unwinds, so this is a panic, not a
             // slow answer — a timeout would claim the backend is alive and still working.
             Err(RecvTimeoutError::Disconnected) => Err(self.worker_panicked(op)),
@@ -217,13 +218,21 @@ mod tests {
         let (wait, ended_by) = reader().bounded_wait(Deadline::from_millis(50));
         assert!(wait <= Duration::from_millis(50), "{wait:?}");
         assert_eq!(ended_by, Whose::Caller);
+
+        // And it is the caller's whole bound, not zero: a Caller branch that waits for nothing
+        // spawns a worker, gives up before it can answer, and reports every read in the window as
+        // the caller running out of time.
+        let (wait, _) = reader().bounded_wait(Deadline::from_millis(5_000));
+        assert!(wait > Duration::from_secs(4), "{wait:?}");
     }
 
     /// The other direction: without it the test above passes on a reader that waits for nothing.
     #[test]
     fn a_caller_that_names_no_deadline_leaves_the_read_its_own_ceiling() {
         let (wait, ended_by) = reader().bounded_wait(Deadline::UNBOUNDED);
-        assert!(wait > CEILING - Duration::from_secs(1), "{wait:?}");
+        // Exactly, not approximately: one clock read makes this branch deterministic, and the
+        // two-read shape it replaced came up short by whatever fell between them.
+        assert_eq!(wait, CEILING, "{wait:?}");
         assert_eq!(ended_by, Whose::Callee);
     }
 
@@ -335,6 +344,17 @@ mod tests {
         assert!(
             matches!(e, GlassError::AccessibilityUnavailable(_)),
             "a caller that named no deadline cannot be the one that ran out: {e}"
+        );
+
+        // The same verdict with a deadline present but further out — the shape of every read
+        // `wait_for_element` makes, where blaming the caller would poll straight through a backend
+        // that has stopped answering (glass#341).
+        let e = impatient()
+            .snapshot(Deadline::from_millis(60_000), hangs())
+            .unwrap_err();
+        assert!(
+            matches!(e, GlassError::AccessibilityUnavailable(_)),
+            "the ceiling fell first, so the caller still had time: {e}"
         );
     }
 

--- a/crates/glass-core/src/deadline.rs
+++ b/crates/glass-core/src/deadline.rs
@@ -49,9 +49,9 @@ impl Deadline {
     /// A tie is the callee's: one that used exactly its own bound must not be reported as a caller
     /// who ran out of time.
     ///
-    /// The only instant-vs-instant comparison this type makes. [`Self::within`] is the same
-    /// question in duration units; a third spelling of "whichever falls first" is a bug, not a
-    /// convenience (glass#432).
+    /// The only instant-vs-instant comparison this type makes — [`Self::within`] is the same
+    /// question in duration units, and a third spelling of "whichever falls first" is a bug
+    /// (glass#432).
     pub fn resolve(self, own: std::time::Instant) -> (std::time::Instant, Whose) {
         match self.0 {
             Some(d) if d < own => (d, Whose::Caller),
@@ -79,8 +79,8 @@ impl Deadline {
         budget: std::time::Duration,
         now: std::time::Instant,
     ) -> std::time::Duration {
-        // Not `cap(now + budget)`: that materialises an instant, and a budget near
-        // `Duration::MAX` overflows the addition. Same comparison, in duration units.
+        // Not `cap(now + budget)`: materialising the instant overflows the addition for a budget
+        // near `Duration::MAX`.
         self.remaining_at(now)
             .map_or(budget, |left| budget.min(left))
     }
@@ -154,7 +154,7 @@ mod tests {
     }
 
     /// `within` is `resolve` in duration units, so a divergence between them is the split this
-    /// type exists to prevent, coming back in a different shape (glass#432).
+    /// type exists to prevent (glass#432).
     #[test]
     fn every_unit_agrees_with_the_one_comparison() {
         let now = std::time::Instant::now();

--- a/crates/glass-core/src/deadline.rs
+++ b/crates/glass-core/src/deadline.rs
@@ -39,27 +39,35 @@ impl Deadline {
         Self(Some(instant))
     }
 
-    /// `proposed`, or this deadline when it falls first — the bound one step of a call runs under.
-    pub fn cap(self, proposed: std::time::Instant) -> std::time::Instant {
-        match self.0 {
-            Some(d) => proposed.min(d),
-            None => proposed,
-        }
-    }
-
-    /// Whether this deadline falls before `proposed`, so a step that runs out was cut off rather
-    /// than unanswered.
+    /// The instant a step is bounded by — the nearer of this deadline and `own`, the callee's own
+    /// bound — and whose bound that is.
     ///
-    /// A tie is deliberately not this deadline: reporting a backend that hung for its whole
-    /// ceiling as a spent caller budget hides it.
-    pub fn governs(self, proposed: std::time::Instant) -> bool {
-        self.0.is_some_and(|d| d < proposed)
+    /// One comparison answers both, so the instant and the blame cannot come from different
+    /// proposals (glass#432), and the blame is settled before the step runs rather than inferred
+    /// from the error it returns (glass#341).
+    ///
+    /// A tie is the callee's: one that used exactly its own bound must not be reported as a caller
+    /// who ran out of time.
+    ///
+    /// The only instant-vs-instant comparison this type makes. [`Self::within`] is the same
+    /// question in duration units; a third spelling of "whichever falls first" is a bug, not a
+    /// convenience (glass#432).
+    pub fn resolve(self, own: std::time::Instant) -> (std::time::Instant, Whose) {
+        match self.0 {
+            Some(d) if d < own => (d, Whose::Caller),
+            _ => (own, Whose::Callee),
+        }
     }
 
     /// How long is left, or `None` when the caller named no instant. Zero once it has passed.
     pub fn remaining(self) -> Option<std::time::Duration> {
-        self.0
-            .map(|d| d.saturating_duration_since(std::time::Instant::now()))
+        self.remaining_at(std::time::Instant::now())
+    }
+
+    /// [`Self::remaining`] measured from `now` — for a caller holding a fixed reference point,
+    /// where reading the clock again would subtract whatever it has since spent.
+    pub fn remaining_at(self, now: std::time::Instant) -> Option<std::time::Duration> {
+        self.0.map(|d| d.saturating_duration_since(now))
     }
 
     /// The budget a call actually gets: its own, or what is left of this deadline at `now`,
@@ -71,10 +79,10 @@ impl Deadline {
         budget: std::time::Duration,
         now: std::time::Instant,
     ) -> std::time::Duration {
-        match self.0 {
-            Some(d) => budget.min(d.saturating_duration_since(now)),
-            None => budget,
-        }
+        // Not `cap(now + budget)`: that materialises an instant, and a budget near
+        // `Duration::MAX` overflows the addition. Same comparison, in duration units.
+        self.remaining_at(now)
+            .map_or(budget, |left| budget.min(left))
     }
 
     /// This deadline pulled in by `reserve`, but never by more than half of what is left — for
@@ -99,49 +107,78 @@ impl Deadline {
     }
 }
 
+/// Whose bound a step ran under: settled before it starts, never inferred from how it ended
+/// (glass#341). [`Deadline::resolve`] answers it where both a caller's bound and the callee's own
+/// exist; a step bounded by one side alone names that side directly.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Whose {
+    /// The caller's deadline fell first: a spent budget, not a fault.
+    Caller,
+    /// The callee's own bound fell first, or level with the caller's — the caller still had time.
+    Callee,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::time::{Duration, Instant};
 
-    /// The two bounds a callee holds — its own and its caller's — resolve to whichever falls
-    /// first, in both directions.
+    /// `UNBOUNDED` is not a deadline of zero, which would stop every call before it started.
     #[test]
-    fn a_deadline_caps_a_proposed_instant_only_when_it_falls_first() {
-        let soon = Deadline::from_millis(1_000);
-        let later = std::time::Instant::now() + std::time::Duration::from_secs(60);
-        assert!(soon.cap(later) < later, "the nearer bound did not govern");
-
-        let now = std::time::Instant::now();
-        assert_eq!(
-            soon.cap(now),
-            now,
-            "a reader's own nearer bound was widened"
-        );
-    }
-
-    /// A caller that named no instant leaves the callee whatever it proposed — `UNBOUNDED` is not a
-    /// deadline of zero, which would stop every call before it started.
-    #[test]
-    fn no_deadline_caps_nothing_and_is_never_spent() {
-        let proposed = std::time::Instant::now() + std::time::Duration::from_secs(60);
-        assert_eq!(Deadline::UNBOUNDED.cap(proposed), proposed);
+    fn an_unbounded_deadline_is_never_spent() {
         assert_eq!(Deadline::UNBOUNDED.remaining(), None);
         assert!(!Deadline::UNBOUNDED.has_passed());
     }
 
-    /// The tie-break is load-bearing: a callee blames its own bound when both fall together, so a
-    /// backend that hung for exactly its ceiling is never reported as a caller who ran out of time.
+    /// Both halves agree at every ordering, and the tie is load-bearing: a callee blames its own
+    /// bound when both fall together, so a backend that hung for exactly its ceiling is never
+    /// reported as a caller who ran out of time.
     #[test]
-    fn a_deadline_governs_a_step_only_when_it_falls_strictly_first() {
+    fn resolve_answers_both_halves_from_one_comparison() {
         let now = std::time::Instant::now();
-        let soon = Deadline::from_millis(1_000);
-        assert!(soon.governs(now + std::time::Duration::from_secs(60)));
-        assert!(!soon.governs(now));
-        assert!(!Deadline::UNBOUNDED.governs(now + std::time::Duration::from_secs(60)));
-        // The tie itself, which only a shared instant can express: `<=` here would blame the
-        // caller for a backend that hung for exactly its own ceiling.
-        assert!(!Deadline::at(now).governs(now));
+        let later = now + std::time::Duration::from_secs(60);
+        let soon_at = now + std::time::Duration::from_secs(1);
+
+        // The caller's bound falls first: it is both the instant and the blame.
+        assert_eq!(
+            Deadline::at(soon_at).resolve(later),
+            (soon_at, Whose::Caller)
+        );
+        // The callee's own falls first, and keeps the blame.
+        assert_eq!(Deadline::at(soon_at).resolve(now), (now, Whose::Callee));
+        // A caller that named nothing leaves the callee its own, and the blame with it.
+        assert_eq!(Deadline::UNBOUNDED.resolve(later), (later, Whose::Callee));
+        // The tie, which only a shared instant can express: `<=` here would blame the caller for
+        // a backend that hung for exactly its own ceiling.
+        assert_eq!(Deadline::at(now).resolve(now), (now, Whose::Callee));
+    }
+
+    /// `within` is `resolve` in duration units, so a divergence between them is the split this
+    /// type exists to prevent, coming back in a different shape (glass#432).
+    #[test]
+    fn every_unit_agrees_with_the_one_comparison() {
+        let now = std::time::Instant::now();
+        let second = std::time::Duration::from_secs(1);
+        for deadline in [
+            Deadline::at(now + second),
+            Deadline::at(now),
+            Deadline::at(now - second),
+            Deadline::UNBOUNDED,
+        ] {
+            let proposed = now + std::time::Duration::from_secs(30);
+            assert_eq!(
+                deadline.within(std::time::Duration::from_secs(30), now),
+                deadline.resolve(proposed).0.saturating_duration_since(now)
+            );
+            // A budget no `Instant` can hold: the deadline is the answer, and computing it must
+            // not overflow on the way.
+            assert_eq!(
+                deadline.within(std::time::Duration::MAX, now),
+                deadline
+                    .remaining_at(now)
+                    .unwrap_or(std::time::Duration::MAX)
+            );
+        }
     }
 
     #[test]

--- a/crates/glass-core/src/deadline.rs
+++ b/crates/glass-core/src/deadline.rs
@@ -163,6 +163,9 @@ mod tests {
             Deadline::at(now + second),
             Deadline::at(now),
             Deadline::at(now - second),
+            // Past `proposed`, so the callee's own bound is the nearer one — without it every
+            // bounded case here takes the caller arm.
+            Deadline::at(now + std::time::Duration::from_secs(60)),
             Deadline::UNBOUNDED,
         ] {
             let proposed = now + std::time::Duration::from_secs(30);

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -81,7 +81,7 @@ pub use platform::{
 };
 
 pub mod deadline;
-pub use deadline::Deadline;
+pub use deadline::{Deadline, Whose};
 
 pub mod accessibility;
 pub use accessibility::{

--- a/crates/glass-core/src/session/lifecycle.rs
+++ b/crates/glass-core/src/session/lifecycle.rs
@@ -290,7 +290,8 @@ mod tests {
             .lock()
             .unwrap()
             .expect("the backend was stopped")
-            .within(std::time::Duration::MAX, started);
+            .remaining_at(started)
+            .expect("a bounded share");
         assert!(
             given >= budget / 3,
             "the sessions were given {given:?} of a {budget:?} budget — the reserve was taken \


### PR DESCRIPTION
Closes #432.

`Deadline::cap(own)` gave the instant a step runs to; `Deadline::governs(own)` gave whose bound
that was. Both consumers called them on the same `own` — in the Android dump loop, nine lines apart
with a subprocess call between — and nothing enforced that sameness. Mismatch them and the call
reports the wrong bound as the cause, which is glass#341: whose bound ended a step is settled
before it, never inferred from the error it returns.

`Deadline::resolve(own) -> (Instant, Whose)` answers both from one comparison. `Whose` replaces
`EndedBy`, a private enum in `a11y_thread` that described a general fact.

## The fix is the signature, and no test can prove it

The defect was two facts derived from two separately-supplied values. `resolve` takes one `own` and
returns both, so no input can make them disagree — there is nothing left to observe. What *is*
testable is the weaker projection, that the pair is coherent at every ordering, and
`resolve_answers_both_halves_from_one_comparison` does that by enumeration: caller-first,
callee-first, unbounded, and the tie.

The tie is the load-bearing one. It is the callee's, so a backend that hung for exactly its own
ceiling is never reported as a caller who ran out of time.

## `cap` and `governs` are both gone

`governs` had no callers left after `resolve`. `cap` turned out to be the third spelling of one
comparison — `resolve(x).0` is exactly it, and `within` was computing the same min again in
duration units. `within` now derives from a new `remaining_at`, the one caller that wants an
instant with no blame to attribute takes `resolve(..).0` and says why, and clippy then reported
`cap` as dead, which is the proof it was redundant rather than merely unpopular.

Deriving `within` through an instant was wrong in a way the suite caught immediately:
`now + Duration::MAX` overflows, and the teardown-reserve test does exactly that. It computes in
duration units instead, and the overflow case is now pinned.

`bounded_wait` also stops reading the clock twice — it was measuring the wait from a later `now`
than the instant it capped against.

## What the review changed

**A mutant that shipped green.** Returning `Duration::ZERO` from `bounded_wait`'s Caller branch
left the entire workspace passing. Every read a `wait_for_element` makes carries a deadline, so
under that mutant each one spawns a worker, gives up before it can answer, and reports the caller
out of time — the wait polling on having never read the tree. The branch had an upper bound and no
lower one; the sibling test's own comment ("without it the test above passes on a reader that waits
for nothing") shows the hazard was understood on the other side and missed on this one.

**`snapshot` with a deadline further out than the ceiling had no consumer test** — the shape of
essentially every production read. Flipping the verdict for that ordering alone was caught only by
the deadline unit test, while blaming the caller for a hung backend is exactly what
`wait_for_element` polls straight through.

**`detached`'s `Whose` argument was unkillable by construction**: it read the verdict only on the
snapshot arm, so `set_value` and `invoke` passed one that could be wrong with nothing able to
notice. It takes a timeout thunk now, so the value exists only where it is read.

Two doc claims were wrong and are fixed: `Whose`'s said `resolve` decided it, which is false at
three of the four sites that construct it, and `Whose::Callee`'s stated a conclusion one consumer
draws on one path ("it stopped answering") as the variant's meaning — it is also what `UNBOUNDED`
returns, where nothing has stopped answering.

## Verified

Four ablations, each shown red: the zero wait, the two-read clock shape, the verdict for
caller-present-but-further-out, and `within` diverging from the one comparison. All three targets
clean — Linux, `x86_64-pc-windows-gnu` all-targets, and `x86_64-apple-darwin` per
`verify-a-change.md` (workspace `--lib` plus the two Apple crates at `--all-targets`; the
whole-workspace form needs a darwin C toolchain this host lacks).

## Adjacent, deliberately untouched

The `NotReady` arm further down the Android loop asks a blame question *after* the fact, from a
fresh `has_passed()`. That is not the two-proposals defect — there is one proposal, and it
deliberately asks a current question ("has the caller gone by now") rather than a pre-decided
one — but it is close enough to the invariant to be worth naming rather than leaving to be
discovered.
