### PR TITLE
ci(android): boot the emulator ourselves, and wait for a window worth driving

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -44,6 +44,11 @@ jobs:
     name: Android device suite (AVD)
     runs-on: Android-CI
     timeout-minutes: 45
+    env:
+      # avdmanager and the `emulator` binary default to different AVD directories on this runner,
+      # so an unpinned AVD lands where the emulator will not look. Job-level: a step's env does
+      # not reach the next, and the create and boot steps must agree.
+      ANDROID_AVD_HOME: ${{ github.workspace }}/.android-avd
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -128,56 +133,49 @@ jobs:
           echo "GLASS_ANDROID_FIXTURE_APK=$apk" >> "$GITHUB_ENV"
 
       - name: Build the device suite's test binaries
-        # Ahead of every step that can have an emulator running — the AVD snapshot below boots
-        # one too. A build beside a booted AVD ANRs the device (glass#439).
+        # Ahead of every step that can have an emulator running. A build beside a booted AVD ANRs
+        # the device (glass#439).
         run: ./scripts/test-android.sh --build-only
 
-      - name: Restore the AVD cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          # Every input that decides what the cached AVD *is* must appear here — the profile, and
-          # via the workflow hash the action SHA, emulator-options and disable-animations.
-          # Otherwise a changed device restores the old snapshot forever: the nightly refreshes
-          # the LRU clock and save is skipped on a hit, so the entry never self-corrects.
-          key: avd-${{ env.API_LEVEL }}-${{ env.EMULATOR_TARGET }}-${{ env.EMULATOR_ARCH }}-${{ env.EMULATOR_PROFILE }}-${{ hashFiles('.github/workflows/android.yml') }}
+      - uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
 
-      - name: Create the AVD snapshot (cache miss only)
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
-        with:
-          api-level: ${{ env.API_LEVEL }}
-          target: ${{ env.EMULATOR_TARGET }}
-          arch: ${{ env.EMULATOR_ARCH }}
-          profile: ${{ env.EMULATOR_PROFILE }}
-          force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: false
-          script: echo "AVD snapshot generated."
+      - name: Define the AVD
+        # Created, not restored from a cache: a cached snapshot resumes mid-churn, the state
+        # ci-android-suite.sh's settle gate has to wait out. avdmanager takes seconds.
+        run: |
+          img="system-images;android-${API_LEVEL};${EMULATOR_TARGET};${EMULATOR_ARCH}"
+          yes | sdkmanager --licenses > /dev/null 2>&1 || true
+          sdkmanager "platform-tools" "emulator" "$img"
+          mkdir -p "$ANDROID_AVD_HOME"
+          echo no | avdmanager create avd -n glass -k "$img" --device "$EMULATOR_PROFILE" --force
+          # Two cores starved the boot badly enough that the launcher could not take focus before
+          # the 5s input-dispatch timeout (glass#441). Capped: the emulator gains nothing from
+          # more cores than it can schedule.
+          cores=$(( $(nproc) / 2 )); [ "$cores" -gt 8 ] && cores=8; [ "$cores" -lt 2 ] && cores=2
+          printf 'hw.cpu.ncore=%s\n' "$cores" >> "$ANDROID_AVD_HOME/glass.avd/config.ini"
+          # avdmanager warns and continues rather than failing, so ask the binary that boots it.
+          "$ANDROID_SDK_ROOT/emulator/emulator" -list-avds | grep -qx glass \
+            || { echo "::error::AVD 'glass' is not visible to the emulator binary"; exit 1; }
+
+      - name: Boot the emulator
+        # Not android-emulator-runner: it waits on sys.boot_completed alone, then sends
+        # `input keyevent 82` with no way to disable it, and input dispatched at that moment ANRs
+        # the launcher (glass#441).
+        run: ./scripts/ci-android-boot.sh glass
 
       - name: Run the device suite
-        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
         env:
           # The 120s default was tuned on a warm dev box, not a cold runner.
           GLASS_EMULATOR_BOOT_TIMEOUT_MS: '300000'
-          # This job's device is the action's. glass defaults to attach-or-boot, so if that
-          # emulator dies mid-suite glass would quietly boot its own and the remaining tests
-          # would pass against a different device.
+          # The device is the one booted above. glass defaults to attach-or-boot, so if it died
+          # mid-suite glass would quietly boot its own and the remaining tests would pass against
+          # a different device.
           GLASS_ANDROID_LIFECYCLE: attach
-        with:
-          api-level: ${{ env.API_LEVEL }}
-          target: ${{ env.EMULATOR_TARGET }}
-          arch: ${{ env.EMULATOR_ARCH }}
-          profile: ${{ env.EMULATOR_PROFILE }}
-          force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: true
-          # Do not inline this script's contents here, and do not move the diagnostics into a
-          # later `if: failure()` step — scripts/ci-android-suite.sh's header says why both fail.
-          script: ./scripts/ci-android-suite.sh
+        run: ./scripts/ci-android-suite.sh
+
+      - name: Stop the emulator
+        if: always()
+        run: adb -s emulator-5554 emu kill || true
 
       - name: Save the fixture APK cache
         # Runs on a failed suite: the APK comes from the build step, not the test run. Skipping on
@@ -188,18 +186,6 @@ jobs:
         with:
           path: ~/glass-fixture
           key: glass-fixture-${{ env.AGENT_TAG }}
-
-      - name: Save the AVD cache
-        # Runs even on a failed suite: the snapshot comes from "Create the AVD snapshot", not the
-        # test run, so a red suite would otherwise re-pay full AVD creation every run. Skipping on
-        # a hit is no longer automatic once restore/save are split.
-        if: always() && steps.avd-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-${{ env.API_LEVEL }}-${{ env.EMULATOR_TARGET }}-${{ env.EMULATOR_ARCH }}-${{ env.EMULATOR_PROFILE }}-${{ hashFiles('.github/workflows/android.yml') }}
 
       - name: Upload failure diagnostics
         if: failure()

--- a/scripts/ci-android-boot.sh
+++ b/scripts/ci-android-boot.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Boot the AVD the device suite runs against, and return only once it is genuinely ready.
+#
+#   ./scripts/ci-android-boot.sh <avd-name>
+#
+# Not android-emulator-runner: it waits on `sys.boot_completed` alone and then sends
+# `input keyevent 82` unconditionally, and input dispatched before the launcher has a focused
+# window ANRs the launcher — whose dialog then takes focus for the rest of the run (glass#441).
+#
+# Readiness here is the focused window rather than a property. The keyguard is dismissed through
+# `wm`, which needs no dispatch and so cannot time out.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+avd="${1:?usage: ci-android-boot.sh <avd-name>}"
+adb="${GLASS_ADB:-adb}"
+emulator="${ANDROID_SDK_ROOT:?ANDROID_SDK_ROOT is not set}/emulator/emulator"
+serial="${GLASS_ANDROID_SERIAL:-emulator-5554}"
+boot_budget="${GLASS_CI_BOOT_BUDGET:-600}"
+
+# An ANR record reports the guest's load average, not the host's, so without both numbers a
+# run's CPU pressure cannot be told from a busy host.
+echo "--- capacity ---"
+echo "host: $(nproc) cpu(s), $(free -g | awk '/^Mem:/ {print $2}')G ram"
+grep -E '^(hw\.cpu\.ncore|hw\.ramSize)' "${ANDROID_AVD_HOME:-$HOME/.android/avd}/$avd.avd/config.ini" 2>/dev/null \
+  || echo "(no cpu/ram overrides in the AVD config)"
+
+# -no-snapshot, not -no-snapshot-save: a restored snapshot resumes mid-churn, the state the
+# settle gate has to wait out. A cold boot costs about a minute.
+#
+# To a file, not this script's stdout: a backgrounded child inherits stdout, so an emulator
+# writing into a pipe holds it open after this script exits, and whatever reads that pipe waits
+# for the emulator.
+mkdir -p diagnostics
+echo "--- launching $avd (log: diagnostics/emulator.log) ---"
+"$emulator" -avd "$avd" -port "${serial##*-}" \
+  -no-snapshot -no-window -noaudio -no-boot-anim \
+  -gpu swiftshader_indirect -camera-back none > diagnostics/emulator.log 2>&1 &
+emulator_pid=$!
+# `emu kill` first: killing the launcher PID can leave the qemu process it forked behind, and a
+# stray emulator makes the next run attach to a device nobody booted.
+trap '"$adb" -s "$serial" emu kill >/dev/null 2>&1; kill "$emulator_pid" 2>/dev/null' EXIT
+
+# One budget covers appearing, booting and reaching a drivable window — the three are one wait
+# from the caller's side. `wait-for-device` is not used: it has no bound, so an emulator that
+# never registers would hold the job open to its own timeout instead of failing here.
+deadline=$((SECONDS + boot_budget))
+while ! "$adb" -s "$serial" get-state > /dev/null 2>&1; do
+  [ "$SECONDS" -lt "$deadline" ] || { echo "::error::$serial never appeared within ${boot_budget}s" >&2; exit 1; }
+  sleep 2
+done
+
+while [ "$($adb -s "$serial" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" != "1" ]; do
+  [ "$SECONDS" -lt "$deadline" ] || { echo "::error::sys.boot_completed never set within ${boot_budget}s" >&2; exit 1; }
+  sleep 2
+done
+echo "boot_completed after $((SECONDS))s"
+
+# A keyguard is dismissed and re-checked, not assumed gone: dismiss-keyguard returns before the
+# window does.
+dismissed=0
+while :; do
+  [ "$SECONDS" -lt "$deadline" ] || { echo "::error::no drivable focused window within ${boot_budget}s; last focus: ${focus:-<none>}" >&2; exit 1; }
+  focus="$($adb -s "$serial" shell dumpsys window displays 2>/dev/null | grep 'mCurrentFocus=' || true)"
+  case "$focus" in
+    *"Application Not Responding"*)
+      echo "::error::an app stopped responding before the suite began: ${focus#*mCurrentFocus=}" >&2
+      exit 1
+      ;;
+    *Keyguard*|*StatusBar*)
+      [ "$dismissed" -eq 1 ] || { echo "dismissing the keyguard"; $adb -s "$serial" shell wm dismiss-keyguard; dismissed=1; }
+      ;;
+    # FallbackHome is the placeholder Android shows while the user is still locked. Focus alone
+    # would call it ready — the same too-early answer as sys.boot_completed.
+    *FallbackHome*|*mCurrentFocus=null*|"")
+      ;;
+    *)
+      echo "focused window after $((SECONDS))s: ${focus#*mCurrentFocus=}"
+      break
+      ;;
+  esac
+  sleep 2
+done
+
+# The suite's timing assertions are written against a device with animations off.
+for scale in window_animation_scale transition_animation_scale animator_duration_scale; do
+  "$adb" -s "$serial" shell settings put global "$scale" 0.0
+done
+
+trap - EXIT
+echo "--- ready ---"


### PR DESCRIPTION
Closes #441.

## Why the action has to go

`android-emulator-runner` waits on `sys.boot_completed` alone, then sends `input keyevent 82` to dismiss the lock screen — unconditionally. From its source at our pinned SHA:

```ts
// wait for emulator to complete booting
await waitForDevice(port, emulatorBootTimeout);
await adb(port, `shell input keyevent 82`);
```

There is no input to disable it, and the current release still does the same.

`boot_completed` is not readiness. On the 2026-08-12 nightly the user was not unlocked for another **11 seconds**:

```
09:56:01  getprop sys.boot_completed → 1      "Emulator booted."
09:56:01  adb shell input keyevent 82         ← injected here
09:56:09  (that command finally returns — 8.2s blocked)
09:56:12  system still running onUnlockedUser 0
09:56:17  ANR: Input dispatching timed out (Application does not have a focused window)
```

The launcher had no focused window, so the input could not be dispatched and the launcher was ANRed. Its dialog then held focus for the whole run — which is how six unrelated-looking tests fail together, and why the run reads as a product regression.

The action's default of **2 cores** is what stretches that window: guest CPU pressure read `some avg10=74.61` during the boot storm. That also explains the intermittency — it is a race against a 5s timer, and 2026-08-09 and the manual dispatch won it.

## What this does instead

The job defines the AVD, sizes cores from the host, boots the emulator, and waits for a focused window that is neither a keyguard, nor `FallbackHome`, nor an ANR dialog. The keyguard is dismissed with `wm dismiss-keyguard` — no input dispatch, so nothing to time out.

The AVD snapshot cache goes too: a restored snapshot resumes mid-churn, which is the state the settle gate exists to wait out, and `avdmanager` takes seconds. That retires the cache-key trap its own comment warned about.

One budget covers appearing, booting and reaching a drivable window. `wait-for-device` is not used — it has no bound, so an emulator that never registers would hold the job to its 45-minute timeout.

## Verification

Against the same AVD spec (`pixel_6`, API 34, `google_apis`, `x86_64`):

```
--- capacity ---
host: 20 cpu(s), 62G ram
hw.cpu.ncore=4
boot_completed after 18s
focused window after 20s: Window{... NexusLauncherActivity}
--- ready ---
```

Full suite against that self-booted device: **14/14**, `device-residue: clean`.

**The budget was shown to bound a real failure**, not just asserted — pointed at a serial nothing will serve, it exits 1 at the deadline and reaps what it started:

```
::error::emulator-5599 never appeared within 10s     exit 1
```

Two defects the local runs caught, both of which would have been invisible until CI:

- An earlier revision accepted `com.android.settings/.FallbackHome` — Android's boot placeholder, shown while the user is still locked — as a drivable window. That is the same too-early answer as `boot_completed`, one layer up.
- The emulator's output now goes to a file. A backgrounded child inherits stdout, so an emulator writing into a pipe holds it open long after the script exits; that presented as a 10-minute hang of a script that had finished in 25 seconds.

`shellcheck -x` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)