### PR TITLE
fix(doctor): each distinct failure gets the remedy for that failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ internal refactors, CI, or test-only changes.
 
 ## [Unreleased]
 
+### Fixed
+- `glass doctor` no longer flattens distinct environment failures into one message with a remedy
+  for a different problem. An X display that answers and refuses the connection is reported as an
+  authorisation failure, pointing at `XAUTHORITY`, instead of one that needs starting; a tool that
+  could not be looked up because `PATH` is unset (common when an MCP client spawns glass-mcp with a
+  stripped environment) is no longer reported as not installed; and a deep probe the host stopped —
+  a thread refused or killed under a low `pids` limit — is no longer reported as its full timeout
+  elapsing. The Wayland backend gets the same treatment: a headless sway that exits immediately is
+  reported as an exit rather than as an eight-second wait.
+
 ## [1.4.0] - 2026-08-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,14 +20,19 @@ internal refactors, CI, or test-only changes.
 ## [Unreleased]
 
 ### Fixed
-- `glass doctor` no longer flattens distinct environment failures into one message with a remedy
-  for a different problem. An X display that answers and refuses the connection is reported as an
-  authorisation failure, pointing at `XAUTHORITY`, instead of one that needs starting; a tool that
-  could not be looked up because `PATH` is unset (common when an MCP client spawns glass-mcp with a
-  stripped environment) is no longer reported as not installed; and a deep probe the host stopped —
-  a thread refused or killed under a low `pids` limit — is no longer reported as its full timeout
-  elapsing. The Wayland backend gets the same treatment: a headless sway that exits immediately is
-  reported as an exit rather than as an eight-second wait.
+- `glass doctor` tells apart the ways attaching to an X display can fail, instead of reporting
+  every one as "cannot connect" with "start that display". A server that answers and refuses the
+  connection now says so and points at `XAUTHORITY`; a `GLASS_DISPLAY` that is not a display name,
+  and a screen the server does not have, each get their own message.
+- `glass doctor` no longer reports a tool as not installed when there was no `$PATH` to look it up
+  in — a stripped environment, which MCP clients routinely hand to the servers they spawn. Xvfb,
+  sway, `bubblewrap`, `dbus-daemon` and the AT-SPI launcher all say so and name their `GLASS_*`
+  override instead.
+- `glass doctor --deep` no longer reports a probe that never started as its full timeout elapsing.
+  A probe the host refused (a low `pids` limit) and one that panicked are now told apart from the
+  backend failing, and each gets the remedy for that, rather than the backend's. On the Wayland
+  backend a headless sway that exits immediately is reported as an exit, not as an eight-second
+  wait it never made.
 
 ## [1.4.0] - 2026-08-17
 

--- a/crates/glass-a11y-linux/src/doctor.rs
+++ b/crates/glass-a11y-linux/src/doctor.rs
@@ -252,7 +252,8 @@ fn a11y_checks(launcher: &Resolved, override_set: bool, facts: &HostA11yFacts) -
             CheckStatus::Warn,
             "at-spi-bus-launcher could not be looked up — PATH is unset in glass's environment",
         )
-        .with_remedy("point GLASS_ATSPI_LAUNCHER at the launcher, or give glass a PATH to search"),
+        // No PATH advice: discovery walks fixed paths and would not read one.
+        .with_remedy("point GLASS_ATSPI_LAUNCHER at the launcher"),
     });
 
     // Concern B — host desktop a11y health (#9). Detect-only; never mutate.

--- a/crates/glass-a11y-linux/src/doctor.rs
+++ b/crates/glass-a11y-linux/src/doctor.rs
@@ -245,6 +245,14 @@ fn a11y_checks(launcher: &Resolved, override_set: bool, facts: &HostA11yFacts) -
         Resolved::Absent => Check::new("a11y", CheckStatus::Warn, "at-spi-bus-launcher not found").with_remedy(
             "install the AT-SPI registry (e.g. `apt install at-spi2-core`) so glass can spawn its private a11y bus",
         ),
+        // Unreachable while discovery walks fixed paths — kept apart because a launcher that was
+        // never looked up is not one that is missing (glass#373).
+        Resolved::NoSearchPath => Check::new(
+            "a11y",
+            CheckStatus::Warn,
+            "at-spi-bus-launcher could not be looked up — PATH is unset in glass's environment",
+        )
+        .with_remedy("point GLASS_ATSPI_LAUNCHER at the launcher, or give glass a PATH to search"),
     });
 
     // Concern B — host desktop a11y health (#9). Detect-only; never mutate.
@@ -496,6 +504,25 @@ mod tests {
         assert_eq!(head.status, CheckStatus::Warn);
         assert!(head.detail.contains("GLASS_ATSPI_LAUNCHER"));
         assert!(!head.remedy.clone().unwrap().contains("at-spi2-core"));
+    }
+
+    /// glass#373: unreachable while the launcher is looked for by path — kept distinct so a
+    /// caller that searches `$PATH` one day does not inherit "install at-spi2-core".
+    #[test]
+    fn a_launcher_that_could_not_be_looked_up_is_not_reported_as_missing() {
+        let cs = a11y_checks(
+            &Resolved::NoSearchPath,
+            false,
+            &facts(HostBusState::NotRunning, 0),
+        );
+        let head = cs.iter().find(|c| c.name == "a11y").unwrap();
+        assert_eq!(head.status, CheckStatus::Warn);
+        assert!(head.detail.contains("PATH"), "{:?}", head.detail);
+        assert!(
+            !head.remedy.clone().unwrap().contains("at-spi2-core"),
+            "the package may well be installed: {:?}",
+            head.remedy
+        );
     }
 
     #[test]

--- a/crates/glass-core/src/doctor.rs
+++ b/crates/glass-core/src/doctor.rs
@@ -5,6 +5,9 @@
 //! present); `glass-mcp` aggregates them into a [`Diagnosis`] and drives the CLI
 //! subcommand and the `glass_doctor` MCP tool.
 
+use std::sync::mpsc;
+use std::time::Duration;
+
 use serde::Serialize;
 
 /// Outcome of a single check.
@@ -133,6 +136,67 @@ impl Check {
     pub fn with_remedy_action(mut self, action: impl Into<String>) -> Self {
         self.remedy_action = Some(action.into());
         self
+    }
+}
+
+/// Why a deep probe — doctor starting the real thing and taking it straight back down — produced
+/// no working backend.
+///
+/// Four outcomes, because they are answers about different machines: two are the backend's and
+/// two are this host's. Collapsing them is how a probe killed on the spot by a `pids` limit came
+/// to report a 24-second wait against Xvfb (glass#373).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ProbeFailure {
+    /// The probe was never started — the host refused the thread or process, so nothing was
+    /// learned about the backend.
+    NotStarted(String),
+    /// The probe ran and the backend failed, carrying what failed.
+    Failed(String),
+    /// The probe was still running, and still not ready, when its budget ran out.
+    TimedOut(Duration),
+    /// The probe ended without answering: its thread unwound.
+    Vanished,
+}
+
+impl ProbeFailure {
+    /// A bounded wait on the probe thread's channel, mapped. `Disconnected` means the sender went
+    /// with a thread that unwound and arrives at once — reported as a timeout it claims a wait
+    /// nobody did.
+    pub fn from_recv(err: mpsc::RecvTimeoutError, budget: Duration) -> Self {
+        match err {
+            mpsc::RecvTimeoutError::Timeout => ProbeFailure::TimedOut(budget),
+            mpsc::RecvTimeoutError::Disconnected => ProbeFailure::Vanished,
+        }
+    }
+
+    /// The detail doctor prints, `what` naming the thing probed ("Xvfb", "headless sway").
+    pub fn detail(&self, what: &str) -> String {
+        match self {
+            ProbeFailure::NotStarted(why) => format!("could not start the {what} probe: {why}"),
+            ProbeFailure::Failed(why) => format!("{what} failed to come up: {why}"),
+            // The budget that was actually waited, passed in — a renderer holding its own copy of
+            // the constant is free to drift from the wait it describes.
+            ProbeFailure::TimedOut(budget) => {
+                format!("{what} was still not ready {budget:?} later")
+            }
+            ProbeFailure::Vanished => {
+                format!("the {what} probe ended without an answer — its thread unwound")
+            }
+        }
+    }
+
+    /// The remedy. `hint` is the backend's own advice, used only for the two outcomes that
+    /// reached the backend; a probe the host stopped taught nothing about it, so that remedy names
+    /// this host instead.
+    pub fn remedy(&self, hint: &str) -> String {
+        match self {
+            ProbeFailure::Failed(_) | ProbeFailure::TimedOut(_) => hint.to_string(),
+            ProbeFailure::NotStarted(_) | ProbeFailure::Vanished => {
+                "the host stopped the probe before it could answer — check this process's thread \
+                 and memory limits (a low `pids` cgroup limit is the usual cause)"
+                    .into()
+            }
+        }
     }
 }
 
@@ -301,6 +365,63 @@ fn summary_count(palette: &Palette, n: u32, attr: &str, label: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// glass#373: a probe thread that died on `EAGAIN` was reported as a budget that elapsed — a
+    /// 24-second timeout that took no time at all, pointing at the backend rather than the host
+    /// limit that stopped it.
+    #[test]
+    fn a_probe_that_ended_without_answering_is_not_a_timeout() {
+        let budget = Duration::from_secs(24);
+        assert_eq!(
+            ProbeFailure::from_recv(mpsc::RecvTimeoutError::Disconnected, budget),
+            ProbeFailure::Vanished
+        );
+        assert_eq!(
+            ProbeFailure::from_recv(mpsc::RecvTimeoutError::Timeout, budget),
+            ProbeFailure::TimedOut(budget)
+        );
+    }
+
+    #[test]
+    fn each_probe_failure_says_something_different() {
+        let details = [
+            ProbeFailure::NotStarted("Resource temporarily unavailable".into()),
+            ProbeFailure::Failed("Xvfb exited during startup".into()),
+            ProbeFailure::TimedOut(Duration::from_secs(24)),
+            ProbeFailure::Vanished,
+        ]
+        .map(|f| f.detail("Xvfb"));
+        assert!(details.iter().all(|d| d.contains("Xvfb")), "{details:?}");
+        let unique: std::collections::BTreeSet<&String> = details.iter().collect();
+        assert_eq!(unique.len(), details.len(), "{details:?}");
+    }
+
+    /// The wait must be the one given, not a constant the renderer holds — the two drifting apart
+    /// is how a zero-second failure came to claim 24 seconds.
+    #[test]
+    fn a_timeout_reports_the_budget_it_was_given() {
+        let d = ProbeFailure::TimedOut(Duration::from_millis(1500)).detail("headless sway");
+        assert!(d.contains("1.5s"), "{d}");
+    }
+
+    /// A host that refused the probe taught nothing about the backend, so its advice would be a
+    /// guess; the two outcomes that did run get it.
+    #[test]
+    fn only_a_probe_that_ran_gets_the_backend_hint() {
+        const HINT: &str = "check Mesa software GL";
+        assert!(ProbeFailure::Failed("x".into()).remedy(HINT).contains(HINT));
+        assert!(
+            ProbeFailure::TimedOut(Duration::from_secs(1))
+                .remedy(HINT)
+                .contains(HINT)
+        );
+        assert!(!ProbeFailure::Vanished.remedy(HINT).contains(HINT));
+        assert!(
+            !ProbeFailure::NotStarted("x".into())
+                .remedy(HINT)
+                .contains(HINT)
+        );
+    }
 
     fn diag() -> Diagnosis {
         Diagnosis::new(vec![

--- a/crates/glass-core/src/doctor.rs
+++ b/crates/glass-core/src/doctor.rs
@@ -147,14 +147,14 @@ impl Check {
 /// to report a 24-second wait against Xvfb (glass#373).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ProbeFailure {
-    /// The probe was never started — the host refused the thread or process, so nothing was
-    /// learned about the backend.
+    /// Nothing was started, for the reason carried here — the host refused the thread or process,
+    /// or glass could not lay out what the probe needs. Nothing was learned about the backend.
     NotStarted(String),
     /// The probe ran and the backend failed, carrying what failed.
     Failed(String),
     /// The probe was still running, and still not ready, when its budget ran out.
     TimedOut(Duration),
-    /// The probe ended without answering: its thread unwound.
+    /// The probe ended without answering: it ran on a thread, and that thread unwound.
     Vanished,
 }
 
@@ -174,8 +174,7 @@ impl ProbeFailure {
         match self {
             ProbeFailure::NotStarted(why) => format!("could not start the {what} probe: {why}"),
             ProbeFailure::Failed(why) => format!("{what} failed to come up: {why}"),
-            // The budget that was actually waited, passed in — a renderer holding its own copy of
-            // the constant is free to drift from the wait it describes.
+            // The budget the wait was given, passed in rather than read from a constant here.
             ProbeFailure::TimedOut(budget) => {
                 format!("{what} was still not ready {budget:?} later")
             }
@@ -186,14 +185,24 @@ impl ProbeFailure {
     }
 
     /// The remedy. `hint` is the backend's own advice, used only for the two outcomes that
-    /// reached the backend; a probe the host stopped taught nothing about it, so that remedy names
-    /// this host instead.
+    /// reached the backend; the other two never did, so naming it there would be a guess.
+    ///
+    /// Those two do not share a remedy either: one is the host refusing what the probe needed, the
+    /// other is glass's own code unwinding.
     pub fn remedy(&self, hint: &str) -> String {
         match self {
             ProbeFailure::Failed(_) | ProbeFailure::TimedOut(_) => hint.to_string(),
-            ProbeFailure::NotStarted(_) | ProbeFailure::Vanished => {
-                "the host stopped the probe before it could answer — check this process's thread \
-                 and memory limits (a low `pids` cgroup limit is the usual cause)"
+            // The detail carries which resource was refused; a remedy that picked one would be
+            // wrong for the others.
+            ProbeFailure::NotStarted(_) => {
+                "the probe never started, so nothing here is about the backend — the cause is in \
+                 the detail: a low `pids` cgroup limit, and a full or read-only temp dir, are the \
+                 usual ones"
+                    .into()
+            }
+            ProbeFailure::Vanished => {
+                "the probe panicked — the panic is on glass's stderr; a `pids` cgroup limit low \
+                 enough to refuse a thread will also do this"
                     .into()
             }
         }
@@ -379,6 +388,28 @@ mod tests {
         assert_eq!(
             ProbeFailure::from_recv(mpsc::RecvTimeoutError::Timeout, budget),
             ProbeFailure::TimedOut(budget)
+        );
+    }
+
+    /// The OS reason is the only text separating a `pids` limit from an out-of-memory or a full
+    /// temp dir, and the shared remedy deliberately names none of them.
+    #[test]
+    fn a_probe_that_never_started_says_what_refused_it() {
+        let detail = ProbeFailure::NotStarted("Resource temporarily unavailable".into())
+            .detail("headless sway");
+        assert!(
+            detail.contains("Resource temporarily unavailable"),
+            "{detail}"
+        );
+    }
+
+    /// A host that refused the probe and glass unwinding are different repairs, and the type
+    /// exists to keep them apart all the way to the printed line.
+    #[test]
+    fn the_two_outcomes_that_never_reached_the_backend_still_differ() {
+        assert_ne!(
+            ProbeFailure::NotStarted("x".into()).remedy("hint"),
+            ProbeFailure::Vanished.remedy("hint")
         );
     }
 

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -56,7 +56,7 @@ pub use diff::{
     diff_with_mask, region_satisfied,
 };
 pub mod doctor;
-pub use doctor::{Check, CheckStatus, Diagnosis, Palette, Section};
+pub use doctor::{Check, CheckStatus, Diagnosis, Palette, ProbeFailure, Section};
 
 pub mod capability;
 pub use capability::{CapabilityMap, CapabilityStatus, Support};

--- a/crates/glass-dbus-linux/src/lib.rs
+++ b/crates/glass-dbus-linux/src/lib.rs
@@ -287,7 +287,9 @@ fn find_launcher_with(
             Resolved::NotExecutable(p) => {
                 first_non_executable.get_or_insert(p);
             }
-            Resolved::Absent => {}
+            // A candidate is one path, judged on its own: `resolve_path` has no search list to
+            // lack, so `NoSearchPath` cannot come from it. Both mean "nothing here" to the walk.
+            Resolved::Absent | Resolved::NoSearchPath => {}
         }
     }
     first_non_executable.map_or(Resolved::Absent, Resolved::NotExecutable)
@@ -375,6 +377,14 @@ fn launcher_or_reason(resolved: Resolved) -> std::result::Result<PathBuf, String
             "at-spi-bus-launcher not found (install at-spi2-core), or set GLASS_ATSPI_LAUNCHER"
                 .into(),
         ),
+        // Unreachable from `find_launcher`, which walks fixed paths — given its own answer so a
+        // caller that does search one day inherits the distinction, not the misdirection
+        // (glass#373).
+        Resolved::NoSearchPath => Err(
+            "at-spi-bus-launcher could not be looked up — PATH is unset in glass's environment; \
+             set GLASS_ATSPI_LAUNCHER to its path"
+                .into(),
+        ),
     }
 }
 
@@ -408,6 +418,12 @@ fn available_with(
         }
         Resolved::Absent => Err(format!(
             "dbus-daemon ({dbus}) not found (install dbus, or set GLASS_DBUS_DAEMON to its path)"
+        )),
+        // dbus may well be installed; what is missing is the environment glass was spawned
+        // with.
+        Resolved::NoSearchPath => Err(format!(
+            "dbus-daemon ({dbus}) could not be looked up — PATH is unset in glass's environment; \
+             set GLASS_DBUS_DAEMON to its path"
         )),
     }
 }
@@ -925,6 +941,27 @@ mod tests {
         assert!(
             !err.contains("install at-spi2-core"),
             "the package is installed; sending the user to reinstall it is the misdirection: {err}"
+        );
+    }
+
+    /// glass#373: a bare `dbus-daemon` and no `$PATH` to look it up in. Reported as "not found",
+    /// it sends the user to install dbus; what is missing is the environment glass was spawned
+    /// with.
+    #[test]
+    fn a_dbus_daemon_that_could_not_be_looked_up_is_not_reported_as_missing() {
+        let err = available_with(
+            Resolved::Found(PathBuf::from("/bin/true")),
+            "dbus-daemon",
+            None,
+        )
+        .expect_err("a bare name with no search list cannot resolve");
+        assert!(
+            err.contains("PATH"),
+            "name the fact the user can act on: {err}"
+        );
+        assert!(
+            !err.contains("install dbus"),
+            "dbus may well be installed: {err}"
         );
     }
 

--- a/crates/glass-dbus-linux/src/lib.rs
+++ b/crates/glass-dbus-linux/src/lib.rs
@@ -965,6 +965,19 @@ mod tests {
         );
     }
 
+    /// The launcher is looked for by path, so this arm is unreachable today — tested because an
+    /// uncovered arm is one a later `$PATH` walk inherits without anyone reading it (glass#373).
+    #[test]
+    fn a_launcher_that_could_not_be_looked_up_is_not_reported_as_missing() {
+        let err = launcher_or_reason(Resolved::NoSearchPath)
+            .expect_err("nothing resolved, so there is nothing to launch");
+        assert!(err.contains("PATH"), "{err}");
+        assert!(
+            !err.contains("install at-spi2-core"),
+            "the package may well be installed: {err}"
+        );
+    }
+
     /// The other preflight branch: an explicit `$GLASS_DBUS_DAEMON` path that is not a file.
     #[test]
     fn available_errors_when_an_explicit_dbus_daemon_path_is_missing() {

--- a/crates/glass-exec-unix/src/lib.rs
+++ b/crates/glass-exec-unix/src/lib.rs
@@ -3,7 +3,9 @@
 //! binary from an installed one it cannot spawn.
 //!
 //! One gap against `execvp` remains: with `$PATH` unset `execvp` searches `confstr(_CS_PATH)`,
-//! while [`resolve_bin`] given no search list reports [`Resolved::NoSearchPath`].
+//! while [`resolve_bin`] given no search list reports [`Resolved::NoSearchPath`]. A `$PATH` that
+//! is set but empty is not that case — `execvp` reads its one zero-length entry as the current
+//! directory, and so does the walk here.
 //!
 //! Consumers: the X11 and Wayland backends (`glass-x11`, `glass-wayland`), the AT-SPI bus launcher
 //! and its doctor check (`glass-dbus-linux`, `glass-a11y-linux`), and the sandbox backends
@@ -85,9 +87,7 @@ pub fn resolve_bin(bin: &str, path: Option<&OsStr>) -> Resolved {
     if bin.contains('/') {
         return resolve_path(Path::new(bin));
     }
-    // `PATH=` is treated as the unset case, not as the one-entry list naming the current
-    // directory that `split_paths` reads it as.
-    let Some(path) = path.filter(|p| !p.is_empty()) else {
+    let Some(path) = path else {
         return Resolved::NoSearchPath;
     };
     let mut first_non_executable = None;
@@ -339,13 +339,15 @@ mod tests {
         assert_eq!(resolve_bin("Xvfb", None), Resolved::NoSearchPath);
     }
 
-    /// `PATH=` carries the same fact as an unset `PATH`, and must not be read as a one-entry list
-    /// naming the current directory — which is what `split_paths` makes of it.
+    /// A set-but-empty `$PATH` is a search list, not the absence of one: `execvp` reads its
+    /// zero-length entry as the current directory, and resolution mirrors `execvp` so that a
+    /// preflight cannot refuse a launch the kernel would have completed.
     #[test]
-    fn an_empty_search_list_is_no_search_list() {
+    fn an_empty_search_list_is_still_a_search_list() {
         assert_eq!(
             resolve_bin("Xvfb", Some(OsStr::new(""))),
-            Resolved::NoSearchPath
+            Resolved::Absent,
+            "an empty entry searches the current directory, which holds no Xvfb"
         );
     }
 

--- a/crates/glass-exec-unix/src/lib.rs
+++ b/crates/glass-exec-unix/src/lib.rs
@@ -3,7 +3,7 @@
 //! binary from an installed one it cannot spawn.
 //!
 //! One gap against `execvp` remains: with `$PATH` unset `execvp` searches `confstr(_CS_PATH)`,
-//! while [`resolve_bin`] given no search list reports [`Resolved::Absent`].
+//! while [`resolve_bin`] given no search list reports [`Resolved::NoSearchPath`].
 //!
 //! Consumers: the X11 and Wayland backends (`glass-x11`, `glass-wayland`), the AT-SPI bus launcher
 //! and its doctor check (`glass-dbus-linux`, `glass-a11y-linux`), and the sandbox backends
@@ -66,9 +66,11 @@ pub enum Resolved {
     Found(PathBuf),
     /// A regular file is there, and this process may not execute it.
     NotExecutable(PathBuf),
-    /// Nothing to point the user at: no such path, a directory, a path that cannot be stat'd, or
-    /// — from [`resolve_bin`] — a bare name with no search list to look it up in.
+    /// Nothing to point the user at: no such path, a directory, or a path that cannot be stat'd.
     Absent,
+    /// A bare name and no `$PATH` to look it up in. Distinct from [`Resolved::Absent`] because the
+    /// tool may well be installed: what is missing is the environment glass was spawned with.
+    NoSearchPath,
 }
 
 /// Resolve a configured tool the way the child will be exec'd: a token containing `/` is an
@@ -83,8 +85,10 @@ pub fn resolve_bin(bin: &str, path: Option<&OsStr>) -> Resolved {
     if bin.contains('/') {
         return resolve_path(Path::new(bin));
     }
-    let Some(path) = path else {
-        return Resolved::Absent;
+    // `PATH=` is treated as the unset case, not as the one-entry list naming the current
+    // directory that `split_paths` reads it as.
+    let Some(path) = path.filter(|p| !p.is_empty()) else {
+        return Resolved::NoSearchPath;
     };
     let mut first_non_executable = None;
     for cand in std::env::split_paths(path).map(|dir| dir.join(bin)) {
@@ -93,7 +97,9 @@ pub fn resolve_bin(bin: &str, path: Option<&OsStr>) -> Resolved {
             Resolved::NotExecutable(p) => {
                 first_non_executable.get_or_insert(p);
             }
-            Resolved::Absent => {}
+            // `resolve_path` judges one path and never wants a search list, so `NoSearchPath`
+            // cannot come from it; both mean "nothing here" to the walk.
+            Resolved::Absent | Resolved::NoSearchPath => {}
         }
     }
     first_non_executable.map_or(Resolved::Absent, Resolved::NotExecutable)
@@ -326,9 +332,21 @@ mod tests {
         );
     }
 
+    /// glass#373: MCP clients routinely spawn glass-mcp with a stripped environment, and "not
+    /// found" then sends the user to install a tool that is already there.
     #[test]
-    fn a_bare_name_with_no_search_list_is_absent() {
-        assert_eq!(resolve_bin("Xvfb", None), Resolved::Absent);
+    fn a_bare_name_with_no_search_list_is_not_reported_as_missing() {
+        assert_eq!(resolve_bin("Xvfb", None), Resolved::NoSearchPath);
+    }
+
+    /// `PATH=` carries the same fact as an unset `PATH`, and must not be read as a one-entry list
+    /// naming the current directory — which is what `split_paths` makes of it.
+    #[test]
+    fn an_empty_search_list_is_no_search_list() {
+        assert_eq!(
+            resolve_bin("Xvfb", Some(OsStr::new(""))),
+            Resolved::NoSearchPath
+        );
     }
 
     #[test]

--- a/crates/glass-sandbox-linux/src/lib.rs
+++ b/crates/glass-sandbox-linux/src/lib.rs
@@ -419,6 +419,11 @@ fn resolved_bwrap(bin: &str, bwrap: Resolved) -> std::result::Result<PathBuf, No
             p.display()
         ))),
         Resolved::Absent => Err(NoSandbox::Missing(format!("bubblewrap ({bin}) not found"))),
+        // Not "not found": nothing was searched, and installing bubblewrap cannot restore a
+        // `PATH`.
+        Resolved::NoSearchPath => Err(NoSandbox::Missing(format!(
+            "bubblewrap ({bin}) could not be looked up — PATH is unset in glass's environment"
+        ))),
     }
 }
 
@@ -1195,6 +1200,23 @@ mod tests {
         assert!(
             no.why().contains("bwrap") && no.why().contains("not found"),
             "actionable message: {no:?}"
+        );
+    }
+
+    /// glass#373: a stripped environment leaves nothing to look a bare `bwrap` up in, and "not
+    /// found" sends the user to install a package they already have.
+    #[test]
+    fn a_bwrap_that_could_not_be_looked_up_is_not_reported_as_missing() {
+        let Err(no) = resolved_bwrap("bwrap", Resolved::NoSearchPath) else {
+            panic!("a bwrap that never resolved must not be probed");
+        };
+        assert!(
+            no.why().contains("PATH"),
+            "the environment is what is missing: {no:?}"
+        );
+        assert!(
+            no.remedy(false).contains("GLASS_BWRAP"),
+            "an absolute path is the other way out: {no:?}"
         );
     }
 

--- a/crates/glass-sandbox-linux/src/lib.rs
+++ b/crates/glass-sandbox-linux/src/lib.rs
@@ -352,6 +352,8 @@ type Probed = std::result::Result<Duration, NoSandbox>;
 enum NoSandbox {
     /// Nothing to run: no `bwrap` resolved, or the one that did cannot be executed.
     Missing(String),
+    /// A bare `bwrap` and no `$PATH` to look it up in, so nothing says whether it is installed.
+    NotLookedUp(String),
     /// bwrap ran and exited non-zero, including without saying why.
     Refused(String),
     /// bwrap had not exited when its budget ran out, so it was sent SIGKILL — which one wedged in
@@ -365,6 +367,8 @@ enum NoSandbox {
 
 const INSTALL_BWRAP: &str = "install `bubblewrap`, or point GLASS_BWRAP at a copy this machine can \
      execute; or run with sandbox:\"off\" (GLASS_SANDBOX=off) to launch unconfined";
+const NAME_BWRAP: &str = "point GLASS_BWRAP at bubblewrap's absolute path, or start glass with a \
+     PATH to search; or run with sandbox:\"off\" (GLASS_SANDBOX=off) to launch unconfined";
 const CHECK_THE_MOUNTS: &str = "the probe read-only-binds the whole root, so a mount that has \
      stopped responding (an unreachable network filesystem) can hold it there; check for one, or \
      run with sandbox:\"off\" (GLASS_SANDBOX=off) to launch unconfined";
@@ -375,6 +379,7 @@ impl NoSandbox {
     fn why(&self) -> &str {
         match self {
             NoSandbox::Missing(why)
+            | NoSandbox::NotLookedUp(why)
             | NoSandbox::Refused(why)
             | NoSandbox::TimedOut(why)
             | NoSandbox::Unfinished(why) => why,
@@ -386,6 +391,7 @@ impl NoSandbox {
     fn remedy(&self, apparmor_restricted: bool) -> &'static str {
         match self {
             NoSandbox::Missing(_) => INSTALL_BWRAP,
+            NoSandbox::NotLookedUp(_) => NAME_BWRAP,
             NoSandbox::Refused(_) => refusal_remedy(apparmor_restricted),
             NoSandbox::TimedOut(_) => CHECK_THE_MOUNTS,
             NoSandbox::Unfinished(_) => NOTHING_LEARNED,
@@ -409,8 +415,8 @@ fn probe() -> Probed {
 /// Pure: what resolving `bwrap` alone decides — the testable seam (no global env). `Ok` carries the
 /// file to probe; that it is runnable is all resolution proves.
 ///
-/// `bin` is the configured name, needed for the [`Resolved::Absent`] message because that variant
-/// carries no path.
+/// `bin` is the configured name, needed for the [`Resolved::Absent`] and
+/// [`Resolved::NoSearchPath`] messages because neither variant carries a path.
 fn resolved_bwrap(bin: &str, bwrap: Resolved) -> std::result::Result<PathBuf, NoSandbox> {
     match bwrap {
         Resolved::Found(p) => Ok(p),
@@ -419,9 +425,9 @@ fn resolved_bwrap(bin: &str, bwrap: Resolved) -> std::result::Result<PathBuf, No
             p.display()
         ))),
         Resolved::Absent => Err(NoSandbox::Missing(format!("bubblewrap ({bin}) not found"))),
-        // Not "not found": nothing was searched, and installing bubblewrap cannot restore a
-        // `PATH`.
-        Resolved::NoSearchPath => Err(NoSandbox::Missing(format!(
+        // Its own variant, not `Missing`: that one's remedy leads with "install `bubblewrap`",
+        // which cannot restore a `PATH` (glass#373).
+        Resolved::NoSearchPath => Err(NoSandbox::NotLookedUp(format!(
             "bubblewrap ({bin}) could not be looked up — PATH is unset in glass's environment"
         ))),
     }
@@ -1214,9 +1220,16 @@ mod tests {
             no.why().contains("PATH"),
             "the environment is what is missing: {no:?}"
         );
+        let remedy = no.remedy(false);
         assert!(
-            no.remedy(false).contains("GLASS_BWRAP"),
-            "an absolute path is the other way out: {no:?}"
+            remedy.contains("GLASS_BWRAP") && remedy.contains("PATH"),
+            "an absolute path or a search list are the ways out: {remedy}"
+        );
+        // The variant is the remedy here: routed through `Missing`, this reads "install
+        // `bubblewrap`" for a machine that may well have it installed.
+        assert!(
+            !remedy.contains("install"),
+            "nothing was searched, so nothing says it is missing: {remedy}"
         );
     }
 

--- a/crates/glass-wayland/src/doctor.rs
+++ b/crates/glass-wayland/src/doctor.rs
@@ -4,9 +4,9 @@
 //! facts to [`Check`]s and is unit-tested without sway.
 
 use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
-use glass_core::{AppSpec, Check, CheckStatus};
+use glass_core::{AppSpec, Check, CheckStatus, ProbeFailure};
 
 use crate::command::{build_sway_command, sway_config};
 use crate::platform::{
@@ -31,7 +31,7 @@ pub fn checks(deep: bool) -> Vec<Check> {
 fn wayland_checks(
     sway: &Result<(PathBuf, VersionAnswer), NoSway>,
     gl_present: bool,
-    deep_spawn: Option<Result<(), String>>,
+    deep_spawn: Option<Result<(), ProbeFailure>>,
 ) -> Vec<Check> {
     let mut checks = Vec::new();
     checks.push(match sway {
@@ -63,9 +63,14 @@ fn wayland_checks(
                 CheckStatus::Ok,
                 "headless sway started and stopped",
             ),
-            Err(e) => Check::new("sway spawn (deep)", CheckStatus::Fail, e).with_remedy(
-                "sway is present but failed to start headless — check Mesa software GL",
-            ),
+            // The remedy comes from the failure itself, which withholds [`SWAY_START_HINT`] from
+            // the outcomes that never reached sway (glass#373).
+            Err(failure) => Check::new(
+                "sway spawn (deep)",
+                CheckStatus::Fail,
+                failure.detail("headless sway"),
+            )
+            .with_remedy(failure.remedy(SWAY_START_HINT)),
         });
     }
     checks
@@ -141,13 +146,29 @@ fn gl_present_in(egl_sonames: &[&str], dri_dirs: &[&str]) -> bool {
     egl && swrast
 }
 
+/// What to check when sway itself is what failed.
+const SWAY_START_HINT: &str = "sway is present but produced no working compositor — check the \
+     host Mesa software GL stack and sway's own dependencies";
+
+/// How long the probe gives sway's IPC to appear — the give-up point, not a target: a working
+/// host answers in well under a second.
+const IPC_READY_BUDGET: Duration = Duration::from_secs(8);
+/// How often the probe asks, between the two answers that end the wait early.
+const IPC_POLL: Duration = Duration::from_millis(100);
+
 /// Spawn a headless sway with a no-op client, confirm its IPC comes up, and tear the
 /// process group down. Bounded so a wedged sway can't hang doctor.
-fn probe_sway(sway: &Path) -> Result<(), String> {
+fn probe_sway(sway: &Path) -> Result<(), ProbeFailure> {
+    probe_sway_within(sway, IPC_READY_BUDGET)
+}
+
+/// [`probe_sway`] with its budget passed in — the seam a test can drive in milliseconds rather
+/// than waiting out [`IPC_READY_BUDGET`].
+fn probe_sway_within(sway: &Path, budget: Duration) -> Result<(), ProbeFailure> {
     let rt = tempfile::Builder::new()
         .prefix("glass-doctor-wl.")
         .tempdir()
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| ProbeFailure::NotStarted(format!("private runtime dir: {e}")))?;
     let config = rt.path().join("sway.cfg");
     let spec = AppSpec {
         build: None,
@@ -162,22 +183,31 @@ fn probe_sway(sway: &Path) -> Result<(), String> {
         sandbox: glass_core::SandboxLevel::Off,
         a11y: false,
     };
-    std::fs::write(&config, sway_config(&spec, rt.path(), None)).map_err(|e| e.to_string())?;
+    std::fs::write(&config, sway_config(&spec, rt.path(), None))
+        .map_err(|e| ProbeFailure::NotStarted(format!("sway config: {e}")))?;
     let mut child = build_sway_command(sway, &config, &spec, rt.path(), None)
         .spawn()
-        .map_err(|e| format!("spawn sway: {e}"))?;
+        .map_err(|e| ProbeFailure::Failed(format!("spawn sway: {e}")))?;
 
-    let mut up = false;
-    for _ in 0..80 {
-        if child.try_wait().ok().flatten().is_some() {
-            break; // sway exited before its IPC came up
+    // A deadline, not a poll count: the failure names the wait it made, and a count times
+    // `IPC_POLL` is not that wait — each turn also spends a connect attempt (glass#373).
+    let deadline = Instant::now() + budget;
+    let outcome = loop {
+        if let Some(status) = child.try_wait().ok().flatten() {
+            // sway exited before its IPC came up — its own answer, and immediate: quoting the
+            // budget below would claim a wait nobody made.
+            break Err(ProbeFailure::Failed(format!(
+                "sway exited before its IPC came up ({status})"
+            )));
         }
         if Ipc::connect(rt.path()).is_ok() {
-            up = true;
-            break;
+            break Ok(());
         }
-        std::thread::sleep(Duration::from_millis(100));
-    }
+        if Instant::now() >= deadline {
+            break Err(ProbeFailure::TimedOut(budget));
+        }
+        std::thread::sleep(IPC_POLL);
+    };
 
     // Snapshot the launch before any of it exits: once sway is reaped its descendants are
     // reparented to init and can no longer be found from its pid.
@@ -187,15 +217,14 @@ fn probe_sway(sway: &Path) -> Result<(), String> {
     let tree = glass_proc_linux::proc_tree_pids(child.id());
     glass_proc_linux::reap_launch(&mut child, &tree, glass_proc_linux::APP_REAP_GRACE);
 
-    if up {
-        Ok(())
-    } else {
-        Err("headless sway did not come up within ~8s".into())
-    }
+    outcome
 }
 
 #[cfg(test)]
 mod tests {
+    use std::os::unix::fs::PermissionsExt;
+    use std::time::Instant;
+
     use super::*;
 
     /// A resolved sway that answered, trimmed of the newline its `--version` ends with.
@@ -399,18 +428,96 @@ mod tests {
             .count()
     }
 
+    /// glass#373: `/bin/false` is gone before the first poll, and this reported "did not come up
+    /// within ~8s" — an eight-second wait that took none. Needs no sway.
     #[test]
-    #[ignore = "starts a real compositor or X server; needs sway, Mesa, Xwayland or Xvfb"]
-    fn probing_something_that_is_not_a_compositor_fails() {
+    fn a_compositor_that_exited_is_not_reported_as_one_that_never_answered() {
         let err = probe_sway(Path::new("/bin/false")).expect_err("no IPC ever appears");
-        assert!(err.contains("did not come up"), "{err}");
+        let ProbeFailure::Failed(why) = &err else {
+            panic!("an exit is the compositor's own answer, not a wait: {err:?}");
+        };
+        assert!(why.contains("exited"), "{why}");
+        assert!(
+            !why.contains("8s"),
+            "no budget elapsed, so none may be quoted: {why}"
+        );
+    }
+
+    /// The other end of the same wait: a "compositor" that starts, stays up and never opens an
+    /// IPC socket. Its budget is the one that elapsed, and it must not outlive the probe.
+    #[test]
+    fn a_compositor_that_never_answers_times_out_and_is_taken_down() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let fake = dir.path().join("sway");
+        let pidfile = dir.path().join("pid");
+        // Rejects an argv that is not the one glass builds, so a probe that stopped passing
+        // sway's arguments cannot pass this test by accident.
+        std::fs::write(
+            &fake,
+            format!(
+                "#!/bin/sh\ncase \"$*\" in *--unsupported-gpu*) ;; *) exit 64;; esac\n\
+                 echo $$ > {}\nexec sleep 30\n",
+                pidfile.display()
+            ),
+        )
+        .expect("write fake sway");
+        std::fs::set_permissions(&fake, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod fake sway");
+
+        let budget = Duration::from_millis(200);
+        let started = Instant::now();
+        let err = probe_sway_within(&fake, budget).expect_err("no IPC ever appears");
+        assert_eq!(err, ProbeFailure::TimedOut(budget));
+        assert!(
+            started.elapsed() < budget * 10,
+            "the wait must be the budget it reports: {:?}",
+            started.elapsed()
+        );
+        let pid: u32 = std::fs::read_to_string(&pidfile)
+            .expect("the fixture records its pid before it sleeps")
+            .trim()
+            .parse()
+            .expect("a pid");
+        assert!(
+            !glass_proc_linux::any_alive(&[pid]),
+            "the probe left its compositor ({pid}) running"
+        );
     }
 
     #[test]
     fn deep_spawn_failure_is_reported() {
-        let cs = wayland_checks(&answered("1.12"), true, Some(Err("no come up".into())));
+        let cs = wayland_checks(
+            &answered("1.12"),
+            true,
+            Some(Err(ProbeFailure::Failed("no come up".into()))),
+        );
         let deep = cs.iter().find(|c| c.name == "sway spawn (deep)").unwrap();
         assert_eq!(deep.status, CheckStatus::Fail);
-        assert_eq!(deep.detail, "no come up");
+        assert!(deep.detail.contains("no come up"), "{:?}", deep.detail);
+        assert!(
+            deep.remedy.as_deref().is_some_and(|r| r.contains("Mesa")),
+            "a probe that reached sway gets sway's advice: {:?}",
+            deep.remedy
+        );
+    }
+
+    /// glass#373 in this backend's terms: a probe the host refused or killed says nothing about
+    /// sway, and Mesa is the wrong lead for a pids limit.
+    #[test]
+    fn a_probe_the_host_stopped_does_not_point_at_the_compositor() {
+        for failure in [
+            ProbeFailure::NotStarted("Resource temporarily unavailable".into()),
+            ProbeFailure::Vanished,
+        ] {
+            let cs = wayland_checks(&answered("1.12"), true, Some(Err(failure)));
+            let deep = cs.iter().find(|c| c.name == "sway spawn (deep)").unwrap();
+            assert_eq!(deep.status, CheckStatus::Fail);
+            assert!(
+                deep.remedy
+                    .as_deref()
+                    .is_some_and(|r| r.contains("limits") && !r.contains("Mesa")),
+                "{deep:?}"
+            );
+        }
     }
 }

--- a/crates/glass-wayland/src/doctor.rs
+++ b/crates/glass-wayland/src/doctor.rs
@@ -63,7 +63,7 @@ fn wayland_checks(
                 CheckStatus::Ok,
                 "headless sway started and stopped",
             ),
-            // The remedy comes from the failure itself, which withholds [`SWAY_START_HINT`] from
+            // The remedy comes from the failure itself, which withholds `SWAY_START_HINT` from
             // the outcomes that never reached sway (glass#373).
             Err(failure) => Check::new(
                 "sway spawn (deep)",
@@ -146,7 +146,8 @@ fn gl_present_in(egl_sonames: &[&str], dri_dirs: &[&str]) -> bool {
     egl && swrast
 }
 
-/// What to check when sway itself is what failed.
+/// What to check when sway itself is what failed — reached only by the outcomes that got as far
+/// as running it.
 const SWAY_START_HINT: &str = "sway is present but produced no working compositor — check the \
      host Mesa software GL stack and sway's own dependencies";
 
@@ -185,9 +186,12 @@ fn probe_sway_within(sway: &Path, budget: Duration) -> Result<(), ProbeFailure> 
     };
     std::fs::write(&config, sway_config(&spec, rt.path(), None))
         .map_err(|e| ProbeFailure::NotStarted(format!("sway config: {e}")))?;
+    // `NotStarted`, not `Failed`: resolution already proved this path executable, so what is left
+    // is the host refusing a process (EAGAIN under a `pids` limit, ENOMEM), which sway's own
+    // advice does not fit (glass#373).
     let mut child = build_sway_command(sway, &config, &spec, rt.path(), None)
         .spawn()
-        .map_err(|e| ProbeFailure::Failed(format!("spawn sway: {e}")))?;
+        .map_err(|e| ProbeFailure::NotStarted(format!("spawn sway: {e}")))?;
 
     // A deadline, not a poll count: the failure names the wait it made, and a count times
     // `IPC_POLL` is not that wait — each turn also spends a connect attempt (glass#373).
@@ -464,13 +468,18 @@ mod tests {
         std::fs::set_permissions(&fake, std::fs::Permissions::from_mode(0o755))
             .expect("chmod fake sway");
 
-        let budget = Duration::from_millis(200);
+        // Long enough that a loaded CI box has written the pidfile below before the probe gives
+        // up on it; short enough that the test is not the slow one in the suite.
+        let budget = Duration::from_millis(500);
         let started = Instant::now();
         let err = probe_sway_within(&fake, budget).expect_err("no IPC ever appears");
         assert_eq!(err, ProbeFailure::TimedOut(budget));
+        // The budget plus the teardown that follows it — the units this actually spans. A wait
+        // that ignored its argument would blow this by `IPC_READY_BUDGET`.
+        let ceiling = budget * 2 + glass_proc_linux::APP_REAP_GRACE * 2;
         assert!(
-            started.elapsed() < budget * 10,
-            "the wait must be the budget it reports: {:?}",
+            started.elapsed() < ceiling,
+            "the wait must be the budget it reports: {:?} against {ceiling:?}",
             started.elapsed()
         );
         let pid: u32 = std::fs::read_to_string(&pidfile)
@@ -501,23 +510,44 @@ mod tests {
         );
     }
 
-    /// glass#373 in this backend's terms: a probe the host refused or killed says nothing about
-    /// sway, and Mesa is the wrong lead for a pids limit.
+    /// glass#373 in this backend's terms: a probe that never started says nothing about sway, so
+    /// Mesa is the wrong lead — for a `pids` limit that refused the fork, or for a temp dir the
+    /// probe could not write.
     #[test]
-    fn a_probe_the_host_stopped_does_not_point_at_the_compositor() {
-        for failure in [
-            ProbeFailure::NotStarted("Resource temporarily unavailable".into()),
-            ProbeFailure::Vanished,
-        ] {
-            let cs = wayland_checks(&answered("1.12"), true, Some(Err(failure)));
-            let deep = cs.iter().find(|c| c.name == "sway spawn (deep)").unwrap();
-            assert_eq!(deep.status, CheckStatus::Fail);
-            assert!(
-                deep.remedy
-                    .as_deref()
-                    .is_some_and(|r| r.contains("limits") && !r.contains("Mesa")),
-                "{deep:?}"
-            );
-        }
+    fn a_probe_that_never_started_does_not_point_at_the_compositor() {
+        let cs = wayland_checks(
+            &answered("1.12"),
+            true,
+            Some(Err(ProbeFailure::NotStarted(
+                "private runtime dir: No space left on device".into(),
+            ))),
+        );
+        let deep = cs.iter().find(|c| c.name == "sway spawn (deep)").unwrap();
+        assert_eq!(deep.status, CheckStatus::Fail);
+        assert!(
+            deep.detail.contains("No space left on device"),
+            "the cause is the only text that names the resource: {deep:?}"
+        );
+        assert!(
+            deep.remedy.as_deref().is_some_and(|r| !r.contains("Mesa")),
+            "{deep:?}"
+        );
+    }
+
+    /// A spawn that never happened is not sway failing to render, and the classification is what
+    /// decides which remedy the operator reads.
+    #[test]
+    fn a_spawn_that_never_happened_is_not_reported_as_sway_failing() {
+        let missing = std::path::Path::new("/nonexistent/glass-doctor/sway");
+        let err = probe_sway(missing).expect_err("nothing to spawn");
+        assert!(
+            matches!(err, ProbeFailure::NotStarted(_)),
+            "a spawn that never happened is not sway's answer: {err:?}"
+        );
+        assert!(
+            !err.remedy(SWAY_START_HINT).contains("Mesa"),
+            "{:?}",
+            err.remedy(SWAY_START_HINT)
+        );
     }
 }

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -237,8 +237,9 @@ pub(crate) struct NoSway {
 const BUILD_A_SWAY: &str = "build it with https://github.com/fixed-width/sway-build \
      (./build.sh && ./build.sh install), or install a distro sway >=1.12";
 const MAKE_IT_RUNNABLE: &str = "chmod +x it, or point GLASS_SWAY at a runnable sway >=1.12";
-const SET_GLASS_SWAY: &str =
-    "point GLASS_SWAY at a sway >=1.12, or start glass with a PATH to search";
+const SET_GLASS_SWAY: &str = "start glass with a PATH to search, or point GLASS_SWAY at a sway \
+     >=1.12; or install the bundle, which is found without a PATH — \
+     https://github.com/fixed-width/sway-build (./build.sh && ./build.sh install)";
 pub(crate) const CHECK_THAT_SWAY: &str =
     "check that binary, or point GLASS_SWAY at a working sway >=1.12";
 
@@ -250,12 +251,12 @@ impl NoSway {
         }
     }
 
-    /// A bare `sway` and no `$PATH` to look it up in. The environment glass was spawned with is
-    /// what is missing, and no build restores it.
+    /// A bare `sway` and no `$PATH` to look it up in, and no bundle either. The bundle lookup did
+    /// run — it reads the glass data dir, not `$PATH` — so a build is still one of the fixes.
     fn no_search_path() -> Self {
         NoSway {
-            cause: "no sway >=1.12 found — PATH is unset in glass's environment, so nothing was \
-                    searched"
+            cause: "no sway >=1.12 found — PATH is unset in glass's environment, and no bundled \
+                    sway is installed"
                 .into(),
             remedy: SET_GLASS_SWAY,
         }
@@ -295,10 +296,11 @@ pub(crate) fn resolve_sway_verdict() -> std::result::Result<PathBuf, NoSway> {
         return overridden;
     }
     // `None` when the environment carries no `$PATH` at all — a walk that never happened, kept
-    // apart from one that came back empty (glass#373). An empty `$PATH` is the same fact: what
-    // `split_paths` makes of it is a one-entry list naming the current directory.
+    // apart from one that came back empty (glass#373).
+    //
+    // The walk stays inline: a `fn` that only splits `$PATH` and delegates has a constant-return
+    // mutation nothing can kill on a host with no sway on `$PATH`.
     let walk = std::env::var_os("PATH")
-        .filter(|path| !path.is_empty())
         .map(|path| sway_in_dirs(std::env::split_paths(&path), VERSION_PROBE_BUDGET));
     sway_verdict(walk, || {
         let data = std::env::var_os("XDG_DATA_HOME")
@@ -315,8 +317,8 @@ pub(crate) fn resolve_sway_verdict() -> std::result::Result<PathBuf, NoSway> {
 /// walk) and what the bundle lookup would find — the testable seam, with no global env and
 /// nothing spawned.
 ///
-/// `bundle` is a thunk, not a value: looking for a bundle a `$PATH` hit has already made
-/// redundant costs a `current_exe` and three `stat`s on every launch.
+/// `bundle` is a thunk, not a value: looking for a bundle a `$PATH` hit has already made redundant
+/// costs a `current_exe` and a `stat` per candidate on every launch.
 fn sway_verdict(
     walk: Option<PathWalk>,
     bundle: impl FnOnce() -> Resolved,
@@ -2939,9 +2941,13 @@ mod pure_tests {
         assert!(no.cause.contains("PATH"), "{no:?}");
         assert!(no.remedy.contains("GLASS_SWAY"), "{no:?}");
         assert!(
-            !no.remedy.contains("sway-build"),
-            "building one cannot restore a PATH: {no:?}"
+            no.remedy.contains("PATH to search"),
+            "restoring the search list is the fix nothing else names: {no:?}"
         );
+        // The bundle lookup reads the glass data dir, not `$PATH`, so it ran and came back empty:
+        // installing the bundle really is one of the ways out, and dropping it would be a worse
+        // message than the one this replaced.
+        assert!(no.remedy.contains("sway-build"), "{no:?}");
     }
 
     /// The other half of the distinction: a list that was walked and held no sway really is a
@@ -2954,8 +2960,8 @@ mod pure_tests {
         assert_eq!(no.remedy, BUILD_A_SWAY);
     }
 
-    /// The bundle lookup is three `stat`s and a `current_exe`, and a `$PATH` hit means the answer
-    /// is already in hand — passing it as a value rather than a thunk would run it regardless.
+    /// The bundle lookup is a `current_exe` and a `stat` per candidate, and a `$PATH` hit means
+    /// the answer is already in hand — passing it as a value would run it regardless.
     #[test]
     fn a_sway_found_on_path_is_taken_without_looking_for_the_bundle() {
         let walk = PathWalk {

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -237,6 +237,8 @@ pub(crate) struct NoSway {
 const BUILD_A_SWAY: &str = "build it with https://github.com/fixed-width/sway-build \
      (./build.sh && ./build.sh install), or install a distro sway >=1.12";
 const MAKE_IT_RUNNABLE: &str = "chmod +x it, or point GLASS_SWAY at a runnable sway >=1.12";
+const SET_GLASS_SWAY: &str =
+    "point GLASS_SWAY at a sway >=1.12, or start glass with a PATH to search";
 pub(crate) const CHECK_THAT_SWAY: &str =
     "check that binary, or point GLASS_SWAY at a working sway >=1.12";
 
@@ -245,6 +247,17 @@ impl NoSway {
         NoSway {
             cause: "no sway >=1.12 found".into(),
             remedy: BUILD_A_SWAY,
+        }
+    }
+
+    /// A bare `sway` and no `$PATH` to look it up in. The environment glass was spawned with is
+    /// what is missing, and no build restores it.
+    fn no_search_path() -> Self {
+        NoSway {
+            cause: "no sway >=1.12 found — PATH is unset in glass's environment, so nothing was \
+                    searched"
+                .into(),
+            remedy: SET_GLASS_SWAY,
         }
     }
 
@@ -281,30 +294,53 @@ pub(crate) fn resolve_sway_verdict() -> std::result::Result<PathBuf, NoSway> {
     if let Some(overridden) = sway_override(std::env::var_os("GLASS_SWAY")) {
         return overridden;
     }
-    // Inlined rather than wrapped: a `fn` that only splits PATH and delegates has a
-    // constant-return mutation nothing can kill on a host where the true answer is that constant
-    // — here, any machine with no sway on PATH.
-    let walk = std::env::var_os("PATH").map_or_else(PathWalk::default, |path| {
-        sway_in_dirs(std::env::split_paths(&path), VERSION_PROBE_BUDGET)
-    });
-    if let Some(p) = walk.found {
-        return Ok(p);
-    }
-    let data = std::env::var_os("XDG_DATA_HOME")
-        .map(PathBuf::from)
-        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".local/share")));
-    let exe_dir = std::env::current_exe()
-        .ok()
-        .and_then(|exe| exe.parent().map(Path::to_path_buf));
-    match sway_bundle_in(data, exe_dir) {
+    // `None` when the environment carries no `$PATH` at all — a walk that never happened, kept
+    // apart from one that came back empty (glass#373). An empty `$PATH` is the same fact: what
+    // `split_paths` makes of it is a one-entry list naming the current directory.
+    let walk = std::env::var_os("PATH")
+        .filter(|path| !path.is_empty())
+        .map(|path| sway_in_dirs(std::env::split_paths(&path), VERSION_PROBE_BUDGET));
+    sway_verdict(walk, || {
+        let data = std::env::var_os("XDG_DATA_HOME")
+            .map(PathBuf::from)
+            .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".local/share")));
+        let exe_dir = std::env::current_exe()
+            .ok()
+            .and_then(|exe| exe.parent().map(Path::to_path_buf));
+        sway_bundle_in(data, exe_dir)
+    })
+}
+
+/// Pure: the verdict, given what the `$PATH` walk found (`None` when there was no `$PATH` to
+/// walk) and what the bundle lookup would find — the testable seam, with no global env and
+/// nothing spawned.
+///
+/// `bundle` is a thunk, not a value: looking for a bundle a `$PATH` hit has already made
+/// redundant costs a `current_exe` and three `stat`s on every launch.
+fn sway_verdict(
+    walk: Option<PathWalk>,
+    bundle: impl FnOnce() -> Resolved,
+) -> std::result::Result<PathBuf, NoSway> {
+    let walk = match walk {
+        Some(PathWalk {
+            found: Some(sway), ..
+        }) => return Ok(sway),
+        walked => walked,
+    };
+    match bundle() {
         Resolved::Found(p) => Ok(p),
         Resolved::NotExecutable(p) => Err(NoSway::not_runnable(format!(
             "{} is not executable",
             p.display()
         ))),
-        // A silent candidate on PATH outranks "nothing qualifies" — telling the user to build one
-        // sends them past the sway they have.
-        Resolved::Absent => Err(walk.silent.unwrap_or_else(NoSway::nothing_qualifies)),
+        // `NoSearchPath` cannot come from the bundle lookup, which walks fixed paths; both mean
+        // there is no bundle to fall back to.
+        Resolved::Absent | Resolved::NoSearchPath => Err(match walk {
+            // A silent candidate on PATH outranks "nothing qualifies" — telling the user to build
+            // one sends them past the sway they have.
+            Some(walked) => walked.silent.unwrap_or_else(NoSway::nothing_qualifies),
+            None => NoSway::no_search_path(),
+        }),
     }
 }
 
@@ -326,7 +362,9 @@ fn sway_bundle_in(data: Option<PathBuf>, exe_dir: Option<PathBuf>) -> Resolved {
             Resolved::NotExecutable(p) => {
                 first_non_executable.get_or_insert(p);
             }
-            Resolved::Absent => {}
+            // Each candidate is one path, judged on its own: `resolve_path` has no search list
+            // to lack, so `NoSearchPath` cannot come from it. Both mean "nothing here".
+            Resolved::Absent | Resolved::NoSearchPath => {}
         }
     }
     first_non_executable.map_or(Resolved::Absent, Resolved::NotExecutable)
@@ -2890,6 +2928,44 @@ mod pure_tests {
             Resolved::Absent
         );
         assert_eq!(sway_bundle_in(None, None), Resolved::Absent);
+    }
+
+    /// glass#373: with no `$PATH` nothing was searched, and "no sway >=1.12 found" then sends the
+    /// user to build one — a build that cannot help, because the search list is what is missing.
+    /// MCP clients routinely spawn glass-mcp with a stripped environment.
+    #[test]
+    fn a_sway_that_could_not_be_looked_up_is_not_reported_as_missing() {
+        let no = sway_verdict(None, || Resolved::Absent).expect_err("nothing resolved");
+        assert!(no.cause.contains("PATH"), "{no:?}");
+        assert!(no.remedy.contains("GLASS_SWAY"), "{no:?}");
+        assert!(
+            !no.remedy.contains("sway-build"),
+            "building one cannot restore a PATH: {no:?}"
+        );
+    }
+
+    /// The other half of the distinction: a list that was walked and held no sway really is a
+    /// host with no sway, and building one is the fix.
+    #[test]
+    fn a_search_that_turned_up_nothing_still_says_build_one() {
+        let no = sway_verdict(Some(PathWalk::default()), || Resolved::Absent)
+            .expect_err("nothing resolved");
+        assert_eq!(no.cause, "no sway >=1.12 found");
+        assert_eq!(no.remedy, BUILD_A_SWAY);
+    }
+
+    /// The bundle lookup is three `stat`s and a `current_exe`, and a `$PATH` hit means the answer
+    /// is already in hand — passing it as a value rather than a thunk would run it regardless.
+    #[test]
+    fn a_sway_found_on_path_is_taken_without_looking_for_the_bundle() {
+        let walk = PathWalk {
+            found: Some(PathBuf::from("/usr/bin/sway")),
+            silent: None,
+        };
+        let found = sway_verdict(Some(walk), || {
+            panic!("the bundle must not be looked for once PATH has answered")
+        });
+        assert_eq!(found, Ok(PathBuf::from("/usr/bin/sway")));
     }
 
     /// The launch path gets one string where doctor gets two columns, so it must carry both.

--- a/crates/glass-x11/src/doctor.rs
+++ b/crates/glass-x11/src/doctor.rs
@@ -137,9 +137,10 @@ fn deep_spawn_check(spawn: &Result<String, ProbeFailure>) -> Check {
     }
 }
 
-/// What to check when Xvfb itself is what failed.
-const XVFB_START_HINT: &str = "Xvfb is installed but produced no working display — check its \
-     dependencies and permissions (the probe already waits out one retry of a stalled server)";
+/// What to check when Xvfb itself is what failed. It does not claim Xvfb is installed: the detail
+/// is `Xvfb::start`'s own message, which for a spawn failure says the opposite.
+const XVFB_START_HINT: &str = "the detail is Xvfb's own answer — check its dependencies and \
+     permissions, or set GLASS_DISPLAY=:N to attach to an existing display instead";
 
 /// Why glass could not attach to the display `GLASS_DISPLAY` names.
 ///
@@ -154,11 +155,18 @@ struct NoAttach {
 
 const START_THE_DISPLAY: &str = "start that display (e.g. `./scripts/sandbox-xvfb.sh start` for \
      :42) or unset GLASS_DISPLAY to self-spawn";
-const FIX_THE_AUTHORITY: &str = "point XAUTHORITY at the cookie file for that display (`xauth \
-     list` shows what it holds), or grant this user access with `xhost`";
-const NAME_A_DISPLAY: &str = "GLASS_DISPLAY must be an X display name — `:42`, `:42.0` or `host:0`";
-const PICK_A_SCREEN: &str = "name a screen that server has (`:42` or `:42.0`), or unset \
-     GLASS_DISPLAY to self-spawn";
+const FIX_THE_AUTHORITY: &str = "set XAUTHORITY to that display's cookie file — for a server \
+     spawned by an MCP client, in the client's `env` block, since glass inherits its environment \
+     (`xauth list` shows what a cookie file holds) — or, from a session that already reaches the \
+     display, run `xhost +si:localuser:$USER`";
+const SERVER_ANSWERED: &str = "the server answered and the connection still failed — its own \
+     reason is in the detail; unset GLASS_DISPLAY to self-spawn instead";
+// `normalize_display` prepends `:` to anything without one, so `host:0` becomes `:host:0` and X
+// then reads `:host` as the hostname: a remote display cannot be named here at all.
+const NAME_A_DISPLAY: &str = "GLASS_DISPLAY names a local display — `:42`, bare `42`, or `:42.0` \
+     to pick a screen; a remote `host:0` is not supported";
+const PICK_A_SCREEN: &str = "name a screen that server has — the `.N` suffix, e.g. `:42.0` (most \
+     servers have only screen 0) — or unset GLASS_DISPLAY to self-spawn";
 
 /// Whether glass can attach to `display`, and when it cannot, why — in the terms the remedy turns
 /// on. The connection is closed again at once.
@@ -168,15 +176,32 @@ fn attach_verdict(display: &str) -> Result<(), NoAttach> {
         .map_err(|e| no_attach(&e))
 }
 
-/// Classify a connect failure. `ConnectError` is `#[non_exhaustive]`, so anything not named here
-/// falls to "nothing answered" — the common case, and the one that advice fits.
+/// Classify a connect failure. What falls to the wildcard is `IoError` — nothing was listening,
+/// the case the advice fits — plus the local failures (`ParseError`, `InsufficientMemory`,
+/// `UnknownError`) and whatever this `#[non_exhaustive]` enum gains next.
 fn no_attach(e: &ConnectError) -> NoAttach {
     match e {
-        // The server answered and turned glass away: an authority problem, not a display that is
-        // down. XAUTHORITY unset or holding a stale cookie is the classic attach failure.
-        ConnectError::SetupAuthenticate(_) | ConnectError::SetupFailed(_) => NoAttach {
+        // The server answered and turned glass away, so it is running and a second one cannot
+        // help. Status 2 is an authentication demand outright; status 0 is the generic refusal,
+        // carrying "Maximum number of clients reached" as readily as an authorisation message, so
+        // its own reason picks the remedy.
+        ConnectError::SetupAuthenticate(_) => NoAttach {
             cause: format!("the server refused the connection ({e})"),
             remedy: FIX_THE_AUTHORITY,
+        },
+        ConnectError::SetupFailed(f) => NoAttach {
+            cause: format!("the server refused the connection ({e})"),
+            remedy: if refused_over_authority(&f.reason) {
+                FIX_THE_AUTHORITY
+            } else {
+                SERVER_ANSWERED
+            },
+        },
+        // The handshake began and did not finish, so something answered: the same reason
+        // "start that display" is wrong for a refusal.
+        ConnectError::Incomplete { .. } | ConnectError::ZeroIdMask => NoAttach {
+            cause: format!("the handshake did not complete ({e})"),
+            remedy: SERVER_ANSWERED,
         },
         ConnectError::DisplayParsingError(_) => NoAttach {
             cause: format!("not a display name X can parse ({e})"),
@@ -191,6 +216,13 @@ fn no_attach(e: &ConnectError) -> NoAttach {
             remedy: START_THE_DISPLAY,
         },
     }
+}
+
+/// Whether a refusal is about authorisation, read from the server's own reason text — X sends the
+/// same status byte for every refusal, so the variant alone cannot say.
+fn refused_over_authority(reason: &[u8]) -> bool {
+    let reason = String::from_utf8_lossy(reason).to_lowercase();
+    reason.contains("authoriz") || reason.contains("authenticat") || reason.contains("cookie")
 }
 
 /// Margin over `Xvfb::start`'s own worst case, so the backstop effectively never fires and
@@ -210,8 +242,9 @@ fn probe_xvfb() -> Result<String, ProbeFailure> {
     let screen = std::env::var("GLASS_XVFB_SCREEN").unwrap_or_else(|_| "1280x800x24".into());
     let budget = probe_budget();
     let (tx, rx) = mpsc::channel();
-    // Named and fallible, unlike a bare `spawn`, which panics when the OS refuses: `Xvfb::start`
-    // spawns two more threads of its own, so a low `pids` limit stops this probe first.
+    // Fallible, unlike a bare `spawn`, which panics when the OS refuses a thread — in doctor that
+    // is an unwind where a check belongs. `Xvfb::start` spawns two more threads with bare `spawn`,
+    // and those unwind inside this one, arriving as `Vanished`.
     std::thread::Builder::new()
         .name("glass-doctor-xvfb".into())
         .spawn(move || {
@@ -464,6 +497,39 @@ mod tests {
         );
     }
 
+    /// Setup status 0 is the server's generic "refused", not an auth verdict: a server at its
+    /// client limit sends it too, and telling that operator to fix a cookie is the misdirection
+    /// this check exists to remove. The reason is the server's own, so it decides.
+    #[test]
+    fn a_refusal_that_is_not_about_authorisation_does_not_get_the_cookie_remedy() {
+        let no = no_attach(&refusal("Maximum number of clients reached"));
+        assert!(no.cause.contains("Maximum number of clients"), "{no:?}");
+        assert!(
+            !no.remedy.contains("XAUTHORITY"),
+            "nothing here is about a cookie: {no:?}"
+        );
+        assert!(
+            !no.remedy.contains("start that display"),
+            "the server answered, so it is running: {no:?}"
+        );
+    }
+
+    /// A handshake that began and did not finish: the server answered, so "start that display" is
+    /// wrong for the same reason it is wrong for a refusal.
+    #[test]
+    fn a_handshake_that_broke_off_is_not_a_display_that_needs_starting() {
+        for e in [
+            ConnectError::Incomplete {
+                expected: 8,
+                received: 2,
+            },
+            ConnectError::ZeroIdMask,
+        ] {
+            let no = no_attach(&e);
+            assert!(!no.remedy.contains("start that display"), "{no:?}");
+        }
+    }
+
     #[test]
     fn nothing_listening_on_the_display_is_still_told_to_start_it() {
         let no = no_attach(&ConnectError::IoError(std::io::Error::from(
@@ -502,6 +568,16 @@ mod tests {
         .expect("a deep probe contributes its check")
     }
 
+    /// The arm every successful deep check renders, and the only one no failure test reaches:
+    /// dropped or restyled, `glass doctor --deep` would report a spawn it never proved.
+    #[test]
+    fn a_deep_probe_that_worked_names_the_display_it_started() {
+        let check = deep(Ok(":42".into()));
+        assert_eq!(check.status, CheckStatus::Ok);
+        assert!(check.detail.contains(":42"), "{:?}", check.detail);
+        assert!(check.remedy.is_none(), "nothing to fix: {check:?}");
+    }
+
     #[test]
     fn deep_spawn_failure_is_reported() {
         let check = deep(Err(ProbeFailure::Failed("boom".into())));
@@ -519,24 +595,37 @@ mod tests {
     /// elapsing, a 24-second timeout that took no time.
     #[test]
     fn a_probe_the_host_stopped_is_not_reported_as_a_wait_that_never_happened() {
-        for failure in [
-            ProbeFailure::NotStarted("Resource temporarily unavailable".into()),
-            ProbeFailure::Vanished,
-        ] {
-            let check = deep(Err(failure.clone()));
-            assert_eq!(check.status, CheckStatus::Fail);
+        let refused = deep(Err(ProbeFailure::NotStarted(
+            "Resource temporarily unavailable".into(),
+        )));
+        assert_eq!(refused.status, CheckStatus::Fail);
+        assert!(
+            refused.detail.contains("Resource temporarily unavailable"),
+            "the OS reason is what separates a pids limit from an OOM: {refused:?}"
+        );
+        assert!(
+            !refused.detail.contains(&format!("{:?}", probe_budget())),
+            "no wait happened, so the budget must not be quoted: {refused:?}"
+        );
+
+        // Both outcomes stopped short of Xvfb, so neither may be answered with Xvfb's advice —
+        // and they are not each other's: one is the host refusing, one is glass unwinding.
+        let vanished = deep(Err(ProbeFailure::Vanished));
+        let (a, b) = (
+            refused.remedy.as_deref().expect("a remedy"),
+            vanished.remedy.as_deref().expect("a remedy"),
+        );
+        for r in [a, b] {
             assert!(
-                !check.detail.contains(&format!("{:?}", probe_budget())),
-                "no wait happened: {check:?}"
-            );
-            assert!(
-                check
-                    .remedy
-                    .as_deref()
-                    .is_some_and(|r| r.contains("limits") && !r.contains("dependencies")),
-                "the host stopped it, so Xvfb's dependencies are not the lead: {check:?}"
+                !r.contains(XVFB_START_HINT),
+                "the probe never reached Xvfb: {r}"
             );
         }
+        assert_ne!(
+            a, b,
+            "a refused probe and a panicked one want different repairs"
+        );
+        assert!(b.contains("panic"), "{b}");
     }
 
     /// The two ways the bounded wait can end, which used to be one `Err(_)` arm. Driven through

--- a/crates/glass-x11/src/doctor.rs
+++ b/crates/glass-x11/src/doctor.rs
@@ -220,9 +220,13 @@ fn no_attach(e: &ConnectError) -> NoAttach {
 
 /// Whether a refusal is about authorisation, read from the server's own reason text — X sends the
 /// same status byte for every refusal, so the variant alone cannot say.
+///
+/// Two terms, because X.org's refusals are worded two ways: "Authorization required, but no
+/// authorization protocol specified" and "Client is not authorized to connect to Server" carry the
+/// first, "Invalid MIT-MAGIC-COOKIE-1 key" only the second.
 fn refused_over_authority(reason: &[u8]) -> bool {
     let reason = String::from_utf8_lossy(reason).to_lowercase();
-    reason.contains("authoriz") || reason.contains("authenticat") || reason.contains("cookie")
+    reason.contains("authoriz") || reason.contains("cookie")
 }
 
 /// Margin over `Xvfb::start`'s own worst case, so the backstop effectively never fires and
@@ -480,6 +484,14 @@ mod tests {
                 "the display is already running: {no:?}"
             );
         }
+    }
+
+    /// A rejected cookie is worded without the word "authorization", so matching that alone would
+    /// send the operator with a stale cookie to "start that display".
+    #[test]
+    fn a_rejected_cookie_is_an_authorisation_failure_too() {
+        let no = no_attach(&refusal("Invalid MIT-MAGIC-COOKIE-1 key"));
+        assert!(no.remedy.contains("XAUTHORITY"), "{no:?}");
     }
 
     /// The refusal reason is the server's own, and the only text that says which of the auth

--- a/crates/glass-x11/src/doctor.rs
+++ b/crates/glass-x11/src/doctor.rs
@@ -6,8 +6,9 @@
 use std::sync::mpsc;
 use std::time::Duration;
 
-use glass_core::{Check, CheckStatus};
+use glass_core::{Check, CheckStatus, ProbeFailure};
 use glass_exec_unix::{Resolved, resolve_bin};
+use x11rb::errors::ConnectError;
 
 use crate::xvfb::Xvfb;
 
@@ -21,86 +22,175 @@ pub fn checks(deep: bool) -> Vec<Check> {
 /// passed in — mutating `GLASS_DISPLAY` to reach the other mode is `unsafe` under edition
 /// 2024, and process-global besides.
 fn checks_for(glass_display: Option<&str>, deep: bool) -> Vec<Check> {
-    let gd = glass_display.map(str::trim).filter(|s| !s.is_empty());
-    let xvfb = resolve_bin(
-        &glass_core::tool_path("GLASS_XVFB", "Xvfb"),
-        std::env::var_os("PATH").as_deref(),
-    );
-    let attach_reachable = gd.map(|d| can_connect(&crate::platform::normalize_display(d)));
-    let deep_spawn = (deep && gd.is_none()).then(probe_xvfb);
-    x11_checks(gd, &xvfb, attach_reachable, deep_spawn)
+    match glass_display.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(display) => x11_checks(&Mode::Attach {
+            display,
+            verdict: attach_verdict(&crate::platform::normalize_display(display)),
+        }),
+        None => {
+            let xvfb = resolve_bin(
+                &glass_core::tool_path("GLASS_XVFB", "Xvfb"),
+                std::env::var_os("PATH").as_deref(),
+            );
+            x11_checks(&Mode::SelfSpawn {
+                xvfb: &xvfb,
+                deep: deep.then(probe_xvfb),
+            })
+        }
+    }
+}
+
+/// What was gathered, in the shape the mapper reads. The two modes cannot be crossed: an attach
+/// has no Xvfb to find, a self-spawn no display to reach. Passed as separate arguments, "probed
+/// and unreachable" and "never probed" were one wildcard arm apart (glass#373).
+enum Mode<'a> {
+    /// `GLASS_DISPLAY` names a display; the only question is whether glass can attach to it.
+    Attach {
+        display: &'a str,
+        verdict: Result<(), NoAttach>,
+    },
+    /// No `GLASS_DISPLAY`: glass starts its own Xvfb, which must be present and — on a deep
+    /// check — provably startable.
+    SelfSpawn {
+        xvfb: &'a Resolved,
+        deep: Option<Result<String, ProbeFailure>>,
+    },
 }
 
 /// Pure: build the X11 checks from gathered facts.
-fn x11_checks(
-    glass_display: Option<&str>,
-    xvfb: &Resolved,
-    attach_reachable: Option<bool>,
-    deep_spawn: Option<Result<String, String>>,
-) -> Vec<Check> {
-    let mut checks = Vec::new();
-    match glass_display {
-        // Self-spawn mode: Xvfb is required.
-        None => {
-            checks.push(Check::new(
-                "GLASS_DISPLAY",
-                CheckStatus::Ok,
-                "unset — glass will spawn a private headless Xvfb",
-            ));
-            checks.push(match xvfb {
-                Resolved::Found(p) => Check::new("Xvfb", CheckStatus::Ok, p.display().to_string()),
-                Resolved::NotExecutable(p) => Check::new(
-                    "Xvfb",
-                    CheckStatus::Fail,
-                    format!("{} — not executable", p.display()),
-                )
-                .with_remedy(format!(
-                    "chmod +x {}, or point GLASS_XVFB at a runnable binary",
-                    p.display()
-                )),
-                Resolved::Absent => Check::new("Xvfb", CheckStatus::Fail, "not found").with_remedy(
-                    "install it (e.g. `apt install xvfb`), set GLASS_XVFB to its path, or set \
-                     GLASS_DISPLAY=:N to attach to an existing display",
-                ),
-            });
-            if let Some(res) = deep_spawn {
-                checks.push(match res {
-                    Ok(d) => Check::new(
-                        "Xvfb spawn (deep)",
-                        CheckStatus::Ok,
-                        format!("started and stopped {d}"),
-                    ),
-                    Err(e) => Check::new("Xvfb spawn (deep)", CheckStatus::Fail, e).with_remedy(
-                        "Xvfb is installed but failed to start — check its dependencies/permissions",
-                    ),
-                });
-            }
-        }
-        // Attach mode: the named display must be reachable.
-        Some(d) => {
-            checks.push(match attach_reachable {
-                Some(true) => Check::new(
+fn x11_checks(mode: &Mode) -> Vec<Check> {
+    match mode {
+        Mode::SelfSpawn { xvfb, deep } => {
+            let mut checks = vec![
+                Check::new(
                     "GLASS_DISPLAY",
                     CheckStatus::Ok,
-                    format!("{d} — reachable; glass will attach to it"),
+                    "unset — glass will spawn a private headless Xvfb",
                 ),
-                _ => Check::new(
-                    "GLASS_DISPLAY",
-                    CheckStatus::Fail,
-                    format!("{d} — cannot connect"),
-                )
-                .with_remedy(
-                    "start that display (e.g. `./scripts/sandbox-xvfb.sh start` for :42) \
-                         or unset GLASS_DISPLAY to self-spawn",
-                ),
-            });
+                xvfb_check(xvfb),
+            ];
+            checks.extend(deep.as_ref().map(deep_spawn_check));
+            checks
         }
+        Mode::Attach { display, verdict } => vec![match verdict {
+            Ok(()) => Check::new(
+                "GLASS_DISPLAY",
+                CheckStatus::Ok,
+                format!("{display} — reachable; glass will attach to it"),
+            ),
+            Err(no) => Check::new(
+                "GLASS_DISPLAY",
+                CheckStatus::Fail,
+                format!("{display} — {}", no.cause),
+            )
+            .with_remedy(no.remedy),
+        }],
     }
-    checks
 }
 
-fn can_connect(display: &str) -> bool {
-    x11rb::connect(Some(display)).is_ok()
+/// The Xvfb glass would spawn: is there one, and can this process run it?
+fn xvfb_check(xvfb: &Resolved) -> Check {
+    match xvfb {
+        Resolved::Found(p) => Check::new("Xvfb", CheckStatus::Ok, p.display().to_string()),
+        Resolved::NotExecutable(p) => Check::new(
+            "Xvfb",
+            CheckStatus::Fail,
+            format!("{} — not executable", p.display()),
+        )
+        .with_remedy(format!(
+            "chmod +x {}, or point GLASS_XVFB at a runnable binary",
+            p.display()
+        )),
+        Resolved::Absent => Check::new("Xvfb", CheckStatus::Fail, "not found").with_remedy(
+            "install it (e.g. `apt install xvfb`), set GLASS_XVFB to its path, or set \
+             GLASS_DISPLAY=:N to attach to an existing display",
+        ),
+        // Nothing was searched, so nothing is known about whether Xvfb is installed. MCP clients
+        // routinely spawn glass-mcp with a stripped environment (glass#373).
+        Resolved::NoSearchPath => Check::new(
+            "Xvfb",
+            CheckStatus::Fail,
+            "could not be looked up — PATH is unset in glass's environment",
+        )
+        .with_remedy(
+            "set GLASS_XVFB to Xvfb's absolute path, give glass a PATH to search, or set \
+             GLASS_DISPLAY=:N to attach to an existing display",
+        ),
+    }
+}
+
+/// What a deep probe proved. Its remedy comes from [`ProbeFailure`], which withholds
+/// [`XVFB_START_HINT`] from the outcomes that never reached Xvfb.
+fn deep_spawn_check(spawn: &Result<String, ProbeFailure>) -> Check {
+    match spawn {
+        Ok(display) => Check::new(
+            "Xvfb spawn (deep)",
+            CheckStatus::Ok,
+            format!("started and stopped {display}"),
+        ),
+        Err(failure) => Check::new(
+            "Xvfb spawn (deep)",
+            CheckStatus::Fail,
+            failure.detail("Xvfb"),
+        )
+        .with_remedy(failure.remedy(XVFB_START_HINT)),
+    }
+}
+
+/// What to check when Xvfb itself is what failed.
+const XVFB_START_HINT: &str = "Xvfb is installed but produced no working display — check its \
+     dependencies and permissions (the probe already waits out one retry of a stalled server)";
+
+/// Why glass could not attach to the display `GLASS_DISPLAY` names.
+///
+/// Cause and remedy travel together because the pairing is the point: a server that answered and
+/// refused glass is running, and the advice to start one sends the operator to start a second
+/// (glass#373).
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NoAttach {
+    cause: String,
+    remedy: &'static str,
+}
+
+const START_THE_DISPLAY: &str = "start that display (e.g. `./scripts/sandbox-xvfb.sh start` for \
+     :42) or unset GLASS_DISPLAY to self-spawn";
+const FIX_THE_AUTHORITY: &str = "point XAUTHORITY at the cookie file for that display (`xauth \
+     list` shows what it holds), or grant this user access with `xhost`";
+const NAME_A_DISPLAY: &str = "GLASS_DISPLAY must be an X display name — `:42`, `:42.0` or `host:0`";
+const PICK_A_SCREEN: &str = "name a screen that server has (`:42` or `:42.0`), or unset \
+     GLASS_DISPLAY to self-spawn";
+
+/// Whether glass can attach to `display`, and when it cannot, why — in the terms the remedy turns
+/// on. The connection is closed again at once.
+fn attach_verdict(display: &str) -> Result<(), NoAttach> {
+    x11rb::connect(Some(display))
+        .map(|_| ())
+        .map_err(|e| no_attach(&e))
+}
+
+/// Classify a connect failure. `ConnectError` is `#[non_exhaustive]`, so anything not named here
+/// falls to "nothing answered" — the common case, and the one that advice fits.
+fn no_attach(e: &ConnectError) -> NoAttach {
+    match e {
+        // The server answered and turned glass away: an authority problem, not a display that is
+        // down. XAUTHORITY unset or holding a stale cookie is the classic attach failure.
+        ConnectError::SetupAuthenticate(_) | ConnectError::SetupFailed(_) => NoAttach {
+            cause: format!("the server refused the connection ({e})"),
+            remedy: FIX_THE_AUTHORITY,
+        },
+        ConnectError::DisplayParsingError(_) => NoAttach {
+            cause: format!("not a display name X can parse ({e})"),
+            remedy: NAME_A_DISPLAY,
+        },
+        ConnectError::InvalidScreen => NoAttach {
+            cause: "the server is running and has no such screen".into(),
+            remedy: PICK_A_SCREEN,
+        },
+        _ => NoAttach {
+            cause: format!("cannot connect ({e})"),
+            remedy: START_THE_DISPLAY,
+        },
+    }
 }
 
 /// Margin over `Xvfb::start`'s own worst case, so the backstop effectively never fires and
@@ -115,26 +205,39 @@ fn probe_budget() -> Duration {
 }
 
 /// Spawn a private Xvfb and tear it down, with a timeout so a wedged Xvfb can't hang
-/// doctor. Returns the display it came up on, or an error string.
-fn probe_xvfb() -> Result<String, String> {
+/// doctor. Returns the display it came up on, or why there was none.
+fn probe_xvfb() -> Result<String, ProbeFailure> {
     let screen = std::env::var("GLASS_XVFB_SCREEN").unwrap_or_else(|_| "1280x800x24".into());
     let budget = probe_budget();
     let (tx, rx) = mpsc::channel();
-    std::thread::spawn(move || {
-        // The Xvfb is dropped at the end of `map` (after we read its display),
-        // tearing the test display back down.
-        let _ = tx.send(
-            Xvfb::start(&screen)
-                .map(|x| x.display.clone())
-                .map_err(|e| e.to_string()),
-        );
-    });
+    // Named and fallible, unlike a bare `spawn`, which panics when the OS refuses: `Xvfb::start`
+    // spawns two more threads of its own, so a low `pids` limit stops this probe first.
+    std::thread::Builder::new()
+        .name("glass-doctor-xvfb".into())
+        .spawn(move || {
+            // The Xvfb is dropped at the end of `map` (after we read its display),
+            // tearing the test display back down.
+            let _ = tx.send(
+                Xvfb::start(&screen)
+                    .map(|x| x.display.clone())
+                    .map_err(|e| e.to_string()),
+            );
+        })
+        .map_err(|e| ProbeFailure::NotStarted(e.to_string()))?;
+    await_probe(&rx, budget)
+}
+
+/// The bounded wait, kept apart from the spawn so a test can drive every outcome without an X
+/// server. A sender that dropped unsent is a probe thread that unwound, and arrives immediately:
+/// called a timeout it claims a wait nobody did (glass#373).
+fn await_probe(
+    rx: &mpsc::Receiver<Result<String, String>>,
+    budget: Duration,
+) -> Result<String, ProbeFailure> {
     match rx.recv_timeout(budget) {
-        Ok(r) => r,
-        Err(_) => Err(format!(
-            "Xvfb did not become ready within {}s (including one retry of a stalled server)",
-            budget.as_secs()
-        )),
+        Ok(Ok(display)) => Ok(display),
+        Ok(Err(e)) => Err(ProbeFailure::Failed(e)),
+        Err(e) => Err(ProbeFailure::from_recv(e, budget)),
     }
 }
 
@@ -144,14 +247,18 @@ mod tests {
 
     use super::*;
 
+    /// A shallow self-spawn check: the mode glass runs in with no `GLASS_DISPLAY` set.
+    fn self_spawn(xvfb: &Resolved) -> Vec<Check> {
+        x11_checks(&Mode::SelfSpawn { xvfb, deep: None })
+    }
+
+    fn found() -> Resolved {
+        Resolved::Found(PathBuf::from("/usr/bin/Xvfb"))
+    }
+
     #[test]
     fn self_spawn_with_xvfb_present_is_ok() {
-        let cs = x11_checks(
-            None,
-            &Resolved::Found(PathBuf::from("/usr/bin/Xvfb")),
-            None,
-            None,
-        );
+        let cs = self_spawn(&found());
         assert_eq!(cs[0].name, "GLASS_DISPLAY");
         assert_eq!(cs[0].status, CheckStatus::Ok);
         assert_eq!(cs[1].name, "Xvfb");
@@ -161,7 +268,7 @@ mod tests {
 
     #[test]
     fn self_spawn_without_xvfb_fails_with_remedy() {
-        let cs = x11_checks(None, &Resolved::Absent, None, None);
+        let cs = self_spawn(&Resolved::Absent);
         let xvfb = cs.iter().find(|c| c.name == "Xvfb").unwrap();
         assert_eq!(xvfb.status, CheckStatus::Fail);
         assert!(xvfb.remedy.as_deref().unwrap().contains("apt install xvfb"));
@@ -169,30 +276,54 @@ mod tests {
 
     #[test]
     fn attach_reachable_is_ok_unreachable_fails() {
-        let ok = x11_checks(Some(":42"), &Resolved::Absent, Some(true), None);
+        let ok = x11_checks(&Mode::Attach {
+            display: ":42",
+            verdict: Ok(()),
+        });
         assert_eq!(ok[0].status, CheckStatus::Ok);
         assert!(
             ok.iter().all(|c| c.name != "Xvfb"),
             "attach mode shouldn't require Xvfb"
         );
 
-        let bad = x11_checks(Some(":42"), &Resolved::Absent, Some(false), None);
+        let bad = x11_checks(&Mode::Attach {
+            display: ":42",
+            verdict: Err(no_attach(&ConnectError::UnknownError)),
+        });
         assert_eq!(bad[0].status, CheckStatus::Fail);
         assert!(bad[0].remedy.is_some());
+    }
+
+    /// The reason is the half that tells two failures apart, and doctor's detail is the only
+    /// place it is printed.
+    #[test]
+    fn an_unreachable_display_carries_the_reason_into_the_detail() {
+        let cs = x11_checks(&Mode::Attach {
+            display: ":42",
+            verdict: Err(no_attach(&refusal("Client is not authorized"))),
+        });
+        assert!(cs[0].detail.contains(":42"), "{:?}", cs[0].detail);
+        assert!(
+            cs[0].detail.contains("Client is not authorized"),
+            "{:?}",
+            cs[0].detail
+        );
     }
 
     #[test]
     #[ignore = "starts a real X server; needs Xvfb"]
     fn a_live_display_is_reachable_and_an_unused_number_is_not() {
         let server = Xvfb::start("640x480x24").expect("Xvfb should start");
-        assert!(
-            can_connect(&server.display),
+        assert_eq!(
+            attach_verdict(&server.display),
+            Ok(()),
             "the display we just started must be reachable"
         );
         drop(server);
-        assert!(
-            !can_connect(":9999"),
-            "an unused display number must not read as reachable"
+        let no = attach_verdict(":9999").expect_err("an unused display number is not reachable");
+        assert_eq!(
+            no.remedy, START_THE_DISPLAY,
+            "nothing is listening, so starting one is the fix: {no:?}"
         );
     }
 
@@ -266,7 +397,7 @@ mod tests {
     #[test]
     fn a_non_executable_xvfb_fails_with_a_chmod_remedy() {
         let p = PathBuf::from("/opt/x/Xvfb");
-        let cs = x11_checks(None, &Resolved::NotExecutable(p), None, None);
+        let cs = self_spawn(&Resolved::NotExecutable(p));
         let xvfb = cs.iter().find(|c| c.name == "Xvfb").expect("an Xvfb check");
         assert_eq!(xvfb.status, CheckStatus::Fail);
         assert!(
@@ -283,16 +414,184 @@ mod tests {
         );
     }
 
+    fn refusal(reason: &str) -> ConnectError {
+        ConnectError::SetupFailed(x11rb::protocol::xproto::SetupFailed {
+            reason: reason.as_bytes().to_vec(),
+            ..Default::default()
+        })
+    }
+
+    /// glass#373: the classic X11 attach failure is authorisation — `XAUTHORITY` unset or holding
+    /// the wrong cookie. Told to start the display, the operator starts a second one and nothing
+    /// anywhere names auth.
+    #[test]
+    fn a_display_that_refused_the_connection_is_not_one_that_needs_starting() {
+        for e in [
+            refusal("Client is not authorized to connect to Server"),
+            ConnectError::SetupAuthenticate(x11rb::protocol::xproto::SetupAuthenticate {
+                reason: b"no cookie".to_vec(),
+                ..Default::default()
+            }),
+        ] {
+            let no = no_attach(&e);
+            assert!(
+                no.cause.contains("refused"),
+                "the server answered, and the detail must say so: {no:?}"
+            );
+            assert!(
+                no.remedy.contains("XAUTHORITY"),
+                "an auth failure wants the cookie, not a second server: {no:?}"
+            );
+            assert!(
+                !no.remedy.contains("start that display"),
+                "the display is already running: {no:?}"
+            );
+        }
+    }
+
+    /// The refusal reason is the server's own, and the only text that says which of the auth
+    /// failures this is.
+    #[test]
+    fn a_refusal_carries_the_servers_reason() {
+        let no = no_attach(&refusal(
+            "Authorization required, but no authorization protocol \
+                                     specified",
+        ));
+        assert!(
+            no.cause.contains("Authorization required"),
+            "{:?}",
+            no.cause
+        );
+    }
+
+    #[test]
+    fn nothing_listening_on_the_display_is_still_told_to_start_it() {
+        let no = no_attach(&ConnectError::IoError(std::io::Error::from(
+            std::io::ErrorKind::ConnectionRefused,
+        )));
+        assert!(no.remedy.contains("start that display"), "{no:?}");
+    }
+
+    /// `GLASS_DISPLAY=localhost` is not a display name, and no display anyone starts will make it
+    /// one.
+    #[test]
+    fn a_display_name_x_cannot_parse_says_that_rather_than_cannot_connect() {
+        let no = no_attach(&ConnectError::DisplayParsingError(
+            x11rb::errors::DisplayParsingError::MalformedValue("localhost".into()),
+        ));
+        assert!(no.remedy.contains("GLASS_DISPLAY"), "{no:?}");
+        assert!(!no.remedy.contains("start that display"), "{no:?}");
+    }
+
+    /// A running server reached on a screen it does not have. Starting another one gives the same
+    /// answer.
+    #[test]
+    fn a_server_without_that_screen_is_not_a_server_that_is_down() {
+        let no = no_attach(&ConnectError::InvalidScreen);
+        assert!(no.cause.contains("screen"), "{no:?}");
+        assert!(!no.remedy.contains("start that display"), "{no:?}");
+    }
+
+    fn deep(spawn: Result<String, ProbeFailure>) -> Check {
+        x11_checks(&Mode::SelfSpawn {
+            xvfb: &found(),
+            deep: Some(spawn),
+        })
+        .into_iter()
+        .find(|c| c.name == "Xvfb spawn (deep)")
+        .expect("a deep probe contributes its check")
+    }
+
     #[test]
     fn deep_spawn_failure_is_reported() {
-        let cs = x11_checks(
-            None,
-            &Resolved::Found(PathBuf::from("/usr/bin/Xvfb")),
-            None,
-            Some(Err("boom".into())),
+        let check = deep(Err(ProbeFailure::Failed("boom".into())));
+        assert_eq!(check.status, CheckStatus::Fail);
+        assert!(check.detail.contains("boom"), "{:?}", check.detail);
+        assert!(
+            check.remedy.as_deref().is_some_and(|r| r.contains("Xvfb")),
+            "a probe that reached Xvfb gets Xvfb's advice: {:?}",
+            check.remedy
         );
-        let deep = cs.iter().find(|c| c.name == "Xvfb spawn (deep)").unwrap();
-        assert_eq!(deep.status, CheckStatus::Fail);
-        assert_eq!(deep.detail, "boom");
+    }
+
+    /// glass#373: `std::thread::spawn` panics on `EAGAIN` and `Xvfb::start` spawns two threads of
+    /// its own, so a low `pids` limit kills the probe on the spot — reported as the budget
+    /// elapsing, a 24-second timeout that took no time.
+    #[test]
+    fn a_probe_the_host_stopped_is_not_reported_as_a_wait_that_never_happened() {
+        for failure in [
+            ProbeFailure::NotStarted("Resource temporarily unavailable".into()),
+            ProbeFailure::Vanished,
+        ] {
+            let check = deep(Err(failure.clone()));
+            assert_eq!(check.status, CheckStatus::Fail);
+            assert!(
+                !check.detail.contains(&format!("{:?}", probe_budget())),
+                "no wait happened: {check:?}"
+            );
+            assert!(
+                check
+                    .remedy
+                    .as_deref()
+                    .is_some_and(|r| r.contains("limits") && !r.contains("dependencies")),
+                "the host stopped it, so Xvfb's dependencies are not the lead: {check:?}"
+            );
+        }
+    }
+
+    /// The two ways the bounded wait can end, which used to be one `Err(_)` arm. Driven through
+    /// the real receiver rather than the mapper, because the collapse was in the wiring.
+    #[test]
+    fn a_probe_thread_that_died_is_told_apart_from_one_still_running() {
+        let (tx, rx) = mpsc::channel::<Result<String, String>>();
+        drop(tx);
+        assert_eq!(
+            await_probe(&rx, Duration::from_secs(24)),
+            Err(ProbeFailure::Vanished),
+            "a dropped sender is a thread that unwound, and arrives at once"
+        );
+
+        // Held open and silent: the shape of an Xvfb that spawned and never reported.
+        let (_tx, rx) = mpsc::channel::<Result<String, String>>();
+        let budget = Duration::from_millis(20);
+        assert_eq!(
+            await_probe(&rx, budget),
+            Err(ProbeFailure::TimedOut(budget))
+        );
+    }
+
+    /// The probe's own success and failure answers, which the wait must pass through untouched.
+    #[test]
+    fn the_wait_carries_the_probes_own_answer() {
+        let (tx, rx) = mpsc::channel();
+        tx.send(Ok(":99".into())).expect("send");
+        assert_eq!(await_probe(&rx, Duration::from_secs(1)), Ok(":99".into()));
+
+        let (tx, rx) = mpsc::channel();
+        tx.send(Err("Xvfb exited during startup".into()))
+            .expect("send");
+        assert_eq!(
+            await_probe(&rx, Duration::from_secs(1)),
+            Err(ProbeFailure::Failed("Xvfb exited during startup".into()))
+        );
+    }
+
+    /// glass#373: an MCP client that hands glass-mcp no PATH leaves nothing to look `Xvfb` up in.
+    /// "not found" sends the user to install a package that is very likely already there.
+    #[test]
+    fn an_unset_path_is_not_reported_as_a_missing_xvfb() {
+        let cs = self_spawn(&Resolved::NoSearchPath);
+        let xvfb = cs.iter().find(|c| c.name == "Xvfb").expect("an Xvfb check");
+        assert_eq!(xvfb.status, CheckStatus::Fail);
+        assert!(xvfb.detail.contains("PATH"), "{:?}", xvfb.detail);
+        let remedy = xvfb.remedy.as_deref().expect("a remedy");
+        assert!(
+            remedy.contains("GLASS_XVFB") && remedy.contains("PATH"),
+            "{remedy}"
+        );
+        assert!(
+            !remedy.contains("apt install"),
+            "installing it again cannot restore a PATH: {remedy}"
+        );
     }
 }


### PR DESCRIPTION
`glass doctor`'s X11 checks flattened several causes into one message whose remedy pointed at a different problem. The Wayland backend had the same shape in two of the three places, so both are fixed here.

## X11 (#373)

- **Attach failures carry the connect error.** `can_connect` was `.is_ok()`, so an X server that answered and *refused* — `XAUTHORITY` unset, a stale cookie — read as ":42 — cannot connect" with "start that display", and the operator started a second one. Refusals now say so and point at the cookie, gated on the server's own reason (status 0 also carries "Maximum number of clients reached"). An unparseable `GLASS_DISPLAY`, a screen the server does not have, and a handshake that broke off each get their own answer.
- **An unset `PATH` is not a missing Xvfb.** `Resolved` grew a `NoSearchPath` variant, so every tool resolution — Xvfb, sway, `bubblewrap`, `dbus-daemon`, the AT-SPI launcher — tells "there is no list to search" from "it is not installed". No install restores a `PATH`, and MCP clients routinely spawn servers with a stripped environment.
- **A probe that never ran is not a timeout.** `recv_timeout`'s `Disconnected` matched the same `Err(_)` as `Timeout`, so a probe thread killed on the spot by a `pids` limit reported the full budget elapsing. Deep-probe outcomes are now `glass_core::ProbeFailure` — never started / failed / timed out / panicked — and only the two that reached the backend get the backend's advice.
- **The mapper takes one `Mode`.** Four independent arguments are what left "probed and unreachable" and "never probed" one wildcard arm apart.

## Wayland

No attach mode exists there, but the other two were present:

- An unset `PATH` reported "no sway >=1.12 found, build one". It now says the search list is missing — while keeping the build advice, because the bundle lookup reads the glass data dir rather than `$PATH`, so installing one really is a fix.
- `probe_sway` reported a headless sway that exited immediately as "did not come up within ~8s", and counted polls where it quoted seconds. It is deadline-bounded now and reports the exit; a spawn the host refused is classified as never-started, like its X11 sibling.

## Verification

2447 workspace tests, `clippy --all-targets -D warnings`, `cargo fmt --check`, plus the display-backed suites: 25 X11 doctor tests against a real Xvfb and 16 Wayland doctor tests against a real sway. Every new assertion was ablated — each fix broken in turn, the matching test watched to fail, then reverted. A six-lens review ran before this PR opened; its findings are the second commit.

Closes #373