### PR TITLE
ci(android): build the device suite before anything boots an emulator

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -127,6 +127,11 @@ jobs:
           test -f "$apk"
           echo "GLASS_ANDROID_FIXTURE_APK=$apk" >> "$GITHUB_ENV"
 
+      - name: Build the device suite's test binaries
+        # Ahead of every step that can have an emulator running — the AVD snapshot below boots
+        # one too. A build beside a booted AVD ANRs the device (glass#439).
+        run: ./scripts/test-android.sh --build-only
+
       - name: Restore the AVD cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: avd-cache

--- a/scripts/ci-android-suite.sh
+++ b/scripts/ci-android-suite.sh
@@ -111,6 +111,14 @@ fi
 ./scripts/test-android.sh "$@" 2>&1 | tee diagnostics/test-output.txt
 rc=${PIPESTATUS[0]}
 
+# The workflow builds these before booting anything, so a `Compiling` line here means the
+# pre-build missed a target and this run competed with a compiler — the failure mode of
+# glass#439.
+if grep -q '^ *Compiling ' diagnostics/test-output.txt; then
+  echo "ci-android-suite: the suite compiled with the device up — the pre-build did not cover \
+every target, so this run's load is not what the settle gate measured" >&2
+fi
+
 if [ "$rc" -ne 0 ]; then
   "$adb" shell dumpsys window        > diagnostics/dumpsys-window.txt 2>&1
   "$adb" shell dumpsys activity top  > diagnostics/dumpsys-top.txt    2>&1

--- a/scripts/test-android.sh
+++ b/scripts/test-android.sh
@@ -10,6 +10,9 @@
 #     GLASS_ANDROID_FIXTURE_APK=/path/to/fixture-compose-debug.apk \
 #     ./scripts/test-android.sh
 #
+# `--build-only` compiles the suite's test binaries and stops, touching no device — CI runs it
+# before any emulator exists, because a build beside a booted AVD ANRs the device (glass#439).
+#
 # Every test needing the jar, the a11y APK or the fixture APK fails loudly without it rather than
 # self-skipping, so all three are required.
 #
@@ -32,6 +35,31 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 . scripts/lib/device-residue.sh
 
+build_only=0
+if [ "${1:-}" = "--build-only" ]; then
+  build_only=1
+  shift
+fi
+
+# One list for both the build and the run — a target added to only one gets compiled during the
+# suite, with the device up.
+android_targets=(
+  --test a11y_loop
+  --test a11y_service_loop
+  --test agent_loop
+  --test doctor_loop
+  --test input_loop
+  --test see_loop
+  --test window_loop
+)
+
+# Before the device checks: this runs with no emulator up.
+if [ "$build_only" -eq 1 ]; then
+  cargo test --no-run -p glass-android "${android_targets[@]}"
+  cargo test --no-run -p glass-mcp --test android_session_loop
+  exit 0
+fi
+
 adb="${GLASS_ADB:-adb}"
 if ! before="$(device_snapshot "$adb")"; then
     echo "cannot read the device (GLASS_ADB=${GLASS_ADB:-<unset>}, \
@@ -45,14 +73,7 @@ assert_clean_baseline "$before" || exit 1
 # nothing.
 rc=0
 
-cargo test --no-fail-fast -p glass-android \
-  --test a11y_loop \
-  --test a11y_service_loop \
-  --test agent_loop \
-  --test doctor_loop \
-  --test input_loop \
-  --test see_loop \
-  --test window_loop \
+cargo test --no-fail-fast -p glass-android "${android_targets[@]}" \
   -- --ignored --test-threads=1 "$@" || rc=$?
 
 # The session-level click leg (glass#287): it lives in glass-mcp because that crate owns the


### PR DESCRIPTION
Closes #439.

The nightly compiled inside the emulator-runner step, beside a booted AVD. On both failing nights the logcat holds one ANR — `nexuslauncher`, *"Input dispatching timed out"* — with the runner's load average on the same line: **17.72** on 2026-08-11, **9.03** on 2026-08-10. Six device tests then failed for reasons that read as their own.

`ci-android-suite.sh`'s settle gate cannot cover this. It waits for the device to go quiet and *then* hands off to `test-android.sh`, which is what compiles — so it measures a machine that is idle precisely because the expensive part has not begun.

## The change

- **`test-android.sh --build-only`** compiles the suite's test binaries and stops, touching no device. It sits before the device checks, so it needs no emulator.
- **The workflow runs it before the AVD snapshot step**, not just before the suite — that step boots an emulator too.
- **The target list is one array**, shared by the build and the run. A target added for one could otherwise be missed by the other, and a target the pre-build skips is compiled during the suite, with the device up.
- **`ci-android-suite.sh` reports a `Compiling` line** reaching the suite anyway, on stderr. Said rather than enforced, like the settle gate above it.

The `Managed AVD lifecycle` job needs nothing: glass boots its own AVD *during* the test there, so its compile already finishes before any emulator exists — which is why that job stayed green on both failing nights.

## Verification

```
$ adb devices                      # nothing attached
$ ./scripts/test-android.sh --build-only
   … 8 test binaries built                                    exit 0
```

Then the suite's own cargo invocation, via `--list` so it needs no device:

```
run command after --build-only        → Compiling lines: 0
after touching glass-android/src/lib.rs → Compiling lines: 1
```

The second line is the point: a zero only means something once the probe is shown able to report non-zero.

`shellcheck -x` clean on both scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)