### PR TITLE
docs: full terse-comments pass over #424, #426, #429 and #431

### DIFF
--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -84,8 +84,7 @@ pub(crate) fn adb_runner(
 /// re-snapshots inside.
 ///
 /// A caller that named a deadline gets [`Deadline::resolve`] of this instead — see
-/// [`dump_until_ready`], which needs the verdict it returns to tell which bound ended an
-/// attempt.
+/// [`dump_until_ready`].
 pub(crate) fn attempt_deadline() -> Instant {
     Instant::now() + AdbOp::Dump.budget()
 }
@@ -263,8 +262,7 @@ fn dump_until_ready(
         let (ends, whose) = caller.resolve(attempt_deadline());
         match dump_once(run, prefix, ends) {
             Attempt::Dumped(xml) => return Ok(xml),
-            // An attempt the *caller's* deadline cut short is not a device that failed. Whose
-            // bound ends it is settled before the attempt, not read off its error (glass#341).
+            // An attempt the *caller's* deadline cut short is not a device that failed.
             //
             // The abandoned attempt's own error is carried, not dropped: a wedged adb reaches
             // here too — it cannot be told apart from a slow one at the moment the budget ends —

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -772,7 +772,7 @@ fn put_secure(adb: &Adb, key: &str, value: &str) -> Result<()> {
     put_secure_until(adb, key, value, Deadline::UNBOUNDED).map(|_| ())
 }
 
-/// [`put_secure`] under a deadline the caller shares with the rest of its sequence.
+/// [`put_secure`] under `deadline`.
 fn put_secure_until(adb: &Adb, key: &str, value: &str, deadline: Deadline) -> Result<String> {
     adb.run_until(["shell", "settings", "put", "secure", key, value], deadline)
 }
@@ -783,7 +783,7 @@ fn put_enabled_services(adb: &Adb, list: &str) -> Result<()> {
     put_enabled_services_until(adb, list, Deadline::UNBOUNDED)
 }
 
-/// [`put_enabled_services`] under a deadline the caller shares with the rest of its sequence.
+/// [`put_enabled_services`] under `deadline`.
 fn put_enabled_services_until(adb: &Adb, list: &str, deadline: Deadline) -> Result<()> {
     if list.is_empty() {
         adb.run_until(

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -718,8 +718,8 @@ impl A11yServiceRegistry {
             READY_ATTEMPT,
             READY_ATTEMPTS,
             &|step| escalate(adb, apk, &want, step, READY_ATTEMPTS),
-            // No deadline: this is the rollback for a failed `ensure` during `glass_start`, not
-            // teardown, so each call keeps its own budget and answers to no shared one.
+            // Unbounded: this is the rollback for a failed `ensure` during `glass_start`, not
+            // teardown, so each call keeps its own budget.
             &|| restore_a11y(adb, prior, prior_a11y, port, Deadline::UNBOUNDED),
         )?;
         *self.state.lock().unwrap() = Some(Active {

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -738,8 +738,7 @@ impl A11yServiceRegistry {
     }
 
     /// Restore the device's prior accessibility state and remove the forward by `deadline`, which
-    /// the rest of teardown shares (glass#422); [`Deadline::UNBOUNDED`] off that path, where each
-    /// call keeps its own budget.
+    /// the rest of teardown shares (glass#422).
     ///
     /// Best-effort and idempotent. No process to kill: disabling unbinds the service.
     pub fn shutdown(&self, deadline: Deadline) {

--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -126,9 +126,8 @@ impl Adb {
         self.run_until(args, Deadline::UNBOUNDED)
     }
 
-    /// [`Adb::run`] under a deadline the whole sequence shares, [`Deadline::UNBOUNDED`] for a call
-    /// that answers to nothing but its own budget. The deadline bounds the run; it does not
-    /// reserve time for the calls behind, which is `Glass::shutdown`'s job (glass#422).
+    /// [`Adb::run`] under a deadline the whole sequence shares. The deadline bounds the run; it
+    /// does not reserve time for the calls behind, which is `Glass::shutdown`'s job (glass#422).
     pub fn run_until<'a, I>(&self, args: I, deadline: Deadline) -> Result<String>
     where
         I: IntoIterator<Item = &'a str>,

--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -763,8 +763,7 @@ mod tests {
                 vec!["shell", "rm", "-f", "/sdcard/glass_dump_1_2_0.xml"],
                 AdbOp::Shell,
             ),
-            // `am` alone is not a launch: force-stop runs during teardown, where a 60s deadline
-            // would outlast the whole budget that calls it.
+            // `am` alone is not a launch — see `AdbOp::Launch`.
             (
                 vec!["shell", "am", "force-stop", "com.example.app"],
                 AdbOp::Shell,

--- a/crates/glass-android/src/agent.rs
+++ b/crates/glass-android/src/agent.rs
@@ -327,7 +327,7 @@ impl AgentRegistry {
     }
 
     /// Kill the device agent (via the host child) and remove the forward by `deadline`, which the
-    /// rest of teardown shares (glass#422); [`Deadline::UNBOUNDED`] off that path. Best-effort.
+    /// rest of teardown shares (glass#422). Best-effort.
     ///
     /// Only the forward removal is under the deadline — dropping `p` then kills and reaps the
     /// agent with an unbounded `wait()`, the gap `AndroidPlatform::stop_app_until` names for

--- a/crates/glass-android/src/avd.rs
+++ b/crates/glass-android/src/avd.rs
@@ -186,8 +186,7 @@ impl EmulatorRegistry {
     }
 
     /// Stop every registered emulator (`adb -s <serial> emu kill`) by `deadline` and clear the
-    /// list. Best-effort: a device already gone is fine, and [`Deadline::UNBOUNDED`] off the
-    /// teardown path, where each call keeps its own budget.
+    /// list. Best-effort: a device already gone is fine.
     ///
     /// `adb emu kill` was observed at 2ms: it acknowledges and lets the VM go down on its own
     /// time (glass#422).

--- a/crates/glass-android/src/lib.rs
+++ b/crates/glass-android/src/lib.rs
@@ -97,8 +97,7 @@ pub(crate) fn unsupported_window_move_resize() -> glass_core::GlassError {
 /// measured at 2ms.
 ///
 /// One function rather than three calls in glass-mcp's hook, so a test can watch the deadline
-/// reach all three — collapsing each registry's `shutdown`/`shutdown_until` pair made losing it a
-/// one-token edit.
+/// reach all three.
 pub fn hand_the_device_back(
     a11y: &A11yServiceRegistry,
     agents: &AgentRegistry,

--- a/crates/glass-android/src/platform.rs
+++ b/crates/glass-android/src/platform.rs
@@ -243,8 +243,7 @@ impl Platform for AndroidPlatform {
         let started = adb.run(launch_args(&target.component).iter().map(String::as_str))?;
         check_am_start(&started)?;
 
-        // The app is on the device from here, but `self.app` is not set until the end, so each
-        // failure below has to reap for itself.
+        // Each failure from here down reaps for itself — see `reap_failed_launch`.
         let (active_id, window) = match self.discover_window(&target.package, spec.timeout_ms) {
             Ok(found) => found,
             Err(e) => return Err(reap_failed_launch(&adb, &target.package, e)),

--- a/crates/glass-android/src/platform.rs
+++ b/crates/glass-android/src/platform.rs
@@ -413,8 +413,11 @@ impl Platform for AndroidPlatform {
 impl Drop for AndroidPlatform {
     /// Force-stop the app on drop, for a platform dropped without an explicit `stop_app()` —
     /// parity with the X11/Wayland/Windows/macOS backends. The device outlives the process, so
-    /// the app would otherwise still be there for the next run (glass#419). `stop_app` takes
-    /// `self.app`, so this is a no-op once it has run, which every path through `Glass` does.
+    /// the app would otherwise still be there for the next run (glass#419).
+    ///
+    /// `stop_app` takes `self.app`, so this is a no-op after it — and `Glass::stop`,
+    /// `Glass::shutdown` and a session replacement all call it. The path they do not reach is a
+    /// launch that failed on the way up, which is [`reap_failed_launch`]'s.
     fn drop(&mut self) {
         let _ = self.stop_app();
     }

--- a/crates/glass-android/src/platform.rs
+++ b/crates/glass-android/src/platform.rs
@@ -273,10 +273,9 @@ impl Platform for AndroidPlatform {
         Ok(window)
     }
 
-    /// Force-stop measures 101ms median, 267ms worst on an emulator with every core saturated,
-    /// against the 3s all of teardown gets — so the deadline is not expected to bind. It is for
-    /// the device that stopped answering, which would otherwise run out the 10s `AdbOp::Shell`
-    /// budget and leave the hook nothing (glass#422).
+    /// Force-stop measures well inside the 3s all of teardown gets (see [`AdbOp::Launch`]), so the
+    /// deadline is not expected to bind. It is for the device that stopped answering, which would
+    /// otherwise run out the 10s `AdbOp::Shell` budget and leave the hook nothing (glass#422).
     fn stop_app_by(&mut self, deadline: Deadline) -> Result<()> {
         self.stop_app_until(deadline)
     }

--- a/crates/glass-android/tests/a11y_service_loop.rs
+++ b/crates/glass-android/tests/a11y_service_loop.rs
@@ -93,8 +93,8 @@ fn a11y_service_snapshot_and_actions() {
     }
 
     p.stop_app().ok();
-    // The guards above restore the service settings and the forwards as they drop, and
-    // scripts/test-android.sh re-reads the device after the suite to confirm they did.
+    // scripts/test-android.sh re-reads the device after the suite to confirm the guards above
+    // restored it.
 }
 
 /// Native invoke against the fixture. Ignored; same environment as the test above.

--- a/crates/glass-android/tests/agent_loop.rs
+++ b/crates/glass-android/tests/agent_loop.rs
@@ -31,8 +31,7 @@ fn agent_clipboard_and_input_roundtrip() {
     // tear the agent down explicitly at the end — in production `Glass`'s shutdown hook does
     // this; a test must not leak the process (the registry doesn't kill on drop).
     let agents = AgentRegistry::new();
-    // Before the platform, so the platform's agent connection closes first — and so a
-    // panicking assertion below cannot skip the teardown (glass#423).
+    // Before the platform — see `common` for why the order matters (glass#423).
     let _stop_agent = common::StopAgent(&agents);
     let mut p = glass_android::AndroidPlatform::from_env(&EmulatorRegistry::new(), &agents)
         .expect("attach + agent");

--- a/crates/glass-android/tests/common/mod.rs
+++ b/crates/glass-android/tests/common/mod.rs
@@ -7,8 +7,7 @@
 //! `scripts/test-android.sh` fails a run that ends with any of it still on.
 //!
 //! Declare a guard BEFORE the platform it serves: locals drop in reverse, so the platform's agent
-//! connection closes before the registry that owns the agent. Order between the two registries
-//! does not matter — separate forwards, and the a11y one has no process.
+//! connection closes before the registry that owns the agent.
 
 #![allow(dead_code)]
 

--- a/crates/glass-android/tests/input_loop.rs
+++ b/crates/glass-android/tests/input_loop.rs
@@ -123,8 +123,7 @@ fn assert_screen_changed(p: &mut glass_android::AndroidPlatform, before: &Frame,
 #[ignore = "requires a booted AVD + GLASS_ANDROID_SERIAL/GLASS_ADB"]
 fn scroll_and_tap_change_the_screen() {
     let agents = glass_android::AgentRegistry::new();
-    // Before the platform, so the platform's agent connection closes first — and so a
-    // panicking assertion below cannot skip the teardown (glass#423).
+    // Before the platform — see `common` for why the order matters (glass#423).
     let _stop_agent = common::StopAgent(&agents);
     let mut p =
         glass_android::AndroidPlatform::from_env(&glass_android::EmulatorRegistry::new(), &agents)

--- a/crates/glass-android/tests/managed_avd.rs
+++ b/crates/glass-android/tests/managed_avd.rs
@@ -89,7 +89,7 @@ fn boots_reuses_and_cleans_up() {
     let registry = EmulatorRegistry::new();
     // `kill_all` below is what this test asserts on, so it stays explicit; this only covers the
     // path where an assertion between here and there panics, which would otherwise leave a
-    // booted emulator behind. Idempotent — `kill_all` takes the list.
+    // booted emulator behind.
     let _kill_emulators = common::KillBootedEmulators(&registry);
 
     // First resolve boots the AVD.

--- a/crates/glass-android/tests/see_loop.rs
+++ b/crates/glass-android/tests/see_loop.rs
@@ -26,8 +26,7 @@ fn settings_spec() -> AppSpec {
 #[ignore = "requires a booted AVD + GLASS_ANDROID_SERIAL"]
 fn see_loop_launches_and_captures_settings() {
     let agents = glass_android::AgentRegistry::new();
-    // Before the platform, so the platform's agent connection closes first — and so a
-    // panicking assertion below cannot skip the teardown (glass#423).
+    // Before the platform — see `common` for why the order matters (glass#423).
     let _stop_agent = common::StopAgent(&agents);
     let mut p =
         glass_android::AndroidPlatform::from_env(&glass_android::EmulatorRegistry::new(), &agents)

--- a/crates/glass-android/tests/window_loop.rs
+++ b/crates/glass-android/tests/window_loop.rs
@@ -26,8 +26,7 @@ fn settings_spec() -> AppSpec {
 #[ignore = "requires a booted AVD + GLASS_ANDROID_SERIAL/GLASS_ADB"]
 fn lists_and_selects_app_windows() {
     let agents = glass_android::AgentRegistry::new();
-    // Before the platform, so the platform's agent connection closes first — and so a
-    // panicking assertion below cannot skip the teardown (glass#423).
+    // Before the platform — see `common` for why the order matters (glass#423).
     let _stop_agent = common::StopAgent(&agents);
     let mut p =
         glass_android::AndroidPlatform::from_env(&glass_android::EmulatorRegistry::new(), &agents)

--- a/crates/glass-core/src/a11y_thread.rs
+++ b/crates/glass-core/src/a11y_thread.rs
@@ -228,8 +228,8 @@ mod tests {
     #[test]
     fn a_caller_that_names_no_deadline_leaves_the_read_its_own_ceiling() {
         let (wait, ended_by) = reader().bounded_wait(Deadline::UNBOUNDED);
-        // One clock read makes this branch deterministic; the two-read shape it replaced came up
-        // short by whatever fell between them.
+        // Exactly `CEILING`: the two-read shape this replaced came up short by whatever fell
+        // between the reads.
         assert_eq!(wait, CEILING, "{wait:?}");
         assert_eq!(ended_by, Whose::Callee);
     }

--- a/crates/glass-core/src/deadline.rs
+++ b/crates/glass-core/src/deadline.rs
@@ -1,9 +1,7 @@
 //! One type for "when the caller stops waiting", shared by every bound in glass.
 //!
-//! It began as the accessibility readers' `AxDeadline`. `Adb` then grew two more spellings fifteen
-//! lines apart — a bare `Instant` for the dump sequence (glass#312) and an `Option<Instant>` for
-//! teardown (glass#431) — and `None` reads as "zero" as readily as "unbounded", which is the
-//! direction that fails quietly: a call given zero is not run at all (glass#430).
+//! Not `Option<Instant>`: `None` reads as "zero" as readily as "unbounded", which is the direction
+//! that fails quietly — a call given zero is not run at all (glass#430).
 //!
 //! Where a bound is *required*, a plain `Instant` is still right and is left alone — the wayland
 //! clipboard transfer, `wait_for_agent_until`, `bounded`'s own `poll_until`. This type is for the
@@ -42,8 +40,7 @@ impl Deadline {
     /// bound — and whose bound that is.
     ///
     /// One comparison answers both, so the instant and the blame cannot come from different
-    /// proposals (glass#432), and the blame is settled before the step runs rather than inferred
-    /// from the error it returns (glass#341).
+    /// proposals (glass#432).
     ///
     /// A tie is the callee's: one that used exactly its own bound must not be reported as a caller
     /// who ran out of time.
@@ -129,9 +126,7 @@ mod tests {
         assert!(!Deadline::UNBOUNDED.has_passed());
     }
 
-    /// Both halves agree at every ordering, and the tie is load-bearing: a callee blames its own
-    /// bound when both fall together, so a backend that hung for exactly its ceiling is never
-    /// reported as a caller who ran out of time.
+    /// Both halves agree at every ordering, the tie included.
     #[test]
     fn resolve_answers_both_halves_from_one_comparison() {
         let now = std::time::Instant::now();
@@ -210,7 +205,7 @@ mod tests {
             Deadline::at(past).within(Duration::from_secs(20), now),
             Duration::ZERO
         );
-        // No deadline is the widest value, not a budget of zero.
+        // The widest value, not a budget of zero.
         assert_eq!(
             Deadline::UNBOUNDED.within(Duration::from_secs(20), now),
             Duration::from_secs(20)

--- a/crates/glass-core/src/platform.rs
+++ b/crates/glass-core/src/platform.rs
@@ -29,8 +29,7 @@ pub const TEARDOWN_REAP_HEADROOM: Duration = Duration::from_millis(750);
 /// A shared deadline bounds a sequence; it does not divide one. Without a reserve, a device that
 /// stops answering during `stop_app` leaves the hook nothing — and `run_bounded_until` does not
 /// start a command with no time left, so its steps are skipped rather than slowed. On Android the
-/// hook is what hands the device back: the companion it enabled, the `adb forward` it opened, the
-/// emulator it booted.
+/// hook is what hands the device back (`glass_android::hand_the_device_back`).
 ///
 /// Five adb calls, the slowest measured at 52ms on an emulator with every core saturated
 /// (glass#422).

--- a/crates/glass-core/src/platform.rs
+++ b/crates/glass-core/src/platform.rs
@@ -11,11 +11,9 @@ use crate::logbuf::Stream;
 /// on `Glass::shutdown` and then exits regardless, so anything a [`Platform::stop_app`] impl was
 /// still waiting on is abandoned mid-flight: on a Unix backend that orphans the app to init.
 ///
-/// Every backend's teardown must therefore fit inside this, with room for the work that follows
-/// it. A backend that waits on the app being polite has to bound that wait against this constant
-/// — it lives here, rather than as a private number in `glass-mcp`, precisely because the
-/// backends are the ones that have to respect it and they cannot see a private one. Each backend
-/// asserts its own budget against it at compile time; grep for `TEARDOWN_BUDGET` to find them.
+/// Every backend's teardown must therefore fit inside this. The four that wait on a local child
+/// assert their grace constants against it at compile time; the two that tear down over a link to
+/// a device have no constants to sum and spend [`Platform::stop_app_by`]'s deadline instead.
 pub const TEARDOWN_BUDGET: Duration = Duration::from_secs(3);
 
 /// How much of [`TEARDOWN_BUDGET`] is held back from the deadline the steps are given.
@@ -258,15 +256,13 @@ pub trait Platform {
 
     /// Terminate the running app (idempotent), giving up by `deadline`.
     ///
-    /// **Cap every wait of your own by it.** On the process-exit path the whole of teardown shares
-    /// [`TEARDOWN_BUDGET`], and a step that overruns is not merely late — it spends what the steps
-    /// behind it needed, and they are skipped rather than slowed (glass#422, glass#427).
+    /// **Cap every wait of your own by it.** Teardown shares [`TEARDOWN_BUDGET`], so a step that
+    /// overruns spends what the steps behind it needed, and they are skipped rather than slowed
+    /// (glass#422, glass#427).
     ///
-    /// A backend whose teardown is a signal ladder over local processes may ignore it — those
-    /// ladders already assert their own constants against [`TEARDOWN_BUDGET`] at compile time
-    /// (x11, wayland, windows, macos, each with the residual its own comment names). One that
-    /// tears down over a link to a device has a tool invocation per step, each with its own budget
-    /// and no sum to assert, so it has nothing but this deadline.
+    /// A backend whose teardown is a signal ladder over local processes may ignore it, having
+    /// asserted its own constants against [`TEARDOWN_BUDGET`] already. One that tears down over a
+    /// link to a device has a tool invocation per step, no sum to assert, and nothing but this.
     ///
     /// Required rather than defaulted, so a new device-linked backend cannot inherit an unbounded
     /// teardown in silence — which is how both device backends came to need glass#422/#427.

--- a/crates/glass-core/src/platform.rs
+++ b/crates/glass-core/src/platform.rs
@@ -35,8 +35,8 @@ pub const TEARDOWN_REAP_HEADROOM: Duration = Duration::from_millis(750);
 /// (glass#422).
 pub const TEARDOWN_HOOK_RESERVE: Duration = Duration::from_millis(750);
 
-// The three have to fit, or the split is a slower way of running out of time. The sessions get
-// what is left — 1.5s, against the ~270ms the slowest measured backend teardown needs.
+// The sessions get what is left — 1.5s, against the ~270ms the slowest measured backend
+// teardown needs.
 const _: () = assert!(
     TEARDOWN_REAP_HEADROOM.as_millis() + TEARDOWN_HOOK_RESERVE.as_millis()
         < TEARDOWN_BUDGET.as_millis(),

--- a/crates/glass-core/src/session/lifecycle.rs
+++ b/crates/glass-core/src/session/lifecycle.rs
@@ -78,9 +78,9 @@ impl Glass {
     }
 
     /// Best-effort teardown of **all** active sessions for process exit. Idempotent:
-    /// a no-op when nothing is active. Errors are swallowed — we are exiting, so a
-    /// failed `stop_app` must not prevent releasing the rest (the OS reaps anything
-    /// left). Distinct from `stop()`, which reports errors to a tool caller.
+    /// a no-op when nothing is active. Errors are swallowed — we are exiting, so a failed
+    /// `stop_app` must not prevent releasing the rest. Distinct from `stop()`, which reports
+    /// errors to a tool caller.
     ///
     /// `deadline` is when teardown is expected to be done. Stopping the sessions is held
     /// [`crate::TEARDOWN_HOOK_RESERVE`] short of it: a shared deadline bounds a sequence without
@@ -89,10 +89,6 @@ impl Glass {
     ///
     /// A third step between them is bounded by neither — dropping the session reaps the backend
     /// (Xvfb, sway, a Job object) and the log-stream children, each an unbounded `wait()`.
-    ///
-    /// Written to drain the session set so the future multi-session registry (a
-    /// `HashMap` instead of this `Option`) reuses it unchanged — it becomes a `for`
-    /// loop with no other change.
     pub fn shutdown(&mut self, deadline: Deadline) {
         if let Some(mut s) = self.active.take() {
             let _ = s

--- a/crates/glass-core/src/session/lifecycle.rs
+++ b/crates/glass-core/src/session/lifecycle.rs
@@ -294,9 +294,7 @@ mod tests {
     }
 
     /// The property this whole split exists for (glass#422): a session that spends everything it is
-    /// given must still leave the hook enough to run. Without the reserve the hook is reached with
-    /// a spent deadline, and `run_bounded_until` does not start a command it has no time for — so
-    /// every step behind it is skipped rather than merely slow.
+    /// given must still leave the hook enough to run.
     #[test]
     fn a_session_that_burns_its_deadline_still_leaves_the_hook_time_to_run() {
         let factory: PlatformFactory = Box::new(move |_backend| {

--- a/crates/glass-core/src/session/lifecycle.rs
+++ b/crates/glass-core/src/session/lifecycle.rs
@@ -143,8 +143,7 @@ mod tests {
         assert_eq!(lines[0].text, "ready");
     }
 
-    /// A deadline far enough out that nothing in these tests is bounded by it — they are about
-    /// what `shutdown` calls, not about what a spent budget does.
+    /// A deadline far enough out that nothing in these tests is bounded by it.
     fn soon() -> Deadline {
         Deadline::at(std::time::Instant::now() + crate::TEARDOWN_BUDGET)
     }
@@ -224,8 +223,7 @@ mod tests {
         );
     }
 
-    /// The budget is only useful if it reaches the code that spends it: a backend that tears down
-    /// over a link, and a hook that does the same for the host's own resources.
+    /// The budget is only useful if it reaches the code that spends it.
     #[test]
     fn shutdown_hands_its_deadline_to_both_the_backend_and_the_hook() {
         let at_stop = Arc::new(Mutex::new(None));
@@ -261,8 +259,8 @@ mod tests {
         );
     }
 
-    /// The other half of the split: the reserve is a fixed 750ms, so without the clamp a caller
-    /// whose whole budget is smaller hands the sessions a deadline already in the past.
+    /// The reserve is a fixed 750ms, so without the clamp a caller whose whole budget is smaller
+    /// hands the sessions a deadline already in the past.
     #[test]
     fn a_budget_smaller_than_the_reserve_still_leaves_the_sessions_time() {
         let at_stop = Arc::new(Mutex::new(None));

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -60,8 +60,8 @@ pub(crate) struct FakePlatform {
     /// `glass_window` op, so the session's cached geometry is stale until something re-reads
     /// it. Empty means "report the current geometry unchanged".
     resized_to: VecDeque<WindowGeometry>,
-    /// The deadline `stop_app_by` was handed, when it was the entry point — `None` after a plain
-    /// `stop_app`, which is how a test tells the two apart.
+    /// The deadline `stop_app_by` was handed. `stop_app` is the provided half of the pair, so it
+    /// records [`crate::Deadline::UNBOUNDED`] rather than nothing.
     stop_deadline: Option<Arc<Mutex<Option<crate::Deadline>>>>,
     /// Makes `stop_app_by` spend its whole deadline, standing in for a device that stopped
     /// answering.
@@ -114,14 +114,14 @@ impl FakePlatform {
         self.stop_count = Some(c);
         self
     }
-    /// Record the deadline `stop_app_by` receives, for proving the teardown budget reaches the
-    /// backend rather than stopping at `Glass`.
     /// Spend the whole deadline in `stop_app_by`, so a test can ask what is left for the step
     /// behind it.
     pub(crate) fn burning_its_deadline(mut self) -> Self {
         self.stop_burns_deadline = true;
         self
     }
+    /// Record the deadline `stop_app_by` receives, for proving the teardown budget reaches the
+    /// backend rather than stopping at `Glass`.
     pub(crate) fn recording_stop_deadline(
         mut self,
         at: Arc<Mutex<Option<crate::Deadline>>>,

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -114,8 +114,7 @@ impl FakePlatform {
         self.stop_count = Some(c);
         self
     }
-    /// Spend the whole deadline in `stop_app_by`, so a test can ask what is left for the step
-    /// behind it.
+    /// Spend the whole deadline in `stop_app_by`.
     pub(crate) fn burning_its_deadline(mut self) -> Self {
         self.stop_burns_deadline = true;
         self

--- a/crates/glass-ios/src/platform.rs
+++ b/crates/glass-ios/src/platform.rs
@@ -67,10 +67,8 @@ impl IdbDriver {
 ///
 /// Capture, logs, clipboard, and window queries run over `xcrun simctl` alone. Input
 /// (tap/type/swipe/scroll) and the accessibility tree additionally need an `idb_companion`
-/// [`IdbDriver`]; when the companion isn't available the backend degrades to observe-only:
-/// capture/logs/clipboard keep working, while input and the accessibility tree report a
-/// clear [`GlassError::Unsupported`]. The failure that disabled the driver is kept in
-/// `driver_error` and surfaced in that message.
+/// [`IdbDriver`]; without it the backend degrades to observe-only and those two report a clear
+/// [`GlassError::Unsupported`], carrying the `driver_error` that disabled the driver.
 pub struct IosPlatform {
     target: SimTarget,
     app: Option<RunningApp>,

--- a/crates/glass-ios/src/platform.rs
+++ b/crates/glass-ios/src/platform.rs
@@ -1410,8 +1410,7 @@ mod teardown_tests {
         assert_eq!(terminations(&fake).len(), 1, "{:?}", fake.calls());
     }
 
-    /// `simctl launch` reporting failure usually means nothing launched — but not always, and the
-    /// launch whose result this backend never sees is the one that leaves an app up.
+    /// The launch whose result this backend never sees is the one that leaves an app up.
     #[test]
     fn a_launch_simctl_reported_as_failed_is_reaped_too() {
         let fake = FakeSimctl::new();

--- a/crates/glass-ios/src/simctl.rs
+++ b/crates/glass-ios/src/simctl.rs
@@ -12,8 +12,8 @@ use glass_core::{Deadline, GlassError, Result, run_bounded_until};
 /// Budgets are ~4x the slowest healthy run measured on the dogfood simulator, floored at 10s — a
 /// bound on a simulator that has stopped answering, not what a call is expected to cost:
 /// `terminate` measured 101ms median over 25 runs. `shutdown` is the one verb whose *expected*
-/// cost (~3.3s) exceeds `glass_core::TEARDOWN_BUDGET`, which is why nothing waits on one during
-/// teardown (glass#427, `SimulatorRegistry::request_shutdown_all`).
+/// cost exceeds `glass_core::TEARDOWN_BUDGET`, which is why nothing waits on one during teardown
+/// (glass#427, `SimulatorRegistry::request_shutdown_all`).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SimctlOp {
     /// `bootstatus -b` — waits out the whole boot.
@@ -129,9 +129,10 @@ impl Simctl {
     /// Start `xcrun simctl <sub...>` and hand back the child unwaited, in a process group of its
     /// own so a signal to glass's group does not take it too.
     ///
-    /// For the one call costing more than its caller's whole budget (`shutdown`, ~3.3s against a
-    /// 3s teardown), where waiting only delays the exit. stdout is closed rather than inherited —
-    /// on stdio an inherited one corrupts the MCP stream.
+    /// For `shutdown`, whose measured cost exceeds the whole teardown budget
+    /// ([`crate::SimulatorRegistry::request_shutdown_all`]), so waiting only delays the exit.
+    /// stdout is closed rather than inherited — on stdio an inherited one corrupts the MCP
+    /// stream.
     pub fn spawn_detached(&self, sub: &[&str]) -> std::io::Result<std::process::Child> {
         let mut cmd = Command::new(self.program());
         cmd.args(self.full_args(sub))

--- a/crates/glass-ios/src/simctl.rs
+++ b/crates/glass-ios/src/simctl.rs
@@ -118,9 +118,8 @@ impl Simctl {
         self.run_until(sub, Deadline::UNBOUNDED)
     }
 
-    /// [`Simctl::run`] under a deadline the whole sequence shares, [`Deadline::UNBOUNDED`] for a
-    /// call that answers to nothing but its own budget. The deadline bounds the run; it does not
-    /// reserve time for the calls behind, which is `Glass::shutdown`'s job (glass#427).
+    /// [`Simctl::run`] under a deadline the whole sequence shares. The deadline bounds the run; it
+    /// does not reserve time for the calls behind, which is `Glass::shutdown`'s job (glass#427).
     pub fn run_until(&self, sub: &[&str], deadline: Deadline) -> Result<String> {
         let out = self.output(sub, deadline)?;
         Ok(String::from_utf8_lossy(&out).into_owned())

--- a/crates/glass-ios/src/target.rs
+++ b/crates/glass-ios/src/target.rs
@@ -232,8 +232,8 @@ mod tests {
         assert!(r.udids().is_empty());
     }
 
-    /// Killing the client at spawn leaves the device Booted 30s later (measured), so a Ctrl-C
-    /// reaching glass's group inside that window would strand the simulator.
+    /// A Ctrl-C reaching glass's group inside the window measured on
+    /// [`SimTarget::request_shutdown_all`] would strand the simulator.
     #[test]
     fn the_shutdown_it_asks_for_runs_in_its_own_process_group() {
         let fake = crate::simctl::FakeSimctl::new();

--- a/crates/glass-ios/src/target.rs
+++ b/crates/glass-ios/src/target.rs
@@ -263,10 +263,9 @@ mod tests {
         String::from_utf8_lossy(&out.stdout).trim().to_string()
     }
 
-    /// The measured defect (glass#427): a real `simctl shutdown` takes ~3.3s, which is over the
-    /// whole teardown budget on its own, so process exit must not wait for it. The fake sleeps 1s
-    /// rather than 3 so the test does not end with its own `TempDir` deleted under a running
-    /// script.
+    /// Process exit must not wait for the shutdown measured on [`SimTarget::request_shutdown_all`]
+    /// (glass#427). The fake sleeps 1s rather than 3 so the test does not end with its own
+    /// `TempDir` deleted under a running script.
     #[test]
     fn shutdown_all_returns_without_waiting_for_the_simulator_to_go_down() {
         let fake = crate::simctl::FakeSimctl::new();

--- a/scripts/lib/device-residue.sh
+++ b/scripts/lib/device-residue.sh
@@ -4,8 +4,7 @@
 # `A11yServiceRegistry::ensure` enables the companion as an accessibility service and opens an
 # `adb forward`; `AgentRegistry::ensure` opens one too. Only their `shutdown` puts that back, and a
 # test panicking past a trailing `shutdown()` leaves the companion in the tree of every later
-# reader on the device (glass#423). The suite reports green while it happens, hence a check around
-# it rather than an assertion inside one test.
+# reader on the device (glass#423), and the suite reports green while it happens.
 #
 # Compared against a snapshot taken BEFORE the run, never against a fixed "clean" value: a dev box
 # may have its own accessibility service enabled, and asserting `null` would fail there forever.

--- a/scripts/test-android.sh
+++ b/scripts/test-android.sh
@@ -63,7 +63,7 @@ cargo test --no-fail-fast -p glass-mcp \
   -- --ignored --test-threads=1 "$@" || rc=$?
 
 # After the suite, not per test: the check costs a settle wait, and a test that leaks hands the
-# device to every test after it anyway, so the run is the unit worth reporting on.
+# device to every test after it anyway.
 residue=0
 report_device_residue "$adb" "$before" || residue=1
 # Only when the suite itself passed, so a leak does not overwrite cargo's 101 with a 1 and hide


### PR DESCRIPTION
A terse-comments re-judgement of the comments I wrote in six merges — #424, #426, #429, #431,
#433 and #434. **1,621 words to 951**, across 24 files, comment-only at every commit.

The trigger was that the sweep shipped inside #433 had covered 8% of what that PR merged. Every
pass since has been an attempt to find the rest, and each one found more than the pass before
it.

## What each pass added, and why the next one existed

| Pass | Scope | Blocks | Words |
|---|---|---|---|
| Generous | 140 blocks from #424/#426/#429/#431 | 6 | ~130 |
| Strict, long | same blocks, ≥5 lines, split at every clause | 9 | 543 |
| Short | the same set, ≤2 lines | 12 | 157 |
| Arc + band | #433/#434, plus the 3–4 line band nothing had judged | 15 | 262 |

**The generous pass found errors; the strict passes found padding.** The first pass caught a
comment being *wrong* — `TEARDOWN_BUDGET` claiming "each backend asserts its own budget against
it at compile time", untrue of both device backends. It approved almost everything else.
Re-reading the same blocks, but splitting at every `.` `;` `:` `—` and `, and` and cutting each
piece that wasn't itself the fact, changed nine of them and removed four times the words.
Reading for errors and reading for padding are different passes.

**The size filters were the real hole.** The strict pass took blocks of five lines or more, on
the theory that padding needs room; the pass after it took one- and two-liners. Nothing ever
judged three and four — 24 blocks. And no pass had enumerated trailing `code(); // comment` at
all, since the block-finder only matched lines beginning with a marker (there turned out to be
two, both fine).

## What was actually wrong

Almost all of it is one fact with more than one home.

A pairwise near-duplicate scan across all 140 blocks found nothing actionable — five hits, all
parallel API docs or two independent panic-safety hazards. That is because the repetition isn't
between comments that read alike; it's a comment restating **the item it points at**, visible
only by reading each one beside its own code.

- `Deadline`'s doc says `UNBOUNDED` leaves the callee its own budget. Five call sites said it
  again — the three registry shutdowns, `Adb::run_until` and `Simctl::run_until`, the last two
  word-for-word.
- The glass#341 invariant ("whose bound ended a step is settled before it") is stated on
  `Whose`, and again on `resolve` and in the Android retry loop.
- `simctl shutdown`'s ~3.3s had four sites; `reap_failed_launch`'s reason had three; the
  teardown hook's three device resources had two.
- `Glass::shutdown`'s doc rationalised a `HashMap` registry refactor that hasn't happened, and
  `Deadline`'s module doc opened with a changelog of the three spellings it replaced.

The rest is a sentence restating the one before it, including the budget assert's comment
restating its own assert message.

## Verified

Comment-only diff proved with the skill's filter at every commit, not asserted, and scored by
words removed on each side. Two new intra-doc links resolve under `--document-private-items`;
the eight unresolved links rustdoc reports are all in files this branch never touches.

Three targets, since this touches macOS and Windows files: Linux `cargo test --workspace` and
clippy, `x86_64-pc-windows-gnu --workspace --all-targets`, and `x86_64-apple-darwin` per
`verify-a-change.md`. `shellcheck -x` on the two scripts.

## Scope — what this is not

This is not a sweep of the tree. glass has **7,354 comment blocks / 241,597 words**; this
branch judged **215 of them (2.9%)**, all lines I added in six merges. The comments those merges
*didn't* touch — including in the same files — and the rest of the tree have not been read.
