### PR TITLE
fix(x11): a clipboard owner that dies says so, and a bad reply is refused not fatal

### DIFF
--- a/crates/glass-x11/src/clipboard.rs
+++ b/crates/glass-x11/src/clipboard.rs
@@ -219,9 +219,7 @@ impl ClipboardOwner {
         let handle = std::thread::Builder::new()
             .name("glass-x11-clip-owner".into())
             .spawn(move || {
-                if let Err(e) =
-                    owner_thread(&display, text_clone, stop_clone, Arc::clone(&ready_clone))
-                {
+                if let Err(e) = owner_thread(&display, text_clone, &stop_clone, ready_clone) {
                     eprintln!("glass: clipboard owner thread error: {e}");
                 }
             })
@@ -289,10 +287,26 @@ impl ClipboardOwner {
         *self.text.lock().expect("clipboard text mutex") = text.to_string();
     }
 
-    /// Returns `true` if the owner thread is still running (i.e. still owns the
-    /// selection; `false` means `SelectionClear` was received).
+    /// Returns `true` while the owner thread is still serving the selection.
+    ///
+    /// `false` covers every way the thread can stop: another client took CLIPBOARD
+    /// (`SelectionClear`), its connection failed, or it panicked. `set_clipboard` spawns a
+    /// replacement on `false`.
     pub fn is_alive(&self) -> bool {
         !self.stop.load(Ordering::Relaxed)
+    }
+}
+
+/// Retires the owner however its thread leaves.
+///
+/// `stop` is the only thing [`ClipboardOwner::is_alive`] consults, and the thread's only way to
+/// say it has gone. A statement at the end of the thread body would miss a panic, which is the
+/// one exit route that reaches no statement at all.
+struct RetireOnExit<'a>(&'a AtomicBool);
+
+impl Drop for RetireOnExit<'_> {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::Relaxed);
     }
 }
 
@@ -424,15 +438,18 @@ fn take_selection(
 fn owner_thread(
     display: &str,
     text: Arc<Mutex<String>>,
-    stop: Arc<AtomicBool>,
+    stop: &AtomicBool,
     ready: Arc<(Mutex<ReadyState>, Condvar)>,
 ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    // First, so no early return below escapes it.
+    let _retire = RetireOnExit(stop);
+
     let Some(Owned {
         conn,
         win,
         utf8_string,
         targets_atom,
-    }) = take_selection(display, &stop, &ready)?
+    }) = take_selection(display, stop, &ready)?
     else {
         return Ok(());
     };
@@ -448,7 +465,15 @@ fn owner_thread(
                 use x11rb::protocol::Event;
                 match event {
                     Event::SelectionRequest(req) => {
-                        handle_selection_request(&conn, &req, &text, utf8_string, targets_atom)?;
+                        // Any client that gives up first leaves a window ID the reply cannot be
+                        // written to, glass's own reader included once its read deadline expires
+                        // (glass#372). A connection that is genuinely broken fails
+                        // `poll_for_event` above.
+                        if let Err(e) =
+                            handle_selection_request(&conn, &req, &text, utf8_string, targets_atom)
+                        {
+                            eprintln!("glass: clipboard owner: selection request: {e}");
+                        }
                     }
                     Event::SelectionClear(_) => {
                         // Another client took ownership; we're done serving.
@@ -467,22 +492,19 @@ fn owner_thread(
     Ok(())
 }
 
-fn handle_selection_request(
+/// Write the converted selection onto the requestor, returning the property it landed in.
+///
+/// `x11rb::NONE` is the ICCCM refusal, for a target this owner cannot produce. An `Err` is the
+/// write itself failing, which the caller turns into a refusal too.
+fn convert_onto_requestor(
     conn: &RustConnection,
     req: &SelectionRequestEvent,
+    reply_prop: Atom,
     text: &Arc<Mutex<String>>,
     utf8_string: Atom,
     targets_atom: Atom,
-) -> std::result::Result<(), Box<dyn std::error::Error>> {
-    // The property to write into on the requestor.  If req.property is NONE
-    // (old clients), fall back to writing into req.target as the property.
-    let reply_prop = if req.property != x11rb::NONE {
-        req.property
-    } else {
-        req.target
-    };
-
-    let granted_prop = if req.target == targets_atom {
+) -> std::result::Result<Atom, Box<dyn std::error::Error>> {
+    if req.target == targets_atom {
         let atoms: &[u32] = &[targets_atom, utf8_string];
         conn.change_property32(
             PropMode::REPLACE,
@@ -492,7 +514,7 @@ fn handle_selection_request(
             atoms,
         )?
         .check()?;
-        reply_prop
+        Ok(reply_prop)
     } else if req.target == utf8_string {
         let data = text.lock().expect("clipboard text mutex").clone();
         conn.change_property8(
@@ -503,15 +525,43 @@ fn handle_selection_request(
             data.as_bytes(),
         )?
         .check()?;
-        reply_prop
+        Ok(reply_prop)
     } else {
-        // Unsupported target: refuse with property = NONE.
-        x11rb::NONE
+        Ok(x11rb::NONE)
+    }
+}
+
+fn handle_selection_request(
+    conn: &RustConnection,
+    req: &SelectionRequestEvent,
+    text: &Arc<Mutex<String>>,
+    utf8_string: Atom,
+    targets_atom: Atom,
+) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    // A NONE property is an old client, which means writing into req.target instead.
+    let reply_prop = if req.property != x11rb::NONE {
+        req.property
+    } else {
+        req.target
     };
+
+    // A write that failed is still a request that must be answered: an owner that goes quiet
+    // keeps the selection, and every later paste on the display waits out its own timeout.
+    let granted_prop =
+        match convert_onto_requestor(conn, req, reply_prop, text, utf8_string, targets_atom) {
+            Ok(prop) => prop,
+            Err(e) => {
+                eprintln!(
+                    "glass: clipboard owner: converting for requestor {:#x}: {e}",
+                    req.requestor
+                );
+                x11rb::NONE
+            }
+        };
 
     // Send SelectionNotify to the requestor.
     let notify = SelectionNotifyEvent {
-        response_type: 31, // SELECTION_NOTIFY event code
+        response_type: SELECTION_NOTIFY_EVENT,
         sequence: 0,
         time: req.time,
         requestor: req.requestor,
@@ -645,6 +695,102 @@ mod tests {
 
     #[test]
     #[ignore = "starts a real X server; needs Xvfb"]
+    fn a_reply_that_cannot_be_delivered_costs_one_request_not_the_owner() {
+        // A requestor that asks and then exits leaves a window ID the reply cannot be written
+        // to — glass's own reader does, dropping its temporary window when its read deadline
+        // expires (glass#372). Ending the thread there hands the next copy to an owner that
+        // serves nobody.
+        let x = TestX::start();
+        let _owner =
+            ClipboardOwner::spawn(x.display().to_string(), "ours".to_string()).expect("spawn");
+        let owner_win = x.clipboard_owner();
+        assert_ne!(owner_win, x11rb::NONE, "the owner should hold CLIPBOARD");
+
+        let into = x.intern(b"TEST_CLIP_TRANSFER");
+        x.selection_request_from(owner_win, x.unused_id(), x.intern(b"UTF8_STRING"), into);
+
+        // The read, not `is_alive`, is what discriminates: a thread that has exited still
+        // reported itself alive before this was fixed (glass#371).
+        assert_eq!(
+            get(x.display()).expect("get"),
+            "ours",
+            "the owner should still be serving after a reply it could not deliver"
+        );
+    }
+
+    #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
+    fn a_conversion_the_owner_cannot_write_is_refused_rather_than_left_unanswered() {
+        // ICCCM: an owner answers every request, refusing with `property = NONE`. Returning
+        // before the reply leaves a live requestor waiting out its own timeout.
+        let x = TestX::start();
+        let _owner =
+            ClipboardOwner::spawn(x.display().to_string(), "ours".to_string()).expect("spawn");
+        let owner_win = x.clipboard_owner();
+        assert_ne!(owner_win, x11rb::NONE, "the owner should hold CLIPBOARD");
+
+        // A live requestor, so the reply has somewhere to go, and an XID where an atom
+        // belongs, so the value write fails with `BadAtom`.
+        let requestor = x.window().unmapped().create();
+        x.selection_request_from(
+            owner_win,
+            requestor,
+            x.intern(b"UTF8_STRING"),
+            x.unused_id(),
+        );
+
+        assert_eq!(
+            x.awaited_selection_notify(requestor, Duration::from_secs(2)),
+            Some(x11rb::NONE),
+            "a conversion the owner could not write is a refusal, not silence"
+        );
+    }
+
+    #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
+    fn an_owner_whose_connection_breaks_stops_reporting_itself_alive() {
+        // `set_clipboard` hands the text to whatever `is_alive` says is still serving, so a
+        // thread that is gone has to say so however it left — here, its connection closed under
+        // it. Reporting `true` puts the copy in a mutex nothing reads.
+        let x = TestX::start();
+        let owner =
+            ClipboardOwner::spawn(x.display().to_string(), "ours".to_string()).expect("spawn");
+        assert!(owner.is_alive());
+
+        let owner_win = x.clipboard_owner();
+        // `KillClient` reads resource 0 as `AllTemporary`, so an owner that never took the
+        // selection would kill nothing here and fail below blaming the retire logic.
+        assert_ne!(owner_win, x11rb::NONE, "the owner should hold CLIPBOARD");
+        x.kill_client(owner_win);
+
+        assert!(
+            eventually(Duration::from_secs(3), || !owner.is_alive()),
+            "the owner thread is gone; is_alive must not keep claiming otherwise"
+        );
+    }
+
+    /// Retiring on the way out is a value's `Drop`, not a statement at the end of the thread
+    /// body, and this is the difference between them: unwinding runs one and skips the other.
+    #[test]
+    fn an_owner_thread_that_panics_retires_like_one_that_returned() {
+        let stop = Arc::new(AtomicBool::new(false));
+        let thread_stop = Arc::clone(&stop);
+        let panicked = std::thread::spawn(move || {
+            let _retire = RetireOnExit(&thread_stop);
+            // The panic message below is the test working, not the test failing.
+            panic!("an owner thread panicking mid-serve");
+        })
+        .join();
+
+        assert!(panicked.is_err(), "the thread was supposed to panic");
+        assert!(
+            stop.load(Ordering::Relaxed),
+            "a thread that panicked is as gone as one that returned"
+        );
+    }
+
+    #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn the_owner_advertises_the_targets_it_can_convert_to() {
         let x = TestX::start();
         let _owner =
@@ -711,7 +857,7 @@ mod tests {
             Duration::from_secs(10),
             "a stalled X server must fail this test, not hang the whole suite",
             move || {
-                owner_thread(&display, text, stop, ready)
+                owner_thread(&display, text, &stop, ready)
                     .err()
                     .map(|e| e.to_string())
             },

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -2694,6 +2694,35 @@ mod display_tests {
         assert_eq!(plat.get_clipboard().expect("get"), "ours again");
     }
 
+    #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
+    fn a_copy_after_the_owner_thread_died_starts_a_fresh_owner() {
+        // glass#371's symptom, in the terms an agent meets it: the copy reports success and
+        // the paste comes back empty. The sibling above covers the SelectionClear route; this
+        // covers a thread that died mid-life.
+        let x = TestX::start();
+        let mut plat = x.platform();
+        plat.set_clipboard("ours").expect("set");
+        assert_eq!(plat.get_clipboard().expect("get"), "ours");
+
+        let owner_win = x.clipboard_owner();
+        assert_ne!(owner_win, x11rb::NONE, "the first copy takes the selection");
+        x.kill_client(owner_win);
+
+        // Wait for the owner to RETIRE, not merely for the selection to change hands: copying
+        // before it does is what put the text somewhere nothing served it.
+        let deadline = Instant::now() + Duration::from_secs(3);
+        while Instant::now() < deadline
+            && plat.clipboard_owner.as_ref().is_some_and(|o| o.is_alive())
+        {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        plat.set_clipboard("ours again")
+            .expect("set after the owner died");
+        assert_eq!(plat.get_clipboard().expect("get"), "ours again");
+    }
+
     // --- the close ladder ------------------------------------------------------------
 
     #[test]

--- a/crates/glass-x11/src/testx.rs
+++ b/crates/glass-x11/src/testx.rs
@@ -191,6 +191,70 @@ impl TestX {
         None
     }
 
+    /// An XID no window was ever created with. x11rb hands these out of the client's own range
+    /// and never reuses one, so naming it as a requestor is a `BadWindow` the owner cannot dodge.
+    pub(crate) fn unused_id(&self) -> u32 {
+        self.conn.generate_id().expect("generate_id")
+    }
+
+    /// Ask `owner` to convert CLIPBOARD to `target` for `requestor`, writing into `into`.
+    ///
+    /// Synthesised rather than driven through `convert_selection` so a test can name a requestor
+    /// or a property the server will reject. Checked, not just flushed: a request the server
+    /// refuses to deliver would leave the owner idle and the test asserting against nothing.
+    pub(crate) fn selection_request_from(
+        &self,
+        owner: Window,
+        requestor: u32,
+        target: Atom,
+        into: Atom,
+    ) {
+        let event = SelectionRequestEvent {
+            response_type: SELECTION_REQUEST_EVENT,
+            sequence: 0,
+            time: x11rb::CURRENT_TIME,
+            owner,
+            requestor,
+            selection: self.intern(b"CLIPBOARD"),
+            target,
+            property: into,
+        };
+        // An empty mask sends the event to the client that created `owner`.
+        self.conn
+            .send_event(false, owner, EventMask::NO_EVENT, event)
+            .expect("send_event")
+            .check()
+            .expect("the server should deliver the synthesised SelectionRequest");
+    }
+
+    /// The property named in the `SelectionNotify` sent to `requestor`, or `None` if none
+    /// arrives within `within`. `x11rb::NONE` is a refusal; anything else is where the value
+    /// landed.
+    pub(crate) fn awaited_selection_notify(
+        &self,
+        requestor: Window,
+        within: Duration,
+    ) -> Option<Atom> {
+        let deadline = Instant::now() + within;
+        while Instant::now() < deadline {
+            if let Some(Event::SelectionNotify(n)) =
+                self.conn.poll_for_event().expect("poll_for_event")
+                && n.requestor == requestor
+            {
+                return Some(n.property);
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        None
+    }
+
+    /// Have the server close `win`'s client connection, the way `xkill` does — how a test breaks
+    /// the owner thread's connection without taking down the display every other client is on.
+    pub(crate) fn kill_client(&self, win: Window) {
+        self.conn.kill_client(win).expect("kill_client");
+        self.flush();
+    }
+
     /// The atoms stored in `prop` on `win` — how a requestor reads a TARGETS reply.
     pub(crate) fn property_atoms(&self, win: Window, prop: Atom) -> Vec<Atom> {
         self.conn


### PR DESCRIPTION
`ClipboardOwner::is_alive()` is `!stop.load(..)`, and `stop` was moved into `owner_thread`, so nothing set it on the way out. A thread that died mid-life — an error from `poll_for_event`, or from answering a `SelectionRequest` — left `is_alive()` reporting `true` forever. `set_clipboard` gates on exactly that, so the copy went into a mutex nothing serves and the next paste came back empty.

## The fix

**Retire from a `Drop` guard.** `owner_thread` now holds a `RetireOnExit`, so `stop` is set however the thread leaves — return, error, or unwind. A statement at the end of the body would miss a panic, the one exit route that reaches no statement at all.

**Answering a request is per-request, not fatal.** A client that asks and then exits leaves a window ID the reply cannot be written to; glass's own reader produces exactly that once its read deadline expires (#372). A genuinely broken connection still fails `poll_for_event` and retires the owner.

**A failed write sends the ICCCM refusal.** `handle_selection_request` used to return before constructing its `SelectionNotify`, so a failed conversion answered nothing. Tolerating that without answering would have been worse than the original bug: the owner keeps the selection, so every later paste on the display waits out its own timeout — where previously the thread died and the selection reverted to unowned. Write failures now join the unsupported-target branch and refuse with `property = NONE`.

## Tests

| Test | Pins |
|---|---|
| `a_reply_that_cannot_be_delivered_costs_one_request_not_the_owner` | per-request tolerance |
| `a_conversion_the_owner_cannot_write_is_refused_rather_than_left_unanswered` | the ICCCM refusal |
| `an_owner_whose_connection_breaks_stops_reporting_itself_alive` | the guard, installed |
| `an_owner_thread_that_panics_retires_like_one_that_returned` | the guard, on unwind — needs no display |
| `a_copy_after_the_owner_thread_died_starts_a_fresh_owner` | the symptom at the `set_clipboard` boundary |

Each was watched red first, and the two halves were ablated separately: reverting only the guard fails the last three, reverting only the per-request handling fails the first.

`an_owner_whose_connection_breaks_stops_reporting_itself_alive` is load-bearing for the *other* half's safety argument — it is the evidence that a broken connection surfaces at `poll_for_event`, without which swallowing per-request errors could leave a thread spinning forever.

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace`, `cargo test -p glass-x11 -- --include-ignored` (159/159), and `./scripts/test-x11.sh clipboard` (4/4) all green.

## Not in this PR

- `glass-wayland`'s `serve_loop` stores the flag at the end rather than from a guard, so it has the same panic hole. Filing separately.
- A serve failure still reaches nobody but stderr; `set_clipboard` returns `Ok`. Pre-existing, and a channel change rather than a bug fix.

Closes #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)