### PR TITLE
chore(release): v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ internal refactors, CI, or test-only changes.
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-08-11
+
 ### Added
 - `glass-mcp doctor` and `glass-mcp env` colorize their output when writing to a terminal: the
   status glyphs take their status's color, a warning or failure colors the check's name so it is
@@ -1097,7 +1099,8 @@ First public release — open core, Apache-2.0.
 - Core tools: `glass_start`, `glass_stop`, `glass_screenshot`, `glass_click`,
   `glass_list_windows`, `glass_select_window`, and `glass_doctor`.
 
-[Unreleased]: https://github.com/fixed-width/glass/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/fixed-width/glass/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/fixed-width/glass/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/fixed-width/glass/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/fixed-width/glass/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/fixed-width/glass/compare/v1.0.0...v1.0.1


### PR DESCRIPTION
Cuts **v1.3.0** — the accumulated `[Unreleased]` changes since v1.2.0, renamed with the release date, fresh `[Unreleased]` above, compare links updated.

## Highlights
**Added**
- `glass-mcp doctor` and `glass-mcp env` colorize their human output when writing to a terminal; piped output is byte-identical, `--color always|never` overrides, and `NO_COLOR` / `TERM=dumb` suppress it.

**Changed**
- `glass_set_value`'s "did not take" error names both what you asked for and what the element holds, and closes with what the backend knows about it — distinguishing a transformed write, a partial write, and one that took no effect.
- On macOS, glass no longer waits for a Simulator it booted to finish shutting down before it exits.

**Fixed**
- Teardown at process exit divides its budget instead of letting the first slow step consume it; skipped steps now say so.
- An accessibility reader that crashes on an app's tree says so, instead of reporting that the backend stopped responding.
- Bounded waits across the Wayland backend, the `sway`/`bwrap` probes, and clipboard transfers, so a quiet compositor or an unresponsive mount can no longer hang `glass_start` or `glass doctor`.
- External tools are resolved to *runnable* binaries — an installed-but-not-executable helper is reported as exactly that.
- Android and iOS hand the device back clean: the app is reaped on drop, and a launch that failed on the way up is reaped too.

## Verification
Six-backend pre-release smoke at `1.2.0-34-gb543f9f`, 8/8 each: x11, wayland, android (this box), macos, ios (mini), windows (lotus). Android device suite 14/14 locally.

Version derives from the release tag at build time (Cargo.toml stays `0.0.0`). Tag `v1.3.0` on the merge commit publishes the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)