### PR TITLE
ci(android): fail when the device is quiet because it is wedged

### DIFF
--- a/scripts/ci-android-suite.sh
+++ b/scripts/ci-android-suite.sh
@@ -108,6 +108,29 @@ else
 running the suite anyway" >&2
 fi
 
+collect_device_state() {
+  "$adb" shell dumpsys window        > diagnostics/dumpsys-window.txt 2>&1
+  "$adb" shell dumpsys activity top  > diagnostics/dumpsys-top.txt    2>&1
+  "$adb" exec-out screencap -p       > diagnostics/screen-after-teardown.png 2>/dev/null
+}
+
+# A device is also quiet when it is wedged: an ANR dialog stops the app behind it from logging,
+# which the settle window above reads as calm. Checked by focused window rather than logcat's
+# `ANR in`, which reports one that happened and may since have been dismissed.
+#
+# `window displays`, not the full `window`: that dump leads with a WINDOW MANAGER LAST ANR section
+# carrying its own mCurrentFocus from the moment of the ANR, so on a wedged device it names the
+# healthy app first and on a recovered one it still shows the dialog.
+focus="$("$adb" shell dumpsys window displays 2>/dev/null | grep 'mCurrentFocus=')"
+case "$focus" in
+  *"Application Not Responding"*)
+    echo "ci-android-suite: an app stopped responding while the device came up, so the suite \
+would drive a device showing its dialog: ${focus#*mCurrentFocus=}" >&2
+    collect_device_state
+    exit 1
+    ;;
+esac
+
 ./scripts/test-android.sh "$@" 2>&1 | tee diagnostics/test-output.txt
 rc=${PIPESTATUS[0]}
 
@@ -120,9 +143,7 @@ every target, so this run's load is not what the settle gate measured" >&2
 fi
 
 if [ "$rc" -ne 0 ]; then
-  "$adb" shell dumpsys window        > diagnostics/dumpsys-window.txt 2>&1
-  "$adb" shell dumpsys activity top  > diagnostics/dumpsys-top.txt    2>&1
-  "$adb" exec-out screencap -p       > diagnostics/screen-after-teardown.png 2>/dev/null
+  collect_device_state
 fi
 
 # Stopped last: the capture then covers the collection above, and that collection is also the


### PR DESCRIPTION
Refs #441. Does not close it — this makes the failure legible and stops it masquerading as six product defects; it does not stop the launcher ANRing.

## The blind spot

`ci-android-suite.sh` waits for logcat to go quiet and treats that as readiness. An ANR dialog stops the app behind it from doing anything, so a wedged device is *silent* — the gate's own signal is produced by the failure it exists to catch.

Three nightlies went that way. The launcher stopped responding during bring-up, **79–94s before** the settle window closed, the gate reported the device settled, and the suite drove a dialog:

| | ANR (device clock) | "device settled" |
|---|---|---|
| 2026-08-10 | 10:13:51 | 10:15:25 (after 100s) |
| 2026-08-11 | 09:55:37 | 09:56:56 (after 85s) |
| 2026-08-12 | 09:56:17 | 09:57:42 (after 90s) |

## The change

After settling, the focused window decides. An ANR dialog aborts the run naming that as the reason, rather than 14 tests reporting it indirectly. Diagnostic collection moves into `collect_device_state` so the new exit keeps the dumpsys pair and the screenshot.

`window displays`, not the full `window`: that dump leads with a `WINDOW MANAGER LAST ANR` section carrying its own `mCurrentFocus` from the moment of the ANR — so it names the healthy app first on a wedged device, and still shows the dialog on a recovered one. It answers the wrong question in both directions, which cost a round of this work.

## Verification

**Fires on real data** — the live `dumpsys window displays` text captured from each red nightly:

```
diag-aug10: FIRES ✓   diag-aug11: FIRES ✓   diag-0812: FIRES ✓
```

**Does not fire when healthy** — against a local emulator, focus is `…NexusLauncherActivity`, and `window displays` there contains **0** `LAST ANR` sections where the full `window` dump contains **1**, so the scoping fix is load-bearing rather than incidental.

**The exit path itself**, run end to end against a stub adb serving the 2026-08-12 text:

```
ci-android-suite: device settled after 10s (last window 0 lines)
ci-android-suite: an app stopped responding while the device came up, so the suite would drive
  a device showing its dialog: Window{6aa9063 u0 Application Not Responding: com.google.android.apps.nexuslauncher}
exit 1
```

The settle gate saying "settled" one line above the abort is the bug, stated by the fix. Diagnostics were collected on that path. `shellcheck -x` clean; the healthy-device run of the real script proceeds into the suite as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)