### PR TITLE
docs: run terse-comments over what #433 merged

### DIFF
--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -83,8 +83,9 @@ pub(crate) fn adb_runner(
 /// the sum of all three, 50s against the 10s a `glass_wait_for_element` asks for by default and
 /// re-snapshots inside.
 ///
-/// A caller that named a deadline gets [`Deadline::cap`] of this instead — see
-/// [`dump_until_ready`], which needs both to tell which of them ended an attempt.
+/// A caller that named a deadline gets [`Deadline::resolve`] of this instead — see
+/// [`dump_until_ready`], which needs the verdict it returns to tell which bound ended an
+/// attempt.
 pub(crate) fn attempt_deadline() -> Instant {
     Instant::now() + AdbOp::Dump.budget()
 }

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -738,9 +738,8 @@ impl A11yServiceRegistry {
     }
 
     /// Restore the device's prior accessibility state and remove the forward by `deadline`, which
-    /// the rest of teardown shares — stopping the app has already spent part of
-    /// `glass_core::TEARDOWN_BUDGET` (glass#422). [`Deadline::UNBOUNDED`] off that path, where
-    /// each call keeps its own budget.
+    /// the rest of teardown shares (glass#422); [`Deadline::UNBOUNDED`] off that path, where each
+    /// call keeps its own budget.
     ///
     /// Best-effort and idempotent. No process to kill: disabling unbinds the service.
     pub fn shutdown(&self, deadline: Deadline) {

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -656,7 +656,7 @@ pub(crate) struct Active {
 // `/bin/sh` script.
 #[cfg(all(test, unix))]
 impl Active {
-    /// An enabled service to restore, for a test that needs a registry with work to do.
+    /// State a shutdown has something to undo.
     pub(crate) fn for_test(adb: Adb, port: u16) -> Self {
         Self {
             adb,

--- a/crates/glass-android/src/avd.rs
+++ b/crates/glass-android/src/avd.rs
@@ -290,9 +290,9 @@ pub fn boot_avd(base: &Adb, get: &dyn Fn(&str) -> Option<String>) -> Result<Stri
     }
 }
 
-/// Budget for `emulator -list-avds`. It reads the AVD directory and prints names — a fast local
-/// query — but a broken SDK can wedge the binary, and this runs first on the `glass_start` boot
-/// path, so an unbounded call here hangs a launch before anything else happens.
+/// Budget for `emulator -list-avds` — a fast local query, but a broken SDK can wedge the binary,
+/// and this runs first on the `glass_start` boot path, so an unbounded call hangs a launch before
+/// anything else happens.
 pub(crate) const EMULATOR_LIST_BUDGET: Duration = Duration::from_secs(15);
 
 fn run_emulator_list(bin: &str) -> Result<String> {

--- a/crates/glass-android/src/avd.rs
+++ b/crates/glass-android/src/avd.rs
@@ -189,8 +189,8 @@ impl EmulatorRegistry {
     /// list. Best-effort: a device already gone is fine, and [`Deadline::UNBOUNDED`] off the
     /// teardown path, where each call keeps its own budget.
     ///
-    /// `adb emu kill` was observed at 2ms — it acknowledges and lets the VM go down on its own
-    /// time — so this is the cheapest step in teardown and the worst one to skip (glass#422).
+    /// `adb emu kill` was observed at 2ms: it acknowledges and lets the VM go down on its own
+    /// time (glass#422).
     pub fn kill_all(&self, deadline: Deadline) {
         let clients = self
             .booted

--- a/crates/glass-android/src/lib.rs
+++ b/crates/glass-android/src/lib.rs
@@ -92,9 +92,9 @@ pub(crate) fn unsupported_window_move_resize() -> glass_core::GlassError {
 ///
 /// `Glass::shutdown` keeps `TEARDOWN_HOOK_RESERVE` back from the sessions so these have time
 /// (glass#422). Between themselves it is first-come-first-served, which makes the order
-/// load-bearing: the emulator goes first, being both the cheapest step (`adb emu kill` measured at
-/// 2ms) and the largest leak. Put it last and a wedged device spends the whole deadline on the
-/// settings restore, leaving a ~2GB VM that was never asked to stop.
+/// load-bearing: put the emulator last and a wedged device spends the whole deadline on the
+/// settings restore, leaving a ~2GB VM that was never asked to stop — for the sake of a step
+/// measured at 2ms.
 ///
 /// One function rather than three calls in glass-mcp's hook, so a test can watch the deadline
 /// reach all three — collapsing each registry's `shutdown`/`shutdown_until` pair made losing it a

--- a/crates/glass-core/src/deadline.rs
+++ b/crates/glass-core/src/deadline.rs
@@ -12,10 +12,9 @@
 
 /// When the caller stops waiting.
 ///
-/// An accessibility reader cannot be interrupted mid-read — [`crate::Glass::wait_for_element`]
-/// re-reads from a synchronous tick — so a 20s `uiautomator dump` answered a 10s wait until
-/// readers took this (glass#338). The obligation is stated on
-/// [`crate::Accessibility::snapshot`], where an implementer meets it; teardown's is on
+/// A callee that cannot be interrupted mid-call has to honour this itself: a 20s `uiautomator
+/// dump` answered a 10s wait until the readers took it (glass#338). The obligation is stated where
+/// an implementer meets it — [`crate::Accessibility::snapshot`] and
 /// [`crate::Platform::stop_app_by`].
 ///
 /// [`Self::UNBOUNDED`] leaves the callee its own budget: it is the *widest* value, as `WalkLimits`'

--- a/crates/glass-core/src/deadline.rs
+++ b/crates/glass-core/src/deadline.rs
@@ -90,7 +90,7 @@ impl Deadline {
     /// budget would otherwise starve the first step entirely.
     ///
     /// [`Self::UNBOUNDED`] stays unbounded: there is nothing to take a share of. Never lands
-    /// before now, so it cannot underflow the monotonic clock the way a bare subtraction can.
+    /// before now, so it cannot underflow the monotonic clock.
     pub fn reserving(self, reserve: std::time::Duration) -> Self {
         Self(self.0.map(|d| {
             let left = d.saturating_duration_since(std::time::Instant::now());

--- a/crates/glass-ios/src/simctl.rs
+++ b/crates/glass-ios/src/simctl.rs
@@ -119,8 +119,8 @@ impl Simctl {
     }
 
     /// [`Simctl::run`] under a deadline the whole sequence shares, [`Deadline::UNBOUNDED`] for a
-    /// call that answers to nothing but its own budget. The deadline bounds the run; it does not reserve time for
-    /// the calls behind, which is `Glass::shutdown`'s job (glass#427).
+    /// call that answers to nothing but its own budget. The deadline bounds the run; it does not
+    /// reserve time for the calls behind, which is `Glass::shutdown`'s job (glass#427).
     pub fn run_until(&self, sub: &[&str], deadline: Deadline) -> Result<String> {
         let out = self.output(sub, deadline)?;
         Ok(String::from_utf8_lossy(&out).into_owned())

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -684,7 +684,8 @@ impl Platform for MacosPlatform {
     /// first, per the `adopted` field's doc. This then falls through to the child/pasteboard
     /// cleanup rather than returning early: a session is `adopted` XOR `child`-backed, so the
     /// fall-through is a no-op, and it keeps `stop_app` and `Drop` structurally identical.
-    /// Ignores the deadline: this teardown is an ask-then-signal ladder, already asserted against TEARDOWN_BUDGET.
+    /// Ignores the deadline — the quit-then-signal ladder is asserted against `TEARDOWN_BUDGET`
+    /// instead.
     fn stop_app_by(&mut self, _deadline: glass_core::Deadline) -> Result<()> {
         if let Some(a) = self.adopted.take() {
             a.reap();

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -1687,7 +1687,8 @@ impl Platform for WaylandPlatform {
         Err(last_err)
     }
 
-    /// Ignores the deadline: this teardown is a signal ladder over local processes, already asserted against TEARDOWN_BUDGET.
+    /// Ignores the deadline — the close-then-reap ladder above is asserted against
+    /// `TEARDOWN_BUDGET` instead.
     fn stop_app_by(&mut self, _deadline: glass_core::Deadline) -> Result<()> {
         self.kill_session();
         Ok(())

--- a/crates/glass-windows/src/lib.rs
+++ b/crates/glass-windows/src/lib.rs
@@ -253,7 +253,7 @@ mod backend {
             }
         }
 
-        /// Ignores the deadline: this teardown is a Job object close, already asserted against TEARDOWN_BUDGET.
+        /// Ignores the deadline — `CLOSE_GRACE` is asserted against `TEARDOWN_BUDGET` instead.
         fn stop_app_by(&mut self, _deadline: glass_core::Deadline) -> Result<()> {
             if let Some(app) = self.app.take() {
                 crate::process::disclose_teardown(app.kill());

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -1051,7 +1051,8 @@ impl Platform for X11Platform {
         }
     }
 
-    /// Ignores the deadline: this teardown is a signal ladder over local processes, already asserted against TEARDOWN_BUDGET.
+    /// Ignores the deadline — the close-then-signal ladder above is asserted against
+    /// `TEARDOWN_BUDGET` instead.
     fn stop_app_by(&mut self, _deadline: glass_core::Deadline) -> Result<()> {
         self.kill_child();
         Ok(())


### PR DESCRIPTION
#433's comment sweeps were done from memory rather than through the terse-comments skill, so the
rubric — split at every `.` `;` `:` `—` and `, and`, then cut every piece that restates, defends,
or addresses a reviewer — never ran on them. This is that pass.

**Coverage:** #433 added 153 comment lines, of which 37 were rename churn and **116 were genuinely
new prose**, forming **33 distinct blocks**. All 33 were read against the rubric. **30 hold up; 3
did not**, plus 7 more that earlier commits on this branch had already found.

## What changed, and why

**One was stale, not wordy.** `attempt_deadline`'s doc pointed at `Deadline::cap`, which #434
deleted, and told the reader `dump_until_ready` "needs both to tell which of them ended an
attempt" — it needs the single verdict `resolve` returns. Rustdoc did not flag the dangling link
because the item is `pub(crate)`.

**Four near-identical comments from one loop of mine**, on x11, wayland, windows and macOS, each
restating what `Platform::stop_app_by`'s own doc already says — down to naming those same four
backends. Each now keeps only what the trait doc cannot carry: which ladder that backend asserts.

**The rest are the rubric's categories, not length:**

- `EmulatorRegistry::kill_all` repeated the ordering rationale that belongs to
  `hand_the_device_back`, where the ablation-verified hazard is.
- `hand_the_device_back` asserted the emulator is "both the cheapest step and the largest leak" one
  sentence before demonstrating exactly that.
- `Deadline::reserving` defended itself against "a bare subtraction" nobody had written.
- `A11yServiceRegistry::shutdown` said the deadline is one "the rest of teardown shares" and then
  said it again as "stopping the app has already spent part of `TEARDOWN_BUDGET`".
- A budget doc explaining that `emulator -list-avds` reads the AVD directory and prints names.
- Two adjacent test-seam docs saying the same thing twice, and `Deadline`'s type doc still opening
  with a reader-only story for a type that no longer belongs to the readers.
- A 114-column line one of my own edits left behind.

Comment-only diffs proven at each step. `cargo test --workspace --locked` green, clippy clean,
`cargo fmt --all --check` clean, no new rustdoc warnings; `x86_64-pc-windows-gnu` and
`x86_64-apple-darwin` clippy clean too, since this touched all four desktop backends.