### PR TITLE
feat(update): glass-mcp update, a self-replacing updater

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,29 +77,35 @@ jobs:
         run: |
           set -euo pipefail
           tag="${GITHUB_REF_NAME}"
-          mkdir -p dist
+          mkdir -p dist stage
           pkg() { # <built-binary> <readme> <suffix>
             local name="glass-mcp-${tag}-$3" dir
-            dir="dist/$name"
+            dir="stage/$name"
             mkdir -p "$dir"
             install -m0755 "$1" "$dir/glass-mcp"
             strip "$dir/glass-mcp"
             cp "packaging/$2" "$dir/README.md"
-            tar -C dist -czf "dist/$name.tar.gz" "$name"
+            tar -C stage -czf "dist/$name.tar.gz" "$name"
+            # The bare, uncompressed binary `glass-mcp update` downloads. Same stripped file the
+            # archive carries, published flat so the updater needs no archive-extraction code.
+            cp "$dir/glass-mcp" "dist/$name"
           }
           pkg target/release/glass-mcp                          README-gnu.md  x86_64-linux-gnu
           pkg target/x86_64-unknown-linux-musl/release/glass-mcp README-musl.md x86_64-linux-musl
-          ( cd dist && for f in *.tar.gz; do sha256sum "$f" > "$f.sha256"; done )
+          ( cd dist && for f in glass-mcp-*; do case "$f" in *.sha256) ;; *) sha256sum "$f" > "$f.sha256";; esac; done )
       - name: Attest build provenance
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
-          subject-path: 'dist/*.tar.gz'
+          subject-path: |
+            dist/*.tar.gz
+            dist/glass-mcp-*-x86_64-linux-gnu
+            dist/glass-mcp-*-x86_64-linux-musl
       - name: Upload to draft release
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           TAG: ${{ github.ref_name }}
-        run: gh release upload "$TAG" dist/*.tar.gz dist/*.tar.gz.sha256 --clobber
+        run: gh release upload "$TAG" dist/glass-mcp-* --clobber
 
   windows:
     needs: create-release
@@ -170,19 +176,26 @@ jobs:
           Copy-Item target/release/glass-mcp.exe "dist/$name/glass-mcp.exe"
           Copy-Item packaging/README-windows.md  "dist/$name/README.md"
           Compress-Archive -Path "dist/$name/*" -DestinationPath "dist/$name.zip" -Force
-          $hash = (Get-FileHash "dist/$name.zip" -Algorithm SHA256).Hash.ToLower()
-          "$hash  $name.zip" | Out-File "dist/$name.zip.sha256" -Encoding ascii
+          # The bare, signed .exe `glass-mcp update` downloads — the same signed binary the
+          # archive carries, published flat so the updater needs no archive-extraction code.
+          Copy-Item target/release/glass-mcp.exe "dist/$name.exe"
+          foreach ($f in Get-ChildItem dist/*.zip, dist/*.exe) {
+            $hash = (Get-FileHash $f.FullName -Algorithm SHA256).Hash.ToLower()
+            "$hash  $($f.Name)" | Out-File "$($f.FullName).sha256" -Encoding ascii
+          }
       - name: Attest build provenance
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
-          subject-path: 'dist/*.zip'
+          subject-path: |
+            dist/*.zip
+            dist/*.exe
       - name: Upload to draft release
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
         run: |
-          $files = (Get-ChildItem dist/*.zip, dist/*.zip.sha256).FullName
+          $files = (Get-ChildItem dist/*.zip, dist/*.zip.sha256, dist/*.exe, dist/*.exe.sha256).FullName
           gh release upload $env:GITHUB_REF_NAME $files --clobber
 
   macos:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,8 +176,10 @@ jobs:
           Copy-Item target/release/glass-mcp.exe "dist/$name/glass-mcp.exe"
           Copy-Item packaging/README-windows.md  "dist/$name/README.md"
           Compress-Archive -Path "dist/$name/*" -DestinationPath "dist/$name.zip" -Force
-          # The bare, signed .exe `glass-mcp update` downloads — the same signed binary the
-          # archive carries, published flat so the updater needs no archive-extraction code.
+          # The bare .exe `glass-mcp update` downloads — the very same file the archive above
+          # carries, published flat so the updater needs no archive-extraction code. Copied from
+          # target/release after the sign step, so it is Authenticode-signed exactly when the
+          # archived copy is: only when the signing secrets are configured (see `creds` above).
           Copy-Item target/release/glass-mcp.exe "dist/$name.exe"
           foreach ($f in Get-ChildItem dist/*.zip, dist/*.exe) {
             $hash = (Get-FileHash $f.FullName -Algorithm SHA256).Hash.ToLower()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,8 +176,7 @@ jobs:
           Copy-Item target/release/glass-mcp.exe "dist/$name/glass-mcp.exe"
           Copy-Item packaging/README-windows.md  "dist/$name/README.md"
           Compress-Archive -Path "dist/$name/*" -DestinationPath "dist/$name.zip" -Force
-          # The bare .exe `glass-mcp update` downloads — the very same file the archive above
-          # carries, published flat so the updater needs no archive-extraction code. Copied from
+          # The bare .exe `glass-mcp update` downloads, as for Linux above. Copied from
           # target/release after the sign step, so it is Authenticode-signed exactly when the
           # archived copy is: only when the signing secrets are configured (see `creds` above).
           Copy-Item target/release/glass-mcp.exe "dist/$name.exe"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ internal refactors, CI, or test-only changes.
 
 ## [Unreleased]
 
+### Added
+- `glass-mcp update` updates the binary in place: it downloads the latest release for your
+  platform, verifies its checksum and (when the GitHub CLI is installed) its build provenance,
+  and swaps it in. `--check` reports the current and latest version without changing anything;
+  `--yes` skips the confirmation prompt. It never asks for elevated privileges — if the install
+  directory isn't writable it prints the release URL instead so you can move the binary into
+  place yourself.
+
 ## [1.3.0] - 2026-08-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,6 +292,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,6 +464,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -449,6 +474,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -543,10 +574,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -562,6 +612,16 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -757,6 +817,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,6 +963,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futures"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1019,14 +1091,29 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "rand_core",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1447,6 +1534,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1686,6 +1788,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1822,6 +1983,12 @@ checksum = "52d3a9855747c17eaf4383823f135220716ab49bea5fbea7dd42cc9a92f8aa31"
 dependencies = [
  "logos-codegen 0.16.1",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mach2"
@@ -2069,6 +2236,12 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "ordered-stream"
@@ -2430,6 +2603,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2451,7 +2681,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
- "getrandom",
+ "getrandom 0.4.3",
  "rand_core",
 ]
 
@@ -2460,6 +2690,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "rayon"
@@ -2565,15 +2804,21 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -2599,6 +2844,20 @@ dependencies = [
  "once_cell",
  "region",
  "slice-pool2",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2656,6 +2915,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2678,6 +2943,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2696,6 +3036,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2729,6 +3078,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2858,6 +3230,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2946,6 +3334,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2994,7 +3388,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -3071,6 +3465,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3097,6 +3506,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -3367,6 +3786,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3396,7 +3821,7 @@ version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -3627,6 +4052,25 @@ checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4070,6 +4514,12 @@ dependencies = [
  "syn 2.0.119",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/crates/glass-mcp/Cargo.toml
+++ b/crates/glass-mcp/Cargo.toml
@@ -40,15 +40,13 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "std"
 futures = { version = "0.3", optional = true }
 # `update`: the only outbound HTTP glass makes. reqwest rather than a lighter client because it
 # is already in Cargo.lock (pinned to rmcp's line below) and hyper/http/tower/tokio are already
-# linked via axum — a second HTTP stack alongside the one already present is the larger cost.
-# Native roots rather than a bundled store so a TLS-inspecting corporate proxy works; a musl
-# static build therefore needs ca-certificates present.
+# linked via axum. Native roots rather than a bundled store so a TLS-inspecting corporate proxy
+# works; a musl static build therefore needs ca-certificates present.
 #
-# reqwest 0.13 dropped the old `rustls-tls`/`rustls-tls-native-roots`/`rustls-tls-webpki-roots`
-# split: `rustls` is now the only rustls feature, and it always pulls in
-# `rustls-platform-verifier`, which verifies against the OS's own trust store (Keychain,
-# CryptoAPI, or the system's ca-certificates) rather than a bundled webpki set — i.e. it already
-# *is* the native-roots behavior this dependency was chosen for.
+# reqwest 0.13 collapsed the old `rustls-tls*` feature split: `rustls` is now the only rustls
+# feature, and it always pulls in `rustls-platform-verifier`, which verifies against the OS's own
+# trust store (Keychain, CryptoAPI, or the system's ca-certificates) rather than a bundled webpki
+# set.
 reqwest = { version = "0.13", default-features = false, features = ["rustls"], optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/crates/glass-mcp/Cargo.toml
+++ b/crates/glass-mcp/Cargo.toml
@@ -15,7 +15,7 @@ network = [
     "dep:futures",
     "rmcp/transport-streamable-http-server",
 ]
-self-update = []
+self-update = ["dep:reqwest"]
 
 [dependencies]
 glass-android.workspace = true
@@ -38,6 +38,18 @@ rand = { version = "0.10" }
 sha2 = "0.11"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 futures = { version = "0.3", optional = true }
+# `update`: the only outbound HTTP glass makes. reqwest rather than a lighter client because it
+# is already in Cargo.lock (pinned to rmcp's line below) and hyper/http/tower/tokio are already
+# linked via axum — a second HTTP stack alongside the one already present is the larger cost.
+# Native roots rather than a bundled store so a TLS-inspecting corporate proxy works; a musl
+# static build therefore needs ca-certificates present.
+#
+# reqwest 0.13 dropped the old `rustls-tls`/`rustls-tls-native-roots`/`rustls-tls-webpki-roots`
+# split: `rustls` is now the only rustls feature, and it always pulls in
+# `rustls-platform-verifier`, which verifies against the OS's own trust store (Keychain,
+# CryptoAPI, or the system's ca-certificates) rather than a bundled webpki set — i.e. it already
+# *is* the native-roots behavior this dependency was chosen for.
+reqwest = { version = "0.13", default-features = false, features = ["rustls"], optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 glass-x11 = { path = "../glass-x11" }

--- a/crates/glass-mcp/Cargo.toml
+++ b/crates/glass-mcp/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 publish.workspace = true
 
 [features]
-default = ["network"]
+default = ["network", "self-update"]
 network = [
     "dep:axum",
     "dep:tower",
@@ -15,6 +15,7 @@ network = [
     "dep:futures",
     "rmcp/transport-streamable-http-server",
 ]
+self-update = []
 
 [dependencies]
 glass-android.workspace = true

--- a/crates/glass-mcp/src/cli.rs
+++ b/crates/glass-mcp/src/cli.rs
@@ -91,9 +91,8 @@ pub enum Command {
         #[arg(long)]
         addr: Option<String>,
     },
-    /// Update this binary to the latest release. Downloads the asset for this platform, verifies
-    /// its checksum (and its build provenance, when the GitHub CLI is installed), and replaces
-    /// this binary in place.
+    /// Update this binary to the latest release. Verifies the downloaded asset's checksum, and its
+    /// build provenance when the GitHub CLI is installed.
     #[cfg(feature = "self-update")]
     Update {
         /// Report the current and latest version without changing anything.

--- a/crates/glass-mcp/src/cli.rs
+++ b/crates/glass-mcp/src/cli.rs
@@ -91,6 +91,27 @@ pub enum Command {
         #[arg(long)]
         addr: Option<String>,
     },
+    /// Update this binary to the latest release. Downloads the asset for this platform, verifies
+    /// its checksum (and its build provenance, when the GitHub CLI is installed), and replaces
+    /// this binary in place.
+    #[cfg(feature = "self-update")]
+    Update {
+        /// Report the current and latest version without changing anything.
+        #[arg(long)]
+        check: bool,
+        /// Skip the confirmation prompt. Does not skip any verification.
+        #[arg(long)]
+        yes: bool,
+        /// Proceed even if `gh attestation verify` fails.
+        #[arg(long)]
+        skip_attestation: bool,
+        /// Machine-readable JSON output.
+        #[arg(long)]
+        json: bool,
+        /// Colorize human output: auto (only a terminal), always, or never. Ignored with --json.
+        #[arg(long, value_enum, default_value_t, value_name = "WHEN")]
+        color: crate::color::ColorChoice,
+    },
     /// Remove the login LaunchAgent so glass stops starting at login (macOS). Then drag
     /// GlassMcp.app to the Trash to remove the app itself.
     Uninstall,
@@ -313,6 +334,47 @@ mod tests {
     fn uninstall_subcommand_parses() {
         let cli = Cli::try_parse_from(["glass-mcp", "uninstall"]).unwrap();
         assert!(matches!(cli.command, Some(Command::Uninstall)));
+    }
+
+    #[cfg(feature = "self-update")]
+    #[test]
+    fn update_flags_parse_and_default_to_false() {
+        let cli = Cli::try_parse_from(["glass-mcp", "update"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Update {
+                check: false,
+                yes: false,
+                skip_attestation: false,
+                json: false,
+                ..
+            })
+        ));
+        let cli = Cli::try_parse_from(["glass-mcp", "update", "--check", "--json"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Update {
+                check: true,
+                json: true,
+                ..
+            })
+        ));
+    }
+
+    /// `--skip-attestation` is kebab-case and is NOT implied by `--yes`.
+    #[cfg(feature = "self-update")]
+    #[test]
+    fn yes_does_not_imply_skipping_attestation() {
+        let cli = Cli::try_parse_from(["glass-mcp", "update", "--yes"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Update {
+                yes: true,
+                skip_attestation: false,
+                ..
+            })
+        ));
+        assert!(Cli::try_parse_from(["glass-mcp", "update", "--skip-attestation"]).is_ok());
     }
 
     #[test]

--- a/crates/glass-mcp/src/lib.rs
+++ b/crates/glass-mcp/src/lib.rs
@@ -30,6 +30,8 @@ pub(crate) mod shutdown;
 pub(crate) mod status;
 mod tools;
 mod untrusted;
+#[cfg(feature = "self-update")]
+pub(crate) mod update;
 
 use anyhow::Context;
 use glass_core::{Backend, BaselineStore, Glass, GlassError, Platform, Result};

--- a/crates/glass-mcp/src/lib.rs
+++ b/crates/glass-mcp/src/lib.rs
@@ -201,6 +201,20 @@ pub fn run_status(addr: Option<&str>) -> anyhow::Result<()> {
     status::run(addr)
 }
 
+/// `glass-mcp update [--check] [--yes] [--skip-attestation] [--json] [--color WHEN]`: replace this
+/// binary with the latest release. A thin `pub` forwarder to the crate-private module, the same
+/// shape as [`run_status`] over `status`.
+#[cfg(feature = "self-update")]
+pub async fn run_update(
+    check: bool,
+    yes: bool,
+    skip_attestation: bool,
+    json: bool,
+    color: color::ColorChoice,
+) -> anyhow::Result<()> {
+    update::run_cli(check, yes, skip_attestation, json, color).await
+}
+
 /// Run the `uninstall` subcommand: stop + remove the login LaunchAgent, then print the "drag
 /// GlassMcp.app to the Trash" note. Doesn't touch the app bundle itself — only the LaunchAgent's
 /// stop/start-at-login registration, which is the part `glass-mcp` can actually reach; removing

--- a/crates/glass-mcp/src/main.rs
+++ b/crates/glass-mcp/src/main.rs
@@ -126,6 +126,14 @@ async fn main() -> anyhow::Result<()> {
             Ok(())
         }
         Some(Command::Status { addr }) => run_status(addr.as_deref()),
+        #[cfg(feature = "self-update")]
+        Some(Command::Update {
+            check,
+            yes,
+            skip_attestation,
+            json,
+            color,
+        }) => glass_mcp::run_update(check, yes, skip_attestation, json, color).await,
         Some(Command::Uninstall) => run_uninstall(),
         Some(Command::DebugGrants) => run_debug_grants(),
         Some(Command::DebugChecklist) => run_debug_checklist(),

--- a/crates/glass-mcp/src/update/mod.rs
+++ b/crates/glass-mcp/src/update/mod.rs
@@ -1,6 +1,7 @@
 //! `glass-mcp update`: fetch the latest release, verify it, and replace this binary.
 
 mod release;
+mod swap;
 #[cfg(test)]
 mod testserver;
 mod verify;

--- a/crates/glass-mcp/src/update/mod.rs
+++ b/crates/glass-mcp/src/update/mod.rs
@@ -437,18 +437,11 @@ fn refusal_message(why: &Refusal, report: &Report) -> String {
              If GitHub is unreachable rather than the artifact being wrong, retry later — or pass \
              --skip-attestation to accept the checksum alone."
         ),
-        Refusal::SmokeCheckFailed(why) => {
-            let mut msg = format!("the downloaded binary did not run: {why}");
-            // Only suggest musl when the gnu asset is what was fetched — a too-old glibc is the
-            // overwhelmingly likely cause there, and nonsense advice everywhere else.
-            if report.asset.as_deref().is_some_and(|a| a.ends_with("-gnu")) {
-                msg.push_str(
-                    "\n  If that is a glibc error, use the musl build instead — \
-                     see docs/reference/platforms.md.",
-                );
-            }
-            msg
-        }
+        Refusal::SmokeCheckFailed(why) => format!(
+            "the downloaded binary did not run: {why}\n  \
+             The error above is from the binary itself. Build variants for this platform are \
+             listed in docs/reference/platforms.md."
+        ),
     }
 }
 
@@ -799,17 +792,6 @@ mod tests {
                 .as_str()
                 .is_some_and(|s| s.contains("/usr/local/bin"))
         );
-    }
-
-    /// The glibc hint is only correct advice when the gnu asset is what failed to run.
-    #[test]
-    fn the_glibc_hint_appears_only_for_the_gnu_asset() {
-        let mut r = report_fixture();
-        r.outcome = Outcome::Refused(Refusal::SmokeCheckFailed("exited 1".into()));
-        assert!(render(&r, &plain(false)).contains("musl build"));
-
-        r.asset = Some("glass-mcp-v1.4.0-x86_64-linux-musl".into());
-        assert!(!render(&r, &plain(false)).contains("musl build"));
     }
 
     /// The macOS behavior the guard above skips: refusing is the feature, not a gap. Asserted on

--- a/crates/glass-mcp/src/update/mod.rs
+++ b/crates/glass-mcp/src/update/mod.rs
@@ -1,9 +1,8 @@
 //! `glass-mcp update`: fetch the latest release, verify it, and replace this binary.
 //!
-//! The step order below is a contract, not an implementation detail, and the tests assert it: the
-//! from-source refusal happens before any network request, the file the download will land in is
-//! created before anything is downloaded, and consent is taken before the download rather than
-//! before the swap.
+//! The step order below is a contract the tests assert: the from-source refusal happens before any
+//! network request, the file the download will land in is created before anything is downloaded,
+//! and consent is taken before the download rather than before the swap.
 
 mod release;
 mod swap;
@@ -23,9 +22,7 @@ use verify::Attestation;
 ///
 /// `interactive`, `smoke` and `attest_program` are separate from the CLI flags so the tests can
 /// drive the non-interactive path, skip executing a fixture that is not a real binary, and reach
-/// step 8b without running the real `gh attestation verify` — which queries GitHub, and nothing in
-/// this suite touches the network. The binary sets `interactive` from the real terminal, always
-/// leaves `smoke` on, and always points `attest_program` at the real `gh`.
+/// step 8b without running the real `gh attestation verify`, which queries GitHub.
 #[derive(Debug, Clone)]
 pub(crate) struct Options {
     pub(crate) check: bool,
@@ -52,9 +49,8 @@ impl Options {
             skip_attestation,
             json,
             color,
-            // `--json` is a machine-facing mode: it must never block on a prompt, and its output
-            // must never share stdout with the three human lines `confirm` prints. Consent under
-            // `--json` comes from `--yes` alone.
+            // `--json` must never block on a prompt, nor share stdout with the three human lines
+            // `confirm` prints; consent there comes from `--yes` alone.
             interactive: !json && std::io::stdin().is_terminal() && std::io::stdout().is_terminal(),
             smoke: true,
             attest_program: verify::GH,
@@ -104,9 +100,7 @@ pub(crate) enum Outcome {
     Error(String),
 }
 
-/// What happened, and everything the renderer needs to say so. One struct rather than data hung
-/// off the `Outcome` variants: `--json` emits the same field set for every outcome, so the
-/// renderer should not have to reach into a different shape per variant.
+/// What happened, and everything the renderer needs to say so.
 #[derive(Debug)]
 pub(crate) struct Report {
     pub(crate) outcome: Outcome,
@@ -122,22 +116,17 @@ pub(crate) struct Report {
     /// Whether the apply path can run on this target at all. Independent of `outcome` because
     /// `--check` reports it on macOS without refusing.
     pub(crate) supported: bool,
-    /// Whether `current` parsed as a released version at all. `false` for a from-source build —
-    /// distinct from `update_available`, which is also `false` there but for a reason a renderer
-    /// must not conflate with "you are up to date": one is "unknown", the other is a fact.
+    /// Whether `current` parsed as a released version at all. `false` for a from-source build,
+    /// where `update_available` is also `false` — "unknown", not "you are up to date".
     pub(crate) current_comparable: bool,
     /// Whether a `glass-mcp serve --http` process is currently answering `/healthz`. Only ever set
-    /// after a successful update (by `run_cli`, which is the only caller that can actually probe
-    /// the real process) — carried on the report rather than printed as a side note so `--json`
-    /// stays the one, complete, parseable object.
+    /// after a successful update, by `run_cli` — the only caller that can probe the real process.
     pub(crate) running_server: bool,
 }
 
 /// The `attestation` field of the JSON output. `NotChecked` is the initial state — reached only by
 /// `--check` and every refusal before step 8b, none of which touch provenance at all. `Skipped` is
-/// `--skip-attestation`; `Unavailable` is `gh` not being installed. Keeping these distinct is the
-/// point — "we did not check", "you told us not to", and "we tried and couldn't" are different
-/// things for a reader auditing an update.
+/// `--skip-attestation`; `Unavailable` is `gh` not being installed.
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum AttestationStatus {
     NotChecked,
@@ -231,13 +220,10 @@ pub(crate) async fn run(
     report.url = Some(url.clone());
 
     // 6. Stage: create the temp file the download will land in, rather than inspect the
-    //    directory's permissions. Opening it is the operation the download will actually perform,
-    //    so a directory this user cannot write to is caught here rather than guessed at from a
-    //    permission bit that may not be what the kernel enforces. It is NOT the same moment,
-    //    though: `download_inner` creates the file again after the consent prompt, and the disk
-    //    can fill or the directory can go away in between — this rules out the permission
-    //    mismatch, not every later failure. Whatever the OS says when it fails is what gets
-    //    reported; this step does not try to work out why.
+    //    directory's permissions — opening it is the operation the download will actually
+    //    perform, so a permission bit the kernel may not enforce is never consulted. Not the
+    //    same moment, though: `download_inner` creates the file again after the consent prompt,
+    //    so this rules out the permission mismatch, not every later failure.
     let dir = exe.parent().unwrap_or_else(|| Path::new("."));
     let temp = dir.join(format!(".glass-mcp.update-{:016x}", rand::random::<u64>()));
     let mut open = std::fs::OpenOptions::new();
@@ -257,13 +243,10 @@ pub(crate) async fn run(
         }));
     }
     // From here on every exit tries to remove `temp`: a refusal that leaves a stray half-download
-    // beside the binary is not the no-op it claims to be, and a test asserts there are none.
-    //
-    // Best-effort, deliberately: the `remove_file` result is dropped because a failed unlink is
-    // not something this command can act on, and surfacing it would replace the real reason for
-    // the exit (a bad checksum, a refused attestation) with a secondary filesystem complaint
-    // about a file the user did not ask about. The one exit that deliberately does NOT remove
-    // `temp` is a failed `swap` at step 9 — see the comment there.
+    // beside the binary is not the no-op it claims to be. Best-effort, deliberately — surfacing a
+    // failed unlink would replace the real reason for the exit (a bad checksum, a refused
+    // attestation) with a secondary filesystem complaint. The one exit that deliberately does NOT
+    // remove `temp` is a failed `swap` at step 9 — see the comment there.
     let discard = |report: Report, why: Refusal| -> anyhow::Result<Report> {
         let _ = std::fs::remove_file(&temp);
         Ok(report.refused(why))
@@ -326,9 +309,9 @@ pub(crate) async fn run(
     // 9. Swap. Not through `abort`: by this point `temp` has been downloaded, checksummed,
     //    attested and proved to run, and if the swap fails it is the only copy of the new binary
     //    on the machine. On Windows's double-failure path — the old binary moved aside and the
-    //    restore also failing — recovery means putting a working binary back at `exe`, and
-    //    keeping this one is what makes that possible without a second download. So it stays, and
-    //    the error names where it is; `swap`'s own message names the displaced old binary.
+    //    restore also failing — recovery means putting a working binary back at `exe` without a
+    //    second download. The error names where this one is; `swap`'s own message names the
+    //    displaced old binary.
     swap::swap(&temp, exe).with_context(|| {
         format!(
             "the verified new binary is still at {} — move it into place by hand",
@@ -360,9 +343,8 @@ pub(crate) async fn run_cli(
     json: bool,
     color: ColorChoice,
 ) -> anyhow::Result<()> {
-    // `.context` rather than folding the io::Error into the message with `{e}`: the latter
-    // discards it as this error's `source()`, which is exactly the mistake release.rs's
-    // `with_context` calls exist to avoid (see the comment on `fetch_text`).
+    // `.context` rather than folding the io::Error in with `{e}`: the latter discards it as this
+    // error's `source()` — see the comment on release.rs's `fetch_text`.
     let exe = std::env::current_exe()
         .and_then(|p| p.canonicalize())
         .context("could not resolve this binary's path")?;
@@ -374,9 +356,8 @@ pub(crate) async fn run_cli(
         &exe,
     );
     // A running `serve --http` keeps its own inode, so it goes on serving the OLD build until it
-    // is restarted — which reads to a connected agent as "the update did nothing". Carried on the
-    // report (rather than printed separately) so `--json` stays one parseable object; reusing the
-    // same loopback probe `status` uses. Only worth checking after a real swap.
+    // is restarted — which reads to a connected agent as "the update did nothing". On the report
+    // rather than printed separately, so `--json` stays one parseable object.
     if matches!(report.outcome, Outcome::Updated) {
         report.running_server = crate::setup::fetch_health("127.0.0.1:7300").is_some();
     }
@@ -387,14 +368,11 @@ pub(crate) async fn run_cli(
     Ok(())
 }
 
-/// Fold a failure out of [`run`] into a report, so every exit from this command renders through
-/// the same path.
+/// Fold a failure out of [`run`] into a report, so every exit renders through the same path.
 ///
-/// Without this, a transport failure propagated out of `run_cli` as `Err` and `main` printed it as
-/// a bare anyhow message — which under `--json` means no JSON object at all, contradicting the
-/// documented contract that `--json` always emits one parseable object. `{e:#}` rather than `{e}`
-/// so the whole source chain survives: release.rs keeps the real cause (a redirect-policy refusal,
-/// a connect error) on `source()` rather than in the top-level message.
+/// Without this a transport failure reached `main` as a bare anyhow message — under `--json`, no
+/// JSON object at all. `{e:#}` rather than `{e}` so the whole source chain survives: release.rs
+/// keeps the real cause (a redirect-policy refusal, a connect error) on `source()`.
 fn or_error(result: anyhow::Result<Report>, current: &str, exe: &Path) -> Report {
     result.unwrap_or_else(|e| {
         Report::initial(current, exe).finished(Outcome::Error(format!("{e:#}")))
@@ -422,7 +400,7 @@ fn render(report: &Report, opts: &Options) -> String {
         ),
         // A from-source build's version is not comparable, so `update_available` is always
         // `false` here regardless of whether a newer release exists — printing "is the latest
-        // release" (the arm below) would be a claim we cannot back. Say what we actually know.
+        // release" (the arm below) would be a claim we cannot back.
         Outcome::Checked if !report.current_comparable => format!(
             "glass-mcp {} is a from-source build; the latest release is {}.\n",
             report.current, latest
@@ -451,9 +429,8 @@ fn render(report: &Report, opts: &Options) -> String {
                         "build provenance NOT verified (--skip-attestation)."
                     )
                 ),
-                // Unreachable: 8b always sets Verified/Unavailable/Skipped/Failed before an
-                // Outcome::Updated can be produced, and a Failed attestation refuses rather than
-                // updating — so neither NotChecked nor Failed can appear here.
+                // Unreachable: 8b sets one of the other three before an `Updated` can be
+                // produced, and a Failed attestation refuses rather than updating.
                 AttestationStatus::NotChecked | AttestationStatus::Failed => String::new(),
             },
             if report.running_server {
@@ -468,8 +445,7 @@ fn render(report: &Report, opts: &Options) -> String {
             p.paint(p.fail, "cannot update:"),
             refusal_message(why, report)
         ),
-        // A different prefix from a refusal on purpose: "cannot update" says a decision was made
-        // about this install, and nothing was decided here.
+        // A different prefix from a refusal: nothing was decided about this install.
         Outcome::Error(why) => format!("{} {why}\n", p.paint(p.fail, "update failed:")),
     }
 }
@@ -488,9 +464,7 @@ fn refusal_message(why: &Refusal, report: &Report) -> String {
         Refusal::UnsupportedTarget => "no release asset is published for this platform. \
              Build from source — see docs/how-to/build-from-source.md."
             .to_string(),
-        // Reports the OS error and stops. Naming a cause here would be a guess: the same branch
-        // is reached by a read-only directory, a full disk, a quota, a path-length limit and an
-        // `EEXIST` race, and only the error text distinguishes them.
+        // Reports the OS error, never a diagnosis of it — see `Refusal::CannotStage`.
         Refusal::CannotStage { dir, why } => format!(
             "could not create the temporary file to download into, in {}: {why}\n  \
              Download the new binary and move it into place yourself:\n  {}",
@@ -544,9 +518,7 @@ fn render_json(report: &Report) -> String {
         "current": report.current,
         "latest": report.latest,
         "update_available": report.update_available,
-        // Without this, `--check --json` on a from-source build reports `update_available: false`
-        // with nothing to say the version was never comparable in the first place — exactly the
-        // "unknown" / "you are up to date" conflation the human renderer above avoids.
+        // Without this, `--check --json` on a from-source build reads as "you are up to date".
         "current_comparable": report.current_comparable,
         "supported": report.supported,
         "asset": report.asset,
@@ -618,8 +590,7 @@ mod tests {
     ///
     /// CI's macOS job runs `cargo test --workspace --lib`, so this module executes there — and on
     /// macOS `run` refuses with `MacosBundle` by design, while an unsupported target has no asset
-    /// name to build. Tests below that drive the apply path return early rather than assert the
-    /// opposite of the intended behavior. The macOS behavior has its own test at the end.
+    /// name to build. The macOS behavior has its own test at the end.
     fn apply_path_exists() -> bool {
         !cfg!(target_os = "macos") && release::asset_suffix().is_some()
     }
@@ -699,10 +670,8 @@ mod tests {
         let src = ReleaseSource::with_base(server.base());
         // opts() already has smoke: true — that is the point of this test.
         //
-        // Retried only on ETXTBSY: `download_to` writes the file that step 8c then executes, and
-        // a `fork` in any other test thread briefly inherits the write handle, which makes that
-        // `execve` fail with "Text file busy". See the note on `verify`'s `is_etxtbsy` — the
-        // window belongs to this multi-threaded test binary, not to the updater. Any other
+        // Retried only on ETXTBSY, a window that belongs to this multi-threaded test binary
+        // rather than to the updater — see the note on `verify`'s `is_etxtbsy`. Any other
         // outcome breaks out on the first attempt.
         let mut attempts = 0;
         let out = loop {
@@ -731,8 +700,7 @@ mod tests {
     /// three-way match on `verify::attest` — never ran in any test: swap its `Verified` and
     /// `Unavailable` arms and the suite stayed green. This drives it with `gh` pointed at a
     /// program that does not exist, which is the one `attest` outcome reachable without making a
-    /// request to GitHub, and asserts the update still completes with the absence recorded rather
-    /// than passed off as a verification.
+    /// request to GitHub.
     #[tokio::test]
     async fn a_missing_gh_is_recorded_rather_than_treated_as_verified() {
         if !apply_path_exists() {
@@ -837,7 +805,7 @@ mod tests {
         // Bind the fields rather than `{ .. }`: the variant alone says nothing about whether the
         // `io::Error` was actually captured. Replacing the capture with `String::new()` leaves a
         // `matches!` on the variant green, and the refusal then prints a trailing colon with
-        // nothing after it — which is the whole defect the rename was meant to fix.
+        // nothing after it.
         let Outcome::Refused(Refusal::CannotStage { dir: named, why }) = &out else {
             panic!("expected a staging refusal, got {out:?}");
         };
@@ -853,8 +821,7 @@ mod tests {
     /// so, unlike the apply-path tests, this one carries no `apply_path_exists()` guard and no
     /// `release::asset_name(...)` (which would return `None` and skip the test on macOS, exactly
     /// the platform this contract most needs covering). The asset name is a literal because
-    /// `--check` never reaches step 5 — it resolves only the tag, never an asset — so the fake
-    /// server's asset/sidecar routes are never hit.
+    /// `--check` resolves only the tag, never an asset.
     #[tokio::test]
     async fn check_reports_on_a_from_source_build() {
         let dir = tempfile::tempdir().unwrap();
@@ -942,11 +909,10 @@ mod tests {
         );
     }
 
-    /// `--json`'s contract is one parseable object per run, and a transport failure used to break
-    /// it: `run` returned `Err`, `run_cli` propagated it, and the command printed a bare anyhow
-    /// message with no object at all. The fake server here answers `/releases/latest` with a
-    /// redirect to an empty tag — the shape a repo with nothing published produces — so `run`
-    /// fails for a real reason without any request leaving the loopback interface.
+    /// `--json`'s contract is one parseable object per run, which a transport failure used to
+    /// break (see `or_error`). The fake server here answers `/releases/latest` with a redirect to
+    /// an empty tag, so `run` fails for a real reason without any request leaving the loopback
+    /// interface.
     #[tokio::test]
     async fn a_failure_to_resolve_the_release_still_renders_one_json_object() {
         if !apply_path_exists() {
@@ -1014,8 +980,7 @@ mod tests {
     ///
     /// No test rendered `Outcome::Updated` at all before this, so the three arms were
     /// interchangeable: swapping `Verified` and `Skipped` would have made `--skip-attestation`
-    /// print "build provenance verified." with nothing to catch it. Each case therefore asserts
-    /// both what must appear and what must not.
+    /// print "build provenance verified." with nothing to catch it.
     #[test]
     fn an_updated_report_states_what_was_done_about_provenance() {
         let rendered = |status: AttestationStatus| {
@@ -1061,8 +1026,7 @@ mod tests {
     /// The two `BadSidecar` messages describe genuinely different failures — a file this cannot
     /// parse, and a file that parsed fine but names another asset — and nothing pinned which
     /// message went with which. Swapping them puts "could not be read" on a sidecar that read
-    /// perfectly, which is the wrong label the split was made to remove. Each case asserts what
-    /// must appear and what must not, so a swap fails both halves.
+    /// perfectly.
     #[test]
     fn the_two_sidecar_failures_are_not_described_as_each_other() {
         let rendered = |e: verify::SidecarError| {
@@ -1104,9 +1068,8 @@ mod tests {
 
         let human = render(&r, &plain(false));
         assert!(human.contains("/usr/local/bin"), "{human}");
-        // The OS error, not a diagnosis of it. `create_new` also fails on a full disk, a quota,
-        // a path-length limit and an EEXIST race, so a message that named permissions would be
-        // wrong for exactly the case this fixture uses.
+        // The OS error, not a diagnosis of it: a message that named permissions would be wrong
+        // for exactly the case this fixture uses.
         assert!(
             human.contains("No space left on device"),
             "the OS error must survive into the message: {human}"

--- a/crates/glass-mcp/src/update/mod.rs
+++ b/crates/glass-mcp/src/update/mod.rs
@@ -1,0 +1,3 @@
+//! `glass-mcp update`: fetch the latest release, verify it, and replace this binary.
+
+mod version;

--- a/crates/glass-mcp/src/update/mod.rs
+++ b/crates/glass-mcp/src/update/mod.rs
@@ -1,4 +1,6 @@
 //! `glass-mcp update`: fetch the latest release, verify it, and replace this binary.
 
 mod release;
+#[cfg(test)]
+mod testserver;
 mod version;

--- a/crates/glass-mcp/src/update/mod.rs
+++ b/crates/glass-mcp/src/update/mod.rs
@@ -421,10 +421,9 @@ fn refusal_message(why: &Refusal, report: &Report) -> String {
             dir.display(),
             report.url.as_deref().unwrap_or("(url unresolved)")
         ),
-        Refusal::NeedsConsent => {
-            "declined. Pass --yes to update without a prompt (there is no terminal to ask on)."
-                .to_string()
-        }
+        Refusal::NeedsConsent => "declined, or no way to ask. Pass --yes to update without a \
+             prompt (required with --json, which never prompts)."
+            .to_string(),
         Refusal::ChecksumMismatch { expected, got } => format!(
             "the downloaded asset does not match the checksum the release published.\n  \
              expected {expected}\n  got      {got}"

--- a/crates/glass-mcp/src/update/mod.rs
+++ b/crates/glass-mcp/src/update/mod.rs
@@ -315,10 +315,25 @@ pub(crate) async fn run(
     swap::swap(&temp, exe).with_context(|| {
         format!(
             "the verified new binary is still at {} — move it into place by hand",
-            temp.display()
+            for_display(&temp)
         )
     })?;
     Ok(report.finished(Outcome::Updated))
+}
+
+/// A path as a user should see it. `canonicalize` yields Windows extended-length paths
+/// (`\\?\C:\…`), which every filesystem call accepts but Explorer rejects — and one caller is the
+/// swap-failure message naming a binary the user has to move by hand.
+///
+/// Display only: the stripped string never goes back to the filesystem. Not `cfg(windows)`,
+/// because it is string work and stays testable on a Linux dev box.
+fn for_display(path: &Path) -> String {
+    let s = path.display().to_string();
+    // `\\?\UNC\server\share` is a UNC path; stripping the whole prefix would leave `UNC\…`.
+    if let Some(rest) = s.strip_prefix(r"\\?\UNC\") {
+        return format!(r"\\{rest}");
+    }
+    s.strip_prefix(r"\\?\").unwrap_or(&s).to_string()
 }
 
 /// Ask on the terminal. Only reached when stdin and stdout are both a tty.
@@ -468,7 +483,7 @@ fn refusal_message(why: &Refusal, report: &Report) -> String {
         Refusal::CannotStage { dir, why } => format!(
             "could not create the temporary file to download into, in {}: {why}\n  \
              Download the new binary and move it into place yourself:\n  {}",
-            dir.display(),
+            for_display(dir),
             report.url.as_deref().unwrap_or("(url unresolved)")
         ),
         Refusal::NeedsConsent => "declined, or no way to ask. Pass --yes to update without a \
@@ -523,7 +538,7 @@ fn render_json(report: &Report) -> String {
         "supported": report.supported,
         "asset": report.asset,
         "url": report.url,
-        "install_path": report.install_path.display().to_string(),
+        "install_path": for_display(&report.install_path),
         "attestation": match report.attestation {
             AttestationStatus::NotChecked => "not_checked",
             AttestationStatus::Verified => "verified",
@@ -1021,6 +1036,31 @@ mod tests {
             assert!(out.contains("updated"), "{out}");
             assert!(!out.contains("provenance"), "{out}");
         }
+    }
+
+    /// `canonicalize` hands back `\\?\C:\…` on Windows, and Explorer will not take it — which
+    /// matters most in the swap-failure message, whose whole job is a path the user can act on.
+    #[test]
+    fn display_paths_drop_the_windows_extended_length_prefix() {
+        use std::path::PathBuf;
+        assert_eq!(
+            for_display(&PathBuf::from(r"\\?\C:\Users\mpd\glass-mcp.exe")),
+            r"C:\Users\mpd\glass-mcp.exe"
+        );
+        // A UNC path must come back as a UNC path, not as `UNC\…`.
+        assert_eq!(
+            for_display(&PathBuf::from(r"\\?\UNC\server\share\glass-mcp.exe")),
+            r"\\server\share\glass-mcp.exe"
+        );
+        // No prefix: unchanged. The Unix case is the only shape this sees on the dev box.
+        assert_eq!(
+            for_display(&PathBuf::from(r"C:\Users\mpd\glass-mcp.exe")),
+            r"C:\Users\mpd\glass-mcp.exe"
+        );
+        assert_eq!(
+            for_display(&PathBuf::from("/opt/bin/glass-mcp")),
+            "/opt/bin/glass-mcp"
+        );
     }
 
     /// The two `BadSidecar` messages describe genuinely different failures — a file this cannot

--- a/crates/glass-mcp/src/update/mod.rs
+++ b/crates/glass-mcp/src/update/mod.rs
@@ -1,3 +1,4 @@
 //! `glass-mcp update`: fetch the latest release, verify it, and replace this binary.
 
+mod release;
 mod version;

--- a/crates/glass-mcp/src/update/mod.rs
+++ b/crates/glass-mcp/src/update/mod.rs
@@ -1,8 +1,9 @@
 //! `glass-mcp update`: fetch the latest release, verify it, and replace this binary.
 //!
 //! The step order below is a contract, not an implementation detail, and the tests assert it: the
-//! from-source refusal happens before any network request, writability is proved before anything
-//! is downloaded, and consent is taken before the download rather than before the swap.
+//! from-source refusal happens before any network request, the file the download will land in is
+//! created before anything is downloaded, and consent is taken before the download rather than
+//! before the swap.
 
 mod release;
 mod swap;
@@ -20,9 +21,11 @@ use verify::Attestation;
 
 /// Everything the flow needs to know that is not the release itself.
 ///
-/// `interactive` and `smoke` are separate from the CLI flags so the tests can drive the
-/// non-interactive path and skip executing a fixture that is not a real binary; the binary always
-/// sets them from the real terminal and always leaves `smoke` on.
+/// `interactive`, `smoke` and `attest_program` are separate from the CLI flags so the tests can
+/// drive the non-interactive path, skip executing a fixture that is not a real binary, and reach
+/// step 8b without running the real `gh attestation verify` — which queries GitHub, and nothing in
+/// this suite touches the network. The binary sets `interactive` from the real terminal, always
+/// leaves `smoke` on, and always points `attest_program` at the real `gh`.
 #[derive(Debug, Clone)]
 pub(crate) struct Options {
     pub(crate) check: bool,
@@ -32,6 +35,7 @@ pub(crate) struct Options {
     pub(crate) color: ColorChoice,
     pub(crate) interactive: bool,
     pub(crate) smoke: bool,
+    pub(crate) attest_program: &'static str,
 }
 
 impl Options {
@@ -53,6 +57,7 @@ impl Options {
             // `--json` comes from `--yes` alone.
             interactive: !json && std::io::stdin().is_terminal() && std::io::stdout().is_terminal(),
             smoke: true,
+            attest_program: verify::GH,
         }
     }
 }
@@ -65,13 +70,23 @@ pub(crate) enum Refusal {
     UnsupportedTarget,
     /// macOS installs are an app bundle, not a bare binary.
     MacosBundle,
-    NotWritable(PathBuf),
+    /// The temp file step 6 creates beside the installed binary could not be created. Named for
+    /// what failed rather than for a diagnosis: a read-only directory is the common cause, but
+    /// `ENOSPC`, a disk quota, a path-length limit and an `EEXIST` race all land here too, and the
+    /// `io::Error` is the only thing that can tell them apart.
+    CannotStage {
+        dir: PathBuf,
+        why: String,
+    },
     NeedsConsent,
     ChecksumMismatch {
         expected: String,
         got: String,
     },
-    BadSidecar(String),
+    /// The `.sha256` sidecar could not be used. Carries the parse error itself rather than its
+    /// text, because "unreadable" and "for a different asset" are different failures and the
+    /// message has to tell them apart.
+    BadSidecar(verify::SidecarError),
     AttestationFailed(String),
     SmokeCheckFailed(String),
 }
@@ -82,6 +97,11 @@ pub(crate) enum Outcome {
     UpToDate,
     Updated,
     Refused(Refusal),
+    /// The flow could not finish: the release endpoint was unreachable, answered with something
+    /// that is not a release, or a download/swap failed. Distinct from `Refused` — a refusal is a
+    /// decision this command made about this install, while this is the command not getting far
+    /// enough to make one.
+    Error(String),
 }
 
 /// What happened, and everything the renderer needs to say so. One struct rather than data hung
@@ -128,6 +148,26 @@ pub(crate) enum AttestationStatus {
 }
 
 impl Report {
+    /// The report before anything has been resolved: everything knowable from the process itself,
+    /// with every field that needs the network still unset. [`run`] starts from this, and
+    /// [`run_cli`] reuses it to render a failure that stopped `run` outright — so a caller parsing
+    /// `--json` sees the same field set whether the run succeeded, refused, or failed.
+    fn initial(current: &str, exe: &Path) -> Report {
+        Report {
+            outcome: Outcome::Checked,
+            current: current.to_string(),
+            latest: None,
+            update_available: false,
+            asset: None,
+            url: None,
+            install_path: exe.to_path_buf(),
+            attestation: AttestationStatus::NotChecked,
+            supported: !cfg!(target_os = "macos") && release::asset_suffix().is_some(),
+            current_comparable: version::Version::parse_released(current).is_some(),
+            running_server: false,
+        }
+    }
+
     fn refused(mut self, why: Refusal) -> Report {
         self.outcome = Outcome::Refused(why);
         self
@@ -148,19 +188,7 @@ pub(crate) async fn run(
     exe: &Path,
 ) -> anyhow::Result<Report> {
     let current_version = version::Version::parse_released(current);
-    let mut report = Report {
-        outcome: Outcome::Checked,
-        current: current.to_string(),
-        latest: None,
-        update_available: false,
-        asset: None,
-        url: None,
-        install_path: exe.to_path_buf(),
-        attestation: AttestationStatus::NotChecked,
-        supported: !cfg!(target_os = "macos") && release::asset_suffix().is_some(),
-        current_comparable: current_version.is_some(),
-        running_server: false,
-    };
+    let mut report = Report::initial(current, exe);
 
     // 1. From-source, before any network request. A `--check` still reports.
     if !opts.check && current_version.is_none() {
@@ -195,16 +223,17 @@ pub(crate) async fn run(
         return Ok(report.finished(Outcome::UpToDate));
     }
 
-    // 5. What we are about to fetch. Resolved before the writability check so a refusal there can
-    //    still print the URL to download by hand.
+    // 5. What we are about to fetch. Resolved before the staging step below so a refusal there
+    //    can still print the URL to download by hand.
     let asset = release::asset_name(&tag).ok_or_else(|| anyhow::anyhow!("unsupported target"))?;
     let url = source.asset_url(&tag, &asset);
     report.asset = Some(asset.clone());
     report.url = Some(url.clone());
 
-    // 6. Writability, proved by creating the temp file we are about to download into rather than
-    //    by inspecting permissions — the same act, so there is no window between the check and
-    //    the use, and no way for the two to disagree.
+    // 6. Stage: create the temp file the download will land in, rather than inspect the
+    //    directory's permissions — the same act as the use, so there is no window between the two
+    //    and no way for them to disagree. Whatever the OS says when it fails is what gets
+    //    reported; this step does not try to work out why.
     let dir = exe.parent().unwrap_or_else(|| Path::new("."));
     let temp = dir.join(format!(".glass-mcp.update-{:016x}", rand::random::<u64>()));
     let mut open = std::fs::OpenOptions::new();
@@ -217,11 +246,20 @@ pub(crate) async fn run(
         // gate that exists to prove the binary runs, with `execve` returning EACCES.
         open.mode(0o755);
     }
-    if open.open(&temp).is_err() {
-        return Ok(report.refused(Refusal::NotWritable(dir.to_path_buf())));
+    if let Err(e) = open.open(&temp) {
+        return Ok(report.refused(Refusal::CannotStage {
+            dir: dir.to_path_buf(),
+            why: e.to_string(),
+        }));
     }
-    // From here on every exit must remove `temp`: a refusal that leaves a stray half-download
+    // From here on every exit tries to remove `temp`: a refusal that leaves a stray half-download
     // beside the binary is not the no-op it claims to be, and a test asserts there are none.
+    //
+    // Best-effort, deliberately: the `remove_file` result is dropped because a failed unlink is
+    // not something this command can act on, and surfacing it would replace the real reason for
+    // the exit (a bad checksum, a refused attestation) with a secondary filesystem complaint
+    // about a file the user did not ask about. The one exit that deliberately does NOT remove
+    // `temp` is a failed `swap` at step 9 — see the comment there.
     let discard = |report: Report, why: Refusal| -> anyhow::Result<Report> {
         let _ = std::fs::remove_file(&temp);
         Ok(report.refused(why))
@@ -254,7 +292,7 @@ pub(crate) async fn run(
         .map_err(abort)?;
     let expected = match verify::parse_sidecar(&sidecar_text, &asset) {
         Ok(h) => h,
-        Err(e) => return discard(report, Refusal::BadSidecar(format!("{e:?}"))),
+        Err(e) => return discard(report, Refusal::BadSidecar(e)),
     };
     if expected != got {
         return discard(report, Refusal::ChecksumMismatch { expected, got });
@@ -264,7 +302,7 @@ pub(crate) async fn run(
     if opts.skip_attestation {
         report.attestation = AttestationStatus::Skipped;
     } else {
-        match verify::attest(&temp) {
+        match verify::attest(opts.attest_program, &temp) {
             Attestation::Verified => report.attestation = AttestationStatus::Verified,
             Attestation::Unavailable => report.attestation = AttestationStatus::Unavailable,
             Attestation::Failed(why) => {
@@ -281,8 +319,18 @@ pub(crate) async fn run(
         return discard(report, Refusal::SmokeCheckFailed(why));
     }
 
-    // 9. Swap.
-    swap::swap(&temp, exe).map_err(abort)?;
+    // 9. Swap. Not through `abort`: by this point `temp` has been downloaded, checksummed,
+    //    attested and proved to run, and if the swap fails it is the only copy of the new binary
+    //    on the machine. On Windows's double-failure path — the old binary moved aside and the
+    //    restore also failing — recovery means putting a working binary back at `exe`, and
+    //    keeping this one is what makes that possible without a second download. So it stays, and
+    //    the error names where it is; `swap`'s own message names the displaced old binary.
+    swap::swap(&temp, exe).with_context(|| {
+        format!(
+            "the verified new binary is still at {} — move it into place by hand",
+            temp.display()
+        )
+    })?;
     Ok(report.finished(Outcome::Updated))
 }
 
@@ -308,7 +356,7 @@ pub(crate) async fn run_cli(
     json: bool,
     color: ColorChoice,
 ) -> anyhow::Result<()> {
-    // `with_context` rather than folding the io::Error into the message with `{e}`: the latter
+    // `.context` rather than folding the io::Error into the message with `{e}`: the latter
     // discards it as this error's `source()`, which is exactly the mistake release.rs's
     // `with_context` calls exist to avoid (see the comment on `fetch_text`).
     let exe = std::env::current_exe()
@@ -316,7 +364,11 @@ pub(crate) async fn run_cli(
         .context("could not resolve this binary's path")?;
     let opts = Options::from_flags(check, yes, skip_attestation, json, color);
     let source = ReleaseSource::github();
-    let mut report = run(opts.clone(), &source, crate::VERSION, &exe).await?;
+    let mut report = or_error(
+        run(opts.clone(), &source, crate::VERSION, &exe).await,
+        crate::VERSION,
+        &exe,
+    );
     // A running `serve --http` keeps its own inode, so it goes on serving the OLD build until it
     // is restarted — which reads to a connected agent as "the update did nothing". Carried on the
     // report (rather than printed separately) so `--json` stays one parseable object; reusing the
@@ -325,10 +377,24 @@ pub(crate) async fn run_cli(
         report.running_server = crate::setup::fetch_health("127.0.0.1:7300").is_some();
     }
     print!("{}", render(&report, &opts));
-    if matches!(report.outcome, Outcome::Refused(_)) {
+    if matches!(report.outcome, Outcome::Refused(_) | Outcome::Error(_)) {
         std::process::exit(1);
     }
     Ok(())
+}
+
+/// Fold a failure out of [`run`] into a report, so every exit from this command renders through
+/// the same path.
+///
+/// Without this, a transport failure propagated out of `run_cli` as `Err` and `main` printed it as
+/// a bare anyhow message — which under `--json` means no JSON object at all, contradicting the
+/// documented contract that `--json` always emits one parseable object. `{e:#}` rather than `{e}`
+/// so the whole source chain survives: release.rs keeps the real cause (a redirect-policy refusal,
+/// a connect error) on `source()` rather than in the top-level message.
+fn or_error(result: anyhow::Result<Report>, current: &str, exe: &Path) -> Report {
+    result.unwrap_or_else(|e| {
+        Report::initial(current, exe).finished(Outcome::Error(format!("{e:#}")))
+    })
 }
 
 /// Human text, or the JSON object under `--json`. Pure in `report` and `opts`, so the whole
@@ -398,6 +464,9 @@ fn render(report: &Report, opts: &Options) -> String {
             p.paint(p.fail, "cannot update:"),
             refusal_message(why, report)
         ),
+        // A different prefix from a refusal on purpose: "cannot update" says a decision was made
+        // about this install, and nothing was decided here.
+        Outcome::Error(why) => format!("{} {why}\n", p.paint(p.fail, "update failed:")),
     }
 }
 
@@ -415,9 +484,12 @@ fn refusal_message(why: &Refusal, report: &Report) -> String {
         Refusal::UnsupportedTarget => "no release asset is published for this platform. \
              Build from source — see docs/how-to/build-from-source.md."
             .to_string(),
-        Refusal::NotWritable(dir) => format!(
-            "{} is not writable by this user. Download the new binary and move it into place \
-             yourself:\n  {}",
+        // Reports the OS error and stops. Naming a cause here would be a guess: the same branch
+        // is reached by a read-only directory, a full disk, a quota, a path-length limit and an
+        // `EEXIST` race, and only the error text distinguishes them.
+        Refusal::CannotStage { dir, why } => format!(
+            "could not create the temporary file to download into, in {}: {why}\n  \
+             Download the new binary and move it into place yourself:\n  {}",
             dir.display(),
             report.url.as_deref().unwrap_or("(url unresolved)")
         ),
@@ -428,34 +500,46 @@ fn refusal_message(why: &Refusal, report: &Report) -> String {
             "the downloaded asset does not match the checksum the release published.\n  \
              expected {expected}\n  got      {got}"
         ),
-        Refusal::BadSidecar(e) => {
-            format!("the release's checksum file could not be read ({e}).")
+        Refusal::BadSidecar(verify::SidecarError::Malformed) => {
+            "the release's checksum file is not a `sha256sum` line this can read.".to_string()
         }
+        Refusal::BadSidecar(verify::SidecarError::WrongAsset(named)) => format!(
+            "the release's checksum file is for a different asset: it names {named}, not {}.",
+            report.asset.as_deref().unwrap_or("the asset downloaded")
+        ),
+        // `gh` exits non-zero for more than a bad artifact, and the text it printed is the only
+        // thing that says which — so name the other causes rather than let the reader assume the
+        // artifact is bad.
         Refusal::AttestationFailed(why) => format!(
             "build provenance could not be verified: {why}\n  \
-             If GitHub is unreachable rather than the artifact being wrong, retry later — or pass \
-             --skip-attestation to accept the checksum alone."
+             If GitHub is unreachable, or `gh` is installed but not signed in \
+             (check with `gh auth status`), rather than the artifact being wrong, fix that and \
+             retry — or pass --skip-attestation to accept the checksum alone."
         ),
         Refusal::SmokeCheckFailed(why) => format!(
             "the downloaded binary did not run: {why}\n  \
-             The error above is from the binary itself. Build variants for this platform are \
-             listed in docs/reference/platforms.md."
+             Build variants for this platform are listed in docs/reference/platforms.md."
         ),
     }
 }
 
-/// The machine-readable form. `reason` appears only on a refusal.
+/// The machine-readable form. `reason` appears only on a refusal or a failure.
 fn render_json(report: &Report) -> String {
     let (action, reason) = match &report.outcome {
         Outcome::Checked | Outcome::UpToDate => ("checked", None),
         Outcome::Updated => ("updated", None),
         Outcome::Refused(why) => ("refused", Some(refusal_message(why, report))),
+        Outcome::Error(why) => ("error", Some(why.clone())),
     };
     let mut obj = serde_json::json!({
         "action": action,
         "current": report.current,
         "latest": report.latest,
         "update_available": report.update_available,
+        // Without this, `--check --json` on a from-source build reports `update_available: false`
+        // with nothing to say the version was never comparable in the first place — exactly the
+        // "unknown" / "you are up to date" conflation the human renderer above avoids.
+        "current_comparable": report.current_comparable,
         "supported": report.supported,
         "asset": report.asset,
         "url": report.url,
@@ -487,6 +571,11 @@ mod tests {
     /// sha256 of BODY. Recompute with `printf '%s' 'pretend binary' | sha256sum` if BODY changes.
     const BODY_SHA: &str = "9f05ef97cc90b003959b48cd01b637658368bdfc78fe54c1a061d5eff0c46104";
 
+    /// A program name no host has on `PATH`, so `attest` reports `Unavailable` deterministically.
+    /// Used instead of the real `gh` by every test that lets step 8b run: `gh attestation verify`
+    /// makes a request to GitHub, and nothing in this suite touches the network.
+    const ABSENT_GH: &str = "glass-mcp-test-no-such-attestation-tool";
+
     /// The apply path, non-interactive, with the two gates that need a real network or a real
     /// executable turned off. Each test that cares re-enables or re-disables what it is testing.
     fn opts() -> Options {
@@ -498,6 +587,7 @@ mod tests {
             color: Default::default(),
             interactive: false,
             smoke: true,
+            attest_program: ABSENT_GH,
         }
     }
 
@@ -600,9 +690,58 @@ mod tests {
         );
         let src = ReleaseSource::with_base(server.base());
         // opts() already has smoke: true — that is the point of this test.
-        let out = run(opts(), &src, "1.3.0", &exe).await.unwrap().outcome;
+        //
+        // Retried only on ETXTBSY: `download_to` writes the file that step 8c then executes, and
+        // a `fork` in any other test thread briefly inherits the write handle, which makes that
+        // `execve` fail with "Text file busy". See the note on `verify`'s `is_etxtbsy` — the
+        // window belongs to this multi-threaded test binary, not to the updater. Any other
+        // outcome breaks out on the first attempt.
+        let mut attempts = 0;
+        let out = loop {
+            let out = run(opts(), &src, "1.3.0", &exe).await.unwrap().outcome;
+            let busy = matches!(
+                &out,
+                Outcome::Refused(Refusal::SmokeCheckFailed(why)) if why.contains("os error 26")
+            );
+            if !busy {
+                break out;
+            }
+            attempts += 1;
+            assert!(
+                attempts < 20,
+                "the smoke gate kept hitting ETXTBSY: {out:?}"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        };
         assert!(matches!(out, Outcome::Updated), "{out:?}");
         assert_eq!(std::fs::read(&exe).unwrap(), SCRIPT);
+    }
+
+    /// Step 8b, actually executed.
+    ///
+    /// Every other apply-path test sets `skip_attestation: true`, so the whole `else` arm — the
+    /// three-way match on `verify::attest` — never ran in any test: swap its `Verified` and
+    /// `Unavailable` arms and the suite stayed green. This drives it with `gh` pointed at a
+    /// program that does not exist, which is the one `attest` outcome reachable without making a
+    /// request to GitHub, and asserts the update still completes with the absence recorded rather
+    /// than passed off as a verification.
+    #[tokio::test]
+    async fn a_missing_gh_is_recorded_rather_than_treated_as_verified() {
+        if !apply_path_exists() {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let exe = install(dir.path(), b"old");
+        let asset = release::asset_name("v1.4.0").expect("supported target");
+        let server = FakeRelease::start("v1.4.0", &asset, BODY, &sidecar(&asset));
+        let src = ReleaseSource::with_base(server.base());
+        let mut o = opts();
+        o.skip_attestation = false; // the point of this test
+        o.smoke = false; // the served bytes are not a runnable binary
+        let report = run(o, &src, "1.3.0", &exe).await.unwrap();
+        assert!(matches!(report.outcome, Outcome::Updated), "{report:?}");
+        assert_eq!(report.attestation, AttestationStatus::Unavailable);
+        assert_eq!(std::fs::read(&exe).unwrap(), BODY);
     }
 
     /// The assertion that matters is the second one: "it errored" says nothing about what it
@@ -688,7 +827,7 @@ mod tests {
 
         std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
         assert!(
-            matches!(out, Outcome::Refused(Refusal::NotWritable(_))),
+            matches!(out, Outcome::Refused(Refusal::CannotStage { .. })),
             "{out:?}"
         );
         assert_eq!(std::fs::read(&exe).unwrap(), b"old");
@@ -761,6 +900,7 @@ mod tests {
         assert_eq!(v["current"], "1.3.0");
         assert_eq!(v["latest"], "1.4.0");
         assert_eq!(v["update_available"], true);
+        assert_eq!(v["current_comparable"], true);
         assert_eq!(v["supported"], true);
         assert_eq!(v["attestation"], "verified");
         assert_eq!(v["install_path"], "/opt/bin/glass-mcp");
@@ -768,13 +908,162 @@ mod tests {
         assert!(v.get("reason").is_none(), "reason is refusal-only");
     }
 
+    /// `update_available: false` has two quite different causes, and the JSON has to separate them
+    /// the way the human renderer does: `cli.md` tells scripts to branch on `update_available`, so
+    /// a from-source build that emitted only `update_available: false` would read to every one of
+    /// them as "you are up to date".
+    #[test]
+    fn the_json_report_separates_a_from_source_build_from_being_up_to_date() {
+        let mut r = report_fixture();
+        r.current = "1.3.0-5-g563feea".into();
+        r.current_comparable = false;
+        r.update_available = false;
+        let v: serde_json::Value = serde_json::from_str(&render(&r, &plain(true))).unwrap();
+        assert_eq!(v["update_available"], false);
+        assert_eq!(
+            v["current_comparable"], false,
+            "a from-source build's version is not comparable, and the object must say so"
+        );
+    }
+
+    /// `--json`'s contract is one parseable object per run, and a transport failure used to break
+    /// it: `run` returned `Err`, `run_cli` propagated it, and the command printed a bare anyhow
+    /// message with no object at all. The fake server here answers `/releases/latest` with a
+    /// redirect to an empty tag — the shape a repo with nothing published produces — so `run`
+    /// fails for a real reason without any request leaving the loopback interface.
+    #[tokio::test]
+    async fn a_failure_to_resolve_the_release_still_renders_one_json_object() {
+        if !apply_path_exists() {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let exe = install(dir.path(), b"old");
+        let server = FakeRelease::start("", "asset", BODY, "");
+        let src = ReleaseSource::with_base(server.base());
+        let result = run(opts(), &src, "1.3.0", &exe).await;
+        assert!(result.is_err(), "the fixture must actually fail `run`");
+
+        let report = or_error(result, "1.3.0", &exe);
+        let v: serde_json::Value = serde_json::from_str(&render(&report, &plain(true)))
+            .expect("a failed run still emits one json object");
+        assert_eq!(v["action"], "error");
+        assert_eq!(v["current"], "1.3.0");
+        assert!(
+            v["reason"].as_str().is_some_and(|s| !s.is_empty()),
+            "the failure has to say what went wrong: {v}"
+        );
+        // Not a refusal: nothing was decided about this install.
+        let human = render(&report, &plain(false));
+        assert!(human.contains("update failed:"), "{human}");
+        assert_eq!(std::fs::read(&exe).unwrap(), b"old");
+    }
+
+    /// `Options::from_flags` is the only place the running binary's `Options` are built, and the
+    /// only place `smoke` is ever set to `true` — flip it to `false` and every real update skips
+    /// the gate that proves the downloaded binary runs, with the whole suite still green, because
+    /// each test constructs `Options` literally. Same for `attest_program`: the tests point it at
+    /// a program that does not exist, so nothing else pins that the binary uses the real `gh`.
+    ///
+    /// `interactive` is asserted only for `json: true`, where `!json` makes it `false` whatever
+    /// the terminal is. Its value with `--json` off depends on whether the test process has a tty
+    /// on both stdin and stdout, which is not something a test can pin.
+    #[test]
+    fn from_flags_passes_the_cli_flags_through_and_always_verifies() {
+        let o = Options::from_flags(true, false, true, false, ColorChoice::Never);
+        assert!(o.check);
+        assert!(!o.yes);
+        assert!(o.skip_attestation);
+        assert!(!o.json);
+        assert_eq!(o.color, ColorChoice::Never);
+        assert!(
+            o.smoke,
+            "the apply path must always execute what it fetched"
+        );
+        assert_eq!(o.attest_program, verify::GH);
+
+        // Every flag the other way round, so a field wired to a constant is caught whichever
+        // constant it was wired to.
+        let o = Options::from_flags(false, true, false, true, ColorChoice::Always);
+        assert!(!o.check);
+        assert!(o.yes);
+        assert!(!o.skip_attestation);
+        assert!(o.json);
+        assert_eq!(o.color, ColorChoice::Always);
+        assert!(o.smoke);
+        assert_eq!(o.attest_program, verify::GH);
+        assert!(!o.interactive, "--json must never prompt");
+    }
+
+    /// Each `AttestationStatus` an `Updated` report can carry renders as its own claim.
+    ///
+    /// No test rendered `Outcome::Updated` at all before this, so the three arms were
+    /// interchangeable: swapping `Verified` and `Skipped` would have made `--skip-attestation`
+    /// print "build provenance verified." with nothing to catch it. Each case therefore asserts
+    /// both what must appear and what must not.
+    #[test]
+    fn an_updated_report_states_what_was_done_about_provenance() {
+        let rendered = |status: AttestationStatus| {
+            let mut r = report_fixture();
+            r.outcome = Outcome::Updated;
+            r.attestation = status;
+            render(&r, &plain(false))
+        };
+
+        let verified = rendered(AttestationStatus::Verified);
+        assert!(
+            verified.contains("build provenance verified."),
+            "{verified}"
+        );
+
+        let unavailable = rendered(AttestationStatus::Unavailable);
+        assert!(unavailable.contains("not checked"), "{unavailable}");
+        assert!(
+            unavailable.contains("gh"),
+            "it must say what to install: {unavailable}"
+        );
+        assert!(
+            !unavailable.contains("provenance verified."),
+            "a missing gh must never read as a verification: {unavailable}"
+        );
+
+        let skipped = rendered(AttestationStatus::Skipped);
+        assert!(skipped.contains("--skip-attestation"), "{skipped}");
+        assert!(
+            !skipped.contains("provenance verified."),
+            "an explicit skip must never read as a verification: {skipped}"
+        );
+
+        // The two states 8b cannot leave behind on an update. They print nothing extra rather
+        // than a claim, and the "updated" line itself still appears.
+        for unreachable in [AttestationStatus::NotChecked, AttestationStatus::Failed] {
+            let out = rendered(unreachable);
+            assert!(out.contains("updated"), "{out}");
+            assert!(!out.contains("provenance"), "{out}");
+        }
+    }
+
     #[test]
     fn a_refusal_names_the_condition_and_never_suggests_sudo() {
         let mut r = report_fixture();
-        r.outcome = Outcome::Refused(Refusal::NotWritable("/usr/local/bin".into()));
+        r.outcome = Outcome::Refused(Refusal::CannotStage {
+            dir: "/usr/local/bin".into(),
+            why: "No space left on device (os error 28)".into(),
+        });
 
         let human = render(&r, &plain(false));
         assert!(human.contains("/usr/local/bin"), "{human}");
+        // The OS error, not a diagnosis of it. `create_new` also fails on a full disk, a quota,
+        // a path-length limit and an EEXIST race, so a message that named permissions would be
+        // wrong for exactly the case this fixture uses.
+        assert!(
+            human.contains("No space left on device"),
+            "the OS error must survive into the message: {human}"
+        );
+        assert!(
+            !human.to_lowercase().contains("not writable")
+                && !human.to_lowercase().contains("permission"),
+            "must not diagnose a cause it did not establish: {human}"
+        );
         assert!(
             human.contains("https://example.invalid/asset"),
             "the manual URL: {human}"

--- a/crates/glass-mcp/src/update/mod.rs
+++ b/crates/glass-mcp/src/update/mod.rs
@@ -12,6 +12,7 @@ mod verify;
 mod version;
 
 use crate::color::ColorChoice;
+use anyhow::Context as _;
 use release::ReleaseSource;
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
@@ -276,9 +277,12 @@ pub(crate) async fn run_cli(
     json: bool,
     color: ColorChoice,
 ) -> anyhow::Result<()> {
+    // `with_context` rather than folding the io::Error into the message with `{e}`: the latter
+    // discards it as this error's `source()`, which is exactly the mistake release.rs's
+    // `with_context` calls exist to avoid (see the comment on `fetch_text`).
     let exe = std::env::current_exe()
         .and_then(|p| p.canonicalize())
-        .map_err(|e| anyhow::anyhow!("could not resolve this binary's path: {e}"))?;
+        .context("could not resolve this binary's path")?;
     let opts = Options::from_flags(check, yes, skip_attestation, json, color);
     let source = ReleaseSource::github();
     let report = run(opts.clone(), &source, crate::VERSION, &exe).await?;

--- a/crates/glass-mcp/src/update/mod.rs
+++ b/crates/glass-mcp/src/update/mod.rs
@@ -231,8 +231,12 @@ pub(crate) async fn run(
     report.url = Some(url.clone());
 
     // 6. Stage: create the temp file the download will land in, rather than inspect the
-    //    directory's permissions — the same act as the use, so there is no window between the two
-    //    and no way for them to disagree. Whatever the OS says when it fails is what gets
+    //    directory's permissions. Opening it is the operation the download will actually perform,
+    //    so a directory this user cannot write to is caught here rather than guessed at from a
+    //    permission bit that may not be what the kernel enforces. It is NOT the same moment,
+    //    though: `download_inner` creates the file again after the consent prompt, and the disk
+    //    can fill or the directory can go away in between — this rules out the permission
+    //    mismatch, not every later failure. Whatever the OS says when it fails is what gets
     //    reported; this step does not try to work out why.
     let dir = exe.parent().unwrap_or_else(|| Path::new("."));
     let temp = dir.join(format!(".glass-mcp.update-{:016x}", rand::random::<u64>()));
@@ -516,8 +520,12 @@ fn refusal_message(why: &Refusal, report: &Report) -> String {
              (check with `gh auth status`), rather than the artifact being wrong, fix that and \
              retry — or pass --skip-attestation to accept the checksum alone."
         ),
+        // "failed the run check", not "did not run": only one of `smoke_check`'s six failure
+        // paths is a spawn failure. On the other five the binary ran — it hung, exited non-zero,
+        // or printed the wrong version — so any lead-in claiming it did not run contradicts the
+        // very error it introduces. Say what the gate concluded and let `why` say the rest.
         Refusal::SmokeCheckFailed(why) => format!(
-            "the downloaded binary did not run: {why}\n  \
+            "the downloaded binary failed the run check: {why}\n  \
              Build variants for this platform are listed in docs/reference/platforms.md."
         ),
     }
@@ -826,9 +834,17 @@ mod tests {
         let out = run(opts(), &src, "1.3.0", &exe).await.unwrap().outcome;
 
         std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
+        // Bind the fields rather than `{ .. }`: the variant alone says nothing about whether the
+        // `io::Error` was actually captured. Replacing the capture with `String::new()` leaves a
+        // `matches!` on the variant green, and the refusal then prints a trailing colon with
+        // nothing after it — which is the whole defect the rename was meant to fix.
+        let Outcome::Refused(Refusal::CannotStage { dir: named, why }) = &out else {
+            panic!("expected a staging refusal, got {out:?}");
+        };
+        assert_eq!(named, dir.path(), "the refusal must name the directory");
         assert!(
-            matches!(out, Outcome::Refused(Refusal::CannotStage { .. })),
-            "{out:?}"
+            !why.is_empty(),
+            "the OS error must be carried into the refusal, not discarded"
         );
         assert_eq!(std::fs::read(&exe).unwrap(), b"old");
     }
@@ -1040,6 +1056,42 @@ mod tests {
             assert!(out.contains("updated"), "{out}");
             assert!(!out.contains("provenance"), "{out}");
         }
+    }
+
+    /// The two `BadSidecar` messages describe genuinely different failures — a file this cannot
+    /// parse, and a file that parsed fine but names another asset — and nothing pinned which
+    /// message went with which. Swapping them puts "could not be read" on a sidecar that read
+    /// perfectly, which is the wrong label the split was made to remove. Each case asserts what
+    /// must appear and what must not, so a swap fails both halves.
+    #[test]
+    fn the_two_sidecar_failures_are_not_described_as_each_other() {
+        let rendered = |e: verify::SidecarError| {
+            let mut r = report_fixture();
+            r.outcome = Outcome::Refused(Refusal::BadSidecar(e));
+            render(&r, &plain(false))
+        };
+
+        let malformed = rendered(verify::SidecarError::Malformed);
+        assert!(malformed.contains("not a `sha256sum` line"), "{malformed}");
+        assert!(
+            !malformed.contains("different asset"),
+            "an unparseable sidecar is not a wrong-asset sidecar: {malformed}"
+        );
+
+        let wrong = rendered(verify::SidecarError::WrongAsset("some-other-asset".into()));
+        assert!(wrong.contains("different asset"), "{wrong}");
+        assert!(
+            wrong.contains("some-other-asset"),
+            "it must name what the sidecar claims: {wrong}"
+        );
+        assert!(
+            wrong.contains("glass-mcp-v1.4.0-x86_64-linux-gnu"),
+            "and what was actually downloaded: {wrong}"
+        );
+        assert!(
+            !wrong.contains("not a `sha256sum` line"),
+            "a sidecar that parsed must not be reported as unreadable: {wrong}"
+        );
     }
 
     #[test]

--- a/crates/glass-mcp/src/update/mod.rs
+++ b/crates/glass-mcp/src/update/mod.rs
@@ -48,7 +48,10 @@ impl Options {
             skip_attestation,
             json,
             color,
-            interactive: std::io::stdin().is_terminal() && std::io::stdout().is_terminal(),
+            // `--json` is a machine-facing mode: it must never block on a prompt, and its output
+            // must never share stdout with the three human lines `confirm` prints. Consent under
+            // `--json` comes from `--yes` alone.
+            interactive: !json && std::io::stdin().is_terminal() && std::io::stdout().is_terminal(),
             smoke: true,
         }
     }
@@ -99,13 +102,25 @@ pub(crate) struct Report {
     /// Whether the apply path can run on this target at all. Independent of `outcome` because
     /// `--check` reports it on macOS without refusing.
     pub(crate) supported: bool,
+    /// Whether `current` parsed as a released version at all. `false` for a from-source build —
+    /// distinct from `update_available`, which is also `false` there but for a reason a renderer
+    /// must not conflate with "you are up to date": one is "unknown", the other is a fact.
+    pub(crate) current_comparable: bool,
+    /// Whether a `glass-mcp serve --http` process is currently answering `/healthz`. Only ever set
+    /// after a successful update (by `run_cli`, which is the only caller that can actually probe
+    /// the real process) — carried on the report rather than printed as a side note so `--json`
+    /// stays the one, complete, parseable object.
+    pub(crate) running_server: bool,
 }
 
-/// The `attestation` field of the JSON output. `Skipped` is `--skip-attestation`; `Unavailable`
-/// is `gh` not being installed. Keeping them distinct is the point — "we did not check" and "you
-/// told us not to" are different things for a reader auditing an update.
+/// The `attestation` field of the JSON output. `NotChecked` is the initial state — reached only by
+/// `--check` and every refusal before step 8b, none of which touch provenance at all. `Skipped` is
+/// `--skip-attestation`; `Unavailable` is `gh` not being installed. Keeping these distinct is the
+/// point — "we did not check", "you told us not to", and "we tried and couldn't" are different
+/// things for a reader auditing an update.
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum AttestationStatus {
+    NotChecked,
     Verified,
     Unavailable,
     Skipped,
@@ -132,6 +147,7 @@ pub(crate) async fn run(
     current: &str,
     exe: &Path,
 ) -> anyhow::Result<Report> {
+    let current_version = version::Version::parse_released(current);
     let mut report = Report {
         outcome: Outcome::Checked,
         current: current.to_string(),
@@ -140,10 +156,11 @@ pub(crate) async fn run(
         asset: None,
         url: None,
         install_path: exe.to_path_buf(),
-        attestation: AttestationStatus::Skipped,
+        attestation: AttestationStatus::NotChecked,
         supported: !cfg!(target_os = "macos") && release::asset_suffix().is_some(),
+        current_comparable: current_version.is_some(),
+        running_server: false,
     };
-    let current_version = version::Version::parse_released(current);
 
     // 1. From-source, before any network request. A `--check` still reports.
     if !opts.check && current_version.is_none() {
@@ -161,7 +178,9 @@ pub(crate) async fn run(
 
     // 3. Resolve the latest release. First network call.
     let tag = source.latest_tag().await?;
-    let latest = version::Version::parse_released(tag.trim_start_matches('v'))
+    // `strip_prefix`, not `trim_start_matches`: the latter strips repeated leading `v`s, which
+    // would silently accept a malformed tag `build.rs`'s own `glass_version()` would not.
+    let latest = version::Version::parse_released(tag.strip_prefix('v').unwrap_or(&tag))
         .ok_or_else(|| anyhow::anyhow!("the latest release tag {tag:?} is not a version"))?;
     report.latest = Some(latest.to_string());
     report.update_available = current_version.as_ref().is_some_and(|c| latest > *c);
@@ -187,14 +206,18 @@ pub(crate) async fn run(
     //    by inspecting permissions — the same act, so there is no window between the check and
     //    the use, and no way for the two to disagree.
     let dir = exe.parent().unwrap_or_else(|| Path::new("."));
-    swap::sweep_old(exe);
     let temp = dir.join(format!(".glass-mcp.update-{:016x}", rand::random::<u64>()));
-    if std::fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(&temp)
-        .is_err()
+    let mut open = std::fs::OpenOptions::new();
+    open.write(true).create_new(true);
+    #[cfg(unix)]
     {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        // 0755 at creation, not left for `swap` (step 9) to set. The smoke check (8c) EXECUTES
+        // this file, and `swap` runs after it — a 0644 temp makes every real update fail at the
+        // gate that exists to prove the binary runs, with `execve` returning EACCES.
+        open.mode(0o755);
+    }
+    if open.open(&temp).is_err() {
         return Ok(report.refused(Refusal::NotWritable(dir.to_path_buf())));
     }
     // From here on every exit must remove `temp`: a refusal that leaves a stray half-download
@@ -212,9 +235,16 @@ pub(crate) async fn run(
     if !opts.yes && !opts.interactive {
         return discard(report, Refusal::NeedsConsent);
     }
-    if !opts.yes && !confirm(&current_version.to_string(), &latest.to_string(), &url)? {
+    if !opts.yes
+        && !confirm(&current_version.to_string(), &latest.to_string(), &url).map_err(abort)?
+    {
         return discard(report, Refusal::NeedsConsent);
     }
+
+    // Sweep any binary a previous update left displaced (Windows only, best-effort) now that we
+    // are committed to proceeding — not at step 6, where a refusal must not have already mutated
+    // the filesystem.
+    swap::sweep_old(exe);
 
     // 8a. Download, hashing in one pass.
     let got = source.download_to(&url, &temp).await.map_err(abort)?;
@@ -265,7 +295,8 @@ fn confirm(current: &str, latest: &str, url: &str) -> anyhow::Result<bool> {
     std::io::stdout().flush()?;
     let mut line = String::new();
     std::io::stdin().read_line(&mut line)?;
-    Ok(matches!(line.trim(), "y" | "Y" | "yes"))
+    let line = line.trim();
+    Ok(line.eq_ignore_ascii_case("y") || line.eq_ignore_ascii_case("yes"))
 }
 
 /// Resolve what `run` needs from the process itself, then render. Split from [`run`] so the flow
@@ -285,27 +316,19 @@ pub(crate) async fn run_cli(
         .context("could not resolve this binary's path")?;
     let opts = Options::from_flags(check, yes, skip_attestation, json, color);
     let source = ReleaseSource::github();
-    let report = run(opts.clone(), &source, crate::VERSION, &exe).await?;
-    print!("{}", render(&report, &opts));
+    let mut report = run(opts.clone(), &source, crate::VERSION, &exe).await?;
+    // A running `serve --http` keeps its own inode, so it goes on serving the OLD build until it
+    // is restarted — which reads to a connected agent as "the update did nothing". Carried on the
+    // report (rather than printed separately) so `--json` stays one parseable object; reusing the
+    // same loopback probe `status` uses. Only worth checking after a real swap.
     if matches!(report.outcome, Outcome::Updated) {
-        report_running_server();
+        report.running_server = crate::setup::fetch_health("127.0.0.1:7300").is_some();
     }
+    print!("{}", render(&report, &opts));
     if matches!(report.outcome, Outcome::Refused(_)) {
         std::process::exit(1);
     }
     Ok(())
-}
-
-/// A running `serve --http` keeps its own inode, so it goes on serving the OLD build until it is
-/// restarted — which reads to a connected agent as "the update did nothing". Only says so when a
-/// server actually answers, reusing the same loopback probe `status` uses.
-fn report_running_server() {
-    if crate::setup::fetch_health("127.0.0.1:7300").is_some() {
-        println!(
-            "note: a glass server is running on 127.0.0.1:7300 and keeps the previous build \
-             until it is restarted."
-        );
-    }
 }
 
 /// Human text, or the JSON object under `--json`. Pure in `report` and `opts`, so the whole
@@ -327,11 +350,18 @@ fn render(report: &Report, opts: &Options) -> String {
                 "This install is not replaced in place — see the setup guide for your platform."
             }
         ),
+        // A from-source build's version is not comparable, so `update_available` is always
+        // `false` here regardless of whether a newer release exists — printing "is the latest
+        // release" (the arm below) would be a claim we cannot back. Say what we actually know.
+        Outcome::Checked if !report.current_comparable => format!(
+            "glass-mcp {} is a from-source build; the latest release is {}.\n",
+            report.current, latest
+        ),
         Outcome::Checked | Outcome::UpToDate => {
             format!("glass-mcp {} is the latest release.\n", report.current)
         }
         Outcome::Updated => format!(
-            "{} glass-mcp {} → {}\n{}",
+            "{} glass-mcp {} → {}\n{}{}",
             p.paint(p.ok, "updated"),
             report.current,
             latest,
@@ -351,8 +381,16 @@ fn render(report: &Report, opts: &Options) -> String {
                         "build provenance NOT verified (--skip-attestation)."
                     )
                 ),
-                // Unreachable: a failed attestation refuses rather than updating.
-                AttestationStatus::Failed => String::new(),
+                // Unreachable: 8b always sets Verified/Unavailable/Skipped/Failed before an
+                // Outcome::Updated can be produced, and a Failed attestation refuses rather than
+                // updating — so neither NotChecked nor Failed can appear here.
+                AttestationStatus::NotChecked | AttestationStatus::Failed => String::new(),
+            },
+            if report.running_server {
+                "note: a glass server is running on 127.0.0.1:7300 and keeps the previous build \
+                 until it is restarted.\n"
+            } else {
+                ""
             }
         ),
         Outcome::Refused(why) => format!(
@@ -431,11 +469,13 @@ fn render_json(report: &Report) -> String {
         "url": report.url,
         "install_path": report.install_path.display().to_string(),
         "attestation": match report.attestation {
+            AttestationStatus::NotChecked => "not_checked",
             AttestationStatus::Verified => "verified",
             AttestationStatus::Unavailable => "unavailable",
             AttestationStatus::Skipped => "skipped",
             AttestationStatus::Failed => "failed",
         },
+        "running_server": report.running_server,
     });
     if let Some(reason) = reason {
         obj["reason"] = serde_json::Value::String(reason);
@@ -544,6 +584,35 @@ mod tests {
         assert_eq!(std::fs::read(&exe).unwrap(), BODY);
     }
 
+    /// The apply path with the smoke gate ON, against a body that is actually runnable.
+    ///
+    /// Every other apply-path test sets `smoke: false`, so this is the only one that exercises
+    /// step 8c — and 8c executes the temp file, which means it also pins the file's MODE. With the
+    /// temp created 0644 this fails with EACCES, which is exactly what shipped before this test.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn the_smoke_gate_runs_the_downloaded_binary() {
+        if !apply_path_exists() {
+            return;
+        }
+        const SCRIPT: &[u8] = b"#!/bin/sh\necho glass-mcp 1.4.0\n";
+        const SCRIPT_SHA: &str = "4605fe04920b0a38e4b11a2b08453755ecae4319cafb5069a19253d0a1ce0cc2";
+        let dir = tempfile::tempdir().unwrap();
+        let exe = install(dir.path(), b"old");
+        let asset = release::asset_name("v1.4.0").expect("supported target");
+        let server = FakeRelease::start(
+            "v1.4.0",
+            &asset,
+            SCRIPT,
+            &format!("{SCRIPT_SHA}  {asset}\n"),
+        );
+        let src = ReleaseSource::with_base(server.base());
+        // opts() already has smoke: true — that is the point of this test.
+        let out = run(opts(), &src, "1.3.0", &exe).await.unwrap().outcome;
+        assert!(matches!(out, Outcome::Updated), "{out:?}");
+        assert_eq!(std::fs::read(&exe).unwrap(), SCRIPT);
+    }
+
     /// The assertion that matters is the second one: "it errored" says nothing about what it
     /// left behind.
     #[tokio::test]
@@ -633,25 +702,39 @@ mod tests {
         assert_eq!(std::fs::read(&exe).unwrap(), b"old");
     }
 
-    /// `--check` reports on every platform and refuses nothing, including on a from-source build.
+    /// `--check` reports on every platform and refuses nothing, including on a from-source build —
+    /// so, unlike the apply-path tests, this one carries no `apply_path_exists()` guard and no
+    /// `release::asset_name(...)` (which would return `None` and skip the test on macOS, exactly
+    /// the platform this contract most needs covering). The asset name is a literal because
+    /// `--check` never reaches step 5 — it resolves only the tag, never an asset — so the fake
+    /// server's asset/sidecar routes are never hit.
     #[tokio::test]
     async fn check_reports_on_a_from_source_build() {
-        if !apply_path_exists() {
-            return;
-        }
         let dir = tempfile::tempdir().unwrap();
         let exe = install(dir.path(), b"old");
-        let asset = release::asset_name("v1.4.0").expect("supported target");
-        let server = FakeRelease::start("v1.4.0", &asset, BODY, &sidecar(&asset));
+        let asset = "glass-mcp-v1.4.0-x86_64-linux-gnu";
+        let server = FakeRelease::start("v1.4.0", asset, BODY, &sidecar(asset));
         let src = ReleaseSource::with_base(server.base());
         let mut o = opts();
         o.check = true;
-        let out = run(o, &src, "1.3.0-5-g563feea", &exe)
-            .await
-            .unwrap()
-            .outcome;
-        assert!(matches!(out, Outcome::Checked), "{out:?}");
+        let report = run(o, &src, "1.3.0-5-g563feea", &exe).await.unwrap();
+        assert!(
+            matches!(report.outcome, Outcome::Checked),
+            "{:?}",
+            report.outcome
+        );
         assert_eq!(std::fs::read(&exe).unwrap(), b"old");
+        // The outcome alone does not distinguish "up to date" from "we don't know" — assert the
+        // actual rendered claim, not just that nothing was refused.
+        let human = render(&report, &plain(false));
+        assert!(
+            human.contains("from-source build"),
+            "must not claim to be the latest release: {human}"
+        );
+        assert!(
+            human.contains("1.4.0"),
+            "must name the real latest release: {human}"
+        );
     }
 
     fn report_fixture() -> Report {
@@ -665,6 +748,8 @@ mod tests {
             install_path: std::path::PathBuf::from("/opt/bin/glass-mcp"),
             attestation: AttestationStatus::Verified,
             supported: true,
+            current_comparable: true,
+            running_server: false,
         }
     }
 
@@ -687,6 +772,7 @@ mod tests {
         assert_eq!(v["supported"], true);
         assert_eq!(v["attestation"], "verified");
         assert_eq!(v["install_path"], "/opt/bin/glass-mcp");
+        assert_eq!(v["running_server"], false);
         assert!(v.get("reason").is_none(), "reason is refusal-only");
     }
 

--- a/crates/glass-mcp/src/update/mod.rs
+++ b/crates/glass-mcp/src/update/mod.rs
@@ -1,4 +1,8 @@
 //! `glass-mcp update`: fetch the latest release, verify it, and replace this binary.
+//!
+//! The step order below is a contract, not an implementation detail, and the tests assert it: the
+//! from-source refusal happens before any network request, writability is proved before anything
+//! is downloaded, and consent is taken before the download rather than before the swap.
 
 mod release;
 mod swap;
@@ -6,3 +10,732 @@ mod swap;
 mod testserver;
 mod verify;
 mod version;
+
+use crate::color::ColorChoice;
+use release::ReleaseSource;
+use std::io::IsTerminal;
+use std::path::{Path, PathBuf};
+use verify::Attestation;
+
+/// Everything the flow needs to know that is not the release itself.
+///
+/// `interactive` and `smoke` are separate from the CLI flags so the tests can drive the
+/// non-interactive path and skip executing a fixture that is not a real binary; the binary always
+/// sets them from the real terminal and always leaves `smoke` on.
+#[derive(Debug, Clone)]
+pub(crate) struct Options {
+    pub(crate) check: bool,
+    pub(crate) yes: bool,
+    pub(crate) skip_attestation: bool,
+    pub(crate) json: bool,
+    pub(crate) color: ColorChoice,
+    pub(crate) interactive: bool,
+    pub(crate) smoke: bool,
+}
+
+impl Options {
+    pub(crate) fn from_flags(
+        check: bool,
+        yes: bool,
+        skip_attestation: bool,
+        json: bool,
+        color: ColorChoice,
+    ) -> Self {
+        Options {
+            check,
+            yes,
+            skip_attestation,
+            json,
+            color,
+            interactive: std::io::stdin().is_terminal() && std::io::stdout().is_terminal(),
+            smoke: true,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum Refusal {
+    /// A local build. Replacing it with a release binary would be a silent substitution.
+    FromSource(String),
+    /// No published asset for this target.
+    UnsupportedTarget,
+    /// macOS installs are an app bundle, not a bare binary.
+    MacosBundle,
+    NotWritable(PathBuf),
+    NeedsConsent,
+    ChecksumMismatch {
+        expected: String,
+        got: String,
+    },
+    BadSidecar(String),
+    AttestationFailed(String),
+    SmokeCheckFailed(String),
+}
+
+#[derive(Debug)]
+pub(crate) enum Outcome {
+    Checked,
+    UpToDate,
+    Updated,
+    Refused(Refusal),
+}
+
+/// What happened, and everything the renderer needs to say so. One struct rather than data hung
+/// off the `Outcome` variants: `--json` emits the same field set for every outcome, so the
+/// renderer should not have to reach into a different shape per variant.
+#[derive(Debug)]
+pub(crate) struct Report {
+    pub(crate) outcome: Outcome,
+    pub(crate) current: String,
+    pub(crate) latest: Option<String>,
+    /// Whether `latest` is strictly newer than `current`. `false` while the latest release is
+    /// still unknown, and `false` for a from-source build, whose version is not comparable.
+    pub(crate) update_available: bool,
+    pub(crate) asset: Option<String>,
+    pub(crate) url: Option<String>,
+    pub(crate) install_path: PathBuf,
+    pub(crate) attestation: AttestationStatus,
+    /// Whether the apply path can run on this target at all. Independent of `outcome` because
+    /// `--check` reports it on macOS without refusing.
+    pub(crate) supported: bool,
+}
+
+/// The `attestation` field of the JSON output. `Skipped` is `--skip-attestation`; `Unavailable`
+/// is `gh` not being installed. Keeping them distinct is the point — "we did not check" and "you
+/// told us not to" are different things for a reader auditing an update.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum AttestationStatus {
+    Verified,
+    Unavailable,
+    Skipped,
+    Failed,
+}
+
+impl Report {
+    fn refused(mut self, why: Refusal) -> Report {
+        self.outcome = Outcome::Refused(why);
+        self
+    }
+
+    fn finished(mut self, outcome: Outcome) -> Report {
+        self.outcome = outcome;
+        self
+    }
+}
+
+/// The whole flow. Takes the current version and this binary's path as arguments rather than
+/// reading them itself, so the tests exercise every branch without a real install.
+pub(crate) async fn run(
+    opts: Options,
+    source: &ReleaseSource,
+    current: &str,
+    exe: &Path,
+) -> anyhow::Result<Report> {
+    let mut report = Report {
+        outcome: Outcome::Checked,
+        current: current.to_string(),
+        latest: None,
+        update_available: false,
+        asset: None,
+        url: None,
+        install_path: exe.to_path_buf(),
+        attestation: AttestationStatus::Skipped,
+        supported: !cfg!(target_os = "macos") && release::asset_suffix().is_some(),
+    };
+    let current_version = version::Version::parse_released(current);
+
+    // 1. From-source, before any network request. A `--check` still reports.
+    if !opts.check && current_version.is_none() {
+        return Ok(report.refused(Refusal::FromSource(current.to_string())));
+    }
+    // 2. Unsupported target, also before the network. `--check` still reports.
+    if !opts.check && !report.supported {
+        let why = if cfg!(target_os = "macos") {
+            Refusal::MacosBundle
+        } else {
+            Refusal::UnsupportedTarget
+        };
+        return Ok(report.refused(why));
+    }
+
+    // 3. Resolve the latest release. First network call.
+    let tag = source.latest_tag().await?;
+    let latest = version::Version::parse_released(tag.trim_start_matches('v'))
+        .ok_or_else(|| anyhow::anyhow!("the latest release tag {tag:?} is not a version"))?;
+    report.latest = Some(latest.to_string());
+    report.update_available = current_version.as_ref().is_some_and(|c| latest > *c);
+
+    if opts.check {
+        return Ok(report.finished(Outcome::Checked));
+    }
+
+    // 4. Nothing to do.
+    let current_version = current_version.expect("checked above for the apply path");
+    if latest <= current_version {
+        return Ok(report.finished(Outcome::UpToDate));
+    }
+
+    // 5. What we are about to fetch. Resolved before the writability check so a refusal there can
+    //    still print the URL to download by hand.
+    let asset = release::asset_name(&tag).ok_or_else(|| anyhow::anyhow!("unsupported target"))?;
+    let url = source.asset_url(&tag, &asset);
+    report.asset = Some(asset.clone());
+    report.url = Some(url.clone());
+
+    // 6. Writability, proved by creating the temp file we are about to download into rather than
+    //    by inspecting permissions — the same act, so there is no window between the check and
+    //    the use, and no way for the two to disagree.
+    let dir = exe.parent().unwrap_or_else(|| Path::new("."));
+    swap::sweep_old(exe);
+    let temp = dir.join(format!(".glass-mcp.update-{:016x}", rand::random::<u64>()));
+    if std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temp)
+        .is_err()
+    {
+        return Ok(report.refused(Refusal::NotWritable(dir.to_path_buf())));
+    }
+    // From here on every exit must remove `temp`: a refusal that leaves a stray half-download
+    // beside the binary is not the no-op it claims to be, and a test asserts there are none.
+    let discard = |report: Report, why: Refusal| -> anyhow::Result<Report> {
+        let _ = std::fs::remove_file(&temp);
+        Ok(report.refused(why))
+    };
+    let abort = |e: anyhow::Error| -> anyhow::Error {
+        let _ = std::fs::remove_file(&temp);
+        e
+    };
+
+    // 7. Consent. A non-tty without --yes refuses rather than assuming it.
+    if !opts.yes && !opts.interactive {
+        return discard(report, Refusal::NeedsConsent);
+    }
+    if !opts.yes && !confirm(&current_version.to_string(), &latest.to_string(), &url)? {
+        return discard(report, Refusal::NeedsConsent);
+    }
+
+    // 8a. Download, hashing in one pass.
+    let got = source.download_to(&url, &temp).await.map_err(abort)?;
+    let sidecar_text = source
+        .fetch_text(&format!("{url}.sha256"))
+        .await
+        .map_err(abort)?;
+    let expected = match verify::parse_sidecar(&sidecar_text, &asset) {
+        Ok(h) => h,
+        Err(e) => return discard(report, Refusal::BadSidecar(format!("{e:?}"))),
+    };
+    if expected != got {
+        return discard(report, Refusal::ChecksumMismatch { expected, got });
+    }
+
+    // 8b. Provenance. Fail closed — see `verify::attest`.
+    if opts.skip_attestation {
+        report.attestation = AttestationStatus::Skipped;
+    } else {
+        match verify::attest(&temp) {
+            Attestation::Verified => report.attestation = AttestationStatus::Verified,
+            Attestation::Unavailable => report.attestation = AttestationStatus::Unavailable,
+            Attestation::Failed(why) => {
+                report.attestation = AttestationStatus::Failed;
+                return discard(report, Refusal::AttestationFailed(why));
+            }
+        }
+    }
+
+    // 8c. Only now is the file executed.
+    if opts.smoke
+        && let Err(why) = verify::smoke_check(&temp, &latest.to_string())
+    {
+        return discard(report, Refusal::SmokeCheckFailed(why));
+    }
+
+    // 9. Swap.
+    swap::swap(&temp, exe).map_err(abort)?;
+    Ok(report.finished(Outcome::Updated))
+}
+
+/// Ask on the terminal. Only reached when stdin and stdout are both a tty.
+fn confirm(current: &str, latest: &str, url: &str) -> anyhow::Result<bool> {
+    use std::io::Write;
+    println!("glass-mcp {current} → {latest}");
+    println!("  {url}");
+    print!("Replace this binary? [y/N] ");
+    std::io::stdout().flush()?;
+    let mut line = String::new();
+    std::io::stdin().read_line(&mut line)?;
+    Ok(matches!(line.trim(), "y" | "Y" | "yes"))
+}
+
+/// Resolve what `run` needs from the process itself, then render. Split from [`run`] so the flow
+/// is testable without a real install: everything impure lives here.
+pub(crate) async fn run_cli(
+    check: bool,
+    yes: bool,
+    skip_attestation: bool,
+    json: bool,
+    color: ColorChoice,
+) -> anyhow::Result<()> {
+    let exe = std::env::current_exe()
+        .and_then(|p| p.canonicalize())
+        .map_err(|e| anyhow::anyhow!("could not resolve this binary's path: {e}"))?;
+    let opts = Options::from_flags(check, yes, skip_attestation, json, color);
+    let source = ReleaseSource::github();
+    let report = run(opts.clone(), &source, crate::VERSION, &exe).await?;
+    print!("{}", render(&report, &opts));
+    if matches!(report.outcome, Outcome::Updated) {
+        report_running_server();
+    }
+    if matches!(report.outcome, Outcome::Refused(_)) {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+/// A running `serve --http` keeps its own inode, so it goes on serving the OLD build until it is
+/// restarted — which reads to a connected agent as "the update did nothing". Only says so when a
+/// server actually answers, reusing the same loopback probe `status` uses.
+fn report_running_server() {
+    if crate::setup::fetch_health("127.0.0.1:7300").is_some() {
+        println!(
+            "note: a glass server is running on 127.0.0.1:7300 and keeps the previous build \
+             until it is restarted."
+        );
+    }
+}
+
+/// Human text, or the JSON object under `--json`. Pure in `report` and `opts`, so the whole
+/// output surface is unit-testable without running an update.
+fn render(report: &Report, opts: &Options) -> String {
+    if opts.json {
+        return render_json(report);
+    }
+    let p = crate::color::palette(opts.color);
+    let latest = report.latest.as_deref().unwrap_or("unknown");
+    match &report.outcome {
+        Outcome::Checked if report.update_available => format!(
+            "glass-mcp {} → {} is available.\n{}\n",
+            report.current,
+            p.paint(p.bold, latest),
+            if report.supported {
+                "Run `glass-mcp update` to install it."
+            } else {
+                "This install is not replaced in place — see the setup guide for your platform."
+            }
+        ),
+        Outcome::Checked | Outcome::UpToDate => {
+            format!("glass-mcp {} is the latest release.\n", report.current)
+        }
+        Outcome::Updated => format!(
+            "{} glass-mcp {} → {}\n{}",
+            p.paint(p.ok, "updated"),
+            report.current,
+            latest,
+            match report.attestation {
+                AttestationStatus::Verified => "build provenance verified.\n".to_string(),
+                AttestationStatus::Unavailable => format!(
+                    "{}\n",
+                    p.paint(
+                        p.dim,
+                        "build provenance not checked — install the GitHub CLI (`gh`) to verify it."
+                    )
+                ),
+                AttestationStatus::Skipped => format!(
+                    "{}\n",
+                    p.paint(
+                        p.warn,
+                        "build provenance NOT verified (--skip-attestation)."
+                    )
+                ),
+                // Unreachable: a failed attestation refuses rather than updating.
+                AttestationStatus::Failed => String::new(),
+            }
+        ),
+        Outcome::Refused(why) => format!(
+            "{} {}\n",
+            p.paint(p.fail, "cannot update:"),
+            refusal_message(why, report)
+        ),
+    }
+}
+
+/// One message per refusal: what happened, and what to do instead. Never suggests `sudo` —
+/// an updater that acquires root on the user's behalf is a much larger thing than this command.
+fn refusal_message(why: &Refusal, report: &Report) -> String {
+    match why {
+        Refusal::FromSource(v) => format!(
+            "this glass-mcp ({v}) was built from source. Update it with \
+             `git pull && cargo build --release` rather than replacing it with a release binary."
+        ),
+        Refusal::MacosBundle => "on macOS glass installs as GlassMcp.app, not a bare binary. \
+             Download the latest .dmg — see docs/how-to/setup-macos.md."
+            .to_string(),
+        Refusal::UnsupportedTarget => "no release asset is published for this platform. \
+             Build from source — see docs/how-to/build-from-source.md."
+            .to_string(),
+        Refusal::NotWritable(dir) => format!(
+            "{} is not writable by this user. Download the new binary and move it into place \
+             yourself:\n  {}",
+            dir.display(),
+            report.url.as_deref().unwrap_or("(url unresolved)")
+        ),
+        Refusal::NeedsConsent => {
+            "declined. Pass --yes to update without a prompt (there is no terminal to ask on)."
+                .to_string()
+        }
+        Refusal::ChecksumMismatch { expected, got } => format!(
+            "the downloaded asset does not match the checksum the release published.\n  \
+             expected {expected}\n  got      {got}"
+        ),
+        Refusal::BadSidecar(e) => {
+            format!("the release's checksum file could not be read ({e}).")
+        }
+        Refusal::AttestationFailed(why) => format!(
+            "build provenance could not be verified: {why}\n  \
+             If GitHub is unreachable rather than the artifact being wrong, retry later — or pass \
+             --skip-attestation to accept the checksum alone."
+        ),
+        Refusal::SmokeCheckFailed(why) => {
+            let mut msg = format!("the downloaded binary did not run: {why}");
+            // Only suggest musl when the gnu asset is what was fetched — a too-old glibc is the
+            // overwhelmingly likely cause there, and nonsense advice everywhere else.
+            if report.asset.as_deref().is_some_and(|a| a.ends_with("-gnu")) {
+                msg.push_str(
+                    "\n  If that is a glibc error, use the musl build instead — \
+                     see docs/reference/platforms.md.",
+                );
+            }
+            msg
+        }
+    }
+}
+
+/// The machine-readable form. `reason` appears only on a refusal.
+fn render_json(report: &Report) -> String {
+    let (action, reason) = match &report.outcome {
+        Outcome::Checked | Outcome::UpToDate => ("checked", None),
+        Outcome::Updated => ("updated", None),
+        Outcome::Refused(why) => ("refused", Some(refusal_message(why, report))),
+    };
+    let mut obj = serde_json::json!({
+        "action": action,
+        "current": report.current,
+        "latest": report.latest,
+        "update_available": report.update_available,
+        "supported": report.supported,
+        "asset": report.asset,
+        "url": report.url,
+        "install_path": report.install_path.display().to_string(),
+        "attestation": match report.attestation {
+            AttestationStatus::Verified => "verified",
+            AttestationStatus::Unavailable => "unavailable",
+            AttestationStatus::Skipped => "skipped",
+            AttestationStatus::Failed => "failed",
+        },
+    });
+    if let Some(reason) = reason {
+        obj["reason"] = serde_json::Value::String(reason);
+    }
+    format!(
+        "{}\n",
+        serde_json::to_string_pretty(&obj).expect("a json object serializes")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::update::testserver::FakeRelease;
+
+    const BODY: &[u8] = b"pretend binary";
+    /// sha256 of BODY. Recompute with `printf '%s' 'pretend binary' | sha256sum` if BODY changes.
+    const BODY_SHA: &str = "9f05ef97cc90b003959b48cd01b637658368bdfc78fe54c1a061d5eff0c46104";
+
+    /// The apply path, non-interactive, with the two gates that need a real network or a real
+    /// executable turned off. Each test that cares re-enables or re-disables what it is testing.
+    fn opts() -> Options {
+        Options {
+            check: false,
+            yes: true,
+            skip_attestation: true,
+            json: false,
+            color: Default::default(),
+            interactive: false,
+            smoke: true,
+        }
+    }
+
+    /// A fake install: a directory holding a "binary" we are allowed to replace.
+    fn install(dir: &std::path::Path, bytes: &[u8]) -> std::path::PathBuf {
+        let exe = dir.join(if cfg!(windows) {
+            "glass-mcp.exe"
+        } else {
+            "glass-mcp"
+        });
+        std::fs::write(&exe, bytes).unwrap();
+        exe
+    }
+
+    fn sidecar(asset: &str) -> String {
+        format!("{BODY_SHA}  {asset}\n")
+    }
+
+    /// Does the apply path exist on this target at all?
+    ///
+    /// CI's macOS job runs `cargo test --workspace --lib`, so this module executes there — and on
+    /// macOS `run` refuses with `MacosBundle` by design, while an unsupported target has no asset
+    /// name to build. Tests below that drive the apply path return early rather than assert the
+    /// opposite of the intended behavior. The macOS behavior has its own test at the end.
+    fn apply_path_exists() -> bool {
+        !cfg!(target_os = "macos") && release::asset_suffix().is_some()
+    }
+
+    #[tokio::test]
+    async fn a_from_source_build_refuses_before_any_network_request() {
+        let dir = tempfile::tempdir().unwrap();
+        let exe = install(dir.path(), b"old");
+        // A base that would fail loudly if it were ever contacted.
+        let src = ReleaseSource::with_base("http://127.0.0.1:1");
+        let out = run(opts(), &src, "1.3.0-5-g563feea", &exe)
+            .await
+            .unwrap()
+            .outcome;
+        assert!(
+            matches!(out, Outcome::Refused(Refusal::FromSource(_))),
+            "{out:?}"
+        );
+        assert_eq!(std::fs::read(&exe).unwrap(), b"old");
+    }
+
+    #[tokio::test]
+    async fn being_on_the_latest_release_is_a_no_op() {
+        if !apply_path_exists() {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let exe = install(dir.path(), b"old");
+        let asset = release::asset_name("v1.3.0").expect("supported target");
+        let server = FakeRelease::start("v1.3.0", &asset, BODY, &sidecar(&asset));
+        let src = ReleaseSource::with_base(server.base());
+        let out = run(opts(), &src, "1.3.0", &exe).await.unwrap().outcome;
+        assert!(matches!(out, Outcome::UpToDate), "{out:?}");
+        assert_eq!(std::fs::read(&exe).unwrap(), b"old");
+    }
+
+    /// The whole flow, end to end, against the real code path.
+    #[tokio::test]
+    async fn a_newer_release_replaces_the_binary() {
+        if !apply_path_exists() {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let exe = install(dir.path(), b"old");
+        let asset = release::asset_name("v1.4.0").expect("supported target");
+        let server = FakeRelease::start("v1.4.0", &asset, BODY, &sidecar(&asset));
+        let src = ReleaseSource::with_base(server.base());
+        let mut o = opts();
+        o.smoke = false; // the served bytes are not a runnable binary
+        let out = run(o, &src, "1.3.0", &exe).await.unwrap().outcome;
+        assert!(matches!(out, Outcome::Updated), "{out:?}");
+        assert_eq!(std::fs::read(&exe).unwrap(), BODY);
+    }
+
+    /// The assertion that matters is the second one: "it errored" says nothing about what it
+    /// left behind.
+    #[tokio::test]
+    async fn a_bad_checksum_refuses_and_leaves_the_binary_untouched() {
+        if !apply_path_exists() {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let exe = install(dir.path(), b"old");
+        let asset = release::asset_name("v1.4.0").expect("supported target");
+        let wrong = format!("{}  {asset}\n", "0".repeat(64));
+        let server = FakeRelease::start("v1.4.0", &asset, BODY, &wrong);
+        let src = ReleaseSource::with_base(server.base());
+        let mut o = opts();
+        o.smoke = false;
+        let out = run(o, &src, "1.3.0", &exe).await.unwrap().outcome;
+        assert!(
+            matches!(out, Outcome::Refused(Refusal::ChecksumMismatch { .. })),
+            "{out:?}"
+        );
+        assert_eq!(std::fs::read(&exe).unwrap(), b"old");
+        let strays: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.starts_with(".glass-mcp.update-"))
+            .collect();
+        assert!(
+            strays.is_empty(),
+            "a failed update must clean up: {strays:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_non_tty_without_yes_refuses_rather_than_assuming_consent() {
+        if !apply_path_exists() {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let exe = install(dir.path(), b"old");
+        let asset = release::asset_name("v1.4.0").expect("supported target");
+        let server = FakeRelease::start("v1.4.0", &asset, BODY, &sidecar(&asset));
+        let src = ReleaseSource::with_base(server.base());
+        let mut o = opts();
+        o.yes = false;
+        o.interactive = false;
+        let out = run(o, &src, "1.3.0", &exe).await.unwrap().outcome;
+        assert!(
+            matches!(out, Outcome::Refused(Refusal::NeedsConsent)),
+            "{out:?}"
+        );
+        assert_eq!(std::fs::read(&exe).unwrap(), b"old");
+    }
+
+    /// Unix-only: this needs directory permissions to actually deny a write, which Windows ACLs
+    /// do not express the same way. It also self-checks that the denial took effect — running as
+    /// root ignores mode 0o555 entirely, and without the probe this test would pass vacuously in
+    /// a root container by refusing for no reason at all.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn an_unwritable_directory_refuses_before_downloading() {
+        if !apply_path_exists() {
+            return;
+        }
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let exe = install(dir.path(), b"old");
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o555)).unwrap();
+
+        let denied = std::fs::File::create(dir.path().join(".probe")).is_err();
+        if !denied {
+            std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
+            eprintln!("skipping: this user can write to a 0o555 directory (root?)");
+            return;
+        }
+
+        let asset = release::asset_name("v1.4.0").expect("supported target");
+        let server = FakeRelease::start("v1.4.0", &asset, BODY, &sidecar(&asset));
+        let src = ReleaseSource::with_base(server.base());
+        let out = run(opts(), &src, "1.3.0", &exe).await.unwrap().outcome;
+
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
+        assert!(
+            matches!(out, Outcome::Refused(Refusal::NotWritable(_))),
+            "{out:?}"
+        );
+        assert_eq!(std::fs::read(&exe).unwrap(), b"old");
+    }
+
+    /// `--check` reports on every platform and refuses nothing, including on a from-source build.
+    #[tokio::test]
+    async fn check_reports_on_a_from_source_build() {
+        if !apply_path_exists() {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let exe = install(dir.path(), b"old");
+        let asset = release::asset_name("v1.4.0").expect("supported target");
+        let server = FakeRelease::start("v1.4.0", &asset, BODY, &sidecar(&asset));
+        let src = ReleaseSource::with_base(server.base());
+        let mut o = opts();
+        o.check = true;
+        let out = run(o, &src, "1.3.0-5-g563feea", &exe)
+            .await
+            .unwrap()
+            .outcome;
+        assert!(matches!(out, Outcome::Checked), "{out:?}");
+        assert_eq!(std::fs::read(&exe).unwrap(), b"old");
+    }
+
+    fn report_fixture() -> Report {
+        Report {
+            outcome: Outcome::Checked,
+            current: "1.3.0".into(),
+            latest: Some("1.4.0".into()),
+            update_available: true,
+            asset: Some("glass-mcp-v1.4.0-x86_64-linux-gnu".into()),
+            url: Some("https://example.invalid/asset".into()),
+            install_path: std::path::PathBuf::from("/opt/bin/glass-mcp"),
+            attestation: AttestationStatus::Verified,
+            supported: true,
+        }
+    }
+
+    /// Color off, so these assert on the text rather than on escape sequences.
+    fn plain(json: bool) -> Options {
+        let mut o = opts();
+        o.json = json;
+        o.color = crate::color::ColorChoice::Never;
+        o
+    }
+
+    #[test]
+    fn the_json_report_carries_every_documented_field() {
+        let out = render(&report_fixture(), &plain(true));
+        let v: serde_json::Value = serde_json::from_str(&out).expect("valid json");
+        assert_eq!(v["action"], "checked");
+        assert_eq!(v["current"], "1.3.0");
+        assert_eq!(v["latest"], "1.4.0");
+        assert_eq!(v["update_available"], true);
+        assert_eq!(v["supported"], true);
+        assert_eq!(v["attestation"], "verified");
+        assert_eq!(v["install_path"], "/opt/bin/glass-mcp");
+        assert!(v.get("reason").is_none(), "reason is refusal-only");
+    }
+
+    #[test]
+    fn a_refusal_names_the_condition_and_never_suggests_sudo() {
+        let mut r = report_fixture();
+        r.outcome = Outcome::Refused(Refusal::NotWritable("/usr/local/bin".into()));
+
+        let human = render(&r, &plain(false));
+        assert!(human.contains("/usr/local/bin"), "{human}");
+        assert!(
+            human.contains("https://example.invalid/asset"),
+            "the manual URL: {human}"
+        );
+        assert!(
+            !human.to_lowercase().contains("sudo"),
+            "must never suggest sudo: {human}"
+        );
+
+        let v: serde_json::Value = serde_json::from_str(&render(&r, &plain(true))).unwrap();
+        assert_eq!(v["action"], "refused");
+        assert!(
+            v["reason"]
+                .as_str()
+                .is_some_and(|s| s.contains("/usr/local/bin"))
+        );
+    }
+
+    /// The glibc hint is only correct advice when the gnu asset is what failed to run.
+    #[test]
+    fn the_glibc_hint_appears_only_for_the_gnu_asset() {
+        let mut r = report_fixture();
+        r.outcome = Outcome::Refused(Refusal::SmokeCheckFailed("exited 1".into()));
+        assert!(render(&r, &plain(false)).contains("musl build"));
+
+        r.asset = Some("glass-mcp-v1.4.0-x86_64-linux-musl".into());
+        assert!(!render(&r, &plain(false)).contains("musl build"));
+    }
+
+    /// The macOS behavior the guard above skips: refusing is the feature, not a gap. Asserted on
+    /// a released version so the from-source refusal cannot be what produces the verdict.
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn the_apply_path_refuses_a_bundle_install() {
+        let dir = tempfile::tempdir().unwrap();
+        let exe = install(dir.path(), b"old");
+        // A base that would fail loudly if the flow ever reached the network — it must refuse first.
+        let src = ReleaseSource::with_base("http://127.0.0.1:1");
+        let out = run(opts(), &src, "1.3.0", &exe).await.unwrap().outcome;
+        assert!(
+            matches!(out, Outcome::Refused(Refusal::MacosBundle)),
+            "{out:?}"
+        );
+        assert_eq!(std::fs::read(&exe).unwrap(), b"old");
+    }
+}

--- a/crates/glass-mcp/src/update/mod.rs
+++ b/crates/glass-mcp/src/update/mod.rs
@@ -3,4 +3,5 @@
 mod release;
 #[cfg(test)]
 mod testserver;
+mod verify;
 mod version;

--- a/crates/glass-mcp/src/update/release.rs
+++ b/crates/glass-mcp/src/update/release.rs
@@ -99,6 +99,170 @@ pub(crate) fn tag_from_location(base: &str, location: &str) -> Result<String, Lo
     Ok(tag.to_string())
 }
 
+use sha2::{Digest, Sha256};
+use std::path::Path;
+use std::time::Duration;
+
+/// How long to wait for a connection before giving up. Short: the endpoint is either reachable
+/// or it is not, and a stalled connect should report rather than hang.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+/// Whole-request budget for the two small metadata requests (the redirect, the sidecar).
+const META_TIMEOUT: Duration = Duration::from_secs(60);
+/// Whole-request budget for the asset body. Generous, but bounded — a stalled download must not
+/// hang forever.
+const ASSET_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// Where to fetch releases from. The base is a constructor argument rather than a constant at
+/// the call site so the tests drive this exact code against a local server; there is deliberately
+/// no environment variable, which would ship a knob that repoints the updater at any host.
+pub(crate) struct ReleaseSource {
+    base: String,
+}
+
+impl ReleaseSource {
+    pub(crate) fn github() -> Self {
+        Self::with_base(GITHUB_BASE)
+    }
+
+    pub(crate) fn with_base(base: impl Into<String>) -> Self {
+        ReleaseSource { base: base.into() }
+    }
+
+    /// The newest published release's tag. `/releases/latest` redirects to the tag page and
+    /// already excludes prereleases and drafts, so the redirect target is the whole answer.
+    pub(crate) async fn latest_tag(&self) -> anyhow::Result<String> {
+        let url = format!("{}{REPO_PATH}/releases/latest", self.base);
+        // Redirects OFF: the Location header IS the result here, not something to follow.
+        let client = reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .connect_timeout(CONNECT_TIMEOUT)
+            .timeout(META_TIMEOUT)
+            .user_agent(concat!("glass-mcp/", env!("GLASS_VERSION")))
+            .build()?;
+        let resp = client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| anyhow::anyhow!("could not reach {url}: {e}"))?;
+        let location = resp
+            .headers()
+            .get(reqwest::header::LOCATION)
+            .and_then(|v| v.to_str().ok())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "{url} did not redirect to a release (HTTP {})",
+                    resp.status()
+                )
+            })?;
+        tag_from_location(&self.base, location).map_err(|e| match e {
+            LocationError::Missing | LocationError::NotATagRedirect => anyhow::anyhow!(
+                "{url} redirected to {location}, which is not a release tag page — \
+                 the repo may have no published release, or GitHub may be returning an error page"
+            ),
+            LocationError::MalformedTag(t) => {
+                anyhow::anyhow!("{url} redirected to an unexpected release tag {t:?}")
+            }
+        })
+    }
+
+    pub(crate) fn asset_url(&self, tag: &str, asset: &str) -> String {
+        format!("{}{REPO_PATH}/releases/download/{tag}/{asset}", self.base)
+    }
+
+    /// Build the client used for asset and sidecar fetches. Redirects ARE followed here (GitHub
+    /// sends release downloads to objects.githubusercontent.com), bounded to five hops, and a
+    /// hop that downgrades the scheme is refused — over https that is the "https all the way"
+    /// rule, and over the tests' loopback http it is the same rule, so production's guard is the
+    /// one under test.
+    fn following_client(&self, timeout: Duration) -> anyhow::Result<reqwest::Client> {
+        let policy = reqwest::redirect::Policy::custom(|attempt| {
+            if attempt.previous().len() >= 5 {
+                return attempt.error("too many redirects");
+            }
+            let downgraded = attempt
+                .previous()
+                .first()
+                .is_some_and(|first| first.scheme() != attempt.url().scheme());
+            if downgraded {
+                return attempt.error("refusing a redirect that changes the URL scheme");
+            }
+            attempt.follow()
+        });
+        Ok(reqwest::Client::builder()
+            .redirect(policy)
+            .connect_timeout(CONNECT_TIMEOUT)
+            .timeout(timeout)
+            .user_agent(concat!("glass-mcp/", env!("GLASS_VERSION")))
+            .build()?)
+    }
+
+    /// Fetch a small text resource — the checksum sidecar.
+    pub(crate) async fn fetch_text(&self, url: &str) -> anyhow::Result<String> {
+        let resp = self
+            .following_client(META_TIMEOUT)?
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| anyhow::anyhow!("could not fetch {url}: {e}"))?;
+        let status = resp.status();
+        if !status.is_success() {
+            anyhow::bail!("{url} returned HTTP {status}");
+        }
+        Ok(resp.text().await?)
+    }
+
+    /// Stream the asset to `dest`, hashing as it goes, and return the lowercase hex SHA-256 of
+    /// what was written. One pass: the binary is never fully buffered in memory, and the digest
+    /// describes the bytes that actually landed rather than a re-read of the file.
+    ///
+    /// On any failure the partial file is removed, so a failed download leaves nothing behind for
+    /// a later run to trip over.
+    pub(crate) async fn download_to(&self, url: &str, dest: &Path) -> anyhow::Result<String> {
+        match self.download_inner(url, dest).await {
+            Ok(digest) => Ok(digest),
+            Err(e) => {
+                let _ = std::fs::remove_file(dest);
+                Err(e)
+            }
+        }
+    }
+
+    async fn download_inner(&self, url: &str, dest: &Path) -> anyhow::Result<String> {
+        use std::io::Write;
+
+        let mut resp = self
+            .following_client(ASSET_TIMEOUT)?
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| anyhow::anyhow!("could not fetch {url}: {e}"))?;
+        let status = resp.status();
+        if !status.is_success() {
+            anyhow::bail!("{url} returned HTTP {status}");
+        }
+        let mut file = std::fs::File::create(dest)
+            .map_err(|e| anyhow::anyhow!("could not write {}: {e}", dest.display()))?;
+        let mut hasher = Sha256::new();
+        while let Some(chunk) = resp.chunk().await? {
+            hasher.update(&chunk);
+            file.write_all(&chunk)?;
+        }
+        file.sync_all()?;
+        Ok(hex(&hasher.finalize()))
+    }
+}
+
+/// Lowercase hex, to match `sha256sum`'s output — which is what the sidecar contains.
+pub(crate) fn hex(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    bytes
+        .iter()
+        .fold(String::with_capacity(bytes.len() * 2), |mut s, b| {
+            let _ = write!(s, "{b:02x}");
+            s
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -164,6 +328,20 @@ mod tests {
         }
     }
 
+    /// De-anchoring regression. `strip_prefix` is anchored at byte 0, which is the only reason a
+    /// URL that merely *contains* the expected prefix is rejected. Nothing else in the suite pins
+    /// that, and cargo-mutants cannot generate a de-anchoring mutant — so without this, an
+    /// accidental switch to a substring match would pass every committed test.
+    #[test]
+    fn a_prefix_appearing_mid_url_is_not_a_tag_redirect() {
+        let loc =
+            "https://attacker.example/x/https://github.com/fixed-width/glass/releases/tag/v1.4.0";
+        assert!(matches!(
+            tag_from_location(BASE, loc),
+            Err(LocationError::NotATagRedirect)
+        ));
+    }
+
     #[test]
     fn a_malformed_tag_in_an_otherwise_valid_location_is_an_error() {
         let loc = "https://github.com/fixed-width/glass/releases/tag/v1.4.0/../../evil";
@@ -222,5 +400,62 @@ mod tests {
         } else {
             assert_eq!(suffix, None, "unsupported targets must refuse, not guess");
         }
+    }
+
+    use crate::update::testserver::FakeRelease;
+
+    const BODY: &[u8] = b"not really a binary, but it hashes just the same";
+    /// sha256 of BODY. Recompute with `printf '%s' '<BODY>' | sha256sum` if BODY changes.
+    const BODY_SHA: &str = "24c71201dd8f823148c6c782b5d0b288376212d1b8669a0ebdefd3c5b3b623fe";
+
+    #[tokio::test]
+    async fn latest_tag_follows_the_redirect() {
+        let server = FakeRelease::start("v1.4.0", "asset", BODY, "");
+        let src = ReleaseSource::with_base(server.base());
+        assert_eq!(src.latest_tag().await.unwrap(), "v1.4.0");
+    }
+
+    #[tokio::test]
+    async fn a_missing_release_is_an_error_not_an_up_to_date_report() {
+        // An empty tag makes the redirect land on `/releases/tag/` with nothing after it — the
+        // same shape as a repo with nothing published, or a GitHub error page. It must be an
+        // error, never a quiet "you are up to date".
+        let server = FakeRelease::start("", "asset", BODY, "");
+        let src = ReleaseSource::with_base(server.base());
+        assert!(src.latest_tag().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn download_writes_the_bytes_and_returns_their_digest() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dest = dir.path().join("downloaded");
+        let server = FakeRelease::start("v1.4.0", "asset", BODY, "");
+        let src = ReleaseSource::with_base(server.base());
+        let url = src.asset_url("v1.4.0", "asset");
+        let digest = src.download_to(&url, &dest).await.unwrap();
+        assert_eq!(std::fs::read(&dest).unwrap(), BODY);
+        assert_eq!(digest, BODY_SHA);
+    }
+
+    #[tokio::test]
+    async fn a_404_asset_is_an_error_and_writes_nothing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dest = dir.path().join("downloaded");
+        let server = FakeRelease::start("v1.4.0", "asset", BODY, "");
+        let src = ReleaseSource::with_base(server.base());
+        let url = src.asset_url("v1.4.0", "no-such-asset");
+        assert!(src.download_to(&url, &dest).await.is_err());
+        assert!(
+            !dest.exists(),
+            "a failed download must leave nothing behind"
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_text_reads_the_sidecar() {
+        let server = FakeRelease::start("v1.4.0", "asset", BODY, "abc123  asset\n");
+        let src = ReleaseSource::with_base(server.base());
+        let url = format!("{}.sha256", src.asset_url("v1.4.0", "asset"));
+        assert_eq!(src.fetch_text(&url).await.unwrap(), "abc123  asset\n");
     }
 }

--- a/crates/glass-mcp/src/update/release.rs
+++ b/crates/glass-mcp/src/update/release.rs
@@ -15,8 +15,6 @@ pub(crate) const REPO_PATH: &str = "/fixed-width/glass";
 
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum LocationError {
-    /// No `Location` header on a response that should have redirected.
-    Missing,
     /// The redirect did not land on this repo's `/releases/tag/` path — a repo with no published
     /// release (GitHub redirects to `/releases`), an error page, or a foreign origin.
     NotATagRedirect,
@@ -161,7 +159,7 @@ impl ReleaseSource {
                 )
             })?;
         tag_from_location(&self.base, location).map_err(|e| match e {
-            LocationError::Missing | LocationError::NotATagRedirect => anyhow::anyhow!(
+            LocationError::NotATagRedirect => anyhow::anyhow!(
                 "{url} redirected to {location}, which is not a release tag page — \
                  the repo may have no published release, or GitHub may be returning an error page"
             ),

--- a/crates/glass-mcp/src/update/release.rs
+++ b/crates/glass-mcp/src/update/release.rs
@@ -3,11 +3,11 @@
 //! "Latest" is resolved by following `/releases/latest`'s redirect rather than through the REST
 //! API: no token, no 60/hr unauthenticated rate limit, no JSON, and GitHub already excludes
 //! prereleases from that endpoint. The cost is that the `Location` header is attacker-influenced
-//! input which then gets interpolated into a download URL, so it is validated twice here — once
-//! for the redirect target's prefix, once for the tag's own shape.
+//! input which then gets interpolated into a download URL; [`tag_from_location`] is what
+//! validates it.
 
-/// Where releases live. A constructor argument on `ReleaseSource` rather than a hardcoded
-/// literal at the call site, so tests can drive the real code path against a local server.
+/// Where releases live. Reached through `ReleaseSource::with_base` rather than read at the call
+/// site — see [`ReleaseSource`].
 pub(crate) const GITHUB_BASE: &str = "https://github.com";
 
 /// The repo path under the base. Part of the redirect prefix check.
@@ -82,10 +82,9 @@ pub(crate) fn is_valid_tag(tag: &str) -> bool {
 
 /// Pull the release tag out of `/releases/latest`'s redirect target.
 ///
-/// Both halves matter. The prefix check pins origin *and* repo path, so a redirect to another
-/// host — or to `/releases`, which is what a repo with no published release returns — cannot be
-/// mistaken for a release. The tag check then pins the remaining segment's shape, so nothing that
-/// could escape the download path survives.
+/// The prefix check pins origin *and* repo path, so nothing [`LocationError::NotATagRedirect`]
+/// lists can be mistaken for a release. The tag check then pins the remaining segment's shape, so
+/// nothing that could escape the download path survives.
 pub(crate) fn tag_from_location(base: &str, location: &str) -> Result<String, LocationError> {
     let prefix = format!("{base}{REPO_PATH}/releases/tag/");
     let tag = location
@@ -102,8 +101,7 @@ use sha2::{Digest, Sha256};
 use std::path::Path;
 use std::time::Duration;
 
-/// How long to wait for a connection before giving up. Short: the endpoint is either reachable
-/// or it is not, and a stalled connect should report rather than hang.
+/// How long to wait for a connection. Short — a stalled connect should report rather than hang.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 /// Whole-request budget for the two small metadata requests (the redirect, the sidecar).
 const META_TIMEOUT: Duration = Duration::from_secs(60);
@@ -112,8 +110,7 @@ const META_TIMEOUT: Duration = Duration::from_secs(60);
 const ASSET_TIMEOUT: Duration = Duration::from_secs(600);
 /// How many redirects an asset fetch may follow. GitHub's real flow uses exactly one (to
 /// `objects.githubusercontent.com`); the bound is what stops a redirect loop. Compared with `>`,
-/// matching reqwest's own `Policy::limited` semantics, so "at most MAX_REDIRECTS followed" is
-/// literally what the code does.
+/// matching reqwest's own `Policy::limited` semantics.
 const MAX_REDIRECTS: usize = 5;
 
 /// Where to fetch releases from. The base is a constructor argument rather than a constant at
@@ -180,8 +177,8 @@ impl ReleaseSource {
     /// sends release downloads to objects.githubusercontent.com), bounded to
     /// [`MAX_REDIRECTS`] hops, and a hop that *changes* the scheme is refused — the check is a
     /// symmetric equality test, so an http→https upgrade is refused exactly as an https→http
-    /// downgrade is. Over https that is the "https all the way" rule, and over the tests' loopback
-    /// http it is the same rule, so production's guard is the one under test.
+    /// downgrade is. The same rule over the tests' loopback http, so production's guard is the
+    /// one under test.
     fn following_client(&self, timeout: Duration) -> anyhow::Result<reqwest::Client> {
         let policy = reqwest::redirect::Policy::custom(|attempt| {
             if attempt.previous().len() > MAX_REDIRECTS {
@@ -209,8 +206,7 @@ impl ReleaseSource {
         // `with_context` rather than folding `e` into the message with `{e}`: reqwest's `Display`
         // for a redirect-policy refusal is just "error following redirect for url (...)" — the
         // policy's own message ("too many redirects", "refusing a redirect that changes the URL
-        // scheme") only exists on `e`'s `source()`. `with_context` keeps `e` as the source instead
-        // of discarding it, so that text is still reachable from the returned error.
+        // scheme") only exists on `e`'s `source()`.
         let resp = self
             .following_client(META_TIMEOUT)?
             .get(url)
@@ -228,10 +224,8 @@ impl ReleaseSource {
     /// what was written. One pass: the binary is never fully buffered in memory, and the digest
     /// describes the bytes that actually landed rather than a re-read of the file.
     ///
-    /// On any failure the partial file is removed, so a failed download leaves nothing behind for
-    /// a later run to trip over. The removal is best-effort: its result is dropped because a
-    /// failed unlink says nothing the caller can act on, and reporting it would hide the download
-    /// error that is the actual reason for the failure.
+    /// On any failure the partial file is removed, best-effort — reporting a failed unlink would
+    /// hide the download error that is the actual reason for the failure.
     pub(crate) async fn download_to(&self, url: &str, dest: &Path) -> anyhow::Result<String> {
         match self.download_inner(url, dest).await {
             Ok(digest) => Ok(digest),
@@ -245,8 +239,7 @@ impl ReleaseSource {
     async fn download_inner(&self, url: &str, dest: &Path) -> anyhow::Result<String> {
         use std::io::Write;
 
-        // See the matching comment on `fetch_text`: `with_context` keeps the redirect policy's
-        // refusal message reachable via the error's source chain instead of discarding it.
+        // See `fetch_text`: `with_context` keeps the policy's refusal message on the source chain.
         let mut resp = self
             .following_client(ASSET_TIMEOUT)?
             .get(url)
@@ -257,8 +250,7 @@ impl ReleaseSource {
         if !status.is_success() {
             anyhow::bail!("{url} returned HTTP {status}");
         }
-        // Same reason as `fetch_text`: keep the `io::Error` on the source chain rather than
-        // flattening it into the message, so the errno behind "could not write" survives.
+        // Same reason as `fetch_text`: keep the `io::Error`'s errno on the source chain.
         let mut file = std::fs::File::create(dest)
             .with_context(|| format!("could not write {}", dest.display()))?;
         let mut hasher = Sha256::new();
@@ -321,7 +313,7 @@ mod tests {
     }
 
     /// A repo with no published release redirects to `/releases`, and a GitHub error page during
-    /// an incident lands here too. Neither may be reported as "you are up to date".
+    /// an incident lands here too — neither may be reported as "you are up to date".
     #[test]
     fn a_redirect_without_a_tag_segment_is_an_error() {
         assert!(matches!(
@@ -370,8 +362,8 @@ mod tests {
         ));
     }
 
-    /// The base is a constructor argument so tests can point at a local server; the prefix check
-    /// has to follow it, or the production origin check would be untested.
+    /// The prefix check has to follow the configured base, or the production origin check would
+    /// be untested.
     #[test]
     fn the_prefix_check_follows_the_configured_base() {
         let base = "http://127.0.0.1:8080";
@@ -388,9 +380,8 @@ mod tests {
 
     /// Asset names embed the tag WITH its `v` — `release.yml` builds them from GITHUB_REF_NAME.
     ///
-    /// Skips where no asset is published (macOS, non-x86_64): CI's macOS job runs
-    /// `cargo test --workspace --lib`, so this module executes there, and `asset_name` correctly
-    /// returns `None`. `the_asset_suffix_matches_this_build` is what asserts that case.
+    /// Returns early where no asset is published (macOS, non-x86_64);
+    /// `the_asset_suffix_matches_this_build` is what asserts that case.
     #[test]
     fn the_asset_name_keeps_the_tags_v() {
         let Some(name) = asset_name("v1.4.0") else {
@@ -437,8 +428,7 @@ mod tests {
     #[tokio::test]
     async fn a_missing_release_is_an_error_not_an_up_to_date_report() {
         // An empty tag makes the redirect land on `/releases/tag/` with nothing after it — the
-        // same shape as a repo with nothing published, or a GitHub error page. It must be an
-        // error, never a quiet "you are up to date".
+        // shape a repo with nothing published, or a GitHub error page, produces.
         let server = FakeRelease::start("", "asset", BODY, "");
         let src = ReleaseSource::with_base(server.base());
         assert!(src.latest_tag().await.is_err());
@@ -504,10 +494,9 @@ mod tests {
         assert_eq!(src.fetch_text(&url).await.unwrap(), "abc123  asset\n");
     }
 
-    /// The scheme guard, which is the reason `following_client` has a custom policy at all. The
-    /// error must be ours, not a TLS/connect failure — asserting on the word "scheme" is what
-    /// distinguishes "the policy refused it" from "it tried https on a plaintext port and
-    /// failed". Two things have to hold for that assertion to mean anything:
+    /// The scheme guard. The error must be ours, not a TLS/connect failure — asserting on the
+    /// word "scheme" is what distinguishes "the policy refused it" from "it tried https on a
+    /// plaintext port and failed". Two things have to hold for that assertion to mean anything:
     ///
     /// - It has to inspect the *root cause*, not `.to_string()` — `anyhow::Error`'s `Display`
     ///   only shows the top-level context ("could not fetch {url}"), never the policy's own
@@ -539,8 +528,7 @@ mod tests {
 
     /// The hop cap. Pins that a bound exists, not its exact value — the value is arbitrary, but a
     /// redirect loop with no bound is a hang. Root cause, not `.to_string()`, for the same reason
-    /// as the scheme test above: the top-level context and reqwest's own `Display` both only
-    /// report a URL, never the policy's "too many redirects" message.
+    /// as the scheme test above.
     #[tokio::test]
     async fn an_endless_redirect_chain_is_cut_off() {
         let dir = tempfile::tempdir().expect("tempdir");

--- a/crates/glass-mcp/src/update/release.rs
+++ b/crates/glass-mcp/src/update/release.rs
@@ -143,11 +143,14 @@ impl ReleaseSource {
             .timeout(META_TIMEOUT)
             .user_agent(concat!("glass-mcp/", env!("GLASS_VERSION")))
             .build()?;
+        // `with_context`, not `anyhow!("...: {e}")`: folding reqwest's `Display` into the message
+        // discards `e` as this error's `source()`, and the useful detail (a DNS failure, a TLS
+        // handshake error, a connect timeout) only lives on that chain.
         let resp = client
             .get(&url)
             .send()
             .await
-            .map_err(|e| anyhow::anyhow!("could not reach {url}: {e}"))?;
+            .with_context(|| format!("could not reach {url}"))?;
         let location = resp
             .headers()
             .get(reqwest::header::LOCATION)
@@ -175,19 +178,20 @@ impl ReleaseSource {
 
     /// Build the client used for asset and sidecar fetches. Redirects ARE followed here (GitHub
     /// sends release downloads to objects.githubusercontent.com), bounded to
-    /// [`MAX_REDIRECTS`] hops, and a hop that downgrades the scheme is refused — over https that
-    /// is the "https all the way" rule, and over the tests' loopback http it is the same rule, so
-    /// production's guard is the one under test.
+    /// [`MAX_REDIRECTS`] hops, and a hop that *changes* the scheme is refused — the check is a
+    /// symmetric equality test, so an http→https upgrade is refused exactly as an https→http
+    /// downgrade is. Over https that is the "https all the way" rule, and over the tests' loopback
+    /// http it is the same rule, so production's guard is the one under test.
     fn following_client(&self, timeout: Duration) -> anyhow::Result<reqwest::Client> {
         let policy = reqwest::redirect::Policy::custom(|attempt| {
             if attempt.previous().len() > MAX_REDIRECTS {
                 return attempt.error("too many redirects");
             }
-            let downgraded = attempt
+            let scheme_changed = attempt
                 .previous()
                 .first()
                 .is_some_and(|first| first.scheme() != attempt.url().scheme());
-            if downgraded {
+            if scheme_changed {
                 return attempt.error("refusing a redirect that changes the URL scheme");
             }
             attempt.follow()
@@ -225,7 +229,9 @@ impl ReleaseSource {
     /// describes the bytes that actually landed rather than a re-read of the file.
     ///
     /// On any failure the partial file is removed, so a failed download leaves nothing behind for
-    /// a later run to trip over.
+    /// a later run to trip over. The removal is best-effort: its result is dropped because a
+    /// failed unlink says nothing the caller can act on, and reporting it would hide the download
+    /// error that is the actual reason for the failure.
     pub(crate) async fn download_to(&self, url: &str, dest: &Path) -> anyhow::Result<String> {
         match self.download_inner(url, dest).await {
             Ok(digest) => Ok(digest),
@@ -251,8 +257,10 @@ impl ReleaseSource {
         if !status.is_success() {
             anyhow::bail!("{url} returned HTTP {status}");
         }
+        // Same reason as `fetch_text`: keep the `io::Error` on the source chain rather than
+        // flattening it into the message, so the errno behind "could not write" survives.
         let mut file = std::fs::File::create(dest)
-            .map_err(|e| anyhow::anyhow!("could not write {}: {e}", dest.display()))?;
+            .with_context(|| format!("could not write {}", dest.display()))?;
         let mut hasher = Sha256::new();
         while let Some(chunk) = resp.chunk().await? {
             hasher.update(&chunk);
@@ -459,6 +467,32 @@ mod tests {
         assert!(
             !dest.exists(),
             "a failed download must leave nothing behind"
+        );
+    }
+
+    /// The cleanup arm in `download_to`, actually exercised.
+    ///
+    /// The other three "leaves nothing behind" assertions in this file (a 404, a refused redirect,
+    /// an endless chain) are all satisfied for the wrong reason: every one of them fails inside
+    /// `send()`, before `File::create` has run, so `dest` never existed and deleting the cleanup
+    /// arm keeps all three green. This case fails mid-body instead — the server declares a
+    /// `Content-Length` larger than the body it sends and then closes — which means the file has
+    /// been created and partly written by the time the error surfaces. Remove the `remove_file`
+    /// in `download_to` and only this test goes red.
+    #[tokio::test]
+    async fn a_download_that_dies_mid_body_removes_the_partial_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dest = dir.path().join("downloaded");
+        let server = FakeRelease::start("v1.4.0", "asset", BODY, "");
+        let src = ReleaseSource::with_base(server.base());
+        let url = format!("{}/truncated", server.base());
+        assert!(
+            src.download_to(&url, &dest).await.is_err(),
+            "a truncated body must not be reported as a completed download"
+        );
+        assert!(
+            !dest.exists(),
+            "a download that failed after the file was created must still leave nothing behind"
         );
     }
 

--- a/crates/glass-mcp/src/update/release.rs
+++ b/crates/glass-mcp/src/update/release.rs
@@ -1,0 +1,226 @@
+//! Where a release lives, and what to call its asset.
+//!
+//! "Latest" is resolved by following `/releases/latest`'s redirect rather than through the REST
+//! API: no token, no 60/hr unauthenticated rate limit, no JSON, and GitHub already excludes
+//! prereleases from that endpoint. The cost is that the `Location` header is attacker-influenced
+//! input which then gets interpolated into a download URL, so it is validated twice here — once
+//! for the redirect target's prefix, once for the tag's own shape.
+
+/// Where releases live. A constructor argument on `ReleaseSource` rather than a hardcoded
+/// literal at the call site, so tests can drive the real code path against a local server.
+pub(crate) const GITHUB_BASE: &str = "https://github.com";
+
+/// The repo path under the base. Part of the redirect prefix check.
+pub(crate) const REPO_PATH: &str = "/fixed-width/glass";
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum LocationError {
+    /// No `Location` header on a response that should have redirected.
+    Missing,
+    /// The redirect did not land on this repo's `/releases/tag/` path — a repo with no published
+    /// release (GitHub redirects to `/releases`), an error page, or a foreign origin.
+    NotATagRedirect,
+    /// The right shape of URL, but the final segment is not a release tag.
+    MalformedTag(String),
+}
+
+/// The platform asset suffix this binary was built for, from compile-time facts rather than
+/// runtime probing: the running binary knows how it was built, so gnu-vs-musl needs no heuristic
+/// and an update is always like-for-like. `None` means this target has no published asset.
+pub(crate) fn asset_suffix() -> Option<&'static str> {
+    #[cfg(all(target_os = "linux", target_arch = "x86_64", target_env = "musl"))]
+    {
+        Some("x86_64-linux-musl")
+    }
+    #[cfg(all(target_os = "linux", target_arch = "x86_64", not(target_env = "musl")))]
+    {
+        Some("x86_64-linux-gnu")
+    }
+    #[cfg(all(windows, target_arch = "x86_64"))]
+    {
+        Some("x86_64-windows.exe")
+    }
+    #[cfg(not(any(
+        all(target_os = "linux", target_arch = "x86_64"),
+        all(windows, target_arch = "x86_64")
+    )))]
+    {
+        None
+    }
+}
+
+/// The bare-binary asset published for `tag` on this target. Keeps the tag's leading `v`:
+/// `release.yml` names assets from `GITHUB_REF_NAME`, which is the tag itself.
+pub(crate) fn asset_name(tag: &str) -> Option<String> {
+    Some(format!("glass-mcp-{tag}-{}", asset_suffix()?))
+}
+
+/// Is this a glass release tag? `v` plus a numeric triple plus an optional letter-initial
+/// prerelease. Anything else — a path separator, a query, whitespace, a `describe` suffix — is
+/// rejected before it reaches a URL.
+pub(crate) fn is_valid_tag(tag: &str) -> bool {
+    let Some(rest) = tag.strip_prefix('v') else {
+        return false;
+    };
+    let (core, pre) = match rest.split_once('-') {
+        Some((core, pre)) => (core, Some(pre)),
+        None => (rest, None),
+    };
+    let mut parts = core.split('.');
+    let triple_ok = (0..3).all(|_| {
+        parts
+            .next()
+            .is_some_and(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()))
+    }) && parts.next().is_none();
+    let pre_ok = match pre {
+        None => true,
+        Some(p) => {
+            p.starts_with(|c: char| c.is_ascii_alphabetic())
+                && p.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'.')
+        }
+    };
+    triple_ok && pre_ok
+}
+
+/// Pull the release tag out of `/releases/latest`'s redirect target.
+///
+/// Both halves matter. The prefix check pins origin *and* repo path, so a redirect to another
+/// host — or to `/releases`, which is what a repo with no published release returns — cannot be
+/// mistaken for a release. The tag check then pins the remaining segment's shape, so nothing that
+/// could escape the download path survives.
+pub(crate) fn tag_from_location(base: &str, location: &str) -> Result<String, LocationError> {
+    let prefix = format!("{base}{REPO_PATH}/releases/tag/");
+    let tag = location
+        .strip_prefix(&prefix)
+        .ok_or(LocationError::NotATagRedirect)?;
+    if !is_valid_tag(tag) {
+        return Err(LocationError::MalformedTag(tag.to_string()));
+    }
+    Ok(tag.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BASE: &str = "https://github.com";
+
+    #[test]
+    fn a_release_tag_is_valid() {
+        assert!(is_valid_tag("v1.3.0"));
+        assert!(is_valid_tag("v1.2.0-rc1"));
+        assert!(is_valid_tag("v10.20.30"));
+    }
+
+    /// The tag is interpolated into a download URL, so anything that could escape the release
+    /// path has to be rejected here rather than sanitized later.
+    #[test]
+    fn a_tag_that_could_escape_the_url_is_rejected() {
+        for t in [
+            "v1.3.0/../../evil",
+            "../v1.3.0",
+            "v1.3.0?x=1",
+            "v1.3.0#f",
+            "v1.3.0 ",
+            "1.3.0",
+            "vv1.3.0",
+            "v1.3.0-5-g563feea",
+            "",
+        ] {
+            assert!(!is_valid_tag(t), "{t:?} must be rejected");
+        }
+    }
+
+    #[test]
+    fn the_tag_comes_out_of_a_well_formed_location() {
+        let loc = "https://github.com/fixed-width/glass/releases/tag/v1.4.0";
+        assert_eq!(tag_from_location(BASE, loc).unwrap(), "v1.4.0");
+    }
+
+    /// A repo with no published release redirects to `/releases`, and a GitHub error page during
+    /// an incident lands here too. Neither may be reported as "you are up to date".
+    #[test]
+    fn a_redirect_without_a_tag_segment_is_an_error() {
+        assert!(matches!(
+            tag_from_location(BASE, "https://github.com/fixed-width/glass/releases"),
+            Err(LocationError::NotATagRedirect)
+        ));
+    }
+
+    #[test]
+    fn a_redirect_off_the_expected_prefix_is_an_error() {
+        for loc in [
+            "https://evil.example/fixed-width/glass/releases/tag/v1.4.0",
+            "http://github.com/fixed-width/glass/releases/tag/v1.4.0",
+            "https://github.com/someone/else/releases/tag/v1.4.0",
+        ] {
+            assert!(
+                matches!(
+                    tag_from_location(BASE, loc),
+                    Err(LocationError::NotATagRedirect)
+                ),
+                "{loc:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn a_malformed_tag_in_an_otherwise_valid_location_is_an_error() {
+        let loc = "https://github.com/fixed-width/glass/releases/tag/v1.4.0/../../evil";
+        assert!(matches!(
+            tag_from_location(BASE, loc),
+            Err(LocationError::MalformedTag(_))
+        ));
+    }
+
+    /// The base is a constructor argument so tests can point at a local server; the prefix check
+    /// has to follow it, or the production origin check would be untested.
+    #[test]
+    fn the_prefix_check_follows_the_configured_base() {
+        let base = "http://127.0.0.1:8080";
+        let loc = "http://127.0.0.1:8080/fixed-width/glass/releases/tag/v1.4.0";
+        assert_eq!(tag_from_location(base, loc).unwrap(), "v1.4.0");
+        assert!(
+            tag_from_location(
+                base,
+                "https://github.com/fixed-width/glass/releases/tag/v1.4.0"
+            )
+            .is_err()
+        );
+    }
+
+    /// Asset names embed the tag WITH its `v` — `release.yml` builds them from GITHUB_REF_NAME.
+    ///
+    /// Skips where no asset is published (macOS, non-x86_64): CI's macOS job runs
+    /// `cargo test --workspace --lib`, so this module executes there, and `asset_name` correctly
+    /// returns `None`. `the_asset_suffix_matches_this_build` is what asserts that case.
+    #[test]
+    fn the_asset_name_keeps_the_tags_v() {
+        let Some(name) = asset_name("v1.4.0") else {
+            return;
+        };
+        assert!(name.starts_with("glass-mcp-v1.4.0-"), "got {name}");
+        assert!(
+            !name.contains("glass-mcp-1.4.0"),
+            "the v must not be stripped: {name}"
+        );
+    }
+
+    #[test]
+    fn the_asset_suffix_matches_this_build() {
+        let suffix = asset_suffix();
+        if cfg!(all(
+            target_os = "linux",
+            target_arch = "x86_64",
+            target_env = "musl"
+        )) {
+            assert_eq!(suffix, Some("x86_64-linux-musl"));
+        } else if cfg!(all(target_os = "linux", target_arch = "x86_64")) {
+            assert_eq!(suffix, Some("x86_64-linux-gnu"));
+        } else if cfg!(all(windows, target_arch = "x86_64")) {
+            assert_eq!(suffix, Some("x86_64-windows.exe"));
+        } else {
+            assert_eq!(suffix, None, "unsupported targets must refuse, not guess");
+        }
+    }
+}

--- a/crates/glass-mcp/src/update/release.rs
+++ b/crates/glass-mcp/src/update/release.rs
@@ -99,6 +99,7 @@ pub(crate) fn tag_from_location(base: &str, location: &str) -> Result<String, Lo
     Ok(tag.to_string())
 }
 
+use anyhow::Context as _;
 use sha2::{Digest, Sha256};
 use std::path::Path;
 use std::time::Duration;
@@ -111,6 +112,11 @@ const META_TIMEOUT: Duration = Duration::from_secs(60);
 /// Whole-request budget for the asset body. Generous, but bounded — a stalled download must not
 /// hang forever.
 const ASSET_TIMEOUT: Duration = Duration::from_secs(600);
+/// How many redirects an asset fetch may follow. GitHub's real flow uses exactly one (to
+/// `objects.githubusercontent.com`); the bound is what stops a redirect loop. Compared with `>`,
+/// matching reqwest's own `Policy::limited` semantics, so "at most MAX_REDIRECTS followed" is
+/// literally what the code does.
+const MAX_REDIRECTS: usize = 5;
 
 /// Where to fetch releases from. The base is a constructor argument rather than a constant at
 /// the call site so the tests drive this exact code against a local server; there is deliberately
@@ -170,13 +176,13 @@ impl ReleaseSource {
     }
 
     /// Build the client used for asset and sidecar fetches. Redirects ARE followed here (GitHub
-    /// sends release downloads to objects.githubusercontent.com), bounded to five hops, and a
-    /// hop that downgrades the scheme is refused — over https that is the "https all the way"
-    /// rule, and over the tests' loopback http it is the same rule, so production's guard is the
-    /// one under test.
+    /// sends release downloads to objects.githubusercontent.com), bounded to
+    /// [`MAX_REDIRECTS`] hops, and a hop that downgrades the scheme is refused — over https that
+    /// is the "https all the way" rule, and over the tests' loopback http it is the same rule, so
+    /// production's guard is the one under test.
     fn following_client(&self, timeout: Duration) -> anyhow::Result<reqwest::Client> {
         let policy = reqwest::redirect::Policy::custom(|attempt| {
-            if attempt.previous().len() >= 5 {
+            if attempt.previous().len() > MAX_REDIRECTS {
                 return attempt.error("too many redirects");
             }
             let downgraded = attempt
@@ -198,12 +204,17 @@ impl ReleaseSource {
 
     /// Fetch a small text resource — the checksum sidecar.
     pub(crate) async fn fetch_text(&self, url: &str) -> anyhow::Result<String> {
+        // `with_context` rather than folding `e` into the message with `{e}`: reqwest's `Display`
+        // for a redirect-policy refusal is just "error following redirect for url (...)" — the
+        // policy's own message ("too many redirects", "refusing a redirect that changes the URL
+        // scheme") only exists on `e`'s `source()`. `with_context` keeps `e` as the source instead
+        // of discarding it, so that text is still reachable from the returned error.
         let resp = self
             .following_client(META_TIMEOUT)?
             .get(url)
             .send()
             .await
-            .map_err(|e| anyhow::anyhow!("could not fetch {url}: {e}"))?;
+            .with_context(|| format!("could not fetch {url}"))?;
         let status = resp.status();
         if !status.is_success() {
             anyhow::bail!("{url} returned HTTP {status}");
@@ -230,12 +241,14 @@ impl ReleaseSource {
     async fn download_inner(&self, url: &str, dest: &Path) -> anyhow::Result<String> {
         use std::io::Write;
 
+        // See the matching comment on `fetch_text`: `with_context` keeps the redirect policy's
+        // refusal message reachable via the error's source chain instead of discarding it.
         let mut resp = self
             .following_client(ASSET_TIMEOUT)?
             .get(url)
             .send()
             .await
-            .map_err(|e| anyhow::anyhow!("could not fetch {url}: {e}"))?;
+            .with_context(|| format!("could not fetch {url}"))?;
         let status = resp.status();
         if !status.is_success() {
             anyhow::bail!("{url} returned HTTP {status}");
@@ -457,5 +470,61 @@ mod tests {
         let src = ReleaseSource::with_base(server.base());
         let url = format!("{}.sha256", src.asset_url("v1.4.0", "asset"));
         assert_eq!(src.fetch_text(&url).await.unwrap(), "abc123  asset\n");
+    }
+
+    /// The scheme guard, which is the reason `following_client` has a custom policy at all. The
+    /// error must be ours, not a TLS/connect failure — asserting on the word "scheme" is what
+    /// distinguishes "the policy refused it" from "it tried https on a plaintext port and
+    /// failed". Two things have to hold for that assertion to mean anything:
+    ///
+    /// - It has to inspect the *root cause*, not `.to_string()` — `anyhow::Error`'s `Display`
+    ///   only shows the top-level context ("could not fetch {url}"), never the policy's own
+    ///   message, which lives on the source chain (see the `with_context` calls in `fetch_text`
+    ///   and `download_inner`).
+    /// - It has to inspect the *last* link in that chain, not "does any link contain the word" —
+    ///   both the context string and reqwest's own `Display` for the failure echo the request
+    ///   URL, and this test's URL is `/redirect/scheme`, which trivially contains "scheme" on its
+    ///   own. Only the deepest cause — the literal string passed to `attempt.error(...)`, which
+    ///   never carries a URL — is guaranteed free of that coincidence.
+    #[tokio::test]
+    async fn a_redirect_that_changes_the_scheme_is_refused() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dest = dir.path().join("downloaded");
+        let server = FakeRelease::start("v1.4.0", "asset", BODY, "");
+        let src = ReleaseSource::with_base(server.base());
+        let url = format!("{}/redirect/scheme", server.base());
+        let err = src.download_to(&url, &dest).await.unwrap_err();
+        let root_cause = err.chain().last().expect("at least one link").to_string();
+        assert!(
+            root_cause.contains("scheme"),
+            "expected the scheme guard as the root cause, got: {root_cause}"
+        );
+        assert!(
+            !dest.exists(),
+            "a refused redirect must leave nothing behind"
+        );
+    }
+
+    /// The hop cap. Pins that a bound exists, not its exact value — the value is arbitrary, but a
+    /// redirect loop with no bound is a hang. Root cause, not `.to_string()`, for the same reason
+    /// as the scheme test above: the top-level context and reqwest's own `Display` both only
+    /// report a URL, never the policy's "too many redirects" message.
+    #[tokio::test]
+    async fn an_endless_redirect_chain_is_cut_off() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dest = dir.path().join("downloaded");
+        let server = FakeRelease::start("v1.4.0", "asset", BODY, "");
+        let src = ReleaseSource::with_base(server.base());
+        let url = format!("{}/redirect/chain/0", server.base());
+        let err = src.download_to(&url, &dest).await.unwrap_err();
+        let root_cause = err.chain().last().expect("at least one link").to_string();
+        assert!(
+            root_cause.contains("too many redirects"),
+            "expected the hop cap as the root cause, got: {root_cause}"
+        );
+        assert!(
+            !dest.exists(),
+            "a refused redirect must leave nothing behind"
+        );
     }
 }

--- a/crates/glass-mcp/src/update/swap.rs
+++ b/crates/glass-mcp/src/update/swap.rs
@@ -69,9 +69,11 @@ fn displaced_path(target: &Path, pid: u32) -> std::path::PathBuf {
 
 /// Is `entry` a binary `swap` displaced — `<exe name>.old-<pid>`?
 ///
-/// Pure, and deliberately NOT cfg-gated: the Windows sweep cannot run on a Linux dev box, so this
-/// keeps the part of it that is ordinary string matching testable everywhere. Requiring the suffix
-/// to be all digits is what stops a user's own `glass-mcp.exe.old-notes.txt` being deleted.
+/// Pure, and gated to `windows` OR `test` rather than to `windows` alone: the Windows sweep cannot
+/// run on a Linux dev box, so this keeps the part of it that is ordinary string matching testable
+/// there. Requiring the suffix to be all digits is what stops a user's own
+/// `glass-mcp.exe.old-notes.txt` being deleted.
+#[cfg(any(windows, test))]
 fn is_displaced(entry: &str, exe_name: &str) -> bool {
     entry
         .strip_prefix(&format!("{exe_name}.old-"))

--- a/crates/glass-mcp/src/update/swap.rs
+++ b/crates/glass-mcp/src/update/swap.rs
@@ -1,0 +1,141 @@
+//! Putting the new binary where the old one was.
+//!
+//! The two platforms need genuinely different mechanisms, so they are two functions with one
+//! signature rather than one function with an internal branch.
+
+use std::path::Path;
+
+/// Replace `target` with `temp`.
+///
+/// Unix: a single `rename` within one directory, which is atomic — there is no instant at which
+/// `target` is missing or half-written. That is why the download lands beside the target rather
+/// than in `/tmp`: a cross-filesystem move would be a copy, and a copy has a window.
+#[cfg(unix)]
+pub(crate) fn swap(temp: &Path, target: &Path) -> anyhow::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(temp, std::fs::Permissions::from_mode(0o755))
+        .map_err(|e| anyhow::anyhow!("could not make {} executable: {e}", temp.display()))?;
+    std::fs::rename(temp, target)
+        .map_err(|e| anyhow::anyhow!("could not replace {}: {e}", target.display()))?;
+    Ok(())
+}
+
+/// Windows cannot do this atomically: the file being replaced is the running image of the process
+/// doing the replacing, and Windows holds a lock against writing or deleting it. It does permit
+/// *renaming* it, so the running image is moved aside first and the new binary takes its place.
+///
+/// If the second rename fails the first is undone, so a failed update leaves the original binary
+/// exactly where it was.
+#[cfg(windows)]
+pub(crate) fn swap(temp: &Path, target: &Path) -> anyhow::Result<()> {
+    let mut displaced = target.as_os_str().to_os_string();
+    displaced.push(format!(".old-{}", std::process::id()));
+    let displaced = std::path::PathBuf::from(displaced);
+
+    std::fs::rename(target, &displaced)
+        .map_err(|e| anyhow::anyhow!("could not move the running binary aside: {e}"))?;
+    if let Err(e) = std::fs::rename(temp, target) {
+        // Put it back. The update fails, but the install is intact.
+        let _ = std::fs::rename(&displaced, target);
+        return Err(anyhow::anyhow!(
+            "could not put the new binary in place: {e}"
+        ));
+    }
+    Ok(())
+}
+
+/// Delete any binaries a previous update moved aside.
+///
+/// Windows only, and best-effort: the displaced file cannot be deleted while it is still some
+/// process's running image, which is exactly the case during the update that created it. The next
+/// run is when it goes away, so failure here is expected and silent.
+#[cfg(windows)]
+pub(crate) fn sweep_old(dir: &Path) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        if name.to_string_lossy().starts_with("glass-mcp.exe.old-") {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
+}
+
+/// No displaced binaries exist on Unix — the rename is atomic and leaves nothing behind.
+#[cfg(unix)]
+pub(crate) fn sweep_old(_dir: &Path) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_target_ends_up_holding_the_new_bytes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("glass-mcp");
+        let temp = dir.path().join(".glass-mcp.update-1");
+        std::fs::write(&target, b"old").unwrap();
+        std::fs::write(&temp, b"new").unwrap();
+
+        swap(&temp, &target).expect("swap");
+
+        assert_eq!(std::fs::read(&target).unwrap(), b"new");
+        assert!(!temp.exists(), "the temp file is consumed by the swap");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn the_swapped_binary_is_executable() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("glass-mcp");
+        let temp = dir.path().join(".glass-mcp.update-1");
+        std::fs::write(&target, b"old").unwrap();
+        std::fs::write(&temp, b"new").unwrap();
+        // Downloaded files land 0644; without the chmod the swapped-in binary cannot be run.
+        std::fs::set_permissions(&temp, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        swap(&temp, &target).expect("swap");
+
+        let mode = std::fs::metadata(&target).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o755, "got {:o}", mode & 0o777);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn the_displaced_binary_is_left_behind_for_the_sweep() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("glass-mcp.exe");
+        let temp = dir.path().join(".glass-mcp.update-1");
+        std::fs::write(&target, b"old").unwrap();
+        std::fs::write(&temp, b"new").unwrap();
+
+        swap(&temp, &target).expect("swap");
+
+        assert_eq!(std::fs::read(&target).unwrap(), b"new");
+        let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.starts_with("glass-mcp.exe.old-"))
+            .collect();
+        assert_eq!(
+            leftovers.len(),
+            1,
+            "expected one displaced binary, got {leftovers:?}"
+        );
+
+        sweep_old(dir.path());
+        let after: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.starts_with("glass-mcp.exe.old-"))
+            .collect();
+        assert!(
+            after.is_empty(),
+            "sweep_old must delete what it can: {after:?}"
+        );
+    }
+}

--- a/crates/glass-mcp/src/update/swap.rs
+++ b/crates/glass-mcp/src/update/swap.rs
@@ -1,7 +1,6 @@
 //! Putting the new binary where the old one was.
 //!
-//! The two platforms need genuinely different mechanisms, so they are two functions with one
-//! signature rather than one function with an internal branch.
+//! The two platforms need genuinely different mechanisms — two functions with one signature.
 
 use std::path::Path;
 
@@ -38,7 +37,7 @@ pub(crate) fn swap(temp: &Path, target: &Path) -> anyhow::Result<()> {
     if let Err(e) = std::fs::rename(temp, target) {
         // Put it back — and check that it worked. If the restore ALSO fails, the target path now
         // holds nothing at all, and reporting "the install is intact" would be a lie at the worst
-        // possible moment. Say what happened and name where the old binary actually is.
+        // possible moment.
         if let Err(restore) = std::fs::rename(&displaced, target) {
             return Err(anyhow::anyhow!(
                 "could not put the new binary in place ({e}), and could not restore the old one \
@@ -86,8 +85,8 @@ fn is_displaced(entry: &str, exe_name: &str) -> bool {
 /// process's running image, which is exactly the case during the update that created it. The next
 /// run is when it goes away, so failure here is expected and silent.
 ///
-/// Takes the executable's path rather than its directory, so the prefix it matches is derived from
-/// the same name `swap` displaced rather than hardcoded a second time.
+/// Takes the executable's path rather than its directory, so the prefix comes from the same name
+/// `swap` displaced.
 #[cfg(windows)]
 pub(crate) fn sweep_old(exe: &Path) {
     let (Some(dir), Some(exe_name)) = (exe.parent(), exe.file_name()) else {
@@ -157,9 +156,8 @@ mod tests {
         );
     }
 
-    /// `is_displaced` is pure and not cfg-gated precisely so this can run on the Linux dev box —
-    /// the Windows sweep itself never executes here, so without this the matching rule would ship
-    /// with no test on any machine a developer actually uses.
+    /// `is_displaced` is pure and not `windows`-gated precisely so this runs on the Linux dev box,
+    /// where the Windows sweep itself never executes.
     #[test]
     fn only_a_pid_suffixed_sibling_counts_as_displaced() {
         assert!(is_displaced("glass-mcp.exe.old-1234", "glass-mcp.exe"));
@@ -184,10 +182,8 @@ mod tests {
         let temp = dir.path().join(".glass-mcp.update-1");
         std::fs::write(&target, b"old").unwrap();
         std::fs::write(&temp, b"new").unwrap();
-        // `mod.rs` creates the temp file 0755 up front (the smoke check has to execute it before
-        // `swap` ever runs), so `swap`'s own chmod is normally a no-op backstop. Set 0644 here
-        // anyway to test that backstop in isolation: without it, a temp file that somehow arrived
-        // non-executable would swap into place unable to run.
+        // `mod.rs` creates the temp file 0755 up front, so `swap`'s own chmod is normally a no-op
+        // backstop. Set 0644 here to test that backstop in isolation.
         std::fs::set_permissions(&temp, std::fs::Permissions::from_mode(0o644)).unwrap();
 
         swap(&temp, &target).expect("swap");

--- a/crates/glass-mcp/src/update/swap.rs
+++ b/crates/glass-mcp/src/update/swap.rs
@@ -5,6 +5,8 @@
 
 use std::path::Path;
 
+use anyhow::Context as _;
+
 /// Replace `target` with `temp`.
 ///
 /// Unix: a single `rename` within one directory, which is atomic — there is no instant at which
@@ -14,9 +16,9 @@ use std::path::Path;
 pub(crate) fn swap(temp: &Path, target: &Path) -> anyhow::Result<()> {
     use std::os::unix::fs::PermissionsExt;
     std::fs::set_permissions(temp, std::fs::Permissions::from_mode(0o755))
-        .map_err(|e| anyhow::anyhow!("could not make {} executable: {e}", temp.display()))?;
+        .with_context(|| format!("could not make {} executable", temp.display()))?;
     std::fs::rename(temp, target)
-        .map_err(|e| anyhow::anyhow!("could not replace {}: {e}", target.display()))?;
+        .with_context(|| format!("could not replace {}", target.display()))?;
     Ok(())
 }
 
@@ -25,23 +27,55 @@ pub(crate) fn swap(temp: &Path, target: &Path) -> anyhow::Result<()> {
 /// *renaming* it, so the running image is moved aside first and the new binary takes its place.
 ///
 /// If the second rename fails the first is undone, so a failed update leaves the original binary
-/// exactly where it was.
+/// exactly where it was — unless the restore itself fails, in which case the error says so rather
+/// than claiming the install is intact.
 #[cfg(windows)]
 pub(crate) fn swap(temp: &Path, target: &Path) -> anyhow::Result<()> {
-    let mut displaced = target.as_os_str().to_os_string();
-    displaced.push(format!(".old-{}", std::process::id()));
-    let displaced = std::path::PathBuf::from(displaced);
+    let displaced = displaced_path(target, std::process::id());
 
     std::fs::rename(target, &displaced)
-        .map_err(|e| anyhow::anyhow!("could not move the running binary aside: {e}"))?;
+        .with_context(|| format!("could not move {} aside", target.display()))?;
     if let Err(e) = std::fs::rename(temp, target) {
-        // Put it back. The update fails, but the install is intact.
-        let _ = std::fs::rename(&displaced, target);
-        return Err(anyhow::anyhow!(
-            "could not put the new binary in place: {e}"
-        ));
+        // Put it back — and check that it worked. If the restore ALSO fails, the target path now
+        // holds nothing at all, and reporting "the install is intact" would be a lie at the worst
+        // possible moment. Say what happened and name where the old binary actually is.
+        if let Err(restore) = std::fs::rename(&displaced, target) {
+            return Err(anyhow::anyhow!(
+                "could not put the new binary in place ({e}), and could not restore the old one \
+                 ({restore}) — {} is now MISSING. The previous binary is at {}; move it back.",
+                target.display(),
+                displaced.display()
+            ));
+        }
+        return Err(e).with_context(|| {
+            format!(
+                "could not put the new binary in place: {}",
+                target.display()
+            )
+        });
     }
     Ok(())
+}
+
+/// Where `swap` moves a displaced binary. Paired with [`is_displaced`] so the name `swap` writes
+/// and the name `sweep_old` looks for cannot drift apart — renaming the binary would otherwise
+/// break the sweep with no compiler or test signal.
+#[cfg(windows)]
+fn displaced_path(target: &Path, pid: u32) -> std::path::PathBuf {
+    let mut p = target.as_os_str().to_os_string();
+    p.push(format!(".old-{pid}"));
+    std::path::PathBuf::from(p)
+}
+
+/// Is `entry` a binary `swap` displaced — `<exe name>.old-<pid>`?
+///
+/// Pure, and deliberately NOT cfg-gated: the Windows sweep cannot run on a Linux dev box, so this
+/// keeps the part of it that is ordinary string matching testable everywhere. Requiring the suffix
+/// to be all digits is what stops a user's own `glass-mcp.exe.old-notes.txt` being deleted.
+fn is_displaced(entry: &str, exe_name: &str) -> bool {
+    entry
+        .strip_prefix(&format!("{exe_name}.old-"))
+        .is_some_and(|rest| !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_digit()))
 }
 
 /// Delete any binaries a previous update moved aside.
@@ -49,14 +83,20 @@ pub(crate) fn swap(temp: &Path, target: &Path) -> anyhow::Result<()> {
 /// Windows only, and best-effort: the displaced file cannot be deleted while it is still some
 /// process's running image, which is exactly the case during the update that created it. The next
 /// run is when it goes away, so failure here is expected and silent.
+///
+/// Takes the executable's path rather than its directory, so the prefix it matches is derived from
+/// the same name `swap` displaced rather than hardcoded a second time.
 #[cfg(windows)]
-pub(crate) fn sweep_old(dir: &Path) {
+pub(crate) fn sweep_old(exe: &Path) {
+    let (Some(dir), Some(exe_name)) = (exe.parent(), exe.file_name()) else {
+        return;
+    };
+    let exe_name = exe_name.to_string_lossy().into_owned();
     let Ok(entries) = std::fs::read_dir(dir) else {
         return;
     };
     for entry in entries.flatten() {
-        let name = entry.file_name();
-        if name.to_string_lossy().starts_with("glass-mcp.exe.old-") {
+        if is_displaced(&entry.file_name().to_string_lossy(), &exe_name) {
             let _ = std::fs::remove_file(entry.path());
         }
     }
@@ -64,7 +104,7 @@ pub(crate) fn sweep_old(dir: &Path) {
 
 /// No displaced binaries exist on Unix — the rename is atomic and leaves nothing behind.
 #[cfg(unix)]
-pub(crate) fn sweep_old(_dir: &Path) {}
+pub(crate) fn sweep_old(_exe: &Path) {}
 
 #[cfg(test)]
 mod tests {
@@ -115,6 +155,24 @@ mod tests {
         );
     }
 
+    /// `is_displaced` is pure and not cfg-gated precisely so this can run on the Linux dev box —
+    /// the Windows sweep itself never executes here, so without this the matching rule would ship
+    /// with no test on any machine a developer actually uses.
+    #[test]
+    fn only_a_pid_suffixed_sibling_counts_as_displaced() {
+        assert!(is_displaced("glass-mcp.exe.old-1234", "glass-mcp.exe"));
+        // A user's own file that merely shares the prefix must survive the sweep.
+        assert!(!is_displaced(
+            "glass-mcp.exe.old-notes.txt",
+            "glass-mcp.exe"
+        ));
+        assert!(!is_displaced("glass-mcp.exe.old-", "glass-mcp.exe"));
+        assert!(!is_displaced("glass-mcp.exe", "glass-mcp.exe"));
+        assert!(!is_displaced("something-else.old-1234", "glass-mcp.exe"));
+        // Derived from the exe's own name, so a renamed binary still matches its own displacements.
+        assert!(is_displaced("other.exe.old-9", "other.exe"));
+    }
+
     #[cfg(unix)]
     #[test]
     fn the_swapped_binary_is_executable() {
@@ -157,7 +215,7 @@ mod tests {
             "expected one displaced binary, got {leftovers:?}"
         );
 
-        sweep_old(dir.path());
+        sweep_old(&target);
         let after: Vec<_> = std::fs::read_dir(dir.path())
             .unwrap()
             .filter_map(|e| e.ok())

--- a/crates/glass-mcp/src/update/swap.rs
+++ b/crates/glass-mcp/src/update/swap.rs
@@ -84,6 +84,37 @@ mod tests {
         assert!(!temp.exists(), "the temp file is consumed by the swap");
     }
 
+    /// `rename` vs `copy`: the target must end up being the temp file's inode, not its own with
+    /// new contents. This is the only assertion here that distinguishes an atomic rename from a
+    /// copy-then-delete — `the_target_ends_up_holding_the_new_bytes` passes identically for both.
+    ///
+    /// It also pins the behavior the post-update notice describes: because the old inode survives
+    /// unlinked, an already-running `serve --http` goes on serving the OLD build until restarted.
+    #[cfg(unix)]
+    #[test]
+    fn the_swap_moves_the_temp_files_inode_into_place() {
+        use std::os::unix::fs::MetadataExt;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("glass-mcp");
+        let temp = dir.path().join(".glass-mcp.update-1");
+        std::fs::write(&target, b"old").unwrap();
+        std::fs::write(&temp, b"new").unwrap();
+        let old_ino = std::fs::metadata(&target).unwrap().ino();
+        let temp_ino = std::fs::metadata(&temp).unwrap().ino();
+
+        swap(&temp, &target).expect("swap");
+
+        let new_ino = std::fs::metadata(&target).unwrap().ino();
+        assert_eq!(
+            new_ino, temp_ino,
+            "the temp file's inode must land at the target path"
+        );
+        assert_ne!(
+            new_ino, old_ino,
+            "a copy would have kept the target's original inode"
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn the_swapped_binary_is_executable() {

--- a/crates/glass-mcp/src/update/swap.rs
+++ b/crates/glass-mcp/src/update/swap.rs
@@ -184,7 +184,10 @@ mod tests {
         let temp = dir.path().join(".glass-mcp.update-1");
         std::fs::write(&target, b"old").unwrap();
         std::fs::write(&temp, b"new").unwrap();
-        // Downloaded files land 0644; without the chmod the swapped-in binary cannot be run.
+        // `mod.rs` creates the temp file 0755 up front (the smoke check has to execute it before
+        // `swap` ever runs), so `swap`'s own chmod is normally a no-op backstop. Set 0644 here
+        // anyway to test that backstop in isolation: without it, a temp file that somehow arrived
+        // non-executable would swap into place unable to run.
         std::fs::set_permissions(&temp, std::fs::Permissions::from_mode(0o644)).unwrap();
 
         swap(&temp, &target).expect("swap");

--- a/crates/glass-mcp/src/update/testserver.rs
+++ b/crates/glass-mcp/src/update/testserver.rs
@@ -1,0 +1,117 @@
+//! A four-route HTTP server for the update tests, hand-rolled over `std::net::TcpListener`.
+//!
+//! Deliberately not axum: that would tie these tests to the optional `network` feature, and glass
+//! already hand-rolls loopback HTTP in `setup::fetch_health`. Four routes, one thread, no
+//! dependencies — and because the base URL is a `ReleaseSource` constructor argument, the tests
+//! drive the real code path rather than a mock of it.
+
+use std::io::{BufRead, BufReader, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::Arc;
+use std::thread;
+
+pub(crate) struct FakeRelease {
+    port: u16,
+    _handle: thread::JoinHandle<()>,
+}
+
+struct Routes {
+    tag: String,
+    asset_name: String,
+    asset: Vec<u8>,
+    sidecar: String,
+}
+
+impl FakeRelease {
+    /// Serve `/fixed-width/glass/releases/latest` as a 302 to `tag`, plus the named asset and its
+    /// `.sha256` sidecar under `/releases/download/<tag>/`. Everything else 404s.
+    pub(crate) fn start(tag: &str, asset_name: &str, asset: &[u8], sidecar: &str) -> FakeRelease {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let port = listener.local_addr().expect("local addr").port();
+        let routes = Arc::new(Routes {
+            tag: tag.to_string(),
+            asset_name: asset_name.to_string(),
+            asset: asset.to_vec(),
+            sidecar: sidecar.to_string(),
+        });
+        let handle = thread::spawn(move || {
+            for stream in listener.incoming().flatten() {
+                let routes = Arc::clone(&routes);
+                // Serve sequentially: the update flow makes its requests one at a time, and a
+                // single-threaded server makes a hung request obvious rather than hidden.
+                serve_one(stream, &routes, port);
+            }
+        });
+        FakeRelease {
+            port,
+            _handle: handle,
+        }
+    }
+
+    pub(crate) fn base(&self) -> String {
+        format!("http://127.0.0.1:{}", self.port)
+    }
+}
+
+fn serve_one(mut stream: TcpStream, routes: &Routes, port: u16) {
+    let mut reader = BufReader::new(match stream.try_clone() {
+        Ok(s) => s,
+        Err(_) => return,
+    });
+    let mut request_line = String::new();
+    if reader.read_line(&mut request_line).unwrap_or(0) == 0 {
+        return;
+    }
+    let path = request_line
+        .split_whitespace()
+        .nth(1)
+        .unwrap_or("")
+        .to_string();
+    // Drain the headers so the client sees a clean response rather than a reset.
+    for line in reader.lines() {
+        match line {
+            Ok(l) if l.is_empty() => break,
+            Ok(_) => {}
+            Err(_) => return,
+        }
+    }
+
+    let latest = "/fixed-width/glass/releases/latest";
+    let download = format!(
+        "/fixed-width/glass/releases/download/{}/{}",
+        routes.tag, routes.asset_name
+    );
+    let sidecar = format!("{download}.sha256");
+
+    if path == latest {
+        let location = format!(
+            "http://127.0.0.1:{port}/fixed-width/glass/releases/tag/{}",
+            routes.tag
+        );
+        let _ = write!(
+            stream,
+            "HTTP/1.1 302 Found\r\nLocation: {location}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+        );
+    } else if path == sidecar {
+        let body = routes.sidecar.as_bytes();
+        let _ = write!(
+            stream,
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len()
+        );
+        let _ = stream.write_all(body);
+    } else if path == download {
+        let _ = write!(
+            stream,
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            routes.asset.len()
+        );
+        let _ = stream.write_all(&routes.asset);
+    } else {
+        let _ = write!(
+            stream,
+            "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+        );
+    }
+    let _ = stream.flush();
+}

--- a/crates/glass-mcp/src/update/testserver.rs
+++ b/crates/glass-mcp/src/update/testserver.rs
@@ -1,9 +1,7 @@
 //! A tiny HTTP server for the update tests, hand-rolled over `std::net::TcpListener`.
 //!
 //! Deliberately not axum: that would tie these tests to the optional `network` feature, and glass
-//! already hand-rolls loopback HTTP in `setup::fetch_health`. A handful of routes, one thread, no
-//! dependencies — and because the base URL is a `ReleaseSource` constructor argument, the tests
-//! drive the real code path rather than a mock of it.
+//! already hand-rolls loopback HTTP in `setup::fetch_health`.
 
 use std::io::{BufRead, BufReader, Write};
 use std::net::{TcpListener, TcpStream};
@@ -37,8 +35,8 @@ impl FakeRelease {
         let handle = thread::spawn(move || {
             for stream in listener.incoming().flatten() {
                 let routes = Arc::clone(&routes);
-                // Serve sequentially: the update flow makes its requests one at a time, and a
-                // single-threaded server makes a hung request obvious rather than hidden.
+                // Serve sequentially — the update flow makes its requests one at a time, and a
+                // hung request is then obvious.
                 serve_one(stream, &routes, port);
             }
         });
@@ -84,8 +82,7 @@ fn serve_one(mut stream: TcpStream, routes: &Routes, port: u16) {
     let sidecar = format!("{download}.sha256");
 
     // Two routes that exist only to drive `following_client`'s security policy: one redirect that
-    // changes the scheme, and one that never terminates. Without them the hop cap and the
-    // scheme-downgrade refusal have no committed coverage at all.
+    // changes the scheme, and one that never terminates.
     if path == "/redirect/scheme" {
         let _ = write!(
             stream,
@@ -94,11 +91,10 @@ fn serve_one(mut stream: TcpStream, routes: &Routes, port: u16) {
         let _ = stream.flush();
         return;
     }
-    // A response that promises more body than it delivers, then hangs up. This is the only route
-    // here that fails AFTER the destination file has been created: 404s and refused redirects all
-    // fail while `download_to` is still in `send()`, so they cannot exercise its cleanup arm at
-    // all. `Content-Length` is deliberately larger than the bytes written, which makes the client
-    // see the close as a truncated message rather than a complete one.
+    // A response that promises more body than it delivers, then hangs up: `Content-Length` is
+    // deliberately larger than the bytes written, which makes the client see the close as a
+    // truncated message rather than a complete one. The only route here that fails AFTER the
+    // destination file has been created.
     if path == "/truncated" {
         let body = b"the first half of a binary";
         let _ = write!(

--- a/crates/glass-mcp/src/update/testserver.rs
+++ b/crates/glass-mcp/src/update/testserver.rs
@@ -1,7 +1,7 @@
-//! A four-route HTTP server for the update tests, hand-rolled over `std::net::TcpListener`.
+//! A tiny HTTP server for the update tests, hand-rolled over `std::net::TcpListener`.
 //!
 //! Deliberately not axum: that would tie these tests to the optional `network` feature, and glass
-//! already hand-rolls loopback HTTP in `setup::fetch_health`. Four routes, one thread, no
+//! already hand-rolls loopback HTTP in `setup::fetch_health`. A handful of routes, one thread, no
 //! dependencies — and because the base URL is a `ReleaseSource` constructor argument, the tests
 //! drive the real code path rather than a mock of it.
 
@@ -91,6 +91,22 @@ fn serve_one(mut stream: TcpStream, routes: &Routes, port: u16) {
             stream,
             "HTTP/1.1 302 Found\r\nLocation: https://127.0.0.1:{port}/fixed-width/glass/releases/latest\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
         );
+        let _ = stream.flush();
+        return;
+    }
+    // A response that promises more body than it delivers, then hangs up. This is the only route
+    // here that fails AFTER the destination file has been created: 404s and refused redirects all
+    // fail while `download_to` is still in `send()`, so they cannot exercise its cleanup arm at
+    // all. `Content-Length` is deliberately larger than the bytes written, which makes the client
+    // see the close as a truncated message rather than a complete one.
+    if path == "/truncated" {
+        let body = b"the first half of a binary";
+        let _ = write!(
+            stream,
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len() + 4096
+        );
+        let _ = stream.write_all(body);
         let _ = stream.flush();
         return;
     }

--- a/crates/glass-mcp/src/update/testserver.rs
+++ b/crates/glass-mcp/src/update/testserver.rs
@@ -83,6 +83,26 @@ fn serve_one(mut stream: TcpStream, routes: &Routes, port: u16) {
     );
     let sidecar = format!("{download}.sha256");
 
+    // Two routes that exist only to drive `following_client`'s security policy: one redirect that
+    // changes the scheme, and one that never terminates. Without them the hop cap and the
+    // scheme-downgrade refusal have no committed coverage at all.
+    if path == "/redirect/scheme" {
+        let _ = write!(
+            stream,
+            "HTTP/1.1 302 Found\r\nLocation: https://127.0.0.1:{port}/fixed-width/glass/releases/latest\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+        );
+        let _ = stream.flush();
+        return;
+    }
+    if let Some(n) = path.strip_prefix("/redirect/chain/") {
+        let next = n.parse::<u32>().unwrap_or(0) + 1;
+        let _ = write!(
+            stream,
+            "HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:{port}/redirect/chain/{next}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+        );
+        let _ = stream.flush();
+        return;
+    }
     if path == latest {
         let location = format!(
             "http://127.0.0.1:{port}/fixed-width/glass/releases/tag/{}",

--- a/crates/glass-mcp/src/update/verify.rs
+++ b/crates/glass-mcp/src/update/verify.rs
@@ -1,0 +1,229 @@
+//! The three gates a downloaded asset passes before it is allowed to replace this binary.
+//!
+//! They run in this order and the order is the point: the checksum proves the bytes are the ones
+//! the release published, the attestation proves the release built them, and only then is the
+//! file executed for the smoke check. Nothing unverified is ever run.
+
+use std::path::Path;
+use std::process::Command;
+use std::time::Duration;
+
+/// How long the downloaded binary gets to print its version before the check gives up. Generous
+/// for a `--version` that only reads a compiled-in constant, bounded so a binary that hangs on
+/// startup fails the gate rather than the process.
+const SMOKE_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum SidecarError {
+    /// No `<hex>  <name>` line at all.
+    Malformed,
+    /// A well-formed line naming a different file — the wrong asset was fetched.
+    WrongAsset(String),
+}
+
+/// What `gh attestation verify` had to say.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum Attestation {
+    Verified,
+    /// `gh` is not on PATH. Reported, never silently skipped.
+    Unavailable,
+    /// `gh` ran and did not succeed. This is a refusal, not a warning — see `attest`.
+    Failed(String),
+}
+
+/// Pull the expected digest out of a `sha256sum` sidecar, checking it names the asset we fetched.
+///
+/// `sha256sum` writes `<hex>  <name>` in text mode and `<hex> *<name>` in binary mode; the
+/// release workflow produces the former, but both are accepted because both are what the tool
+/// emits and neither is ambiguous.
+pub(crate) fn parse_sidecar(text: &str, asset: &str) -> Result<String, SidecarError> {
+    let line = text
+        .lines()
+        .find(|l| !l.trim().is_empty())
+        .ok_or(SidecarError::Malformed)?;
+    let (hexpart, name) = line
+        .split_once(char::is_whitespace)
+        .ok_or(SidecarError::Malformed)?;
+    let name = name.trim_start().trim_start_matches('*').trim();
+    if hexpart.len() != 64 || !hexpart.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(SidecarError::Malformed);
+    }
+    if name != asset {
+        return Err(SidecarError::WrongAsset(name.to_string()));
+    }
+    Ok(hexpart.to_ascii_lowercase())
+}
+
+/// Verify the artifact's build provenance with the GitHub CLI, when it is available.
+///
+/// Any non-success is [`Attestation::Failed`], and the caller treats that as a refusal. That is
+/// deliberate: `gh attestation verify` queries GitHub's attestations API, so a GitHub outage makes
+/// it fail for a reason unrelated to the artifact — and telling "bad signature" apart from
+/// "couldn't reach GitHub" by scraping another tool's stderr is exactly the brittleness worth not
+/// building. Fail closed; `--skip-attestation` is the conscious override.
+pub(crate) fn attest(path: &Path) -> Attestation {
+    let out = Command::new("gh")
+        .args(["attestation", "verify"])
+        .arg(path)
+        .args(["--repo", "fixed-width/glass"])
+        .output();
+    match out {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Attestation::Unavailable,
+        Err(e) => Attestation::Failed(format!("could not run gh: {e}")),
+        Ok(o) if o.status.success() => Attestation::Verified,
+        Ok(o) => Attestation::Failed(String::from_utf8_lossy(&o.stderr).trim().to_string()),
+    }
+}
+
+/// Does this `--version` output report exactly `expect`?
+///
+/// Whitespace-separated exact match on a token, not a prefix test: a prefix would accept `1.4.0`
+/// where `1.4.0-rc1` was expected, and the other way round.
+pub(crate) fn version_matches(stdout: &str, expect: &str) -> bool {
+    stdout.split_whitespace().any(|tok| tok == expect)
+}
+
+/// Run the verified binary and require it to report `expect`.
+///
+/// A checksum proves the right *file* arrived; only executing it proves it runs *here*. A
+/// too-old glibc or a wrong-architecture asset passes every hash check and then fails on first
+/// use, and this is the gate that catches that before the swap rather than after.
+pub(crate) fn smoke_check(path: &Path, expect: &str) -> Result<(), String> {
+    let mut child = Command::new(path)
+        .arg("--version")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("could not run the downloaded binary: {e}"))?;
+
+    let deadline = std::time::Instant::now() + SMOKE_TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => break,
+            Ok(None) if std::time::Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(format!(
+                    "the downloaded binary did not print its version within {}s",
+                    SMOKE_TIMEOUT.as_secs()
+                ));
+            }
+            Ok(None) => std::thread::sleep(Duration::from_millis(20)),
+            Err(e) => return Err(format!("could not wait on the downloaded binary: {e}")),
+        }
+    }
+    let out = child
+        .wait_with_output()
+        .map_err(|e| format!("could not read the downloaded binary's output: {e}"))?;
+    if !out.status.success() {
+        return Err(format!(
+            "the downloaded binary exited {} — stderr: {}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    if !version_matches(&stdout, expect) {
+        return Err(format!(
+            "the downloaded binary reported {:?}, expected {expect}",
+            stdout.trim()
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ASSET: &str = "glass-mcp-v1.4.0-x86_64-linux-gnu";
+    const SHA: &str = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08";
+
+    #[test]
+    fn a_sha256sum_line_parses() {
+        let text = format!("{SHA}  {ASSET}\n");
+        assert_eq!(parse_sidecar(&text, ASSET).unwrap(), SHA);
+    }
+
+    /// `sha256sum` emits two spaces for text mode and ` *` for binary mode. Both are real.
+    #[test]
+    fn binary_mode_marker_parses() {
+        let text = format!("{SHA} *{ASSET}\n");
+        assert_eq!(parse_sidecar(&text, ASSET).unwrap(), SHA);
+    }
+
+    #[test]
+    fn uppercase_hex_is_normalized() {
+        let text = format!("{}  {ASSET}\n", SHA.to_uppercase());
+        assert_eq!(parse_sidecar(&text, ASSET).unwrap(), SHA);
+    }
+
+    /// A sidecar naming a different asset means the wrong file was fetched, which is exactly the
+    /// mix-up a checksum is supposed to catch — so it must not be accepted just because the hex
+    /// is well formed.
+    #[test]
+    fn a_sidecar_for_another_asset_is_rejected() {
+        let text = format!("{SHA}  some-other-asset\n");
+        assert!(matches!(
+            parse_sidecar(&text, ASSET),
+            Err(SidecarError::WrongAsset(_))
+        ));
+    }
+
+    #[test]
+    fn malformed_sidecars_are_rejected() {
+        for text in [
+            "",
+            "\n",
+            "not-hex-at-all  glass-mcp-v1.4.0-x86_64-linux-gnu\n",
+            "9f86d081  glass-mcp-v1.4.0-x86_64-linux-gnu\n",
+            "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08\n",
+            // Right length (64), wrong alphabet — none of the above cases are the right length,
+            // so this one is the only case that exercises the hex-digit check rather than the
+            // length check.
+            "gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg  glass-mcp-v1.4.0-x86_64-linux-gnu\n",
+        ] {
+            assert!(
+                parse_sidecar(text, ASSET).is_err(),
+                "{text:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn the_smoke_check_accepts_only_the_expected_version() {
+        assert!(version_matches("1.4.0\n", "1.4.0"));
+        assert!(version_matches("glass-mcp 1.4.0\n", "1.4.0"));
+        assert!(!version_matches("1.3.0\n", "1.4.0"));
+        assert!(!version_matches("", "1.4.0"));
+        // A prefix match would accept 1.4.0 for an expected 1.4.0-rc1 and vice versa.
+        assert!(!version_matches("1.4.0\n", "1.4.0-rc1"));
+        assert!(!version_matches("1.4.0-rc1\n", "1.4.0"));
+    }
+
+    /// The spawn half of the smoke check, against a real executable. Unix-only: the fixture is a
+    /// shell script. The Windows spawn path is covered by the manual `lotus` run in the close-out.
+    #[cfg(unix)]
+    #[test]
+    fn the_smoke_check_runs_the_binary_and_reads_its_version() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let good = dir.path().join("good");
+        std::fs::write(&good, "#!/bin/sh\necho 1.4.0\n").unwrap();
+        std::fs::set_permissions(&good, std::fs::Permissions::from_mode(0o755)).unwrap();
+        assert!(smoke_check(&good, "1.4.0").is_ok());
+
+        let bad = dir.path().join("bad");
+        std::fs::write(&bad, "#!/bin/sh\nexit 127\n").unwrap();
+        std::fs::set_permissions(&bad, std::fs::Permissions::from_mode(0o755)).unwrap();
+        assert!(smoke_check(&bad, "1.4.0").is_err());
+
+        // Exits 0 — a naive check that only looked at the exit status would pass this — but
+        // prints the wrong version, which is exactly the mismatch the gate exists to catch.
+        let wrong_version = dir.path().join("wrong-version");
+        std::fs::write(&wrong_version, "#!/bin/sh\necho 1.3.0\n").unwrap();
+        std::fs::set_permissions(&wrong_version, std::fs::Permissions::from_mode(0o755)).unwrap();
+        assert!(smoke_check(&wrong_version, "1.4.0").is_err());
+    }
+}

--- a/crates/glass-mcp/src/update/verify.rs
+++ b/crates/glass-mcp/src/update/verify.rs
@@ -54,6 +54,13 @@ pub(crate) fn parse_sidecar(text: &str, asset: &str) -> Result<String, SidecarEr
     Ok(hexpart.to_ascii_lowercase())
 }
 
+/// The GitHub CLI, as the binary invokes it. Named here and passed in as an argument rather than
+/// written as a literal inside [`attest`], so a test can point the same code at a program that is
+/// guaranteed absent (or guaranteed to fail) instead of depending on whether the host happens to
+/// have `gh` installed — and, more importantly, without any test ever running the real
+/// `gh attestation verify`, which queries GitHub over the network.
+pub(crate) const GH: &str = "gh";
+
 /// Verify the artifact's build provenance with the GitHub CLI, when it is available.
 ///
 /// Any non-success is [`Attestation::Failed`], and the caller treats that as a refusal. That is
@@ -61,17 +68,27 @@ pub(crate) fn parse_sidecar(text: &str, asset: &str) -> Result<String, SidecarEr
 /// it fail for a reason unrelated to the artifact — and telling "bad signature" apart from
 /// "couldn't reach GitHub" by scraping another tool's stderr is exactly the brittleness worth not
 /// building. Fail closed; `--skip-attestation` is the conscious override.
-pub(crate) fn attest(path: &Path) -> Attestation {
-    let out = Command::new("gh")
+pub(crate) fn attest(program: &str, path: &Path) -> Attestation {
+    let out = Command::new(program)
         .args(["attestation", "verify"])
         .arg(path)
         .args(["--repo", "fixed-width/glass"])
         .output();
     match out {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Attestation::Unavailable,
-        Err(e) => Attestation::Failed(format!("could not run gh: {e}")),
+        Err(e) => Attestation::Failed(format!("could not run {program}: {e}")),
         Ok(o) if o.status.success() => Attestation::Verified,
-        Ok(o) => Attestation::Failed(String::from_utf8_lossy(&o.stderr).trim().to_string()),
+        Ok(o) => {
+            // `gh` normally explains itself on stderr, but it is not required to: a tool that
+            // exits non-zero silently would otherwise produce a refusal whose reason is the empty
+            // string. Fall back to the one fact we always have.
+            let stderr = String::from_utf8_lossy(&o.stderr).trim().to_string();
+            Attestation::Failed(if stderr.is_empty() {
+                format!("{program} exited {} without explaining why", o.status)
+            } else {
+                stderr
+            })
+        }
     }
 }
 
@@ -183,8 +200,9 @@ mod tests {
             // so this one is the only case that exercises the hex-digit check rather than the
             // length check.
             "gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg  glass-mcp-v1.4.0-x86_64-linux-gnu\n",
-            // 65 hex chars. Without an over-length case, weakening `len() != 64` to `len() < 64`
-            // survives the whole suite — and this crate is mutation-gated in CI.
+            // 65 hex chars — the only over-length case here. Every other input in this list is
+            // either too short or not hex, so all of them are still rejected if `len() != 64` is
+            // weakened to `len() < 64`; this is the one that stops that weakening passing.
             "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08a  glass-mcp-v1.4.0-x86_64-linux-gnu\n",
         ] {
             assert!(
@@ -192,6 +210,29 @@ mod tests {
                 "{text:?} must be rejected"
             );
         }
+    }
+
+    /// A tool that exits non-zero without printing anything. `String::from_utf8_lossy(&stderr)`
+    /// is empty there, so the refusal built straight from it would read "build provenance could
+    /// not be verified: " — a refusal with no reason at all. Unix-only, because `false` is what
+    /// makes a silent non-zero exit available without shipping a fixture.
+    ///
+    /// The `Unavailable` arm has its own coverage through the whole flow, in `mod.rs`'s
+    /// `a_missing_gh_is_recorded_rather_than_treated_as_verified`. It is not duplicated here on
+    /// purpose: spawning a program that does *not* exist leaves the forked child holding every
+    /// inherited descriptor until its failed `execve` returns, and this test binary has other
+    /// threads writing files they are about to execute — see [`is_etxtbsy`] below.
+    #[cfg(unix)]
+    #[test]
+    fn a_silent_non_zero_exit_still_says_something() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("artifact");
+        std::fs::write(&path, b"bytes").unwrap();
+        let Attestation::Failed(why) = attest("false", &path) else {
+            panic!("a non-zero exit must be Failed");
+        };
+        assert!(!why.trim().is_empty(), "the reason must not be empty");
+        assert!(why.contains("false"), "it must name the tool: {why}");
     }
 
     #[test]
@@ -205,6 +246,35 @@ mod tests {
         assert!(!version_matches("1.4.0-rc1\n", "1.4.0"));
     }
 
+    /// Is this failure the test harness rather than the code under test?
+    ///
+    /// Writing a file and then executing it inside one multi-threaded process is racy on Linux
+    /// through no fault of either step: `cargo test` runs these tests in threads, a `fork` in any
+    /// other thread inherits every descriptor open at that instant — including the write handle
+    /// this thread still holds on the fixture — and the child keeps it until its own `execve`
+    /// returns. `execve` on a file some process holds open for writing fails with ETXTBSY. The
+    /// updater itself is one sequential flow that never forks while its download is open, so this
+    /// window exists only inside the test binary — but it is wide enough to fail runs, which is
+    /// why [`retry_etxtbsy`] exists.
+    #[cfg(unix)]
+    fn is_etxtbsy(message: &str) -> bool {
+        message.contains("Text file busy") || message.contains("os error 26")
+    }
+
+    /// Call `f` until it stops reporting ETXTBSY. Bounded, and every other error is returned on
+    /// the first attempt — this retries the harness race described above and nothing else, so a
+    /// smoke check that genuinely fails still fails immediately.
+    #[cfg(unix)]
+    fn retry_etxtbsy(mut f: impl FnMut() -> Result<(), String>) -> Result<(), String> {
+        for _ in 0..20 {
+            match f() {
+                Err(e) if is_etxtbsy(&e) => std::thread::sleep(Duration::from_millis(20)),
+                other => return other,
+            }
+        }
+        f()
+    }
+
     /// The spawn half of the smoke check, against a real executable. Unix-only: the fixture is a
     /// shell script. The Windows spawn path is covered by the manual `lotus` run in the close-out.
     #[cfg(unix)]
@@ -215,7 +285,7 @@ mod tests {
         let good = dir.path().join("good");
         std::fs::write(&good, "#!/bin/sh\necho 1.4.0\n").unwrap();
         std::fs::set_permissions(&good, std::fs::Permissions::from_mode(0o755)).unwrap();
-        assert!(smoke_check(&good, "1.4.0").is_ok());
+        assert!(retry_etxtbsy(|| smoke_check(&good, "1.4.0")).is_ok());
 
         let bad = dir.path().join("bad");
         std::fs::write(&bad, "#!/bin/sh\nexit 127\n").unwrap();

--- a/crates/glass-mcp/src/update/verify.rs
+++ b/crates/glass-mcp/src/update/verify.rs
@@ -1,8 +1,8 @@
 //! The three gates a downloaded asset passes before it is allowed to replace this binary.
 //!
-//! They run in this order and the order is the point: the checksum proves the bytes are the ones
-//! the release published, the attestation proves the release built them, and only then is the
-//! file executed for the smoke check. Nothing unverified is ever run.
+//! They run in this order: the checksum proves the bytes are the ones the release published, the
+//! attestation proves the release built them, and only then is the file executed for the smoke
+//! check.
 
 use std::path::Path;
 use std::process::Command;
@@ -35,7 +35,7 @@ pub(crate) enum Attestation {
 ///
 /// `sha256sum` writes `<hex>  <name>` in text mode and `<hex> *<name>` in binary mode; the
 /// release workflow produces the former, but both are accepted because both are what the tool
-/// emits and neither is ambiguous.
+/// emits.
 pub(crate) fn parse_sidecar(text: &str, asset: &str) -> Result<String, SidecarError> {
     let line = text
         .lines()
@@ -54,11 +54,8 @@ pub(crate) fn parse_sidecar(text: &str, asset: &str) -> Result<String, SidecarEr
     Ok(hexpart.to_ascii_lowercase())
 }
 
-/// The GitHub CLI, as the binary invokes it. Named here and passed in as an argument rather than
-/// written as a literal inside [`attest`], so a test can point the same code at a program that is
-/// guaranteed absent (or guaranteed to fail) instead of depending on whether the host happens to
-/// have `gh` installed — and, more importantly, without any test ever running the real
-/// `gh attestation verify`, which queries GitHub over the network.
+/// The GitHub CLI, as the binary invokes it. An argument to [`attest`] rather than a literal
+/// inside it, so no test ever runs the real `gh attestation verify`, which queries GitHub.
 pub(crate) const GH: &str = "gh";
 
 /// Verify the artifact's build provenance with the GitHub CLI, when it is available.
@@ -220,11 +217,10 @@ mod tests {
     /// not be verified: " — a refusal with no reason at all. Unix-only, because `false` is what
     /// makes a silent non-zero exit available without shipping a fixture.
     ///
-    /// The `Unavailable` arm has its own coverage through the whole flow, in `mod.rs`'s
-    /// `a_missing_gh_is_recorded_rather_than_treated_as_verified`. It is not duplicated here on
-    /// purpose: spawning a program that does *not* exist leaves the forked child holding every
-    /// inherited descriptor until its failed `execve` returns, and this test binary has other
-    /// threads writing files they are about to execute — see [`is_etxtbsy`] below.
+    /// The `Unavailable` arm is covered through the whole flow by `mod.rs`'s
+    /// `a_missing_gh_is_recorded_rather_than_treated_as_verified`, not duplicated here: spawning a
+    /// program that does *not* exist leaves the forked child holding every inherited descriptor
+    /// until its failed `execve` returns — see [`is_etxtbsy`] below.
     #[cfg(unix)]
     #[test]
     fn a_silent_non_zero_exit_still_says_something() {
@@ -251,22 +247,20 @@ mod tests {
 
     /// Is this failure the test harness rather than the code under test?
     ///
-    /// Writing a file and then executing it inside one multi-threaded process is racy on Linux
-    /// through no fault of either step: `cargo test` runs these tests in threads, a `fork` in any
-    /// other thread inherits every descriptor open at that instant — including the write handle
-    /// this thread still holds on the fixture — and the child keeps it until its own `execve`
-    /// returns. `execve` on a file some process holds open for writing fails with ETXTBSY. The
-    /// updater itself is one sequential flow that never forks while its download is open, so this
-    /// window exists only inside the test binary — but it is wide enough to fail runs, which is
-    /// why [`retry_etxtbsy`] exists.
+    /// Writing a file and then executing it inside one multi-threaded process is racy on Linux:
+    /// `cargo test` runs these tests in threads, a `fork` in any other thread inherits every
+    /// descriptor open at that instant — including the write handle this thread still holds on the
+    /// fixture — and the child keeps it until its own `execve` returns. `execve` on a file some
+    /// process holds open for writing fails with ETXTBSY. The updater itself is one sequential
+    /// flow that never forks while its download is open, so this window exists only inside the
+    /// test binary — but it is wide enough to fail runs, which is why [`retry_etxtbsy`] exists.
     #[cfg(unix)]
     fn is_etxtbsy(message: &str) -> bool {
         message.contains("Text file busy") || message.contains("os error 26")
     }
 
     /// Call `f` until it stops reporting ETXTBSY. Bounded, and every other error is returned on
-    /// the first attempt — this retries the harness race described above and nothing else, so a
-    /// smoke check that genuinely fails still fails immediately.
+    /// the first attempt, so a smoke check that genuinely fails still fails immediately.
     #[cfg(unix)]
     fn retry_etxtbsy(mut f: impl FnMut() -> Result<(), String>) -> Result<(), String> {
         for _ in 0..20 {
@@ -295,8 +289,8 @@ mod tests {
         std::fs::set_permissions(&bad, std::fs::Permissions::from_mode(0o755)).unwrap();
         assert!(smoke_check(&bad, "1.4.0").is_err());
 
-        // Exits 0 — a naive check that only looked at the exit status would pass this — but
-        // prints the wrong version, which is exactly the mismatch the gate exists to catch.
+        // Exits 0 — a check that only looked at the exit status would pass this — but prints the
+        // wrong version.
         let wrong_version = dir.path().join("wrong-version");
         std::fs::write(&wrong_version, "#!/bin/sh\necho 1.3.0\n").unwrap();
         std::fs::set_permissions(&wrong_version, std::fs::Permissions::from_mode(0o755)).unwrap();

--- a/crates/glass-mcp/src/update/verify.rs
+++ b/crates/glass-mcp/src/update/verify.rs
@@ -183,6 +183,9 @@ mod tests {
             // so this one is the only case that exercises the hex-digit check rather than the
             // length check.
             "gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg  glass-mcp-v1.4.0-x86_64-linux-gnu\n",
+            // 65 hex chars. Without an over-length case, weakening `len() != 64` to `len() < 64`
+            // survives the whole suite — and this crate is mutation-gated in CI.
+            "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08a  glass-mcp-v1.4.0-x86_64-linux-gnu\n",
         ] {
             assert!(
                 parse_sidecar(text, ASSET).is_err(),

--- a/crates/glass-mcp/src/update/verify.rs
+++ b/crates/glass-mcp/src/update/verify.rs
@@ -200,9 +200,12 @@ mod tests {
             // so this one is the only case that exercises the hex-digit check rather than the
             // length check.
             "gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg  glass-mcp-v1.4.0-x86_64-linux-gnu\n",
-            // 65 hex chars — the only over-length case here. Every other input in this list is
-            // either too short or not hex, so all of them are still rejected if `len() != 64` is
-            // weakened to `len() < 64`; this is the one that stops that weakening passing.
+            // 65 hex chars — the only over-length case here, and the only one that reaches the
+            // length check with too MANY characters. Of the rest: the empty and blank inputs stop
+            // at the "no non-empty line" guard, the bare 64-char digest has no filename and so
+            // stops at `split_once`, and the others are too short or not hex. Every one of them is
+            // therefore still rejected if `len() != 64` is weakened to `len() < 64` — this input
+            // is what stops that weakening passing.
             "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08a  glass-mcp-v1.4.0-x86_64-linux-gnu\n",
         ] {
             assert!(

--- a/crates/glass-mcp/src/update/version.rs
+++ b/crates/glass-mcp/src/update/version.rs
@@ -63,10 +63,11 @@ fn parse_number(s: &str) -> Option<u64> {
 
 /// Is this suffix a real prerelease tag rather than a `git describe` artifact?
 ///
-/// The whole classification turns on the first character: a release tag's suffix starts with a
-/// letter (`rc1`), while `describe` always starts with the commit count (`5-g563feea`). `dirty`
-/// starts with a letter too, so it is excluded by name — it is the one `describe` suffix that
-/// would otherwise slip through.
+/// In practice a `describe` suffix (`5-g563feea`) is rejected by its internal dash, which the
+/// byte-class check below catches on its own. The first-character check exists for the case the
+/// byte-class check can't reach: a dash-free, digit-initial suffix (`5`, `563feea`) that would
+/// otherwise pass as a prerelease tag. `dirty` starts with a letter too, so it is excluded by
+/// name — it is the one `describe` suffix the other two checks would let through.
 fn is_release_prerelease(p: &str) -> bool {
     p != "dirty"
         && p.starts_with(|c: char| c.is_ascii_alphabetic())
@@ -139,6 +140,19 @@ mod tests {
     fn a_dirty_tree_is_rejected() {
         assert!(Version::parse_released("1.3.0-dirty").is_none());
         assert!(Version::parse_released("1.3.0-5-g563feea-dirty").is_none());
+    }
+
+    /// The `starts_with(alphabetic)` clause's own case, and the only one that exercises it.
+    ///
+    /// Every `git describe` suffix in real use carries an internal dash (`5-g563feea`), which the
+    /// byte-class guard rejects by itself — so without a dash-free, digit-initial input that clause
+    /// is redundant against the whole suite, and the mutation gate would rightly flag it as a
+    /// survivor. These two inputs are what make the stated rule ("the first character decides")
+    /// actually load-bearing.
+    #[test]
+    fn a_digit_initial_suffix_is_not_a_release_prerelease() {
+        assert!(Version::parse_released("1.3.0-5").is_none());
+        assert!(Version::parse_released("1.3.0-563feea").is_none());
     }
 
     /// `git describe --always` with no tags in reach emits a bare short SHA.

--- a/crates/glass-mcp/src/update/version.rs
+++ b/crates/glass-mcp/src/update/version.rs
@@ -1,0 +1,190 @@
+//! Classifying and comparing glass versions.
+//!
+//! `crate::VERSION` comes from `build.rs::glass_version()`, which emits two quite different
+//! shapes: a CI tag build gives the tag with its leading `v` stripped (`1.3.0`), while a local
+//! build gives `git describe --tags --always --dirty` (`1.3.0-5-g563feea`, `1.3.0-dirty`, or a
+//! bare short SHA). Only the first shape may be updated over.
+
+use std::cmp::Ordering;
+use std::fmt;
+
+/// A released glass version: what `build.rs` embeds for a CI tag build, or a release tag with
+/// its `v` stripped.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Version {
+    major: u64,
+    minor: u64,
+    patch: u64,
+    /// `Some("rc1")` for `1.2.0-rc1`, `None` for a final release.
+    pre: Option<String>,
+}
+
+impl Version {
+    /// Parse a *released* version. Returns `None` for anything a local build could produce, which
+    /// is what stops the apply path from overwriting a from-source binary.
+    pub(crate) fn parse_released(s: &str) -> Option<Version> {
+        // The no-VCS fallback. It is a well-formed triple, so it has to be rejected by value.
+        if s == "0.0.0" {
+            return None;
+        }
+        let (core, pre) = match s.split_once('-') {
+            Some((core, pre)) => (core, Some(pre)),
+            None => (s, None),
+        };
+        let mut parts = core.split('.');
+        let major = parse_number(parts.next()?)?;
+        let minor = parse_number(parts.next()?)?;
+        let patch = parse_number(parts.next()?)?;
+        if parts.next().is_some() {
+            return None;
+        }
+        let pre = match pre {
+            None => None,
+            Some(p) if is_release_prerelease(p) => Some(p.to_string()),
+            Some(_) => return None,
+        };
+        Some(Version {
+            major,
+            minor,
+            patch,
+            pre,
+        })
+    }
+}
+
+/// A component of the `MAJOR.MINOR.PATCH` core. Rejects the empty string and any sign, which
+/// `u64::from_str` would otherwise accept in part (`+1`) or reject unhelpfully.
+fn parse_number(s: &str) -> Option<u64> {
+    if s.is_empty() || !s.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    s.parse().ok()
+}
+
+/// Is this suffix a real prerelease tag rather than a `git describe` artifact?
+///
+/// The whole classification turns on the first character: a release tag's suffix starts with a
+/// letter (`rc1`), while `describe` always starts with the commit count (`5-g563feea`). `dirty`
+/// starts with a letter too, so it is excluded by name — it is the one `describe` suffix that
+/// would otherwise slip through.
+fn is_release_prerelease(p: &str) -> bool {
+    p != "dirty"
+        && p.starts_with(|c: char| c.is_ascii_alphabetic())
+        && p.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'.')
+}
+
+impl Ord for Version {
+    /// Numeric on the triple, then "a prerelease is older than its own final release".
+    ///
+    /// Deliberately **not** general semver. The only comparison production ever performs is a
+    /// local version against `/releases/latest`, which never returns a prerelease — so the
+    /// both-are-prereleases arm below cannot fire in production and exists for totality. Its
+    /// lexicographic order would sort `rc10` before `rc2`; that is acceptable precisely because
+    /// nothing reaches it, and it is documented here so no one later mistakes this for a complete
+    /// semver implementation.
+    fn cmp(&self, other: &Self) -> Ordering {
+        (self.major, self.minor, self.patch)
+            .cmp(&(other.major, other.minor, other.patch))
+            .then_with(|| match (&self.pre, &other.pre) {
+                (None, None) => Ordering::Equal,
+                (None, Some(_)) => Ordering::Greater,
+                (Some(_), None) => Ordering::Less,
+                (Some(a), Some(b)) => a.cmp(b),
+            })
+    }
+}
+
+impl PartialOrd for Version {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl fmt::Display for Version {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)?;
+        match &self.pre {
+            Some(p) => write!(f, "-{p}"),
+            None => Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_ci_tag_build_parses() {
+        let v = Version::parse_released("1.3.0").expect("a released version");
+        assert_eq!(v.to_string(), "1.3.0");
+    }
+
+    #[test]
+    fn a_prerelease_tag_parses_and_keeps_its_suffix() {
+        let v = Version::parse_released("1.2.0-rc1").expect("rc tags are released versions");
+        assert_eq!(v.to_string(), "1.2.0-rc1");
+    }
+
+    /// The discriminating pair. `1.2.0-rc1` and `1.3.0-5-g563feea` BOTH carry a `-` suffix, so a
+    /// classifier that merely looks for a dash gets one of them wrong whichever way it guesses.
+    /// Only asserting both in one test proves the rule keys on the suffix's first character.
+    #[test]
+    fn a_describe_suffix_is_rejected_while_an_rc_tag_is_accepted() {
+        assert!(Version::parse_released("1.3.0-5-g563feea").is_none());
+        assert!(Version::parse_released("1.2.0-rc1").is_some());
+    }
+
+    #[test]
+    fn a_dirty_tree_is_rejected() {
+        assert!(Version::parse_released("1.3.0-dirty").is_none());
+        assert!(Version::parse_released("1.3.0-5-g563feea-dirty").is_none());
+    }
+
+    /// `git describe --always` with no tags in reach emits a bare short SHA.
+    #[test]
+    fn a_bare_sha_is_rejected() {
+        assert!(Version::parse_released("563feea").is_none());
+    }
+
+    /// `build.rs` falls back to CARGO_PKG_VERSION when there is no VCS at all, and that is
+    /// pinned at 0.0.0. It parses as a valid triple, so it needs its own rejection.
+    #[test]
+    fn the_no_vcs_fallback_is_rejected() {
+        assert!(Version::parse_released("0.0.0").is_none());
+    }
+
+    #[test]
+    fn malformed_versions_are_rejected() {
+        for s in ["", "1.3", "1.3.0.1", "1.3.x", "v1.3.0", "1.-3.0", "1.3.0-"] {
+            assert!(Version::parse_released(s).is_none(), "{s:?} must not parse");
+        }
+    }
+
+    #[test]
+    fn ordering_compares_the_triple_numerically() {
+        let older = Version::parse_released("1.3.0").unwrap();
+        let newer = Version::parse_released("1.4.0").unwrap();
+        assert!(newer > older);
+        assert!(
+            Version::parse_released("1.10.0").unwrap() > Version::parse_released("1.9.0").unwrap()
+        );
+        assert!(
+            Version::parse_released("2.0.0").unwrap() > Version::parse_released("1.99.99").unwrap()
+        );
+        assert_eq!(older, Version::parse_released("1.3.0").unwrap());
+    }
+
+    /// The rule that makes this worth hand-rolling: `/releases/latest` never returns a
+    /// prerelease, so someone on `1.4.0-rc1` must be told they are AHEAD of `1.3.0` rather than
+    /// offered a downgrade. Both directions, because an implementation that swapped the arms
+    /// would still pass a one-directional test.
+    #[test]
+    fn a_prerelease_is_older_than_its_own_final_release() {
+        let rc = Version::parse_released("1.4.0-rc1").unwrap();
+        let fin = Version::parse_released("1.4.0").unwrap();
+        assert!(rc < fin);
+        assert!(fin > rc);
+        assert!(rc > Version::parse_released("1.3.0").unwrap());
+    }
+}

--- a/crates/glass-mcp/src/update/version.rs
+++ b/crates/glass-mcp/src/update/version.rs
@@ -80,9 +80,8 @@ impl Ord for Version {
     /// Deliberately **not** general semver. The only comparison production ever performs is a
     /// local version against `/releases/latest`, which never returns a prerelease — so the
     /// both-are-prereleases arm below cannot fire in production and exists for totality. Its
-    /// lexicographic order would sort `rc10` before `rc2`; that is acceptable precisely because
-    /// nothing reaches it, and it is documented here so no one later mistakes this for a complete
-    /// semver implementation.
+    /// lexicographic order would sort `rc10` before `rc2`, which is acceptable precisely because
+    /// nothing reaches it.
     fn cmp(&self, other: &Self) -> Ordering {
         (self.major, self.minor, self.patch)
             .cmp(&(other.major, other.minor, other.patch))
@@ -129,10 +128,8 @@ mod tests {
 
     /// The discriminating pair for the *shape* rule. `1.2.0-rc1` and `1.3.0-5-g563feea` BOTH carry
     /// a `-` suffix, so a classifier that merely looks for a dash gets one of them wrong whichever
-    /// way it guesses.
-    ///
-    /// What rejects the describe suffix here is the byte-class guard — `5-g563feea` holds an
-    /// internal dash — not the first-character rule. The first-character rule is covered by
+    /// way it guesses. What rejects the describe suffix here is the byte-class guard, not the
+    /// first-character rule — that one is covered by
     /// `a_digit_initial_suffix_is_not_a_release_prerelease`.
     #[test]
     fn a_describe_suffix_is_rejected_while_an_rc_tag_is_accepted() {
@@ -146,13 +143,9 @@ mod tests {
         assert!(Version::parse_released("1.3.0-5-g563feea-dirty").is_none());
     }
 
-    /// The `starts_with(alphabetic)` clause's own case, and the only one that exercises it.
-    ///
-    /// Every `git describe` suffix in real use carries an internal dash (`5-g563feea`), which the
-    /// byte-class guard rejects by itself — so a dash-free, digit-initial input is the only kind
-    /// that reaches the `starts_with(alphabetic)` clause at all. Delete that clause and every
-    /// other case in this file still passes; these two are what make the stated rule ("the first
-    /// character decides") load-bearing.
+    /// The `starts_with(alphabetic)` clause's own case, and the only one that exercises it: a
+    /// dash-free, digit-initial suffix is the only kind the byte-class guard does not reject
+    /// first. Delete the clause and every other case in this file still passes.
     #[test]
     fn a_digit_initial_suffix_is_not_a_release_prerelease() {
         assert!(Version::parse_released("1.3.0-5").is_none());

--- a/crates/glass-mcp/src/update/version.rs
+++ b/crates/glass-mcp/src/update/version.rs
@@ -149,10 +149,10 @@ mod tests {
     /// The `starts_with(alphabetic)` clause's own case, and the only one that exercises it.
     ///
     /// Every `git describe` suffix in real use carries an internal dash (`5-g563feea`), which the
-    /// byte-class guard rejects by itself — so without a dash-free, digit-initial input that clause
-    /// is redundant against the whole suite, and the mutation gate would rightly flag it as a
-    /// survivor. These two inputs are what make the stated rule ("the first character decides")
-    /// actually load-bearing.
+    /// byte-class guard rejects by itself — so a dash-free, digit-initial input is the only kind
+    /// that reaches the `starts_with(alphabetic)` clause at all. Delete that clause and every
+    /// other case in this file still passes; these two are what make the stated rule ("the first
+    /// character decides") load-bearing.
     #[test]
     fn a_digit_initial_suffix_is_not_a_release_prerelease() {
         assert!(Version::parse_released("1.3.0-5").is_none());

--- a/crates/glass-mcp/src/update/version.rs
+++ b/crates/glass-mcp/src/update/version.rs
@@ -127,9 +127,13 @@ mod tests {
         assert_eq!(v.to_string(), "1.2.0-rc1");
     }
 
-    /// The discriminating pair. `1.2.0-rc1` and `1.3.0-5-g563feea` BOTH carry a `-` suffix, so a
-    /// classifier that merely looks for a dash gets one of them wrong whichever way it guesses.
-    /// Only asserting both in one test proves the rule keys on the suffix's first character.
+    /// The discriminating pair for the *shape* rule. `1.2.0-rc1` and `1.3.0-5-g563feea` BOTH carry
+    /// a `-` suffix, so a classifier that merely looks for a dash gets one of them wrong whichever
+    /// way it guesses.
+    ///
+    /// What rejects the describe suffix here is the byte-class guard — `5-g563feea` holds an
+    /// internal dash — not the first-character rule. The first-character rule is covered by
+    /// `a_digit_initial_suffix_is_not_a_release_prerelease`.
     #[test]
     fn a_describe_suffix_is_rejected_while_an_rc_tag_is_accepted() {
         assert!(Version::parse_released("1.3.0-5-g563feea").is_none());

--- a/crates/glass-mcp/tests/release_artifact_names.rs
+++ b/crates/glass-mcp/tests/release_artifact_names.rs
@@ -26,8 +26,7 @@ fn repo_root() -> PathBuf {
 /// The suffix ends at the first `.`, whitespace, or closing backtick — whichever comes first. All
 /// three bounds are load-bearing: the bare Linux assets are documented with no extension at all,
 /// so a scan that only stopped at `.` would run straight past the closing backtick and swallow
-/// whatever prose followed until the next full stop anywhere later in the file. That made the
-/// wording of the docs a constraint on this test rather than the other way round.
+/// whatever prose followed until the next full stop anywhere later in the file.
 fn documented_suffixes(platforms_md: &str) -> BTreeSet<String> {
     platforms_md
         .split("glass-mcp-<tag>-")
@@ -71,8 +70,7 @@ fn documented_release_suffixes_are_produced_by_the_workflow() {
 /// that the interesting strings are not unique in the file: `dist/glass-mcp-*` also appears in the
 /// Linux attestation block and `dist/*.exe` appears three times, so a whole-file `contains` for
 /// either stays green with the *upload* line deleted — and a release with no bare assets 404s
-/// every `glass-mcp update`. Each assertion below therefore names the line that has to carry the
-/// string, not the file.
+/// every `glass-mcp update`.
 fn the_line<'a>(release_yml: &'a str, what: &str, pred: impl Fn(&str) -> bool) -> &'a str {
     let mut hits = release_yml.lines().map(str::trim).filter(|l| pred(l));
     let first = hits
@@ -91,9 +89,8 @@ fn the_line<'a>(release_yml: &'a str, what: &str, pred: impl Fn(&str) -> bool) -
 /// Anchoring to the right line is only half the job: every glob this test looks for is a *prefix*
 /// of a longer token that legitimately sits on the same line — `dist/*.exe` of
 /// `dist/*.exe.sha256`, `dist/glass-mcp-*` of `dist/glass-mcp-*.tar.gz`, `glass-mcp-*` of
-/// `glass-mcp-*.tar.gz`. A `contains` check is therefore satisfied by the *narrowed* form, which
-/// is exactly the edit that stops the bare binaries being published and 404s every
-/// `glass-mcp update`. Comparing whole tokens is what makes the narrowing fail.
+/// `glass-mcp-*.tar.gz`. A `contains` check is therefore satisfied by the *narrowed* form;
+/// comparing whole tokens is what makes the narrowing fail.
 ///
 /// Tokens are split on whitespace, `,`, and parentheses — the last because PowerShell writes
 /// `(Get-ChildItem …).FullName`, so the final path would otherwise carry `).FullName` with it.
@@ -151,8 +148,7 @@ fn the_bare_binary_assets_are_documented_and_produced() {
     // Two lines copy the built .exe — one into the archive's staging directory
     // (`dist/$name/glass-mcp.exe`), one flat beside it (`dist/$name.exe`) — so this cannot anchor
     // on a single line the way the others do. It asserts instead that among all of those copies,
-    // one lands flat. Whole-token comparison is what tells the two destinations apart; a
-    // `contains` would let the staging copy satisfy the check for the flat one.
+    // one lands flat.
     let exe_copies: Vec<&str> = release_yml
         .lines()
         .map(str::trim)

--- a/crates/glass-mcp/tests/release_artifact_names.rs
+++ b/crates/glass-mcp/tests/release_artifact_names.rs
@@ -20,13 +20,23 @@ fn repo_root() -> PathBuf {
         .expect("resolve repo root from CARGO_MANIFEST_DIR")
 }
 
-/// Platform suffixes documented as `glass-mcp-<tag>-<suffix>.<ext>` in platforms.md, excluding the
-/// `<platform>` placeholder used in prose.
+/// Platform suffixes documented as `glass-mcp-<tag>-<suffix>` in platforms.md, with any `.<ext>`
+/// trimmed off, and excluding the `<platform>` placeholder used in prose.
+///
+/// The suffix ends at the first `.`, whitespace, or closing backtick — whichever comes first. All
+/// three bounds are load-bearing: the bare Linux assets are documented with no extension at all,
+/// so a scan that only stopped at `.` would run straight past the closing backtick and swallow
+/// whatever prose followed until the next full stop anywhere later in the file. That made the
+/// wording of the docs a constraint on this test rather than the other way round.
 fn documented_suffixes(platforms_md: &str) -> BTreeSet<String> {
     platforms_md
         .split("glass-mcp-<tag>-")
         .skip(1)
-        .map(|rest| rest.chars().take_while(|c| *c != '.').collect::<String>())
+        .map(|rest| {
+            rest.chars()
+                .take_while(|c| *c != '.' && *c != '`' && !c.is_whitespace())
+                .collect::<String>()
+        })
         .filter(|s| !s.is_empty() && !s.contains('<') && !s.contains('>'))
         .collect()
 }
@@ -54,6 +64,28 @@ fn documented_release_suffixes_are_produced_by_the_workflow() {
     }
 }
 
+/// The one line of `release.yml` that satisfies `pred`, trimmed. Panics unless exactly one line
+/// matches, so a needle that has silently become ambiguous is a failure rather than a coin toss.
+///
+/// The whole reason this test works line-by-line instead of with `release_yml.contains(..)` is
+/// that the interesting strings are not unique in the file: `dist/glass-mcp-*` also appears in the
+/// Linux attestation block and `dist/*.exe` appears three times, so a whole-file `contains` for
+/// either stays green with the *upload* line deleted — and a release with no bare assets 404s
+/// every `glass-mcp update`. Each assertion below therefore names the line that has to carry the
+/// string, not the file.
+fn the_line<'a>(release_yml: &'a str, what: &str, pred: impl Fn(&str) -> bool) -> &'a str {
+    let mut hits = release_yml.lines().map(str::trim).filter(|l| pred(l));
+    let first = hits
+        .next()
+        .unwrap_or_else(|| panic!("release.yml no longer has {what}"));
+    assert!(
+        hits.next().is_none(),
+        "more than one line of release.yml looks like {what} — this guard can no longer tell \
+         which one it is checking"
+    );
+    first
+}
+
 /// The bare, uncompressed binary assets `glass-mcp update` downloads. The archives stay — these
 /// are additional — so this is a second, independent direction of the same doc↔workflow guard:
 /// documenting an updater asset the workflow never builds would leave `update` fetching a 404.
@@ -65,23 +97,63 @@ fn the_bare_binary_assets_are_documented_and_produced() {
     let release_yml = std::fs::read_to_string(root.join(".github/workflows/release.yml"))
         .expect("read .github/workflows/release.yml");
 
-    // Assert on text the workflow literally contains. The per-platform suffixes never appear
-    // inside a full asset name there — `pkg` takes the suffix as an argument and builds the name
-    // at run time — so this checks the lines that emit and upload the bare files instead.
-    for needle in [
-        // Linux: the bare copy out of the staging dir, and an upload glob wide enough to carry it.
-        r#"cp "$dir/glass-mcp" "dist/$name""#,
-        r#"dist/glass-mcp-*"#,
-        // Windows: the bare copy of the signed .exe, and its upload glob.
-        r#"Copy-Item target/release/glass-mcp.exe "dist/$name.exe""#,
-        r#"dist/*.exe"#,
-    ] {
+    // The per-platform suffixes never appear inside a full asset name in the workflow — `pkg`
+    // takes the suffix as an argument and builds the name at run time — so what is checkable here
+    // is the set of lines that produce, hash and upload the bare files.
+
+    // Linux: produced by copying the staged binary flat beside the archive...
+    assert!(
+        release_yml.contains(r#"cp "$dir/glass-mcp" "dist/$name""#),
+        "release.yml no longer copies the bare linux binary into dist/"
+    );
+    // ...hashed by a loop whose glob covers it. Narrowed back to `*.tar.gz` and the bare assets
+    // ship with no `.sha256`, which is a 404 at `update`'s sidecar fetch.
+    let linux_sidecars = the_line(&release_yml, "the linux sha256sum loop", |l| {
+        l.contains("sha256sum")
+    });
+    assert!(
+        linux_sidecars.contains("for f in glass-mcp-*"),
+        "the linux checksum loop no longer covers the bare binaries: {linux_sidecars}"
+    );
+    // ...and uploaded by a glob wide enough to carry it.
+    let linux_upload = the_line(&release_yml, "the linux release upload", |l| {
+        l.contains("gh release upload") && l.contains("$TAG") && !l.contains("dmg")
+    });
+    assert!(
+        linux_upload.contains("dist/glass-mcp-*"),
+        "the linux upload no longer publishes the bare binaries: {linux_upload}"
+    );
+
+    // Windows: the same three steps, in PowerShell.
+    assert!(
+        release_yml.contains(r#"Copy-Item target/release/glass-mcp.exe "dist/$name.exe""#),
+        "release.yml no longer copies the bare glass-mcp.exe into dist/"
+    );
+    let windows_sidecars = the_line(&release_yml, "the windows Get-FileHash loop", |l| {
+        l.starts_with("foreach ($f in Get-ChildItem")
+    });
+    assert!(
+        windows_sidecars.contains("dist/*.exe"),
+        "the windows checksum loop no longer covers the bare .exe: {windows_sidecars}"
+    );
+    // The windows upload passes `$files`, so the assignment is what decides the asset set.
+    let windows_upload = the_line(&release_yml, "the windows upload file list", |l| {
+        l.starts_with("$files = ")
+    });
+    for needle in ["dist/*.exe", "dist/*.exe.sha256"] {
         assert!(
-            release_yml.contains(needle),
-            "release.yml no longer contains {needle:?} — `glass-mcp update` downloads the bare \
-             binary assets those lines publish"
+            windows_upload.contains(needle),
+            "the windows upload no longer publishes {needle}: {windows_upload}"
         );
     }
+    let windows_gh = the_line(&release_yml, "the windows release upload", |l| {
+        l.contains("gh release upload") && l.contains("GITHUB_REF_NAME")
+    });
+    assert!(
+        windows_gh.contains("$files"),
+        "the windows upload no longer uses the file list above: {windows_gh}"
+    );
+
     assert!(
         platforms.contains("uncompressed"),
         "platforms.md must document the bare binary assets as what `update` fetches"

--- a/crates/glass-mcp/tests/release_artifact_names.rs
+++ b/crates/glass-mcp/tests/release_artifact_names.rs
@@ -53,3 +53,37 @@ fn documented_release_suffixes_are_produced_by_the_workflow() {
         );
     }
 }
+
+/// The bare, uncompressed binary assets `glass-mcp update` downloads. The archives stay — these
+/// are additional — so this is a second, independent direction of the same doc↔workflow guard:
+/// documenting an updater asset the workflow never builds would leave `update` fetching a 404.
+#[test]
+fn the_bare_binary_assets_are_documented_and_produced() {
+    let root = repo_root();
+    let platforms = std::fs::read_to_string(root.join("docs/reference/platforms.md"))
+        .expect("read docs/reference/platforms.md");
+    let release_yml = std::fs::read_to_string(root.join(".github/workflows/release.yml"))
+        .expect("read .github/workflows/release.yml");
+
+    // Assert on text the workflow literally contains. The per-platform suffixes never appear
+    // inside a full asset name there — `pkg` takes the suffix as an argument and builds the name
+    // at run time — so this checks the lines that emit and upload the bare files instead.
+    for needle in [
+        // Linux: the bare copy out of the staging dir, and an upload glob wide enough to carry it.
+        r#"cp "$dir/glass-mcp" "dist/$name""#,
+        r#"dist/glass-mcp-*"#,
+        // Windows: the bare copy of the signed .exe, and its upload glob.
+        r#"Copy-Item target/release/glass-mcp.exe "dist/$name.exe""#,
+        r#"dist/*.exe"#,
+    ] {
+        assert!(
+            release_yml.contains(needle),
+            "release.yml no longer contains {needle:?} — `glass-mcp update` downloads the bare \
+             binary assets those lines publish"
+        );
+    }
+    assert!(
+        platforms.contains("uncompressed"),
+        "platforms.md must document the bare binary assets as what `update` fetches"
+    );
+}

--- a/crates/glass-mcp/tests/release_artifact_names.rs
+++ b/crates/glass-mcp/tests/release_artifact_names.rs
@@ -86,6 +86,25 @@ fn the_line<'a>(release_yml: &'a str, what: &str, pred: impl Fn(&str) -> bool) -
     first
 }
 
+/// Is `needle` one of `line`'s whole tokens?
+///
+/// Anchoring to the right line is only half the job: every glob this test looks for is a *prefix*
+/// of a longer token that legitimately sits on the same line — `dist/*.exe` of
+/// `dist/*.exe.sha256`, `dist/glass-mcp-*` of `dist/glass-mcp-*.tar.gz`, `glass-mcp-*` of
+/// `glass-mcp-*.tar.gz`. A `contains` check is therefore satisfied by the *narrowed* form, which
+/// is exactly the edit that stops the bare binaries being published and 404s every
+/// `glass-mcp update`. Comparing whole tokens is what makes the narrowing fail.
+///
+/// Tokens are split on whitespace, `,`, and parentheses — the last because PowerShell writes
+/// `(Get-ChildItem …).FullName`, so the final path would otherwise carry `).FullName` with it.
+/// Quotes, `;` and braces are trimmed off each end for the same reason: `sh` writes
+/// `for f in glass-mcp-*;`.
+fn has_token(line: &str, needle: &str) -> bool {
+    line.split([' ', '\t', ',', '(', ')'])
+        .map(|t| t.trim_matches(['"', '\'', ';', '`', '{', '}']))
+        .any(|t| t == needle)
+}
+
 /// The bare, uncompressed binary assets `glass-mcp update` downloads. The archives stay — these
 /// are additional — so this is a second, independent direction of the same doc↔workflow guard:
 /// documenting an updater asset the workflow never builds would leave `update` fetching a 404.
@@ -102,9 +121,12 @@ fn the_bare_binary_assets_are_documented_and_produced() {
     // is the set of lines that produce, hash and upload the bare files.
 
     // Linux: produced by copying the staged binary flat beside the archive...
+    let linux_copy = the_line(&release_yml, "the bare linux binary copy", |l| {
+        l.starts_with(r#"cp "$dir/glass-mcp""#)
+    });
     assert!(
-        release_yml.contains(r#"cp "$dir/glass-mcp" "dist/$name""#),
-        "release.yml no longer copies the bare linux binary into dist/"
+        has_token(linux_copy, "dist/$name"),
+        "the bare linux binary no longer lands at dist/<asset name>: {linux_copy}"
     );
     // ...hashed by a loop whose glob covers it. Narrowed back to `*.tar.gz` and the bare assets
     // ship with no `.sha256`, which is a 404 at `update`'s sidecar fetch.
@@ -112,7 +134,7 @@ fn the_bare_binary_assets_are_documented_and_produced() {
         l.contains("sha256sum")
     });
     assert!(
-        linux_sidecars.contains("for f in glass-mcp-*"),
+        has_token(linux_sidecars, "glass-mcp-*"),
         "the linux checksum loop no longer covers the bare binaries: {linux_sidecars}"
     );
     // ...and uploaded by a glob wide enough to carry it.
@@ -120,20 +142,31 @@ fn the_bare_binary_assets_are_documented_and_produced() {
         l.contains("gh release upload") && l.contains("$TAG") && !l.contains("dmg")
     });
     assert!(
-        linux_upload.contains("dist/glass-mcp-*"),
+        has_token(linux_upload, "dist/glass-mcp-*"),
         "the linux upload no longer publishes the bare binaries: {linux_upload}"
     );
 
     // Windows: the same three steps, in PowerShell.
+    //
+    // Two lines copy the built .exe — one into the archive's staging directory
+    // (`dist/$name/glass-mcp.exe`), one flat beside it (`dist/$name.exe`) — so this cannot anchor
+    // on a single line the way the others do. It asserts instead that among all of those copies,
+    // one lands flat. Whole-token comparison is what tells the two destinations apart; a
+    // `contains` would let the staging copy satisfy the check for the flat one.
+    let exe_copies: Vec<&str> = release_yml
+        .lines()
+        .map(str::trim)
+        .filter(|l| l.starts_with("Copy-Item target/release/glass-mcp.exe"))
+        .collect();
     assert!(
-        release_yml.contains(r#"Copy-Item target/release/glass-mcp.exe "dist/$name.exe""#),
-        "release.yml no longer copies the bare glass-mcp.exe into dist/"
+        exe_copies.iter().any(|l| has_token(l, "dist/$name.exe")),
+        "nothing copies the bare .exe flat into dist/ — the copies are {exe_copies:?}"
     );
     let windows_sidecars = the_line(&release_yml, "the windows Get-FileHash loop", |l| {
         l.starts_with("foreach ($f in Get-ChildItem")
     });
     assert!(
-        windows_sidecars.contains("dist/*.exe"),
+        has_token(windows_sidecars, "dist/*.exe"),
         "the windows checksum loop no longer covers the bare .exe: {windows_sidecars}"
     );
     // The windows upload passes `$files`, so the assignment is what decides the asset set.
@@ -142,7 +175,7 @@ fn the_bare_binary_assets_are_documented_and_produced() {
     });
     for needle in ["dist/*.exe", "dist/*.exe.sha256"] {
         assert!(
-            windows_upload.contains(needle),
+            has_token(windows_upload, needle),
             "the windows upload no longer publishes {needle}: {windows_upload}"
         );
     }
@@ -150,7 +183,7 @@ fn the_bare_binary_assets_are_documented_and_produced() {
         l.contains("gh release upload") && l.contains("GITHUB_REF_NAME")
     });
     assert!(
-        windows_gh.contains("$files"),
+        has_token(windows_gh, "$files"),
         "the windows upload no longer uses the file list above: {windows_gh}"
     );
 

--- a/crates/glass-mcp/tests/update_cli.rs
+++ b/crates/glass-mcp/tests/update_cli.rs
@@ -2,7 +2,9 @@
 //! a release would reach github.com, and nothing in this suite touches the network. What is
 //! provable here is the refusal ORDER — that a from-source build is turned away before any
 //! request is made — and CI builds glass-mcp from a git checkout, so `crate::VERSION` carries a
-//! `git describe` suffix and this is exactly that case.
+//! `git describe` suffix and this is ordinarily exactly that case. The one test that exercises it
+//! checks the built binary's actual version first and skips rather than assume, since a checkout
+//! sitting exactly on a tag would otherwise drive a real request.
 
 use std::process::Command;
 
@@ -10,6 +12,26 @@ const GLASS: &str = env!("CARGO_BIN_EXE_glass-mcp");
 
 #[test]
 fn update_refuses_a_from_source_build_without_touching_the_network() {
+    // A checkout sitting exactly on a released tag reports a plain MAJOR.MINOR.PATCH with no
+    // `git describe` suffix — the one shape `update` treats as a real release, which would send
+    // it resolving a real latest tag over the network. Every other shape (a commit count,
+    // `-dirty`, or a bare SHA) carries a dash and is guaranteed to hit the from-source refusal
+    // before any request. Skip rather than let a from-a-tag checkout reach github.com.
+    let version_out = Command::new(GLASS)
+        .arg("--version")
+        .output()
+        .expect("run glass-mcp");
+    let version = String::from_utf8_lossy(&version_out.stdout)
+        .trim()
+        .to_string();
+    if !version.contains('-') {
+        eprintln!(
+            "skipping: version {version:?} carries no git-describe suffix (checkout is exactly \
+             on a tag) — running `update` here would reach github.com"
+        );
+        return;
+    }
+
     let out = Command::new(GLASS)
         .arg("update")
         .output()

--- a/crates/glass-mcp/tests/update_cli.rs
+++ b/crates/glass-mcp/tests/update_cli.rs
@@ -3,8 +3,7 @@
 //! provable here is the refusal ORDER — that a from-source build is turned away before any
 //! request is made — and CI builds glass-mcp from a git checkout, so `crate::VERSION` carries a
 //! `git describe` suffix and this is ordinarily exactly that case. The one test that exercises it
-//! checks the built binary's actual version first and skips rather than assume, since a checkout
-//! sitting exactly on a tag would otherwise drive a real request.
+//! skips a checkout sitting exactly on a tag, which would drive a real request.
 
 use std::process::Command;
 
@@ -61,13 +60,12 @@ fn looks_released_matches_the_release_shape() {
 fn update_refuses_a_from_source_build_without_touching_the_network() {
     // A checkout sitting exactly on a released tag reports a plain MAJOR.MINOR.PATCH (or a real
     // prerelease tag like `1.2.0-rc1`) — the one shape `update` treats as a real release, which
-    // would send it resolving a real latest tag over the network. Every other shape (a commit
-    // count, `-dirty`, or a bare SHA) is guaranteed to hit the from-source refusal before any
-    // request. Skip rather than let a from-a-tag checkout reach github.com.
+    // would send it resolving a real latest tag over the network. Skip rather than let that reach
+    // github.com; every other shape (a commit count, `-dirty`, a bare SHA) is guaranteed to hit
+    // the from-source refusal before any request.
     //
-    // `--version` renders as `glass-mcp <version>` — take the LAST whitespace-separated token,
-    // not the whole line: the binary's own name contains a hyphen, so a naive `.contains('-')`
-    // check against the full stdout is unconditionally true regardless of the version.
+    // `--version` renders as `glass-mcp <version>`, so take the LAST whitespace-separated token
+    // rather than matching against the whole line.
     let version_out = Command::new(GLASS)
         .arg("--version")
         .output()

--- a/crates/glass-mcp/tests/update_cli.rs
+++ b/crates/glass-mcp/tests/update_cli.rs
@@ -10,24 +10,74 @@ use std::process::Command;
 
 const GLASS: &str = env!("CARGO_BIN_EXE_glass-mcp");
 
+/// Is this the version shape `build.rs` emits for a real release build?
+///
+/// Mirrors `update::version::Version::parse_released`, which an integration test cannot reach —
+/// it is `pub(crate)`. Deliberately conservative: anything that might be a released version
+/// causes a skip, because being wrong here means a real network request from the test suite.
+fn looks_released(version: &str) -> bool {
+    if version == "0.0.0" {
+        return false;
+    }
+    let (core, pre) = match version.split_once('-') {
+        Some((core, pre)) => (core, Some(pre)),
+        None => (version, None),
+    };
+    let mut parts = core.split('.');
+    let triple_ok = (0..3).all(|_| {
+        parts
+            .next()
+            .is_some_and(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()))
+    }) && parts.next().is_none();
+    let pre_ok = match pre {
+        None => true,
+        Some(p) => p != "dirty" && p.starts_with(|c: char| c.is_ascii_alphabetic()),
+    };
+    triple_ok && pre_ok
+}
+
+/// The guard this whole suite depends on to never reach the network: a guard whose own logic is
+/// untested is how the `.contains('-')` version of it shipped inert (`glass-mcp` itself has a
+/// hyphen in its name, so that check was unconditionally true against the whole `--version` line).
+#[test]
+fn looks_released_matches_the_release_shape() {
+    // Not released: every shape build.rs's local-build path can actually produce.
+    assert!(
+        !looks_released("1.3.0-18-g5579f99"),
+        "a git-describe commit-count suffix"
+    );
+    assert!(!looks_released("1.3.0-dirty"), "a dirty working tree");
+    assert!(!looks_released("0.0.0"), "the no-VCS fallback");
+    assert!(
+        !looks_released("5579f99"),
+        "a bare SHA with no reachable tag"
+    );
+    // Released: what a CI tag build, or a checkout sitting exactly on a tag, reports.
+    assert!(looks_released("1.3.0"), "a plain released version");
+    assert!(looks_released("1.2.0-rc1"), "a real prerelease tag");
+}
+
 #[test]
 fn update_refuses_a_from_source_build_without_touching_the_network() {
-    // A checkout sitting exactly on a released tag reports a plain MAJOR.MINOR.PATCH with no
-    // `git describe` suffix — the one shape `update` treats as a real release, which would send
-    // it resolving a real latest tag over the network. Every other shape (a commit count,
-    // `-dirty`, or a bare SHA) carries a dash and is guaranteed to hit the from-source refusal
-    // before any request. Skip rather than let a from-a-tag checkout reach github.com.
+    // A checkout sitting exactly on a released tag reports a plain MAJOR.MINOR.PATCH (or a real
+    // prerelease tag like `1.2.0-rc1`) — the one shape `update` treats as a real release, which
+    // would send it resolving a real latest tag over the network. Every other shape (a commit
+    // count, `-dirty`, or a bare SHA) is guaranteed to hit the from-source refusal before any
+    // request. Skip rather than let a from-a-tag checkout reach github.com.
+    //
+    // `--version` renders as `glass-mcp <version>` — take the LAST whitespace-separated token,
+    // not the whole line: the binary's own name contains a hyphen, so a naive `.contains('-')`
+    // check against the full stdout is unconditionally true regardless of the version.
     let version_out = Command::new(GLASS)
         .arg("--version")
         .output()
         .expect("run glass-mcp");
-    let version = String::from_utf8_lossy(&version_out.stdout)
-        .trim()
-        .to_string();
-    if !version.contains('-') {
+    let stdout = String::from_utf8_lossy(&version_out.stdout);
+    let version = stdout.split_whitespace().last().unwrap_or_default();
+    if looks_released(version) {
         eprintln!(
-            "skipping: version {version:?} carries no git-describe suffix (checkout is exactly \
-             on a tag) — running `update` here would reach github.com"
+            "skipping: this build reports a released version ({version}), so `update` would \
+             resolve a real release — see looks_released"
         );
         return;
     }

--- a/crates/glass-mcp/tests/update_cli.rs
+++ b/crates/glass-mcp/tests/update_cli.rs
@@ -1,0 +1,46 @@
+//! `update` through the real binary. Deliberately narrow: any test that let the command resolve
+//! a release would reach github.com, and nothing in this suite touches the network. What is
+//! provable here is the refusal ORDER — that a from-source build is turned away before any
+//! request is made — and CI builds glass-mcp from a git checkout, so `crate::VERSION` carries a
+//! `git describe` suffix and this is exactly that case.
+
+use std::process::Command;
+
+const GLASS: &str = env!("CARGO_BIN_EXE_glass-mcp");
+
+#[test]
+fn update_refuses_a_from_source_build_without_touching_the_network() {
+    let out = Command::new(GLASS)
+        .arg("update")
+        .output()
+        .expect("run glass-mcp");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let all = format!("{stdout}{stderr}");
+    assert!(
+        all.contains("built from source"),
+        "expected the from-source refusal, got: {all}"
+    );
+    assert_eq!(out.status.code(), Some(1), "a refusal exits 1");
+}
+
+#[test]
+fn update_help_lists_the_flags() {
+    let out = Command::new(GLASS)
+        .args(["update", "--help"])
+        .output()
+        .expect("run glass-mcp");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for flag in [
+        "--check",
+        "--yes",
+        "--skip-attestation",
+        "--json",
+        "--color",
+    ] {
+        assert!(
+            stdout.contains(flag),
+            "{flag} missing from update --help: {stdout}"
+        );
+    }
+}

--- a/docs/how-to/build-from-source.md
+++ b/docs/how-to/build-from-source.md
@@ -13,8 +13,10 @@ cargo build --release -p glass-mcp        # → target/release/glass-mcp
 ```
 
 glass pins a nightly toolchain in `rust-toolchain.toml`, which rustup installs automatically on the
-first build — there's no toolchain to choose. On **macOS**, building additionally needs the Xcode
-Command Line Tools (the notarized `.dmg` does not):
+first build — there's no toolchain to choose. On every platform the build also needs **`cmake` and a
+C compiler** on `PATH`: the TLS stack behind `glass-mcp update` compiles `aws-lc-sys` from C sources
+(`apt install cmake build-essential`, or the equivalent for your distro). On **macOS**, building
+additionally needs the Xcode Command Line Tools (the notarized `.dmg` does not):
 
 ```bash
 xcode-select --install

--- a/docs/how-to/setup-linux.md
+++ b/docs/how-to/setup-linux.md
@@ -32,6 +32,8 @@ aarch64 host, say), [build from source](build-from-source.md) instead; that is a
 want to hack on glass. The full asset list is in
 [reference/platforms.md](../reference/platforms.md#release-artifacts).
 
+Subsequent upgrades can use `glass-mcp update` instead of repeating these steps by hand.
+
 ## Prerequisites
 
 glass needs a display dependency for your backend and a containment runtime, both covered below.

--- a/docs/how-to/setup-linux.md
+++ b/docs/how-to/setup-linux.md
@@ -27,9 +27,15 @@ If `glass-mcp` is not found afterwards, start a new login shell — many distrib
 yourself.
 
 Use the `…-x86_64-linux-musl.tar.gz` build instead if you need a fully static binary with no glibc
-dependency — Alpine, or any musl distro. If you are on an architecture with no published asset (an
-aarch64 host, say), [build from source](build-from-source.md) instead; that is also the path if you
-want to hack on glass. The full asset list is in
+dependency — Alpine, or any musl distro. It still needs the distro's CA certificates installed
+(`apk add ca-certificates` on Alpine) for `glass-mcp update`: HTTPS verification goes through the
+system trust store, with no built-in certificate bundle to fall back on, so on a bare install
+`update` cannot reach the release endpoint. `update` is the only thing in glass that makes an
+outbound HTTPS request; everything else works without it.
+
+If you are on an architecture with no published asset (an aarch64 host, say),
+[build from source](build-from-source.md) instead; that is also the path if you want to hack on
+glass. The full asset list is in
 [reference/platforms.md](../reference/platforms.md#release-artifacts).
 
 Subsequent upgrades can use `glass-mcp update` instead of repeating these steps by hand.

--- a/docs/how-to/setup-macos.md
+++ b/docs/how-to/setup-macos.md
@@ -86,6 +86,8 @@ remove glass entirely.
   take effect — is explained in [the permission model](../explanation/macos-permissions.md).
 - **Sandboxing:** launched apps run under Seatbelt by default; the profile and the clipboard-isolation
   behaviour are in [explanation/containment.md](../explanation/containment.md).
+- **Checking for updates:** `glass-mcp update --check` reports whether a newer release exists, but
+  upgrading itself means downloading and opening a newer `.dmg` — there is no in-place update on macOS.
 - **Building from source** (contributors, unreleased checkouts): [build-from-source.md](build-from-source.md).
 - **Android** from a macOS host: [setup-android.md](setup-android.md).
 - **iOS** (the Simulator, on this macOS host): [setup-ios.md](setup-ios.md).

--- a/docs/how-to/setup-windows.md
+++ b/docs/how-to/setup-windows.md
@@ -51,6 +51,8 @@ copy `glass-mcp.exe` into a directory that's already on `PATH` instead.
 If you want to hack on glass or are on an architecture with no published asset,
 [build from source](build-from-source.md) instead.
 
+Subsequent upgrades can use `glass-mcp update` instead of repeating these steps by hand.
+
 > **First run — SmartScreen.** The prebuilt `glass-mcp.exe` is Authenticode-signed (publisher: **Fixed
 > Width LLC**). Windows may still show Microsoft Defender SmartScreen's "Windows protected your PC" on
 > first download until the certificate builds reputation; if it does, click **More info → Run anyway**.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -60,6 +60,44 @@ List every `GLASS_*` variable with its purpose, default, and current value (see
 Report whether glass is running and at what endpoint (reads `/healthz`). Primarily used with the
 macOS menu-bar LaunchAgent — see [how-to/setup-macos.md](../how-to/setup-macos.md).
 
+## `update`
+
+Update this binary to the latest published release: resolve the latest tag, download the asset for
+this platform, verify its checksum, and replace this binary in place. Verifies build provenance with
+the GitHub CLI (`gh attestation verify`) when it is installed; if `gh` is not on `PATH` the update
+still proceeds, but says so.
+
+- `--check` — report the current and latest version without changing anything. Refuses nothing:
+  unlike a real update, `--check` works on every platform, including macOS and a from-source build.
+- `--yes` — skip the confirmation prompt. Does **not** skip any verification (checksum, provenance,
+  or the post-download smoke check) — pair it with `--skip-attestation` explicitly if that is also
+  wanted.
+- `--skip-attestation` — proceed even if `gh attestation verify` fails or `gh` is unavailable.
+- `--json` — machine-readable output.
+- `--color <when>` — `auto` (default; color only when writing to a terminal), `always`, or `never`.
+  Ignored with `--json`. A non-empty `NO_COLOR`, or `TERM=dumb`, suppresses `auto`.
+
+Exit code: `0` for a successful update, for "already up to date", and for every `--check` run
+(whether or not a newer release exists) — a script should read `--json`'s `update_available` field,
+not the exit code, to learn whether news exists. `1` for a refusal or any other error.
+
+`update` refuses to run rather than guess in several cases:
+- **A from-source build.** A binary built locally (its version carries a `git describe` suffix)
+  is not something a release binary should silently replace — rebuild it with `git pull && cargo
+  build --release` instead.
+- **macOS.** glass installs there as `GlassMcp.app`, not a bare binary — download the latest `.dmg`
+  instead (see [how-to/setup-macos.md](../how-to/setup-macos.md)).
+- **An unsupported architecture**, where no release asset is published — build from source instead
+  (see [how-to/build-from-source.md](../how-to/build-from-source.md)).
+- **An install directory that is not writable** by the current user. `update` never escalates
+  privileges to get around this (no `sudo` re-exec) — it prints the release URL so you can download
+  and move the binary into place by hand.
+- **A non-interactive run without `--yes`.** With no terminal to confirm on and no `--yes`, `update`
+  declines rather than assuming consent.
+
+If a `glass-mcp serve --http` process is already running, it keeps serving the previous build in
+memory until it is restarted — `update` replaces the file on disk, not the running process.
+
 ## `uninstall`
 
 Stop glass from starting at login: remove the LaunchAgent and boot out the running job (macOS). Does

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -81,7 +81,10 @@ Exit code: `0` for a successful update, for "already up to date", and for every 
 (whether or not a newer release exists) — a script should read `--json`'s `update_available` field,
 not the exit code, to learn whether news exists. `1` for a refusal or any other error.
 
-`--json` always prints exactly one object, whatever happened. Its fields:
+`--json` prints exactly one object for every outcome of the update itself — including a refusal,
+and including a failure to reach or resolve the release. (The exception is a failure before the
+update starts at all, such as `glass-mcp` being unable to resolve its own path; that reports as a
+plain error message with no JSON.) Its fields:
 
 | Field | Meaning |
 |---|---|

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -72,7 +72,7 @@ still proceeds, but says so.
 - `--yes` — skip the confirmation prompt. Does **not** skip any verification (checksum, provenance,
   or the post-download smoke check) — pair it with `--skip-attestation` explicitly if that is also
   wanted.
-- `--skip-attestation` — proceed even if `gh attestation verify` fails or `gh` is unavailable.
+- `--skip-attestation` — proceed even if `gh attestation verify` fails.
 - `--json` — machine-readable output.
 - `--color <when>` — `auto` (default; color only when writing to a terminal), `always`, or `never`.
   Ignored with `--json`. A non-empty `NO_COLOR`, or `TERM=dumb`, suppresses `auto`.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -81,6 +81,22 @@ Exit code: `0` for a successful update, for "already up to date", and for every 
 (whether or not a newer release exists) — a script should read `--json`'s `update_available` field,
 not the exit code, to learn whether news exists. `1` for a refusal or any other error.
 
+`--json` always prints exactly one object, whatever happened. Its fields:
+
+| Field | Meaning |
+|---|---|
+| `action` | `checked`, `updated`, `refused`, or `error` (the release could not be resolved, downloaded, or installed at all) |
+| `current` | the version of the binary that is running |
+| `latest` | the latest published release, or `null` if it was never resolved |
+| `update_available` | `true` only when `latest` is known **and** strictly newer than `current` |
+| `current_comparable` | `false` when `current` is not a released version (a from-source build), so `update_available: false` means "unknown", not "up to date" |
+| `supported` | whether this platform is one `update` can replace in place at all |
+| `asset` · `url` | the release asset chosen for this platform, and where it lives — `null` before they are resolved |
+| `install_path` | the binary that would be, or was, replaced |
+| `attestation` | `not_checked`, `verified`, `unavailable` (no `gh` on `PATH`), `skipped` (`--skip-attestation`), or `failed` |
+| `running_server` | whether a `glass-mcp serve --http` is answering on `127.0.0.1:7300` and therefore still running the previous build |
+| `reason` | present only for `refused` and `error`: the same text the human output prints |
+
 `update` refuses to run rather than guess in several cases:
 - **A from-source build.** A binary built locally (its version carries a `git describe` suffix)
   is not something a release binary should silently replace — rebuild it with `git pull && cargo
@@ -89,9 +105,12 @@ not the exit code, to learn whether news exists. `1` for a refusal or any other 
   instead (see [how-to/setup-macos.md](../how-to/setup-macos.md)).
 - **An unsupported architecture**, where no release asset is published — build from source instead
   (see [how-to/build-from-source.md](../how-to/build-from-source.md)).
-- **An install directory that is not writable** by the current user. `update` never escalates
-  privileges to get around this (no `sudo` re-exec) — it prints the release URL so you can download
-  and move the binary into place by hand.
+- **An install directory it cannot stage the download in.** Before downloading anything, `update`
+  creates the temporary file it is about to download into, beside the installed binary. If that
+  fails it reports the operating system's own error — a read-only directory is the usual reason,
+  but a full disk or a quota lands here too — and stops. It never escalates privileges to get
+  around this (no `sudo` re-exec); it prints the release URL so you can download and move the
+  binary into place by hand.
 - **A non-interactive run without `--yes`.** With no terminal to confirm on and no `--yes`, `update`
   declines rather than assuming consent.
 

--- a/docs/reference/platforms.md
+++ b/docs/reference/platforms.md
@@ -54,9 +54,22 @@ Every tagged release attaches these assets, where `<tag>` is the release tag (e.
 | Linux x86-64 (static) | `glass-mcp-<tag>-x86_64-linux-musl.tar.gz` — no glibc dependency (Alpine and other musl distros) |
 | Windows x86-64 | `glass-mcp-<tag>-x86_64-windows.zip` |
 
-Each asset is accompanied by a `.sha256` checksum file, and every release carries Sigstore build
-provenance attestations. No aarch64 Linux asset is published; that architecture is built from source
-(see [how-to/build-from-source.md](../how-to/build-from-source.md)).
+`glass-mcp update` fetches a second, **uncompressed** kind of asset instead of an archive — the same
+binary the matching archive carries, published flat with no wrapping `.tar.gz`/`.zip` so the updater
+needs no archive-extraction code:
+
+| Platform | Uncompressed asset |
+|---|---|
+| Linux x86-64 (glibc) | the bare binary; checksum sidecar `glass-mcp-<tag>-x86_64-linux-gnu.sha256` |
+| Linux x86-64 (static) | the bare binary; checksum sidecar `glass-mcp-<tag>-x86_64-linux-musl.sha256` |
+| Windows x86-64 | the bare, Authenticode-signed `.exe`; checksum sidecar `glass-mcp-<tag>-x86_64-windows.exe.sha256` |
+
+No uncompressed macOS asset is published — upgrading there means the `.dmg` (see
+[setup-macos.md](../how-to/setup-macos.md)).
+
+Every asset, compressed or bare, is accompanied by a `.sha256` checksum file and carries a Sigstore
+build provenance attestation. No aarch64 Linux asset is published; that architecture is built from
+source (see [how-to/build-from-source.md](../how-to/build-from-source.md)).
 
 These asset names are **stable across the 1.x series** — an installer or script can depend on the
 `glass-mcp-<tag>-<platform>.<ext>` pattern and the per-platform suffixes above. See

--- a/docs/reference/platforms.md
+++ b/docs/reference/platforms.md
@@ -60,9 +60,9 @@ needs no archive-extraction code:
 
 | Platform | Uncompressed asset |
 |---|---|
-| Linux x86-64 (glibc) | the bare binary; checksum sidecar `glass-mcp-<tag>-x86_64-linux-gnu.sha256` |
-| Linux x86-64 (static) | the bare binary; checksum sidecar `glass-mcp-<tag>-x86_64-linux-musl.sha256` |
-| Windows x86-64 | the bare, Authenticode-signed `.exe`; checksum sidecar `glass-mcp-<tag>-x86_64-windows.exe.sha256` |
+| Linux x86-64 (glibc) | `glass-mcp-<tag>-x86_64-linux-gnu` — the bare binary, no extension; checksum sidecar `glass-mcp-<tag>-x86_64-linux-gnu.sha256` |
+| Linux x86-64 (static) | `glass-mcp-<tag>-x86_64-linux-musl` — the bare binary, no extension; checksum sidecar `glass-mcp-<tag>-x86_64-linux-musl.sha256` |
+| Windows x86-64 | `glass-mcp-<tag>-x86_64-windows.exe` — the same binary the `.zip` carries, Authenticode-signed exactly when the archived copy is (i.e. when the release's signing secrets are configured); checksum sidecar `glass-mcp-<tag>-x86_64-windows.exe.sha256` |
 
 No uncompressed macOS asset is published — upgrading there means the `.dmg` (see
 [setup-macos.md](../how-to/setup-macos.md)).
@@ -72,7 +72,9 @@ build provenance attestation. No aarch64 Linux asset is published; that architec
 source (see [how-to/build-from-source.md](../how-to/build-from-source.md)).
 
 These asset names are **stable across the 1.x series** — an installer or script can depend on the
-`glass-mcp-<tag>-<platform>.<ext>` pattern and the per-platform suffixes above. See
+per-platform suffixes above in either shape they take: `glass-mcp-<tag>-<platform>.<ext>` for the
+archives and their sidecars, and `glass-mcp-<tag>-<platform>` with no extension at all for the bare
+Linux binaries (the bare Windows binary keeps its `.exe`). See
 [Stability and versioning](stability.md) for the guarantee.
 
 ## Notes


### PR DESCRIPTION
Adds `glass-mcp update`, which replaces the running binary with the latest release, and publishes
the assets it downloads.

## What it does

```
glass-mcp update [--check] [--yes] [--skip-attestation] [--json] [--color WHEN]
```

Resolves the latest release by following `/releases/latest`'s redirect, downloads the bare binary
for this platform, verifies it, and swaps it in. `--check` reports without changing anything and
works on every platform.

## Design decisions worth knowing

**The release now publishes an uncompressed binary alongside the archives.** Every existing asset is
a `.tar.gz` or `.zip`, so an updater would need `tar`, `flate2` and `zip` linked in purely to pull
one file out of two archive formats. Publishing the binary flat removes that code and its
extraction-safety surface entirely: the download path is fetch one file, check one digest, set the
mode, rename. Existing asset names and contents are unchanged — this only adds.

**Three gates, in a fixed order, and the order is the contract.** The checksum proves the bytes are
what the release published; the attestation proves the release built them; only then is the file
executed for a smoke check. Nothing unverified is ever run.

**Attestation fails closed.** `gh attestation verify` queries GitHub's API, so an outage makes it
fail for reasons unrelated to the artifact — and telling "bad signature" from "couldn't reach
GitHub" by scraping another tool's stderr is brittle. Any non-success refuses, with
`--skip-attestation` as the explicit override. `gh` being absent is a separate, reported outcome
that does not block.

**Refusal ordering is a contract, asserted by tests.** From-source build → unsupported platform →
resolve latest (the first network call) → not-newer → staging → consent → download/verify/smoke →
swap. A from-source build is refused before any network request, so `cargo build` output is never
silently replaced with a release binary.

**One new dependency**, `reqwest`, behind a default-on `self-update` feature; `--no-default-features`
builds neither it nor the subcommand. No environment variable is added — the base URL is a
constructor argument so tests drive the real code path. It never escalates privileges: when the
install directory cannot be staged into, it prints the download URL and stops.

## Verification

`cargo fmt --check`, `clippy --workspace --all-targets -D warnings`, `--no-default-features`, the
`x86_64-pc-windows-gnu` cross-check, and `cargo test --workspace` (2415 passing) all clean.

Checked on a Windows 11 host, because CI structurally cannot reach these:

- The updater's temp file has no `.exe` extension; Windows spawns it, so the smoke check works.
- Renaming a running `.exe` aside and moving a new binary into the vacated path both succeed.
- The displaced image cannot be deleted while running (`Access is denied`) but can once it is not —
  which is why the sweep runs on the next invocation rather than immediately.
- `update --check` against live GitHub succeeds, confirming TLS via the OS trust store.

## Not yet verified

- **No end-to-end `update` has run against a real release**, because the first release carrying the
  bare assets is the first one that can be updated *to*. That run is the remaining check.
- **The Windows double-failure path** — both renames failing — has no test; there is no seam to
  inject a second rename failure. The surrounding algorithm is verified on hardware as above.
- **`gh attestation verify` pins `--repo` only.** Adding `--signer-workflow` would be stricter, but
  nothing here can observe its behavior and a wrong value fails closed for every user. Worth
  settling during the first real update.
