### PR TITLE
feat: color the human output of doctor and env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ internal refactors, CI, or test-only changes.
   status glyphs take their status's color, a warning or failure colors the check's name so it is
   findable in a long report, and skipped checks and remedies recede. Piped or redirected output is
   unchanged, byte for byte, as is `--json`. `--color always|never` overrides the detection, and
-  `NO_COLOR` or `TERM=dumb` suppresses it.
+  a non-empty `NO_COLOR` or `TERM=dumb` suppresses it.
 
 ### Changed
 - `glass_set_value`'s "did not take" error now names both what you asked for and what the element

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ internal refactors, CI, or test-only changes.
 
 ## [Unreleased]
 
+### Added
+- `glass-mcp doctor` and `glass-mcp env` colorize their output when writing to a terminal: the
+  status glyphs take their status's color, a warning or failure colors the check's name so it is
+  findable in a long report, and skipped checks and remedies recede. Piped or redirected output is
+  unchanged, byte for byte, as is `--json`. `--color always|never` overrides the detection, and
+  `NO_COLOR` or `TERM=dumb` suppresses it.
+
 ### Changed
 - `glass_set_value`'s "did not take" error now names both what you asked for and what the element
   holds, and closes with what the backend that made the write knows about it. Three outcomes used

--- a/crates/glass-core/src/doctor.rs
+++ b/crates/glass-core/src/doctor.rs
@@ -213,15 +213,26 @@ impl Diagnosis {
     /// Human-readable report. Non-default backend sections are flagged, and their
     /// failures shown as warnings, to match [`Diagnosis::overall`].
     pub fn render_text(&self, default_backend: &str) -> String {
-        let mut out = String::from("glass doctor\n");
+        self.render_styled(default_backend, &Palette::PLAIN)
+    }
+
+    /// [`Diagnosis::render_text`] drawn with `palette`. Through [`Palette::PLAIN`] the two are
+    /// byte-identical; a color palette only wraps spans of the same text in escapes.
+    pub fn render_styled(&self, default_backend: &str, palette: &Palette) -> String {
+        let mut out = format!("{}\n", palette.paint(palette.bold, "glass doctor"));
         let (mut ok, mut warn, mut fail) = (0u32, 0u32, 0u32);
         for s in &self.sections {
             let critical = Self::is_critical(s, default_backend);
             let note = match &s.backend {
-                Some(b) if !critical => format!("  (only needed for backend={b})"),
+                Some(b) if !critical => {
+                    palette.paint(palette.dim, &format!("  (only needed for backend={b})"))
+                }
                 _ => String::new(),
             };
-            out.push_str(&format!("\n[{}]{note}\n", s.title));
+            out.push_str(&format!(
+                "\n{}{note}\n",
+                palette.paint(palette.heading, &format!("[{}]", s.title))
+            ));
             for c in &s.checks {
                 let eff = Self::effective(c.status, critical);
                 match eff {
@@ -230,28 +241,63 @@ impl Diagnosis {
                     CheckStatus::Fail => fail += 1,
                     CheckStatus::Skip => {}
                 }
-                out.push_str(&format!("  {} {}: {}\n", eff.glyph(), c.name, c.detail));
+                let attr = palette.for_status(eff);
+                let glyph = eff.glyph().to_string();
+                out.push_str(&match eff {
+                    // Dim in full: a skipped check reports something that did not run.
+                    CheckStatus::Skip => {
+                        palette.paint(attr, &format!("  {glyph} {}: {}", c.name, c.detail))
+                    }
+                    // The name carries the color too, because the name is what you scan a
+                    // failing report for; a lone glyph at a fixed column is easy to miss.
+                    CheckStatus::Warn | CheckStatus::Fail => format!(
+                        "  {} {}: {}",
+                        palette.paint(attr, &glyph),
+                        palette.paint(attr, &c.name),
+                        c.detail
+                    ),
+                    // Glyph only, so a healthy report is not a wall of green.
+                    CheckStatus::Ok => {
+                        format!("  {} {}: {}", palette.paint(attr, &glyph), c.name, c.detail)
+                    }
+                });
+                out.push('\n');
                 if eff != CheckStatus::Ok {
                     if let Some(r) = &c.remedy {
-                        out.push_str(&format!("      → {r}\n"));
+                        out.push_str(&palette.paint(palette.dim, &format!("      → {r}")));
+                        out.push('\n');
                     }
                     if let Some(a) = &c.remedy_action {
-                        out.push_str(&format!("      ↪ {a}\n"));
+                        out.push_str(&palette.paint(palette.dim, &format!("      ↪ {a}")));
+                        out.push('\n');
                     }
                 }
             }
         }
         let overall = self.overall(default_backend);
         out.push_str(&format!(
-            "\nSummary: {ok} ok, {warn} warning(s), {fail} failure(s) — {}\n",
-            match overall {
-                CheckStatus::Fail => "FAIL",
-                CheckStatus::Warn => "OK (with warnings)",
-                _ => "OK",
-            }
+            "\nSummary: {}, {}, {} — {}\n",
+            summary_count(palette, ok, palette.ok, "ok"),
+            summary_count(palette, warn, palette.warn, "warning(s)"),
+            summary_count(palette, fail, palette.fail, "failure(s)"),
+            palette.paint(
+                &format!("{}{}", palette.bold, palette.for_status(overall)),
+                match overall {
+                    CheckStatus::Fail => "FAIL",
+                    CheckStatus::Warn => "OK (with warnings)",
+                    _ => "OK",
+                }
+            ),
         ));
         out
     }
+}
+
+/// One `N label` cell of the summary line, in `attr` when `n` is non-zero and dim when it is
+/// zero — a red `0 failure(s)` reads as an alarm about a number that means "fine".
+fn summary_count(palette: &Palette, n: u32, attr: &str, label: &str) -> String {
+    let attr = if n == 0 { palette.dim } else { attr };
+    palette.paint(attr, &format!("{n} {label}"))
 }
 
 #[cfg(test)]
@@ -452,5 +498,113 @@ mod tests {
         assert_ne!(p.ok, p.warn);
         assert_ne!(p.warn, p.fail);
         assert_ne!(p.fail, p.dim);
+    }
+
+    #[test]
+    fn the_plain_palette_renders_the_same_bytes_as_render_text() {
+        let d = diag();
+        assert_eq!(
+            d.render_styled("x11", &Palette::PLAIN),
+            d.render_text("x11")
+        );
+    }
+
+    #[test]
+    fn color_adds_escapes_and_changes_nothing_else() {
+        // The load-bearing property. Strip the escapes from a colored render and it must equal
+        // the plain one byte for byte — this fails if color adds, drops, or reorders a single
+        // text byte. Both backends, so the non-default-section path is covered too.
+        let d = diag();
+        for backend in ["x11", "wayland"] {
+            assert_eq!(
+                strip_ansi(&d.render_styled(backend, &Palette::ANSI)),
+                d.render_text(backend),
+                "backend {backend}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_skipped_check_is_dim_across_its_whole_line() {
+        let p = Palette::ANSI;
+        let d = Diagnosis::new(vec![Section::new(
+            "android",
+            None,
+            vec![Check::new("agent", CheckStatus::Skip, "not configured")],
+        )]);
+        let out = d.render_styled("x11", &p);
+        assert!(
+            out.contains(&format!("{}  – agent: not configured{}", p.dim, p.reset)),
+            "{out:?}"
+        );
+    }
+
+    #[test]
+    fn a_warning_colors_its_name_but_a_passing_check_does_not() {
+        let p = Palette::ANSI;
+        let d = Diagnosis::new(vec![Section::new(
+            "general",
+            None,
+            vec![
+                Check::new("device", CheckStatus::Warn, "none online"),
+                Check::new("glass", CheckStatus::Ok, "1.2.0"),
+            ],
+        )]);
+        let out = d.render_styled("x11", &p);
+        // Warn: the name carries the color too — it is what you scan a failing report for.
+        assert!(
+            out.contains(&format!("{}device{}", p.warn, p.reset)),
+            "{out:?}"
+        );
+        // Ok: glyph only, so a healthy report is not a wall of green.
+        assert!(
+            out.contains(&format!("{}✓{} glass: 1.2.0", p.ok, p.reset)),
+            "{out:?}"
+        );
+        assert!(
+            !out.contains(&format!("{}glass{}", p.ok, p.reset)),
+            "{out:?}"
+        );
+    }
+
+    #[test]
+    fn a_zero_count_is_dim_and_a_non_zero_one_takes_its_status_color() {
+        // diag() under x11 is 2 ok, 1 warning, 0 failures.
+        let p = Palette::ANSI;
+        let out = diag().render_styled("x11", &p);
+        assert!(out.contains(&format!("{}2 ok{}", p.ok, p.reset)), "{out:?}");
+        assert!(
+            out.contains(&format!("{}1 warning(s){}", p.warn, p.reset)),
+            "{out:?}"
+        );
+        // Red on a zero would read as an alarm about a number that means "fine".
+        assert!(
+            out.contains(&format!("{}0 failure(s){}", p.dim, p.reset)),
+            "{out:?}"
+        );
+        assert!(
+            !out.contains(&format!("{}0 failure(s){}", p.fail, p.reset)),
+            "{out:?}"
+        );
+    }
+
+    #[test]
+    fn the_verdict_is_bold_in_the_overall_status_color() {
+        let p = Palette::ANSI;
+        let out = diag().render_styled("wayland", &p);
+        assert!(
+            out.contains(&format!("{}{}FAIL{}", p.bold, p.fail, p.reset)),
+            "{out:?}"
+        );
+    }
+
+    #[test]
+    fn the_mcp_and_json_renderings_carry_no_escapes() {
+        // `render_text` is what server.rs hands the glass_doctor MCP tool, and the same Diagnosis
+        // is what --json serializes. Either carrying an escape would put terminal control bytes
+        // into an agent's JSON.
+        let d = diag();
+        assert!(!d.render_text("x11").contains('\x1b'));
+        assert!(!serde_json::to_string(&d).unwrap().contains('\x1b'));
     }
 }

--- a/crates/glass-core/src/doctor.rs
+++ b/crates/glass-core/src/doctor.rs
@@ -501,15 +501,6 @@ mod tests {
     }
 
     #[test]
-    fn the_plain_palette_renders_the_same_bytes_as_render_text() {
-        let d = diag();
-        assert_eq!(
-            d.render_styled("x11", &Palette::PLAIN),
-            d.render_text("x11")
-        );
-    }
-
-    #[test]
     fn color_adds_escapes_and_changes_nothing_else() {
         // The load-bearing property. Strip the escapes from a colored render and it must equal
         // the plain one byte for byte — this fails if color adds, drops, or reorders a single

--- a/crates/glass-core/src/doctor.rs
+++ b/crates/glass-core/src/doctor.rs
@@ -40,10 +40,9 @@ impl CheckStatus {
     }
 }
 
-/// ANSI attributes for the human `doctor` and `env` renderings — a table of escape-sequence
-/// prefixes plus one reset. [`Palette::PLAIN`] leaves every field empty, so rendering through it
-/// emits no escapes at all and is byte-identical to the uncolored form. Deciding *whether* a
-/// terminal wants color is the caller's job; this type only says what the escapes are.
+/// ANSI attributes for the human `doctor` and `env` renderings — a table of SGR prefixes plus one
+/// reset. [`Palette::PLAIN`] leaves every field empty, so rendering through it is byte-identical
+/// to the uncolored form. Whether a terminal wants color is the caller's decision.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Palette {
     pub ok: &'static str,
@@ -78,8 +77,9 @@ impl Palette {
         reset: "\x1b[0m",
     };
 
-    /// `text` wrapped in `attr` and this palette's reset. An empty `attr` returns `text`
-    /// unchanged — with no reset appended, which is what keeps [`Palette::PLAIN`] byte-identical.
+    /// `text` wrapped in `attr` and this palette's reset. An empty `attr` returns `text` with no
+    /// reset appended; appending one unconditionally would cost [`Palette::PLAIN`] its
+    /// byte-identity.
     pub fn paint(&self, attr: &str, text: &str) -> String {
         if attr.is_empty() {
             text.to_string()
@@ -88,8 +88,7 @@ impl Palette {
         }
     }
 
-    /// The attribute a check of this status is drawn in. `Skip` shares `dim`: it reports
-    /// something that did not run, so nothing in it should draw the eye.
+    /// The attribute a check of this status is drawn in.
     pub fn for_status(&self, status: CheckStatus) -> &'static str {
         match status {
             CheckStatus::Ok => self.ok,
@@ -216,8 +215,8 @@ impl Diagnosis {
         self.render_styled(default_backend, &Palette::PLAIN)
     }
 
-    /// [`Diagnosis::render_text`] drawn with `palette`. Through [`Palette::PLAIN`] the two are
-    /// byte-identical; a color palette only wraps spans of the same text in escapes.
+    /// [`Diagnosis::render_text`] drawn with `palette` — the same text, with spans wrapped in
+    /// escapes.
     pub fn render_styled(&self, default_backend: &str, palette: &Palette) -> String {
         let mut out = format!("{}\n", palette.paint(palette.bold, "glass doctor"));
         let (mut ok, mut warn, mut fail) = (0u32, 0u32, 0u32);
@@ -248,8 +247,7 @@ impl Diagnosis {
                     CheckStatus::Skip => {
                         palette.paint(attr, &format!("  {glyph} {}: {}", c.name, c.detail))
                     }
-                    // The name carries the color too, because the name is what you scan a
-                    // failing report for; a lone glyph at a fixed column is easy to miss.
+                    // The name is painted too: it is what you scan a failing report for.
                     CheckStatus::Warn | CheckStatus::Fail => format!(
                         "  {} {}: {}",
                         palette.paint(attr, &glyph),
@@ -293,8 +291,8 @@ impl Diagnosis {
     }
 }
 
-/// One `N label` cell of the summary line, in `attr` when `n` is non-zero and dim when it is
-/// zero — a red `0 failure(s)` reads as an alarm about a number that means "fine".
+/// One `N label` cell of the summary line, in `attr` or dim when `n` is zero — a red
+/// `0 failure(s)` reads as an alarm about a number that means "fine".
 fn summary_count(palette: &Palette, n: u32, attr: &str, label: &str) -> String {
     let attr = if n == 0 { palette.dim } else { attr };
     palette.paint(attr, &format!("{n} {label}"))
@@ -425,10 +423,10 @@ mod tests {
         ));
     }
 
-    /// Drop every `\x1b[…m` SGR sequence, leaving the text bytes behind. Test-only: the
-    /// byte-identity assertions compare a colored render against a plain one through it.
+    /// Drop every `\x1b[…m` SGR sequence, leaving the text bytes behind — how the byte-identity
+    /// assertions compare a colored render against a plain one.
     ///
-    /// Deliberately duplicated in glass-mcp's `env` tests rather than shared — exporting a
+    /// Deliberately duplicated in glass-mcp's `env` tests rather than shared: exporting a
     /// test-only helper from this crate's public API to serve one consumer is the worse trade.
     /// Leave both copies alone.
     fn strip_ansi(s: &str) -> String {
@@ -458,9 +456,8 @@ mod tests {
 
     #[test]
     fn strip_ansi_is_not_the_identity_function() {
-        // The byte-identity tests compare `strip_ansi(colored)` against `plain`. A helper that
-        // returned its input unchanged would make them pass against an implementation that
-        // emitted no color at all, so pin that it actually removes something.
+        // A `strip_ansi` that returned its input would make the byte-identity tests pass against
+        // an implementation that emitted no color at all.
         let colored = Palette::ANSI.paint(Palette::ANSI.ok, "x");
         assert!(colored.len() > "x".len(), "expected escapes: {colored:?}");
         assert_eq!(strip_ansi(&colored), "x");
@@ -468,15 +465,13 @@ mod tests {
 
     #[test]
     fn a_plain_paint_appends_nothing_at_all() {
-        // Not merely "looks the same": an implementation that always appended `reset` would
-        // render identically to the eye while adding an escape to every painted span, and every
-        // byte-identity assertion downstream rests on this.
+        // An implementation that always appended `reset` would look the same while adding an
+        // escape to every painted span, and every byte-identity assertion downstream rests on this.
         let p = Palette::PLAIN;
         assert_eq!(p.paint(p.bold, "text"), "text");
         assert_eq!(p.paint(p.ok, "✓"), "✓");
-        // The PLAIN assertions above cannot discriminate on their own: PLAIN's `reset` is empty
-        // too, so appending it appends nothing. Only an empty attribute against a palette with a
-        // real reset separates "skip the reset" from "append it unconditionally".
+        // PLAIN's `reset` is empty too, so the assertions above cannot discriminate on their own;
+        // only an empty attribute against a palette with a real reset can.
         assert_eq!(Palette::ANSI.paint("", "text"), "text");
     }
 
@@ -502,9 +497,8 @@ mod tests {
 
     #[test]
     fn color_adds_escapes_and_changes_nothing_else() {
-        // The load-bearing property. Strip the escapes from a colored render and it must equal
-        // the plain one byte for byte — this fails if color adds, drops, or reorders a single
-        // text byte. Both backends, so the non-default-section path is covered too.
+        // The load-bearing property: escapes aside, colored and plain must agree byte for byte.
+        // Both backends, so the non-default-section path is covered too.
         let d = diag();
         for backend in ["x11", "wayland"] {
             assert_eq!(
@@ -542,12 +536,12 @@ mod tests {
             ],
         )]);
         let out = d.render_styled("x11", &p);
-        // Warn: the name carries the color too — it is what you scan a failing report for.
+        // Warn: the name is painted as well as the glyph.
         assert!(
             out.contains(&format!("{}device{}", p.warn, p.reset)),
             "{out:?}"
         );
-        // Ok: glyph only, so a healthy report is not a wall of green.
+        // Ok: the glyph only; the third assertion pins that the name is not painted.
         assert!(
             out.contains(&format!("{}✓{} glass: 1.2.0", p.ok, p.reset)),
             "{out:?}"
@@ -568,7 +562,6 @@ mod tests {
             out.contains(&format!("{}1 warning(s){}", p.warn, p.reset)),
             "{out:?}"
         );
-        // Red on a zero would read as an alarm about a number that means "fine".
         assert!(
             out.contains(&format!("{}0 failure(s){}", p.dim, p.reset)),
             "{out:?}"
@@ -591,12 +584,9 @@ mod tests {
 
     #[test]
     fn every_span_of_a_colored_report_is_painted_as_written_here() {
-        // The escape-stripping byte-identity test above cannot see a *missing* escape: deleting
-        // one leaves the stripped text unchanged. So one golden, over a fixture small enough to
-        // read, pinning each structural span literally — the title, the section heading, the
-        // glyph and name of a Warn and a Fail, both remedy lines, every summary cell, and the
-        // verdict. Written as escape literals on purpose: building the expectation from
-        // `palette.*` would make it pass against any palette, which is the hole it closes.
+        // The byte-identity test above cannot see a *missing* escape — stripping one leaves the
+        // text unchanged — so one golden pins every structural span literally. Escape literals on
+        // purpose: an expectation built from `palette.*` would pass against any palette.
         let d = Diagnosis::new(vec![Section::new(
             "general",
             None,
@@ -642,9 +632,8 @@ mod tests {
 
     #[test]
     fn the_mcp_and_json_renderings_carry_no_escapes() {
-        // `render_text` is what server.rs hands the glass_doctor MCP tool, and the same Diagnosis
-        // is what --json serializes. Either carrying an escape would put terminal control bytes
-        // into an agent's JSON.
+        // `render_text` feeds the glass_doctor MCP tool and the same Diagnosis feeds --json; an
+        // escape in either would land in an agent's JSON.
         let d = diag();
         assert!(!d.render_text("x11").contains('\x1b'));
         assert!(!serde_json::to_string(&d).unwrap().contains('\x1b'));

--- a/crates/glass-core/src/doctor.rs
+++ b/crates/glass-core/src/doctor.rs
@@ -590,6 +590,57 @@ mod tests {
     }
 
     #[test]
+    fn every_span_of_a_colored_report_is_painted_as_written_here() {
+        // The escape-stripping byte-identity test above cannot see a *missing* escape: deleting
+        // one leaves the stripped text unchanged. So one golden, over a fixture small enough to
+        // read, pinning each structural span literally — the title, the section heading, the
+        // glyph and name of a Warn and a Fail, both remedy lines, every summary cell, and the
+        // verdict. Written as escape literals on purpose: building the expectation from
+        // `palette.*` would make it pass against any palette, which is the hole it closes.
+        let d = Diagnosis::new(vec![Section::new(
+            "general",
+            None,
+            vec![
+                Check::new("device", CheckStatus::Warn, "none online"),
+                Check::new("sway", CheckStatus::Fail, "not found")
+                    .with_remedy("build it")
+                    .with_remedy_action("open: https://example.invalid/sway"),
+            ],
+        )]);
+        assert_eq!(
+            d.render_styled("x11", &Palette::ANSI),
+            concat!(
+                "\x1b[1mglass doctor\x1b[0m\n",
+                "\n\x1b[1;36m[general]\x1b[0m\n",
+                "  \x1b[33m⚠\x1b[0m \x1b[33mdevice\x1b[0m: none online\n",
+                "  \x1b[31m✗\x1b[0m \x1b[31msway\x1b[0m: not found\n",
+                "\x1b[2m      → build it\x1b[0m\n",
+                "\x1b[2m      ↪ open: https://example.invalid/sway\x1b[0m\n",
+                "\nSummary: \x1b[2m0 ok\x1b[0m, \x1b[33m1 warning(s)\x1b[0m, ",
+                "\x1b[31m1 failure(s)\x1b[0m — \x1b[1m\x1b[31mFAIL\x1b[0m\n",
+            )
+        );
+    }
+
+    #[test]
+    fn the_non_default_backend_note_is_dim() {
+        // The one structural span the golden above cannot carry: it needs a section for a
+        // backend other than the default.
+        let d = Diagnosis::new(vec![Section::new(
+            "wayland",
+            Some("wayland".into()),
+            vec![Check::new("sway >=1.12", CheckStatus::Ok, "found")],
+        )]);
+        let out = d.render_styled("x11", &Palette::ANSI);
+        assert!(
+            out.contains(
+                "\x1b[1;36m[wayland]\x1b[0m\x1b[2m  (only needed for backend=wayland)\x1b[0m\n"
+            ),
+            "{out:?}"
+        );
+    }
+
+    #[test]
     fn the_mcp_and_json_renderings_carry_no_escapes() {
         // `render_text` is what server.rs hands the glass_doctor MCP tool, and the same Diagnosis
         // is what --json serializes. Either carrying an escape would put terminal control bytes

--- a/crates/glass-core/src/doctor.rs
+++ b/crates/glass-core/src/doctor.rs
@@ -428,6 +428,10 @@ mod tests {
         let p = Palette::PLAIN;
         assert_eq!(p.paint(p.bold, "text"), "text");
         assert_eq!(p.paint(p.ok, "✓"), "✓");
+        // The PLAIN assertions above cannot discriminate on their own: PLAIN's `reset` is empty
+        // too, so appending it appends nothing. Only an empty attribute against a palette with a
+        // real reset separates "skip the reset" from "append it unconditionally".
+        assert_eq!(Palette::ANSI.paint("", "text"), "text");
     }
 
     #[test]

--- a/crates/glass-core/src/doctor.rs
+++ b/crates/glass-core/src/doctor.rs
@@ -40,6 +40,66 @@ impl CheckStatus {
     }
 }
 
+/// ANSI attributes for the human `doctor` and `env` renderings — a table of escape-sequence
+/// prefixes plus one reset. [`Palette::PLAIN`] leaves every field empty, so rendering through it
+/// emits no escapes at all and is byte-identical to the uncolored form. Deciding *whether* a
+/// terminal wants color is the caller's job; this type only says what the escapes are.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Palette {
+    pub ok: &'static str,
+    pub warn: &'static str,
+    pub fail: &'static str,
+    pub dim: &'static str,
+    pub bold: &'static str,
+    pub heading: &'static str,
+    pub reset: &'static str,
+}
+
+impl Palette {
+    /// No color.
+    pub const PLAIN: Palette = Palette {
+        ok: "",
+        warn: "",
+        fail: "",
+        dim: "",
+        bold: "",
+        heading: "",
+        reset: "",
+    };
+
+    /// Basic SGR attributes, which every terminal that renders ANSI at all handles.
+    pub const ANSI: Palette = Palette {
+        ok: "\x1b[32m",
+        warn: "\x1b[33m",
+        fail: "\x1b[31m",
+        dim: "\x1b[2m",
+        bold: "\x1b[1m",
+        heading: "\x1b[1;36m",
+        reset: "\x1b[0m",
+    };
+
+    /// `text` wrapped in `attr` and this palette's reset. An empty `attr` returns `text`
+    /// unchanged — with no reset appended, which is what keeps [`Palette::PLAIN`] byte-identical.
+    pub fn paint(&self, attr: &str, text: &str) -> String {
+        if attr.is_empty() {
+            text.to_string()
+        } else {
+            format!("{attr}{text}{}", self.reset)
+        }
+    }
+
+    /// The attribute a check of this status is drawn in. `Skip` shares `dim`: it reports
+    /// something that did not run, so nothing in it should draw the eye.
+    pub fn for_status(&self, status: CheckStatus) -> &'static str {
+        match status {
+            CheckStatus::Ok => self.ok,
+            CheckStatus::Warn => self.warn,
+            CheckStatus::Fail => self.fail,
+            CheckStatus::Skip => self.dim,
+        }
+    }
+}
+
 /// One diagnostic check.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct Check {
@@ -317,5 +377,76 @@ mod tests {
         assert!(out.contains(
             "↪ open: x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
         ));
+    }
+
+    /// Drop every `\x1b[…m` SGR sequence, leaving the text bytes behind. Test-only: the
+    /// byte-identity assertions compare a colored render against a plain one through it.
+    ///
+    /// Deliberately duplicated in glass-mcp's `env` tests rather than shared — exporting a
+    /// test-only helper from this crate's public API to serve one consumer is the worse trade.
+    /// Leave both copies alone.
+    fn strip_ansi(s: &str) -> String {
+        let mut out = String::with_capacity(s.len());
+        let mut chars = s.chars();
+        while let Some(c) = chars.next() {
+            if c == '\x1b' {
+                for c in chars.by_ref() {
+                    if c == 'm' {
+                        break;
+                    }
+                }
+            } else {
+                out.push(c);
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn strip_ansi_removes_escapes_and_keeps_everything_else() {
+        assert_eq!(strip_ansi("plain"), "plain");
+        assert_eq!(strip_ansi("\x1b[32m✓\x1b[0m"), "✓");
+        assert_eq!(strip_ansi("\x1b[1m\x1b[36m[x11]\x1b[0m"), "[x11]");
+        assert_eq!(strip_ansi("done\x1b[0m"), "done");
+    }
+
+    #[test]
+    fn strip_ansi_is_not_the_identity_function() {
+        // The byte-identity tests compare `strip_ansi(colored)` against `plain`. A helper that
+        // returned its input unchanged would make them pass against an implementation that
+        // emitted no color at all, so pin that it actually removes something.
+        let colored = Palette::ANSI.paint(Palette::ANSI.ok, "x");
+        assert!(colored.len() > "x".len(), "expected escapes: {colored:?}");
+        assert_eq!(strip_ansi(&colored), "x");
+    }
+
+    #[test]
+    fn a_plain_paint_appends_nothing_at_all() {
+        // Not merely "looks the same": an implementation that always appended `reset` would
+        // render identically to the eye while adding an escape to every painted span, and every
+        // byte-identity assertion downstream rests on this.
+        let p = Palette::PLAIN;
+        assert_eq!(p.paint(p.bold, "text"), "text");
+        assert_eq!(p.paint(p.ok, "✓"), "✓");
+    }
+
+    #[test]
+    fn an_ansi_paint_wraps_the_text_in_the_attribute_and_a_reset() {
+        let p = Palette::ANSI;
+        assert_eq!(p.paint(p.ok, "✓"), "\x1b[32m✓\x1b[0m");
+    }
+
+    #[test]
+    fn each_status_draws_in_its_own_attribute() {
+        // Compared pairwise rather than checked non-empty, so swapping two match arms fails.
+        let p = Palette::ANSI;
+        assert_eq!(p.for_status(CheckStatus::Ok), p.ok);
+        assert_eq!(p.for_status(CheckStatus::Warn), p.warn);
+        assert_eq!(p.for_status(CheckStatus::Fail), p.fail);
+        assert_eq!(p.for_status(CheckStatus::Skip), p.dim);
+        // and the attributes are distinct, so those comparisons can discriminate
+        assert_ne!(p.ok, p.warn);
+        assert_ne!(p.warn, p.fail);
+        assert_ne!(p.fail, p.dim);
     }
 }

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -56,7 +56,7 @@ pub use diff::{
     diff_with_mask, region_satisfied,
 };
 pub mod doctor;
-pub use doctor::{Check, CheckStatus, Diagnosis, Section};
+pub use doctor::{Check, CheckStatus, Diagnosis, Palette, Section};
 
 pub mod capability;
 pub use capability::{CapabilityMap, CapabilityStatus, Support};

--- a/crates/glass-mcp/src/cli.rs
+++ b/crates/glass-mcp/src/cli.rs
@@ -35,12 +35,18 @@ pub enum Command {
         /// Machine-readable JSON output.
         #[arg(long)]
         json: bool,
+        /// Colorize human output: auto (only a terminal), always, or never. Ignored with --json.
+        #[arg(long, value_enum, default_value_t, value_name = "WHEN")]
+        color: crate::color::ColorChoice,
     },
     /// List glass's configuration environment variables (purpose, default, current).
     Env {
         /// Machine-readable JSON output.
         #[arg(long)]
         json: bool,
+        /// Colorize human output: auto (only a terminal), always, or never. Ignored with --json.
+        #[arg(long, value_enum, default_value_t, value_name = "WHEN")]
+        color: crate::color::ColorChoice,
     },
     /// Serve MCP over the network via Streamable HTTP.
     Serve {
@@ -119,7 +125,8 @@ mod tests {
             cli.command,
             Some(Command::Doctor {
                 deep: true,
-                json: true
+                json: true,
+                ..
             })
         ));
         // flags default to false
@@ -128,7 +135,8 @@ mod tests {
             cli.command,
             Some(Command::Doctor {
                 deep: false,
-                json: false
+                json: false,
+                ..
             })
         ));
     }
@@ -136,7 +144,42 @@ mod tests {
     #[test]
     fn env_json_parses() {
         let cli = Cli::try_parse_from(["glass-mcp", "env", "--json"]).unwrap();
-        assert!(matches!(cli.command, Some(Command::Env { json: true })));
+        assert!(matches!(cli.command, Some(Command::Env { json: true, .. })));
+    }
+
+    #[test]
+    fn color_defaults_to_auto_and_parses_each_choice() {
+        use crate::color::ColorChoice;
+        let cli = Cli::try_parse_from(["glass-mcp", "doctor"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Doctor {
+                color: ColorChoice::Auto,
+                ..
+            })
+        ));
+        let cli = Cli::try_parse_from(["glass-mcp", "doctor", "--color", "always"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Doctor {
+                color: ColorChoice::Always,
+                ..
+            })
+        ));
+        let cli = Cli::try_parse_from(["glass-mcp", "env", "--color", "never"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Env {
+                color: ColorChoice::Never,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn an_unknown_color_choice_is_rejected() {
+        let err = Cli::try_parse_from(["glass-mcp", "doctor", "--color", "rainbow"]).unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::InvalidValue);
     }
 
     #[test]

--- a/crates/glass-mcp/src/color.rs
+++ b/crates/glass-mcp/src/color.rs
@@ -50,6 +50,13 @@ fn vt_ready() -> bool {
     true
 }
 
+/// Whether a console that may not render ANSI should still get it. `Always` ignores `vt_ready`
+/// — the user asked for color explicitly, so a legacy console gets escapes rather than a silent
+/// downgrade — while `Auto` defers to it rather than printing escapes as visible text.
+fn vt_gate_allows(vt_ready: bool, choice: ColorChoice) -> bool {
+    vt_ready || choice != ColorChoice::Auto
+}
+
 /// The palette to render with, from the flag plus the process facts.
 ///
 /// `Always` still asks [`vt_ready`] — so forcing color on a legacy Windows console produces color
@@ -57,15 +64,18 @@ fn vt_ready() -> bool {
 pub(crate) fn palette(choice: ColorChoice) -> &'static Palette {
     let no_color = std::env::var("NO_COLOR").ok();
     let term = std::env::var("TERM").ok();
-    if !resolve(
+    let want = resolve(
         choice,
         std::io::stdout().is_terminal(),
         no_color.as_deref(),
         term.as_deref(),
-    ) {
+    );
+    if !want {
         return &Palette::PLAIN;
     }
-    if !vt_ready() && choice == ColorChoice::Auto {
+    // `vt_ready()` is called only past this point, and deliberately so: on Windows it MUTATES
+    // the console mode, so a `--color never` run must never reach it.
+    if !vt_gate_allows(vt_ready(), choice) {
         return &Palette::PLAIN;
     }
     &Palette::ANSI
@@ -97,6 +107,8 @@ mod tests {
             None,
             Some("xterm-256color")
         ));
+        // TERM unset is a common real case (non-interactive shells, some Windows shells).
+        assert!(resolve(ColorChoice::Auto, true, None, None));
     }
 
     #[test]
@@ -132,5 +144,19 @@ mod tests {
     #[test]
     fn auto_is_the_default_choice() {
         assert_eq!(ColorChoice::default(), ColorChoice::Auto);
+    }
+
+    #[test]
+    fn an_explicit_always_ignores_a_console_that_cannot_render() {
+        // The legacy-conhost case: the user asked for color, so a console that refuses VT mode
+        // still gets escapes rather than a silent downgrade to plain.
+        assert!(vt_gate_allows(false, ColorChoice::Always));
+    }
+
+    #[test]
+    fn auto_defers_to_the_console() {
+        // Auto must not emit escapes a console will render as visible text.
+        assert!(!vt_gate_allows(false, ColorChoice::Auto));
+        assert!(vt_gate_allows(true, ColorChoice::Auto));
     }
 }

--- a/crates/glass-mcp/src/color.rs
+++ b/crates/glass-mcp/src/color.rs
@@ -5,6 +5,7 @@
 //! the process.
 
 use glass_core::Palette;
+use std::env::VarError;
 use std::io::IsTerminal;
 
 /// `--color` on the `doctor` and `env` subcommands.
@@ -38,6 +39,43 @@ pub(crate) fn resolve(
     }
 }
 
+/// [`resolve`], with `NO_COLOR` and `TERM` looked up **by name** through `env`.
+///
+/// Split out from [`resolve`] so the names are pinned by a test rather than by argument order:
+/// `resolve` takes the two values positionally, so swapping them at the call site type-checks,
+/// and `TERM` in the `no_color` slot is non-empty on any real terminal — `auto` would then never
+/// color anything.
+fn resolve_from_env(
+    choice: ColorChoice,
+    is_tty: bool,
+    env: &dyn Fn(&str) -> Option<String>,
+) -> bool {
+    let no_color = env("NO_COLOR");
+    let term = env("TERM");
+    resolve(choice, is_tty, no_color.as_deref(), term.as_deref())
+}
+
+/// Read `name` from the process environment for the color decision.
+fn env_lookup(name: &str) -> Option<String> {
+    value_of(std::env::var(name))
+}
+
+/// A `VarError` mapped to what [`resolve`] means by "present".
+///
+/// A variable set to non-UTF-8 bytes is *set*, and by construction non-empty, so it must arrive
+/// as a non-empty `Some` and suppress color. `std::env::var(..).ok()` instead collapses it into
+/// `None`, indistinguishable from truly unset — the fail-open `tools::floor_from_var` avoids for
+/// `GLASS_SANDBOX_FLOOR`, here enabling color for a `NO_COLOR` that asked for the opposite. The
+/// lossy conversion cannot yield an empty string, since an empty `OsString` is valid UTF-8 and
+/// never reaches this arm.
+fn value_of(v: Result<String, VarError>) -> Option<String> {
+    match v {
+        Ok(s) => Some(s),
+        Err(VarError::NotPresent) => None,
+        Err(VarError::NotUnicode(raw)) => Some(raw.to_string_lossy().into_owned()),
+    }
+}
+
 /// Whether the terminal will actually interpret the escapes. A Windows console renders them as
 /// text until it is switched into VT mode, so ask it; everywhere else there is nothing to switch.
 #[cfg(windows)]
@@ -50,31 +88,44 @@ fn vt_ready() -> bool {
     true
 }
 
-/// Whether a console that may not render ANSI should still get it. `Always` ignores `vt_ready`
-/// — the user asked for color explicitly, so a legacy console gets escapes rather than a silent
-/// downgrade — while `Auto` defers to it rather than printing escapes as visible text.
+/// Whether a console that reports it will not interpret ANSI should be given it anyway.
+///
+/// `vt_ready` is `false` for a console that *refuses* the mode (legacy conhost), where escapes
+/// really do show up as visible text. `Always` ignores that — the user asked for color
+/// explicitly, so refusing consoles get escapes rather than a silent downgrade to plain — while
+/// `Auto` defers to it.
 fn vt_gate_allows(vt_ready: bool, choice: ColorChoice) -> bool {
     vt_ready || choice != ColorChoice::Auto
 }
 
-/// The palette to render with, from the flag plus the process facts.
-///
-/// `Always` still asks [`vt_ready`] — so forcing color on a legacy Windows console produces color
-/// rather than visible escape text — but ignores the answer, because the user asked explicitly.
+/// The palette to render with, from the flag plus this process's facts.
 pub(crate) fn palette(choice: ColorChoice) -> &'static Palette {
-    let no_color = std::env::var("NO_COLOR").ok();
-    let term = std::env::var("TERM").ok();
-    let want = resolve(
+    palette_with(
         choice,
         std::io::stdout().is_terminal(),
-        no_color.as_deref(),
-        term.as_deref(),
-    );
-    if !want {
+        &env_lookup,
+        vt_ready,
+    )
+}
+
+/// [`palette`] with every process fact injected, so the decision is testable without a pty, a
+/// console, or a mutated process environment.
+///
+/// `vt_ready` is reached only after the want-color decision, and deliberately so: on Windows the
+/// call MUTATES the console mode, so a `--color never` run — a flag whose whole meaning is "don't
+/// do color things" — must never get that far. Past that point it is called for exactly that side
+/// effect: switching a VT-capable Windows console into VT mode is what makes `--color always`
+/// produce color there instead of visible escape text. Only its *return value* is ignored for
+/// `Always`, which is the console that refuses the mode outright (see [`vt_gate_allows`]).
+fn palette_with(
+    choice: ColorChoice,
+    is_tty: bool,
+    env: &dyn Fn(&str) -> Option<String>,
+    vt_ready: impl FnOnce() -> bool,
+) -> &'static Palette {
+    if !resolve_from_env(choice, is_tty, env) {
         return &Palette::PLAIN;
     }
-    // `vt_ready()` is called only past this point, and deliberately so: on Windows it MUTATES
-    // the console mode, so a `--color never` run must never reach it.
     if !vt_gate_allows(vt_ready(), choice) {
         return &Palette::PLAIN;
     }
@@ -84,6 +135,32 @@ pub(crate) fn palette(choice: ColorChoice) -> &'static Palette {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::Cell;
+    use std::ffi::OsString;
+
+    /// An env lookup that answers `name` with `value` and reports every other name unset.
+    fn only(name: &'static str, value: &'static str) -> impl Fn(&str) -> Option<String> {
+        move |k: &str| (k == name).then(|| value.to_string())
+    }
+
+    /// An env lookup that reports everything unset.
+    fn nothing_set(_: &str) -> Option<String> {
+        None
+    }
+
+    /// Bytes that are not valid UTF-8, in this platform's `OsString` encoding — what the OS hands
+    /// back as `VarError::NotUnicode`.
+    #[cfg(unix)]
+    fn not_unicode() -> OsString {
+        use std::os::unix::ffi::OsStringExt as _;
+        OsString::from_vec(vec![0xff, 0xfe])
+    }
+    #[cfg(windows)]
+    fn not_unicode() -> OsString {
+        use std::os::windows::ffi::OsStringExt as _;
+        // An unpaired high surrogate: representable in a Windows `OsString`, not in a `String`.
+        OsString::from_wide(&[0xd800])
+    }
 
     #[test]
     fn always_and_never_ignore_every_other_fact() {
@@ -158,5 +235,117 @@ mod tests {
         // Auto must not emit escapes a console will render as visible text.
         assert!(!vt_gate_allows(false, ColorChoice::Auto));
         assert!(vt_gate_allows(true, ColorChoice::Auto));
+    }
+
+    #[test]
+    fn the_suppressing_variable_is_the_one_named_no_color() {
+        // `resolve` takes the two values positionally, so swapping them at the call site
+        // type-checks and every decision-table test above still passes. In production TERM is
+        // non-empty on any real terminal, so a swap would suppress color forever.
+        assert!(!resolve_from_env(
+            ColorChoice::Auto,
+            true,
+            &only("NO_COLOR", "1")
+        ));
+    }
+
+    #[test]
+    fn the_terminal_type_is_read_from_the_variable_named_term() {
+        assert!(!resolve_from_env(
+            ColorChoice::Auto,
+            true,
+            &only("TERM", "dumb")
+        ));
+    }
+
+    #[test]
+    fn an_empty_no_color_still_colors_a_real_terminal() {
+        assert!(resolve_from_env(
+            ColorChoice::Auto,
+            true,
+            &only("NO_COLOR", "")
+        ));
+    }
+
+    #[test]
+    fn an_unset_variable_reads_as_none_and_an_empty_one_as_empty() {
+        assert_eq!(value_of(Err(VarError::NotPresent)), None);
+        assert_eq!(value_of(Ok(String::new())), Some(String::new()));
+    }
+
+    #[test]
+    fn a_variable_set_to_non_utf8_bytes_reads_as_set_and_non_empty() {
+        // `.ok()` would report this as unset, which for NO_COLOR is fail-open: the variable is
+        // set, so it must suppress.
+        let v = value_of(Err(VarError::NotUnicode(not_unicode())));
+        assert!(
+            v.as_deref().is_some_and(|s| !s.is_empty()),
+            "a set-but-non-UTF-8 value must arrive non-empty, got {v:?}"
+        );
+    }
+
+    #[test]
+    fn a_non_utf8_no_color_suppresses_color() {
+        let env = |k: &str| {
+            value_of(if k == "NO_COLOR" {
+                Err(VarError::NotUnicode(not_unicode()))
+            } else {
+                Err(VarError::NotPresent)
+            })
+        };
+        assert!(!resolve_from_env(ColorChoice::Auto, true, &env));
+    }
+
+    #[test]
+    fn never_does_not_touch_the_console() {
+        // On Windows `vt_ready` mutates the console mode, so `--color never` must not reach it.
+        let asked = Cell::new(false);
+        let p = palette_with(ColorChoice::Never, true, &nothing_set, || {
+            asked.set(true);
+            true
+        });
+        assert!(!asked.get(), "--color never must not call vt_ready");
+        assert_eq!(p, &Palette::PLAIN);
+    }
+
+    #[test]
+    fn a_piped_auto_does_not_touch_the_console() {
+        let asked = Cell::new(false);
+        let p = palette_with(ColorChoice::Auto, false, &nothing_set, || {
+            asked.set(true);
+            true
+        });
+        assert!(!asked.get(), "a redirected auto must not call vt_ready");
+        assert_eq!(p, &Palette::PLAIN);
+    }
+
+    #[test]
+    fn always_asks_the_console_and_colors_whatever_it_answers() {
+        let asked = Cell::new(false);
+        let p = palette_with(ColorChoice::Always, false, &nothing_set, || {
+            asked.set(true);
+            false
+        });
+        assert!(
+            asked.get(),
+            "always must still call vt_ready, for the side effect that enables VT mode"
+        );
+        assert_eq!(p, &Palette::ANSI);
+    }
+
+    #[test]
+    fn auto_on_a_console_that_refuses_vt_mode_stays_plain() {
+        assert_eq!(
+            palette_with(ColorChoice::Auto, true, &nothing_set, || false),
+            &Palette::PLAIN
+        );
+    }
+
+    #[test]
+    fn auto_on_a_terminal_that_renders_ansi_colors() {
+        assert_eq!(
+            palette_with(ColorChoice::Auto, true, &nothing_set, || true),
+            &Palette::ANSI
+        );
     }
 }

--- a/crates/glass-mcp/src/color.rs
+++ b/crates/glass-mcp/src/color.rs
@@ -1,0 +1,136 @@
+//! Whether `doctor`/`env` human output carries ANSI color, and which palette that means.
+//!
+//! [`resolve`] is pure in the facts it takes, so the whole decision table is unit-tested without
+//! a pty and without mutating the process environment; [`palette`] is the only part that reads
+//! the process.
+
+use glass_core::Palette;
+use std::io::IsTerminal;
+
+/// `--color` on the `doctor` and `env` subcommands.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, clap::ValueEnum)]
+pub enum ColorChoice {
+    /// Color when stdout is a terminal that will render it.
+    #[default]
+    Auto,
+    /// Color whatever stdout is.
+    Always,
+    /// Never color.
+    Never,
+}
+
+/// Should ANSI be emitted?
+///
+/// `no_color` follows <https://no-color.org>: present **and non-empty** suppresses color, so
+/// `NO_COLOR=""` still colors.
+pub(crate) fn resolve(
+    choice: ColorChoice,
+    is_tty: bool,
+    no_color: Option<&str>,
+    term: Option<&str>,
+) -> bool {
+    match choice {
+        ColorChoice::Always => true,
+        ColorChoice::Never => false,
+        ColorChoice::Auto => {
+            is_tty && !no_color.is_some_and(|v| !v.is_empty()) && term != Some("dumb")
+        }
+    }
+}
+
+/// Whether the terminal will actually interpret the escapes. A Windows console renders them as
+/// text until it is switched into VT mode, so ask it; everywhere else there is nothing to switch.
+#[cfg(windows)]
+fn vt_ready() -> bool {
+    glass_windows::console::enable_vt_processing()
+}
+
+#[cfg(not(windows))]
+fn vt_ready() -> bool {
+    true
+}
+
+/// The palette to render with, from the flag plus the process facts.
+///
+/// `Always` still asks [`vt_ready`] — so forcing color on a legacy Windows console produces color
+/// rather than visible escape text — but ignores the answer, because the user asked explicitly.
+pub(crate) fn palette(choice: ColorChoice) -> &'static Palette {
+    let no_color = std::env::var("NO_COLOR").ok();
+    let term = std::env::var("TERM").ok();
+    if !resolve(
+        choice,
+        std::io::stdout().is_terminal(),
+        no_color.as_deref(),
+        term.as_deref(),
+    ) {
+        return &Palette::PLAIN;
+    }
+    if !vt_ready() && choice == ColorChoice::Auto {
+        return &Palette::PLAIN;
+    }
+    &Palette::ANSI
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn always_and_never_ignore_every_other_fact() {
+        for tty in [true, false] {
+            assert!(resolve(ColorChoice::Always, tty, Some("1"), Some("dumb")));
+            assert!(!resolve(ColorChoice::Never, tty, None, Some("xterm")));
+        }
+    }
+
+    #[test]
+    fn auto_colors_a_terminal_and_not_a_pipe() {
+        assert!(resolve(
+            ColorChoice::Auto,
+            true,
+            None,
+            Some("xterm-256color")
+        ));
+        assert!(!resolve(
+            ColorChoice::Auto,
+            false,
+            None,
+            Some("xterm-256color")
+        ));
+    }
+
+    #[test]
+    fn auto_is_suppressed_by_a_non_empty_no_color() {
+        assert!(!resolve(ColorChoice::Auto, true, Some("1"), Some("xterm")));
+        assert!(!resolve(
+            ColorChoice::Auto,
+            true,
+            Some("anything"),
+            Some("xterm")
+        ));
+    }
+
+    #[test]
+    fn an_empty_no_color_does_not_suppress() {
+        // no-color.org: the variable suppresses when present *and non-empty*. Easy to write
+        // backwards, so it gets its own test rather than riding along in the one above.
+        assert!(resolve(ColorChoice::Auto, true, Some(""), Some("xterm")));
+    }
+
+    #[test]
+    fn auto_is_suppressed_by_a_dumb_terminal() {
+        assert!(!resolve(ColorChoice::Auto, true, None, Some("dumb")));
+        // but only by exactly "dumb"
+        assert!(resolve(
+            ColorChoice::Auto,
+            true,
+            None,
+            Some("dumb-something")
+        ));
+    }
+
+    #[test]
+    fn auto_is_the_default_choice() {
+        assert_eq!(ColorChoice::default(), ColorChoice::Auto);
+    }
+}

--- a/crates/glass-mcp/src/color.rs
+++ b/crates/glass-mcp/src/color.rs
@@ -41,10 +41,9 @@ pub(crate) fn resolve(
 
 /// [`resolve`], with `NO_COLOR` and `TERM` looked up **by name** through `env`.
 ///
-/// Split out from [`resolve`] so the names are pinned by a test rather than by argument order:
-/// `resolve` takes the two values positionally, so swapping them at the call site type-checks,
-/// and `TERM` in the `no_color` slot is non-empty on any real terminal — `auto` would then never
-/// color anything.
+/// Split out so the names are pinned by a test rather than by argument order: `resolve` takes the
+/// two values positionally, so swapping them at the call site type-checks, and `TERM` in the
+/// `no_color` slot is non-empty on any real terminal — `auto` would then never color anything.
 fn resolve_from_env(
     choice: ColorChoice,
     is_tty: bool,
@@ -62,12 +61,11 @@ fn env_lookup(name: &str) -> Option<String> {
 
 /// A `VarError` mapped to what [`resolve`] means by "present".
 ///
-/// A variable set to non-UTF-8 bytes is *set*, and by construction non-empty, so it must arrive
-/// as a non-empty `Some` and suppress color. `std::env::var(..).ok()` instead collapses it into
-/// `None`, indistinguishable from truly unset — the fail-open `tools::floor_from_var` avoids for
-/// `GLASS_SANDBOX_FLOOR`, here enabling color for a `NO_COLOR` that asked for the opposite. The
-/// lossy conversion cannot yield an empty string, since an empty `OsString` is valid UTF-8 and
-/// never reaches this arm.
+/// A variable set to non-UTF-8 bytes is *set*, and by construction non-empty, so it must arrive as
+/// a non-empty `Some` and suppress color. `std::env::var(..).ok()` instead collapses it into
+/// `None`, indistinguishable from truly unset — fail-open, enabling color for a `NO_COLOR` that
+/// asked for the opposite. The lossy conversion cannot yield an empty string: an empty `OsString`
+/// is valid UTF-8 and never reaches this arm.
 fn value_of(v: Result<String, VarError>) -> Option<String> {
     match v {
         Ok(s) => Some(s),
@@ -91,9 +89,8 @@ fn vt_ready() -> bool {
 /// Whether a console that reports it will not interpret ANSI should be given it anyway.
 ///
 /// `vt_ready` is `false` for a console that *refuses* the mode (legacy conhost), where escapes
-/// really do show up as visible text. `Always` ignores that — the user asked for color
-/// explicitly, so refusing consoles get escapes rather than a silent downgrade to plain — while
-/// `Auto` defers to it.
+/// really do show up as visible text. `Auto` defers to that; `Always` ignores it, so an explicit
+/// request gets escapes rather than a silent downgrade to plain.
 fn vt_gate_allows(vt_ready: bool, choice: ColorChoice) -> bool {
     vt_ready || choice != ColorChoice::Auto
 }
@@ -111,12 +108,11 @@ pub(crate) fn palette(choice: ColorChoice) -> &'static Palette {
 /// [`palette`] with every process fact injected, so the decision is testable without a pty, a
 /// console, or a mutated process environment.
 ///
-/// `vt_ready` is reached only after the want-color decision, and deliberately so: on Windows the
-/// call MUTATES the console mode, so a `--color never` run — a flag whose whole meaning is "don't
-/// do color things" — must never get that far. Past that point it is called for exactly that side
-/// effect: switching a VT-capable Windows console into VT mode is what makes `--color always`
-/// produce color there instead of visible escape text. Only its *return value* is ignored for
-/// `Always`, which is the console that refuses the mode outright (see [`vt_gate_allows`]).
+/// `vt_ready` is reached only after the want-color decision: on Windows the call MUTATES the
+/// console mode, so a `--color never` run must never get that far. Past that point it is called
+/// for exactly that side effect — switching a VT-capable Windows console into VT mode is what
+/// makes `--color always` produce color there instead of visible escape text. Its *return value*
+/// is [`vt_gate_allows`]'s business.
 fn palette_with(
     choice: ColorChoice,
     is_tty: bool,
@@ -201,8 +197,7 @@ mod tests {
 
     #[test]
     fn an_empty_no_color_does_not_suppress() {
-        // no-color.org: the variable suppresses when present *and non-empty*. Easy to write
-        // backwards, so it gets its own test rather than riding along in the one above.
+        // no-color.org: suppresses when present *and non-empty* — easy to write backwards.
         assert!(resolve(ColorChoice::Auto, true, Some(""), Some("xterm")));
     }
 
@@ -225,8 +220,7 @@ mod tests {
 
     #[test]
     fn an_explicit_always_ignores_a_console_that_cannot_render() {
-        // The legacy-conhost case: the user asked for color, so a console that refuses VT mode
-        // still gets escapes rather than a silent downgrade to plain.
+        // The legacy-conhost case: a console that refuses VT mode still gets escapes.
         assert!(vt_gate_allows(false, ColorChoice::Always));
     }
 
@@ -239,9 +233,8 @@ mod tests {
 
     #[test]
     fn the_suppressing_variable_is_the_one_named_no_color() {
-        // `resolve` takes the two values positionally, so swapping them at the call site
-        // type-checks and every decision-table test above still passes. In production TERM is
-        // non-empty on any real terminal, so a swap would suppress color forever.
+        // A swapped call site would still pass every decision-table test above; this one names
+        // the variable.
         assert!(!resolve_from_env(
             ColorChoice::Auto,
             true,
@@ -275,8 +268,7 @@ mod tests {
 
     #[test]
     fn a_variable_set_to_non_utf8_bytes_reads_as_set_and_non_empty() {
-        // `.ok()` would report this as unset, which for NO_COLOR is fail-open: the variable is
-        // set, so it must suppress.
+        // `.ok()` would report this as unset — fail-open for NO_COLOR, which is set here.
         let v = value_of(Err(VarError::NotUnicode(not_unicode())));
         assert!(
             v.as_deref().is_some_and(|s| !s.is_empty()),

--- a/crates/glass-mcp/src/env.rs
+++ b/crates/glass-mcp/src/env.rs
@@ -733,10 +733,109 @@ mod tests {
             out.contains(&format!("{}current: strict (override){}", p.ok, p.reset)),
             "{out:?}"
         );
-        // GLASS_BACKEND is unset.
+        // GLASS_BACKEND is unset. The whole cell plus the reset, so this half is no weaker
+        // than the set half above.
         assert!(
-            out.contains(&format!("{}current: (unset \u{2192} x11", p.dim)),
+            out.contains(&format!(
+                "{}current: (unset \u{2192} x11 (or windows on Windows, macos on macOS)){}",
+                p.dim, p.reset
+            )),
             "{out:?}"
+        );
+    }
+
+    #[test]
+    fn the_purpose_column_starts_at_a_fixed_offset() {
+        // `color_adds_escapes_and_changes_nothing_else` compares an ANSI-stripped render against
+        // a PLAIN one, and both sides pad with the same constant — so it is blind to the constant
+        // itself being wrong. Pin the absolute geometry instead, with the offset written as a
+        // literal: deriving it from NAME_COL would inherit exactly the error guarded against.
+        let out = render_styled(&stub, &Palette::PLAIN);
+        let line = |starts: &str| {
+            out.lines()
+                .find(|l| l.starts_with(starts))
+                .unwrap_or_else(|| panic!("no {starts:?} line in:\n{out}"))
+                .to_string()
+        };
+        // 29 = the two-space indent + the 26-column name field + one separating space.
+        let name_line = line("  GLASS_AVD");
+        assert_eq!(
+            name_line.find("which AVD to boot when none is running"),
+            Some(29),
+            "{name_line:?}"
+        );
+        // The second line of the pair puts `default:` in that same column.
+        let default_line = out
+            .lines()
+            .find(|l| l.contains("default: the sole AVD"))
+            .unwrap_or_else(|| panic!("no GLASS_AVD default line in:\n{out}"));
+        assert_eq!(default_line.find("default: "), Some(29), "{default_line:?}");
+    }
+
+    #[test]
+    fn a_name_wider_than_the_column_keeps_exactly_one_space() {
+        // GLASS_EMULATOR_BOOT_TIMEOUT_MS is 30 chars, the only name that reaches the
+        // saturating_sub clamp: the pad is empty and only the separating space remains.
+        let out = render_styled(&stub, &Palette::PLAIN);
+        assert!(
+            out.contains(
+                "\n  GLASS_EMULATOR_BOOT_TIMEOUT_MS max wait for the booting emulator to reach \
+                 sys.boot_completed\n"
+            ),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn every_span_of_the_colored_listing_is_painted_as_written_here() {
+        // Stripping escapes cannot see a *missing* escape, so the byte-identity test above passes
+        // with any span left unpainted. One golden over two adjacent lines pins them literally —
+        // the bold name, the dim `default:` cell, the current cell — plus the title, a group
+        // heading, the standard-env heading and the closing note. Escape literals on purpose:
+        // an expectation built from `palette.*` would pass against any palette at all.
+        let out = render_styled(&stub, &Palette::ANSI);
+        assert!(
+            out.starts_with("\x1b[1mglass environment\x1b[0m\n\n\x1b[1;36m[all]\x1b[0m\n"),
+            "{out:?}"
+        );
+        assert!(
+            out.contains(concat!(
+                "  \x1b[1mGLASS_AVD\x1b[0m                  which AVD to boot when none is running\n",
+                "                             \x1b[2mdefault: the sole AVD\x1b[0m | \x1b[2mcurrent: (unset \u{2192} the sole AVD)\x1b[0m\n",
+            )),
+            "{out:?}"
+        );
+        assert!(
+            out.contains("\n\x1b[1;36mstandard env (read, not glass-specific)\x1b[0m\n"),
+            "{out:?}"
+        );
+        assert!(
+            out.ends_with(
+                "\n\x1b[2mnote: the X11 backend ignores ambient DISPLAY; set GLASS_DISPLAY \
+                 instead.\x1b[0m\n"
+            ),
+            "{out:?}"
+        );
+    }
+
+    #[test]
+    fn a_standard_variable_that_is_set_is_green_and_an_unset_one_is_dim() {
+        // The GLASS_* loop and the STD_ENV loop each decide this for themselves; the test above
+        // only exercises the first. `stub` sets PATH and nothing else in STD_ENV.
+        let out = render_styled(&stub, &Palette::ANSI);
+        let line = |name: &str| {
+            let head = format!("  \x1b[1m{name}\x1b[0m");
+            out.lines()
+                .find(|l| l.starts_with(&head))
+                .unwrap_or_else(|| panic!("no {name} line in:\n{out:?}"))
+                .to_string()
+        };
+        let path = line("PATH");
+        assert!(path.ends_with("\x1b[32mcurrent: set\x1b[0m"), "{path:?}");
+        let windir = line("WINDIR");
+        assert!(
+            windir.ends_with("\x1b[2mcurrent: (unset)\x1b[0m"),
+            "{windir:?}"
         );
     }
 

--- a/crates/glass-mcp/src/env.rs
+++ b/crates/glass-mcp/src/env.rs
@@ -418,12 +418,8 @@ fn current_cell(doc: &EnvVarDoc, current: Option<&str>) -> String {
     }
 }
 
-/// Render the text listing. `current` returns the live value of a var (`None` = unset).
-pub(crate) fn render_text(current: &dyn Fn(&str) -> Option<String>) -> String {
-    render_styled(current, &Palette::PLAIN)
-}
-
-/// [`render_text`] drawn with `palette`. Through [`Palette::PLAIN`] the two are byte-identical.
+/// Render the listing with `palette`. Callers that want the plain text pass [`Palette::PLAIN`],
+/// which produces byte-identical output to painting nothing at all.
 ///
 /// Names are padded *before* they are painted: `{:<26}` counts escape bytes toward the column
 /// width, so painting first would push every purpose one column right per escape.
@@ -618,7 +614,7 @@ mod tests {
 
     #[test]
     fn text_shows_default_override_and_unset_markers() {
-        let out = render_text(&stub);
+        let out = render_styled(&stub, &Palette::PLAIN);
         // a set non-secret shows value + (override)
         assert!(out.contains("current: strict (override)"), "{out}");
         // an unset non-secret shows (unset → default)
@@ -637,7 +633,7 @@ mod tests {
 
     #[test]
     fn text_groups_are_in_fixed_scope_order() {
-        let out = render_text(&stub);
+        let out = render_styled(&stub, &Palette::PLAIN);
         let idx = |s: &str| {
             out.find(s)
                 .unwrap_or_else(|| panic!("missing {s} in:\n{out}"))
@@ -666,7 +662,7 @@ mod tests {
 
     #[test]
     fn secret_value_is_never_emitted() {
-        let text = render_text(&stub);
+        let text = render_styled(&stub, &Palette::PLAIN);
         let json = render_json(&stub);
         assert!(
             !text.contains("supersecret"),
@@ -724,7 +720,7 @@ mod tests {
         // right by the width of the escapes, and that shows up here as a byte difference.
         assert_eq!(
             strip_ansi(&render_styled(&stub, &Palette::ANSI)),
-            render_text(&stub)
+            render_styled(&stub, &Palette::PLAIN)
         );
     }
 
@@ -764,7 +760,7 @@ mod tests {
     fn the_standard_env_list_documents_the_color_variables() {
         // `color::palette` reads NO_COLOR and TERM, so `glass-mcp env` must say so — STD_ENV is
         // the inventory of non-GLASS_* env glass reads.
-        let out = render_text(&stub);
+        let out = render_styled(&stub, &Palette::PLAIN);
         assert!(out.contains("NO_COLOR"), "{out}");
         assert!(out.contains("TERM"), "{out}");
     }

--- a/crates/glass-mcp/src/env.rs
+++ b/crates/glass-mcp/src/env.rs
@@ -719,11 +719,6 @@ mod tests {
     }
 
     #[test]
-    fn the_plain_palette_renders_the_same_bytes_as_render_text() {
-        assert_eq!(render_styled(&stub, &Palette::PLAIN), render_text(&stub));
-    }
-
-    #[test]
     fn color_adds_escapes_and_changes_nothing_else() {
         // Also the column guard: painting a name before padding it would push the purpose column
         // right by the width of the escapes, and that shows up here as a byte difference.

--- a/crates/glass-mcp/src/env.rs
+++ b/crates/glass-mcp/src/env.rs
@@ -418,11 +418,10 @@ fn current_cell(doc: &EnvVarDoc, current: Option<&str>) -> String {
     }
 }
 
-/// Render the listing with `palette`. Callers that want the plain text pass [`Palette::PLAIN`],
-/// which produces byte-identical output to painting nothing at all.
+/// Render the listing with `palette`; [`Palette::PLAIN`] gives the uncolored text.
 ///
-/// Names are padded *before* they are painted: `{:<26}` counts escape bytes toward the column
-/// width, so painting first would push every purpose one column right per escape.
+/// Pad names *before* painting them: `{:<26}` counts an escape's characters toward the width, so
+/// painting first pulls the purpose column left by the width of the escapes.
 pub(crate) fn render_styled(current: &dyn Fn(&str) -> Option<String>, palette: &Palette) -> String {
     /// Width of the name column, matching the `{:<26}` this replaced.
     const NAME_COL: usize = 26;
@@ -686,7 +685,7 @@ mod tests {
 
     /// Drop every `\x1b[…m` SGR sequence, leaving the text bytes behind.
     ///
-    /// Deliberately duplicated from glass-core's `doctor` tests rather than shared — exporting a
+    /// Deliberately duplicated from glass-core's `doctor` tests rather than shared: exporting a
     /// test-only helper from glass-core's public API to serve one consumer is the worse trade.
     /// Leave both copies alone.
     fn strip_ansi(s: &str) -> String {
@@ -716,8 +715,8 @@ mod tests {
 
     #[test]
     fn color_adds_escapes_and_changes_nothing_else() {
-        // Also the column guard: painting a name before padding it would push the purpose column
-        // right by the width of the escapes, and that shows up here as a byte difference.
+        // Also the column guard: painting a name before padding it would pull the purpose column
+        // left by the width of the escapes, which shows up here as a byte difference.
         assert_eq!(
             strip_ansi(&render_styled(&stub, &Palette::ANSI)),
             render_styled(&stub, &Palette::PLAIN)
@@ -733,7 +732,7 @@ mod tests {
             out.contains(&format!("{}current: strict (override){}", p.ok, p.reset)),
             "{out:?}"
         );
-        // GLASS_BACKEND is unset. The whole cell plus the reset, so this half is no weaker
+        // GLASS_BACKEND is unset — the whole cell plus the reset, so this half is no weaker
         // than the set half above.
         assert!(
             out.contains(&format!(
@@ -746,10 +745,9 @@ mod tests {
 
     #[test]
     fn the_purpose_column_starts_at_a_fixed_offset() {
-        // `color_adds_escapes_and_changes_nothing_else` compares an ANSI-stripped render against
-        // a PLAIN one, and both sides pad with the same constant — so it is blind to the constant
-        // itself being wrong. Pin the absolute geometry instead, with the offset written as a
-        // literal: deriving it from NAME_COL would inherit exactly the error guarded against.
+        // The byte-identity test pads both sides with the same constant, so it is blind to the
+        // constant itself being wrong. The offset here is a literal: deriving it from NAME_COL
+        // would inherit exactly the error guarded against.
         let out = render_styled(&stub, &Palette::PLAIN);
         let line = |starts: &str| {
             out.lines()
@@ -775,7 +773,7 @@ mod tests {
     #[test]
     fn a_name_wider_than_the_column_keeps_exactly_one_space() {
         // GLASS_EMULATOR_BOOT_TIMEOUT_MS is 30 chars, the only name that reaches the
-        // saturating_sub clamp: the pad is empty and only the separating space remains.
+        // saturating_sub clamp.
         let out = render_styled(&stub, &Palette::PLAIN);
         assert!(
             out.contains(
@@ -788,11 +786,9 @@ mod tests {
 
     #[test]
     fn every_span_of_the_colored_listing_is_painted_as_written_here() {
-        // Stripping escapes cannot see a *missing* escape, so the byte-identity test above passes
-        // with any span left unpainted. One golden over two adjacent lines pins them literally —
-        // the bold name, the dim `default:` cell, the current cell — plus the title, a group
-        // heading, the standard-env heading and the closing note. Escape literals on purpose:
-        // an expectation built from `palette.*` would pass against any palette at all.
+        // Same hole as glass-core's golden: stripping escapes cannot see a *missing* one, so the
+        // byte-identity test above passes with any span left unpainted. Escape literals on
+        // purpose — an expectation built from `palette.*` would pass against any palette.
         let out = render_styled(&stub, &Palette::ANSI);
         assert!(
             out.starts_with("\x1b[1mglass environment\x1b[0m\n\n\x1b[1;36m[all]\x1b[0m\n"),

--- a/crates/glass-mcp/src/env.rs
+++ b/crates/glass-mcp/src/env.rs
@@ -3,6 +3,7 @@
 //! distinct from `doctor` (health). The registry and rendering are pure so they are
 //! unit-tested without mutating the process environment.
 
+use glass_core::Palette;
 use serde::Serialize;
 
 /// Which part of glass a variable affects (controls grouping in the listing).
@@ -389,6 +390,14 @@ pub(crate) const STD_ENV: &[(&str, &str)] = &[
         "Linux accessibility (AT-SPI) bus",
     ),
     ("WINDIR", "Windows system directory"),
+    (
+        "NO_COLOR",
+        "Suppress color in doctor/env human output when set to a non-empty value (no-color.org)",
+    ),
+    (
+        "TERM",
+        "Terminal type; `dumb` suppresses color in doctor/env human output",
+    ),
 ];
 
 const DISPLAY_NOTE: &str =
@@ -411,34 +420,69 @@ fn current_cell(doc: &EnvVarDoc, current: Option<&str>) -> String {
 
 /// Render the text listing. `current` returns the live value of a var (`None` = unset).
 pub(crate) fn render_text(current: &dyn Fn(&str) -> Option<String>) -> String {
-    let mut out = String::from("glass environment\n");
+    render_styled(current, &Palette::PLAIN)
+}
+
+/// [`render_text`] drawn with `palette`. Through [`Palette::PLAIN`] the two are byte-identical.
+///
+/// Names are padded *before* they are painted: `{:<26}` counts escape bytes toward the column
+/// width, so painting first would push every purpose one column right per escape.
+pub(crate) fn render_styled(current: &dyn Fn(&str) -> Option<String>, palette: &Palette) -> String {
+    /// Width of the name column, matching the `{:<26}` this replaced.
+    const NAME_COL: usize = 26;
+    let pad_to_col = |name: &str| " ".repeat(NAME_COL.saturating_sub(name.chars().count()));
+
+    let mut out = format!("{}\n", palette.paint(palette.bold, "glass environment"));
     for scope in SCOPE_ORDER {
         let group: Vec<&EnvVarDoc> = GLASS_ENV.iter().filter(|d| d.scope == scope).collect();
         if group.is_empty() {
             continue;
         }
-        out.push_str(&format!("\n[{}]\n", scope.label()));
+        out.push_str(&format!(
+            "\n{}\n",
+            palette.paint(palette.heading, &format!("[{}]", scope.label()))
+        ));
         for d in group {
             let cur = current(d.name);
-            out.push_str(&format!("  {:<26} {}\n", d.name, d.purpose));
             out.push_str(&format!(
-                "  {:<26} default: {} | current: {}\n",
+                "  {}{} {}\n",
+                palette.paint(palette.bold, d.name),
+                pad_to_col(d.name),
+                d.purpose
+            ));
+            let cur_attr = if cur.is_some() {
+                palette.ok
+            } else {
+                palette.dim
+            };
+            out.push_str(&format!(
+                "  {:<width$} {} | {}\n",
                 "",
-                d.default,
-                current_cell(d, cur.as_deref()),
+                palette.paint(palette.dim, &format!("default: {}", d.default)),
+                palette.paint(
+                    cur_attr,
+                    &format!("current: {}", current_cell(d, cur.as_deref()))
+                ),
+                width = NAME_COL,
             ));
         }
     }
-    out.push_str("\nstandard env (read, not glass-specific)\n");
+    out.push_str(&format!(
+        "\n{}\n",
+        palette.paint(palette.heading, "standard env (read, not glass-specific)")
+    ));
     for (name, purpose) in STD_ENV {
-        let cur = if current(name).is_some() {
-            "set"
-        } else {
-            "(unset)"
-        };
-        out.push_str(&format!("  {name:<26} {purpose} | current: {cur}\n"));
+        let set = current(name).is_some();
+        let cur = if set { "set" } else { "(unset)" };
+        let attr = if set { palette.ok } else { palette.dim };
+        out.push_str(&format!(
+            "  {}{} {purpose} | {}\n",
+            palette.paint(palette.bold, name),
+            pad_to_col(name),
+            palette.paint(attr, &format!("current: {cur}")),
+        ));
     }
-    out.push_str(&format!("\n{DISPLAY_NOTE}\n"));
+    out.push_str(&format!("\n{}\n", palette.paint(palette.dim, DISPLAY_NOTE)));
     out
 }
 
@@ -642,6 +686,92 @@ mod tests {
             .map(|(_, b)| b)
             .unwrap();
         assert!(token_line.contains("current: set"), "{token_line}");
+    }
+
+    /// Drop every `\x1b[…m` SGR sequence, leaving the text bytes behind.
+    ///
+    /// Deliberately duplicated from glass-core's `doctor` tests rather than shared — exporting a
+    /// test-only helper from glass-core's public API to serve one consumer is the worse trade.
+    /// Leave both copies alone.
+    fn strip_ansi(s: &str) -> String {
+        let mut out = String::with_capacity(s.len());
+        let mut chars = s.chars();
+        while let Some(c) = chars.next() {
+            if c == '\x1b' {
+                for c in chars.by_ref() {
+                    if c == 'm' {
+                        break;
+                    }
+                }
+            } else {
+                out.push(c);
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn strip_ansi_removes_escapes_and_is_not_the_identity() {
+        assert_eq!(strip_ansi("plain"), "plain");
+        assert_eq!(strip_ansi("\x1b[1mGLASS_BACKEND\x1b[0m"), "GLASS_BACKEND");
+        let colored = Palette::ANSI.paint(Palette::ANSI.bold, "x");
+        assert!(colored.len() > "x".len(), "expected escapes: {colored:?}");
+    }
+
+    #[test]
+    fn the_plain_palette_renders_the_same_bytes_as_render_text() {
+        assert_eq!(render_styled(&stub, &Palette::PLAIN), render_text(&stub));
+    }
+
+    #[test]
+    fn color_adds_escapes_and_changes_nothing_else() {
+        // Also the column guard: painting a name before padding it would push the purpose column
+        // right by the width of the escapes, and that shows up here as a byte difference.
+        assert_eq!(
+            strip_ansi(&render_styled(&stub, &Palette::ANSI)),
+            render_text(&stub)
+        );
+    }
+
+    #[test]
+    fn a_set_variable_is_green_and_an_unset_one_is_dim() {
+        let p = Palette::ANSI;
+        let out = render_styled(&stub, &p);
+        // GLASS_SANDBOX is set to "strict" by `stub`.
+        assert!(
+            out.contains(&format!("{}current: strict (override){}", p.ok, p.reset)),
+            "{out:?}"
+        );
+        // GLASS_BACKEND is unset.
+        assert!(
+            out.contains(&format!("{}current: (unset \u{2192} x11", p.dim)),
+            "{out:?}"
+        );
+    }
+
+    #[test]
+    fn a_secret_value_never_leaks_through_the_styled_rendering_either() {
+        // A coloring bug that painted the raw value would be a leak, and the existing
+        // `secret_value_is_never_emitted` only looks at the plain and JSON forms.
+        let out = render_styled(&stub, &Palette::ANSI);
+        assert!(
+            !out.contains("supersecret"),
+            "secret leaked in styled:\n{out}"
+        );
+        let p = Palette::ANSI;
+        assert!(
+            out.contains(&format!("{}current: set{}", p.ok, p.reset)),
+            "{out:?}"
+        );
+    }
+
+    #[test]
+    fn the_standard_env_list_documents_the_color_variables() {
+        // `color::palette` reads NO_COLOR and TERM, so `glass-mcp env` must say so — STD_ENV is
+        // the inventory of non-GLASS_* env glass reads.
+        let out = render_text(&stub);
+        assert!(out.contains("NO_COLOR"), "{out}");
+        assert!(out.contains("TERM"), "{out}");
     }
 
     #[test]

--- a/crates/glass-mcp/src/lib.rs
+++ b/crates/glass-mcp/src/lib.rs
@@ -177,12 +177,12 @@ pub(crate) fn backend_env_unrecognized(env: Option<&str>) -> bool {
 }
 
 /// `glass-mcp env [--json]`: print glass's configuration env vars (secrets redacted).
-pub fn run_env(json: bool) -> ! {
+pub fn run_env(json: bool, color: color::ColorChoice) -> ! {
     let current = |name: &str| env::current_from_env(name);
     let out = if json {
         env::render_json(&current)
     } else {
-        env::render_text(&current)
+        env::render_styled(&current, color::palette(color))
     };
     print!("{out}");
     std::process::exit(0);
@@ -278,7 +278,7 @@ pub fn run_debug_checklist() -> anyhow::Result<()> {
 }
 
 /// Run the `doctor` subcommand and exit.
-pub fn run_doctor(deep: bool, json: bool, audit_log: Option<&str>) -> ! {
+pub fn run_doctor(deep: bool, json: bool, audit_log: Option<&str>, color: color::ColorChoice) -> ! {
     let backend = default_backend(std::env::var("GLASS_BACKEND").ok().as_deref());
     let report = audit::report_from_config(audit_log, |k| std::env::var(k).ok());
     let diag = doctor::diagnose_with_audit(deep, &report);
@@ -288,7 +288,7 @@ pub fn run_doctor(deep: bool, json: bool, audit_log: Option<&str>) -> ! {
             serde_json::to_string_pretty(&diag).expect("serialize diagnosis")
         );
     } else {
-        print!("{}", diag.render_text(backend));
+        print!("{}", diag.render_styled(backend, color::palette(color)));
     }
     std::process::exit(diag.exit_code(backend));
 }

--- a/crates/glass-mcp/src/lib.rs
+++ b/crates/glass-mcp/src/lib.rs
@@ -9,6 +9,7 @@ pub const VERSION: &str = env!("GLASS_VERSION");
 pub mod audit;
 pub mod capabilities;
 pub mod cli;
+pub mod color;
 pub mod doctor;
 mod env;
 pub(crate) mod health;

--- a/crates/glass-mcp/src/lib.rs
+++ b/crates/glass-mcp/src/lib.rs
@@ -176,7 +176,8 @@ pub(crate) fn backend_env_unrecognized(env: Option<&str>) -> bool {
     matches!(env, Some(v) if recognized_backend(v).is_none())
 }
 
-/// `glass-mcp env [--json]`: print glass's configuration env vars (secrets redacted).
+/// `glass-mcp env [--json] [--color <auto|always|never>]`: print glass's configuration env vars
+/// (secrets redacted).
 pub fn run_env(json: bool, color: color::ColorChoice) -> ! {
     let current = |name: &str| env::current_from_env(name);
     let out = if json {

--- a/crates/glass-mcp/src/main.rs
+++ b/crates/glass-mcp/src/main.rs
@@ -33,8 +33,10 @@ async fn main() -> anyhow::Result<()> {
                 run_stdio(boot(sink), report).await
             }
         },
-        Some(Command::Doctor { deep, json }) => run_doctor(deep, json, audit_log.as_deref()),
-        Some(Command::Env { json }) => run_env(json),
+        Some(Command::Doctor { deep, json, color }) => {
+            run_doctor(deep, json, audit_log.as_deref(), color)
+        }
+        Some(Command::Env { json, color }) => run_env(json, color),
         Some(Command::Serve {
             http,
             addr,

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -807,11 +807,14 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(&text).unwrap();
         assert_eq!(v["ok"], true);
         assert_eq!(v["tool"], "glass_doctor");
+        // Escape-free as well as non-empty: this is the seam that carries the risk. Handing the
+        // tool a `render_styled(backend, &Palette::ANSI)` here would put raw terminal control
+        // bytes into an agent's JSON, and nothing else in the suite would notice.
         assert!(
             v["result"]["report"]
                 .as_str()
-                .is_some_and(|s| !s.is_empty()),
-            "expected a non-empty result.report string, got {v}"
+                .is_some_and(|s| !s.is_empty() && !s.contains('\x1b')),
+            "expected a non-empty, escape-free result.report string, got {v}"
         );
     }
 

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -807,9 +807,8 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(&text).unwrap();
         assert_eq!(v["ok"], true);
         assert_eq!(v["tool"], "glass_doctor");
-        // Escape-free as well as non-empty: this is the seam that carries the risk. Handing the
-        // tool a `render_styled(backend, &Palette::ANSI)` here would put raw terminal control
-        // bytes into an agent's JSON, and nothing else in the suite would notice.
+        // Escape-free as well as non-empty — this is the seam where a styled render would reach
+        // an agent's JSON.
         assert!(
             v["result"]["report"]
                 .as_str()

--- a/crates/glass-mcp/tests/color.rs
+++ b/crates/glass-mcp/tests/color.rs
@@ -1,0 +1,66 @@
+//! `--color` end to end through the real binary — the tty detection and palette wiring that a
+//! unit test calling `render_styled` directly cannot reach.
+//!
+//! `env` rather than `doctor` for most cases: it runs no probes, so it is fast and its output
+//! does not depend on what the host has installed.
+
+use std::process::Command;
+
+const GLASS: &str = env!("CARGO_BIN_EXE_glass-mcp");
+
+/// Run glass-mcp and return its stdout. `NO_COLOR` is cleared so a developer who sets it in their
+/// own shell doesn't silently turn these assertions into no-ops.
+fn stdout_of(args: &[&str]) -> String {
+    let out = Command::new(GLASS)
+        .args(args)
+        .env_remove("NO_COLOR")
+        .output()
+        .expect("run glass-mcp");
+    String::from_utf8(out.stdout).expect("stdout is utf-8")
+}
+
+#[test]
+fn color_always_emits_escapes() {
+    assert!(stdout_of(&["env", "--color", "always"]).contains('\x1b'));
+}
+
+#[test]
+fn color_never_emits_none() {
+    assert!(!stdout_of(&["env", "--color", "never"]).contains('\x1b'));
+}
+
+#[test]
+fn the_default_is_plain_when_stdout_is_not_a_terminal() {
+    // The harness captures stdout through a pipe — exactly the redirected case auto must not
+    // color, and the reason `glass-mcp env > file` stays machine-readable.
+    assert!(!stdout_of(&["env"]).contains('\x1b'));
+}
+
+#[test]
+fn an_explicit_always_overrides_no_color() {
+    let out = Command::new(GLASS)
+        .args(["env", "--color", "always"])
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("run glass-mcp");
+    assert!(String::from_utf8(out.stdout).unwrap().contains('\x1b'));
+}
+
+#[test]
+fn json_is_never_colored_even_when_color_is_forced() {
+    let out = stdout_of(&["env", "--json", "--color", "always"]);
+    assert!(!out.contains('\x1b'), "{out}");
+    serde_json::from_str::<serde_json::Value>(&out).expect("still valid json");
+}
+
+#[test]
+fn doctor_is_wired_to_the_same_flag() {
+    // Only that the aggregator path colors — not the exit code, which depends on what this host
+    // has installed.
+    let out = Command::new(GLASS)
+        .args(["doctor", "--color", "always"])
+        .env_remove("NO_COLOR")
+        .output()
+        .expect("run glass-mcp");
+    assert!(String::from_utf8(out.stdout).unwrap().contains('\x1b'));
+}

--- a/crates/glass-mcp/tests/color.rs
+++ b/crates/glass-mcp/tests/color.rs
@@ -8,32 +8,42 @@ use std::process::Command;
 
 const GLASS: &str = env!("CARGO_BIN_EXE_glass-mcp");
 
-/// Run glass-mcp and return its stdout. `NO_COLOR` is cleared so a developer who sets it in their
-/// own shell doesn't silently turn these assertions into no-ops.
-fn stdout_of(args: &[&str]) -> String {
+/// Run glass-mcp and return its stdout, having first confirmed the command actually produced its
+/// report. `banner` is text the subcommand always prints, colored or not — asserting it stops the
+/// escape assertions below from passing vacuously on the empty output of a crashed or
+/// silently-exiting binary.
+///
+/// `NO_COLOR` is cleared so a developer who sets it in their own shell doesn't quietly turn these
+/// assertions into no-ops.
+fn stdout_of(args: &[&str], banner: &str) -> String {
     let out = Command::new(GLASS)
         .args(args)
         .env_remove("NO_COLOR")
         .output()
         .expect("run glass-mcp");
-    String::from_utf8(out.stdout).expect("stdout is utf-8")
+    let stdout = String::from_utf8(out.stdout).expect("stdout is utf-8");
+    assert!(
+        stdout.contains(banner),
+        "expected {banner:?} in stdout; got {stdout:?}"
+    );
+    stdout
 }
 
 #[test]
 fn color_always_emits_escapes() {
-    assert!(stdout_of(&["env", "--color", "always"]).contains('\x1b'));
+    assert!(stdout_of(&["env", "--color", "always"], "glass environment").contains('\x1b'));
 }
 
 #[test]
 fn color_never_emits_none() {
-    assert!(!stdout_of(&["env", "--color", "never"]).contains('\x1b'));
+    assert!(!stdout_of(&["env", "--color", "never"], "glass environment").contains('\x1b'));
 }
 
 #[test]
 fn the_default_is_plain_when_stdout_is_not_a_terminal() {
     // The harness captures stdout through a pipe — exactly the redirected case auto must not
     // color, and the reason `glass-mcp env > file` stays machine-readable.
-    assert!(!stdout_of(&["env"]).contains('\x1b'));
+    assert!(!stdout_of(&["env"], "glass environment").contains('\x1b'));
 }
 
 #[test]
@@ -48,7 +58,10 @@ fn an_explicit_always_overrides_no_color() {
 
 #[test]
 fn json_is_never_colored_even_when_color_is_forced() {
-    let out = stdout_of(&["env", "--json", "--color", "always"]);
+    // `serde_json::from_str` below already fails on empty input, so this call doesn't need the
+    // `stdout_of` banner guard to avoid a vacuous pass — but the `"glass"` top-level key is real
+    // JSON output, so it doubles as a cheap sanity check on top of that.
+    let out = stdout_of(&["env", "--json", "--color", "always"], "\"glass\"");
     assert!(!out.contains('\x1b'), "{out}");
     serde_json::from_str::<serde_json::Value>(&out).expect("still valid json");
 }
@@ -57,10 +70,5 @@ fn json_is_never_colored_even_when_color_is_forced() {
 fn doctor_is_wired_to_the_same_flag() {
     // Only that the aggregator path colors — not the exit code, which depends on what this host
     // has installed.
-    let out = Command::new(GLASS)
-        .args(["doctor", "--color", "always"])
-        .env_remove("NO_COLOR")
-        .output()
-        .expect("run glass-mcp");
-    assert!(String::from_utf8(out.stdout).unwrap().contains('\x1b'));
+    assert!(stdout_of(&["doctor", "--color", "always"], "glass doctor").contains('\x1b'));
 }

--- a/crates/glass-mcp/tests/color.rs
+++ b/crates/glass-mcp/tests/color.rs
@@ -1,19 +1,18 @@
 //! `--color` end to end through the real binary — the tty detection and palette wiring that a
 //! unit test calling `render_styled` directly cannot reach.
 //!
-//! `env` rather than `doctor` for most cases: it runs no probes, so it is fast and its output
-//! does not depend on what the host has installed.
+//! `env` rather than `doctor` for most cases: it runs no probes, so it is fast and
+//! host-independent.
 
 use std::process::Command;
 
 const GLASS: &str = env!("CARGO_BIN_EXE_glass-mcp");
 
-/// Run glass-mcp and return its stdout, having first confirmed the command actually produced its
-/// report. `banner` is text the subcommand always prints, colored or not — asserting it stops the
-/// escape assertions below from passing vacuously on the empty output of a crashed or
-/// silently-exiting binary.
+/// Run glass-mcp and return its stdout. `banner` is text the subcommand always prints, colored or
+/// not; asserting it keeps the escape assertions below from passing vacuously on the empty output
+/// of a crashed or silently-exiting binary.
 ///
-/// `NO_COLOR` is cleared so a developer who sets it in their own shell doesn't quietly turn these
+/// `NO_COLOR` is cleared so a developer who sets it in their own shell doesn't turn these
 /// assertions into no-ops.
 fn stdout_of(args: &[&str], banner: &str) -> String {
     let out = Command::new(GLASS)
@@ -41,8 +40,7 @@ fn color_never_emits_none() {
 
 #[test]
 fn the_default_is_plain_when_stdout_is_not_a_terminal() {
-    // The harness captures stdout through a pipe — exactly the redirected case auto must not
-    // color, and the reason `glass-mcp env > file` stays machine-readable.
+    // The harness captures stdout through a pipe — the redirected case auto must not color.
     assert!(!stdout_of(&["env"], "glass environment").contains('\x1b'));
 }
 
@@ -58,9 +56,7 @@ fn an_explicit_always_overrides_no_color() {
 
 #[test]
 fn json_is_never_colored_even_when_color_is_forced() {
-    // `serde_json::from_str` below already fails on empty input, so this call doesn't need the
-    // `stdout_of` banner guard to avoid a vacuous pass — but the `"glass"` top-level key is real
-    // JSON output, so it doubles as a cheap sanity check on top of that.
+    // The banner here is a top-level JSON key rather than plain text.
     let out = stdout_of(&["env", "--json", "--color", "always"], "\"glass\"");
     assert!(!out.contains('\x1b'), "{out}");
     serde_json::from_str::<serde_json::Value>(&out).expect("still valid json");

--- a/crates/glass-windows/Cargo.toml
+++ b/crates/glass-windows/Cargo.toml
@@ -35,6 +35,8 @@ windows = { version = "0.62", features = [
   # private clipboard: host named-pipe server + scoped security descriptor
   "Win32_System_Pipes", "Win32_Storage_FileSystem", "Win32_System_IO",
   "Win32_Security_Authorization",
+  # doctor/env color: switch the console into ANSI-interpreting mode before emitting escapes.
+  "Win32_System_Console",
 ] }
 
 # The onbox examples + tests set Per-Monitor-V2 awareness at runtime (they carry no manifest); the

--- a/crates/glass-windows/src/console.rs
+++ b/crates/glass-windows/src/console.rs
@@ -1,0 +1,44 @@
+//! Console mode: switch a Windows console into ANSI-interpreting mode.
+//!
+//! A Windows console does not interpret ANSI escapes until
+//! `ENABLE_VIRTUAL_TERMINAL_PROCESSING` is set on its output handle. Windows Terminal sets it for
+//! its own sessions; legacy conhost does not, and renders escapes as visible text.
+
+/// Turn on `ENABLE_VIRTUAL_TERMINAL_PROCESSING` for stdout, reporting whether it took. `false`
+/// for a redirected handle (which has no console mode to set) or a host that refuses the mode —
+/// the caller then suppresses color rather than printing escapes as text.
+#[cfg(windows)]
+pub fn enable_vt_processing() -> bool {
+    use windows::Win32::System::Console::{
+        CONSOLE_MODE, ENABLE_VIRTUAL_TERMINAL_PROCESSING, GetConsoleMode, GetStdHandle,
+        STD_OUTPUT_HANDLE, SetConsoleMode,
+    };
+    // SAFETY: `GetStdHandle` returns a process-owned handle that we neither close nor store past
+    // this call. `GetConsoleMode` writes through `&mut mode`, which we own and have initialized.
+    // `SetConsoleMode` takes that same handle by value. Every call's result is checked, so a
+    // redirected handle (no console mode) returns false instead of proceeding on an unread `mode`.
+    unsafe {
+        let Ok(handle) = GetStdHandle(STD_OUTPUT_HANDLE) else {
+            return false;
+        };
+        let mut mode = CONSOLE_MODE::default();
+        if GetConsoleMode(handle, &mut mode).is_err() {
+            return false;
+        }
+        SetConsoleMode(handle, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING).is_ok()
+    }
+}
+
+#[cfg(all(windows, test))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enabling_twice_reports_the_same_answer() {
+        // The strong assertion — "returns true on a console, false when redirected" — can't be
+        // written portably: under `cargo test` stdout is a pipe, so this is the redirected case,
+        // and under `--nocapture` on a real console it is not. Idempotence holds either way, and
+        // still catches a first call that leaves the mode in a state the second one chokes on.
+        assert_eq!(enable_vt_processing(), enable_vt_processing());
+    }
+}

--- a/crates/glass-windows/src/console.rs
+++ b/crates/glass-windows/src/console.rs
@@ -28,17 +28,3 @@ pub fn enable_vt_processing() -> bool {
         SetConsoleMode(handle, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING).is_ok()
     }
 }
-
-#[cfg(all(windows, test))]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn enabling_twice_reports_the_same_answer() {
-        // The strong assertion — "returns true on a console, false when redirected" — can't be
-        // written portably: under `cargo test` stdout is a pipe, so this is the redirected case,
-        // and under `--nocapture` on a real console it is not. Idempotence holds either way, and
-        // still catches a first call that leaves the mode in a state the second one chokes on.
-        assert_eq!(enable_vt_processing(), enable_vt_processing());
-    }
-}

--- a/crates/glass-windows/src/console.rs
+++ b/crates/glass-windows/src/console.rs
@@ -1,12 +1,11 @@
-//! Console mode: switch a Windows console into ANSI-interpreting mode.
+//! Switching a Windows console into ANSI-interpreting mode.
 //!
 //! A Windows console does not interpret ANSI escapes until
 //! `ENABLE_VIRTUAL_TERMINAL_PROCESSING` is set on its output handle. Windows Terminal sets it for
 //! its own sessions; legacy conhost does not, and renders escapes as visible text.
 
-/// Turn on `ENABLE_VIRTUAL_TERMINAL_PROCESSING` for stdout, reporting whether it took. `false`
-/// for a redirected handle (which has no console mode to set) or a host that refuses the mode —
-/// the caller then suppresses color rather than printing escapes as text.
+/// Turn on `ENABLE_VIRTUAL_TERMINAL_PROCESSING` for stdout, reporting whether it took: `false` for
+/// a redirected handle (which has no console mode to set) or a host that refuses the mode.
 #[cfg(windows)]
 pub fn enable_vt_processing() -> bool {
     use windows::Win32::System::Console::{

--- a/crates/glass-windows/src/lib.rs
+++ b/crates/glass-windows/src/lib.rs
@@ -13,6 +13,7 @@
 
 use glass_core::capability::{CapabilityMap, CapabilityStatus};
 
+pub mod console; // cfg(windows) console-mode switch for ANSI output; no host-testable surface
 pub mod containment; // Windows containment provider seam (pure config is host-tested)
 pub mod discovery; // pure window-discovery poll-loop decision — cross-platform, host-tested
 pub mod doctor; // pure check-mapping cross-platform; Windows fact-gathering is cfg(windows)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -44,7 +44,7 @@ if the default backend can't run (CI-friendly). The agent can run the same check
 - `--deep` — additionally spawn and tear down the display to prove it starts.
 - `--json` — machine-readable output.
 - `--color <when>` — `auto` (default; color only when writing to a terminal), `always`, or `never`.
-  Ignored with `--json`. `NO_COLOR` and `TERM=dumb` suppress `auto`.
+  Ignored with `--json`. A non-empty `NO_COLOR`, or `TERM=dumb`, suppresses `auto`.
 
 ## `env`
 
@@ -53,7 +53,7 @@ List every `GLASS_*` variable with its purpose, default, and current value (see
 
 - `--json` — machine-readable output.
 - `--color <when>` — `auto` (default; color only when writing to a terminal), `always`, or `never`.
-  Ignored with `--json`. `NO_COLOR` and `TERM=dumb` suppress `auto`.
+  Ignored with `--json`. A non-empty `NO_COLOR`, or `TERM=dumb`, suppresses `auto`.
 
 ## `status`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -43,6 +43,8 @@ if the default backend can't run (CI-friendly). The agent can run the same check
 
 - `--deep` — additionally spawn and tear down the display to prove it starts.
 - `--json` — machine-readable output.
+- `--color <when>` — `auto` (default; color only when writing to a terminal), `always`, or `never`.
+  Ignored with `--json`. `NO_COLOR` and `TERM=dumb` suppress `auto`.
 
 ## `env`
 
@@ -50,6 +52,8 @@ List every `GLASS_*` variable with its purpose, default, and current value (see
 [reference/environment.md](environment.md)). `GLASS_TOKEN` is shown only as `set`/`(unset)`.
 
 - `--json` — machine-readable output.
+- `--color <when>` — `auto` (default; color only when writing to a terminal), `always`, or `never`.
+  Ignored with `--json`. `NO_COLOR` and `TERM=dumb` suppress `auto`.
 
 ## `status`
 


### PR DESCRIPTION
`glass-mcp doctor` and `glass-mcp env` colorize their human output when writing to a terminal.
Status glyphs take their status's color; a warning or failure also colors the check's *name*, so
it is findable in a thirty-line report; skipped checks and remedies recede.

`--color <auto|always|never>` on both subcommands, defaulting to `auto`. A non-empty `NO_COLOR`
or `TERM=dumb` suppresses `auto`; `--color always|never` overrides the detection.

## Plain output is byte-identical

The load-bearing constraint. `Diagnosis::render_text` also feeds the `glass_doctor` MCP tool's
JSON report (`server.rs:68`) and the macOS setup flow (`setup.rs:366`), so color could not go
into the shared renderer. Instead a `Palette` of `&'static str` attributes is threaded through
new `render_styled` functions; `Palette::PLAIN` has every field empty, and `paint` returns its
input untouched — with no reset appended — for an empty attribute.

Piped, redirected, and `--json` output are unchanged byte for byte, and every pre-existing
assertion in both renderers passes untouched. The only pre-existing tests edited are two in
`cli.rs` that pattern-matched every field of a variant that gained one.

No new dependency. No `unsafe` outside `glass-windows`.

## Verified

- `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, and
  `cargo clippy --target x86_64-pc-windows-gnu -p glass-windows` — all clean.
- `cargo test --workspace --locked` — 2352 passed, 0 failed, 297 ignored.
- Colored output rendered and inspected in a real terminal, not merely asserted to contain
  escapes.

## NOT verified: the interactive Windows console

`glass-windows/src/console.rs` switches a console into VT mode so it interprets ANSI rather than
printing escapes as text. CI's `windows-latest` job compiles and runs it, but CI redirects
stdout, so `GetConsoleMode` fails there and **the branch that actually flips a console's mode
never executes**. Wine gives no signal either — the real function and a deliberately-broken
mutant both hang in pre-`main` COM init from unrelated dependencies.

Before release, someone on a Windows box should run `glass-mcp doctor --color always` in both
Windows Terminal and legacy conhost.

## Notes for the reviewer

- `color.rs` reads `NO_COLOR`/`TERM` through a lookup seam that matches `VarError` explicitly
  rather than `.ok()`, mirroring `tools.rs`'s `floor_from_var`: a non-UTF-8 value is present and
  non-empty, so it must suppress color, and `.ok()` would have made it *enable* color.
- `palette()` calls `vt_ready()` only after deciding color is wanted. On Windows that function
  mutates console mode, so a `--color never` run must never reach it; the ordering is asserted,
  not just commented.
- `env.rs` pads variable names before painting them — painting first would eat the padding and
  pull every purpose column left. The column geometry is pinned to a literal offset.
- `env::render_text` was removed once `run_env` moved to `render_styled` and it had no production
  caller; its old body was `render_styled(current, &Palette::PLAIN)`, so the test call sites were
  inlined to exactly that.
- `setup.rs:366` deliberately stays plain — outside this change's scope.
- Pre-existing and untouched: `env.rs`'s `current_from_env` has the same `.ok()` non-UTF-8 gap,
  which this branch makes reachable for `NO_COLOR`/`TERM` in the `env` listing.

Draft until CI is green and the Windows console check above has been done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)