### PR TITLE
fix(a11y): a host a11y bus that hangs warns instead of reading green

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,11 @@ internal refactors, CI, or test-only changes.
 ### Fixed
 - `glass doctor` no longer reports a desktop accessibility bus that has hung as a green "no
   desktop a11y bus running". A bus that takes `GetAddress` and never answers, one that advertises
-  an address glass cannot connect to, and a check that could not run at all now each say so and
-  warn; a host that genuinely has no a11y bus still reads green.
+  an address glass cannot use, a question the session bus answered with an error, and a check that
+  could not run at all now each say so and warn; a host that genuinely has no a11y bus still reads
+  green. The check also asks for the address before trying to connect — the connection asks for it
+  too — so a bus that answers nothing costs one wait instead of two, and one that is still starting
+  up is no longer reported as unusable.
 - `glass doctor` tells apart the ways attaching to an X display can fail, instead of reporting
   every one as "cannot connect" with "start that display". A server that answers and refuses the
   connection now says so and points at `XAUTHORITY`; a `GLASS_DISPLAY` that is not a display name,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ internal refactors, CI, or test-only changes.
 ## [Unreleased]
 
 ### Fixed
+- `glass doctor` no longer reports a desktop accessibility bus that has hung as a green "no
+  desktop a11y bus running". A bus that takes `GetAddress` and never answers, one that advertises
+  an address glass cannot connect to, and a check that could not run at all now each say so and
+  warn; a host that genuinely has no a11y bus still reads green.
 - `glass doctor` tells apart the ways attaching to an X display can fail, instead of reporting
   every one as "cannot connect" with "start that display". A server that answers and refuses the
   connection now says so and points at `XAUTHORITY`; a `GLASS_DISPLAY` that is not a display name,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,6 +1124,7 @@ dependencies = [
  "glass-core",
  "glass-dbus-linux",
  "glass-exec-unix",
+ "glass-proc-linux",
  "glass-wayland",
  "glass-x11",
  "tempfile",

--- a/crates/glass-a11y-linux/Cargo.toml
+++ b/crates/glass-a11y-linux/Cargo.toml
@@ -16,6 +16,7 @@ zbus.workspace = true
 tokio.workspace = true
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
+glass-proc-linux.workspace = true
 glass-x11 = { path = "../glass-x11" }
 glass-wayland = { path = "../glass-wayland" }
 tempfile.workspace = true

--- a/crates/glass-a11y-linux/src/doctor.rs
+++ b/crates/glass-a11y-linux/src/doctor.rs
@@ -13,12 +13,11 @@ use glass_core::capability::CapabilityStatus;
 use glass_core::{Check, CheckStatus, ProbeFailure};
 use glass_exec_unix::Resolved;
 
-/// How long each host-bus probe may take before doctor stops waiting on it. A bus that answers
-/// nothing costs this once: the connection is attempted only once an address has been answered.
+/// How long each host-bus probe may take before doctor stops waiting on it.
 pub const PROBE_BUDGET: Duration = Duration::from_secs(3);
 
 /// The action the states that found a bus and could not use it call for. Its diagnosis stays in
-/// each check's detail: "its socket got unlinked" is wrong for a bus that never answered at all.
+/// each check's detail — "its socket got unlinked" is wrong for a bus that never answered.
 /// The PIDs are the host's — glass's own private bus is an `at-spi-bus-launcher` too.
 const RESTART_AT_SPI: &str = "restart the host's at-spi: kill its at-spi-bus-launcher / \
      at-spi2-registryd / a11y dbus-daemon processes by PID, then re-activate with any a11y client \
@@ -31,10 +30,9 @@ const ASK_FAILED: &str = "the error is the session bus's own — reproduce it wi
      activation failure there means at-spi-bus-launcher is failing to start. glass's own a11y is \
      unaffected (it uses a private bus).";
 
-/// What a check that produced no answer of its own calls for — one action, because both ways of
-/// producing none are read the same way. Not [`ProbeFailure::remedy`]'s text: its "full or
-/// read-only temp dir" is a cause for the deep probes that lay one out; this one needs a thread
-/// and a runtime.
+/// What a check that produced no answer of its own calls for. Not [`ProbeFailure::remedy`]'s
+/// text: its "full or read-only temp dir" is a cause for the deep probes that lay one out, and
+/// this one needs only a thread and a runtime.
 const COULD_NOT_ASK: &str = "nothing here is about your desktop bus — glass got no answer of its \
      own. The detail names the cause when the host refused the probe (a `pids` cgroup limit, or an \
      fd limit low enough to refuse a runtime); a probe that panicked leaves the panic on glass's \
@@ -109,10 +107,8 @@ fn read_proc_entries() -> Vec<ProcEntry> {
 
 /// Run `work` on a private thread with its own current-thread runtime, and wait `budget` for it.
 ///
-/// A private thread because the reader drives the same async API and `block_on` panics inside the
-/// caller's runtime, and because a bus that never answers must not hang doctor with it. The thread
-/// is detached: a wait that ends does not end the work, and a worker that died is not a wait that
-/// elapsed (glass#455).
+/// A private thread because `block_on` panics inside the caller's runtime, which the reader also
+/// drives. The thread is detached: a wait that ends does not end the work (glass#455).
 fn probe_on_a_private_runtime<T, Fut>(
     budget: Duration,
     work: impl FnOnce() -> Fut + Send + 'static,
@@ -144,14 +140,14 @@ where
     }
 }
 
-/// The D-Bus error for a name nothing serves and nothing can start — the answer a host with no
-/// desktop accessibility stack gives, and the only failure that means "there is no bus".
+/// The D-Bus error for a name nothing serves and nothing can start — what a host with no desktop
+/// accessibility stack answers.
 const NO_SUCH_SERVICE: &str = "org.freedesktop.DBus.Error.ServiceUnknown";
 
 /// Ask the host session bus what a11y address it advertises (`org.a11y.Bus.GetAddress`).
 ///
-/// `Ok(None)` is the settled answer that there is no host bus; an error means the question itself
-/// could not be answered, which is not the same thing (glass#455).
+/// `Ok(None)` is the settled answer that there is no host bus; an error means the question could
+/// not be answered (glass#455).
 fn advertised_a11y_address() -> Result<Option<String>, ProbeFailure> {
     probe_on_a_private_runtime(PROBE_BUDGET, || async {
         // No session bus is no desktop a11y bus. The "session bus" check below reports the cause.
@@ -179,9 +175,9 @@ fn advertised_a11y_address() -> Result<Option<String>, ProbeFailure> {
 
 /// Gather host a11y facts (impure: live probe + GetAddress + `/proc`). Read-only — never mutates.
 ///
-/// The address is asked for first because `AccessibilityConnection::new` asks for it too before it
-/// connects (atspi-connection 0.14): probing the connection first spends the budget on the same
-/// question, and reports a bus still warming up as one that cannot be connected to.
+/// The address is asked for first because `AccessibilityConnection::new` asks for it too
+/// (atspi-connection 0.14): probing the connection first reports a bus still warming up as one
+/// that cannot be connected to.
 fn gather_host_a11y() -> HostA11yFacts {
     let session_bus = std::env::var_os("DBUS_SESSION_BUS_ADDRESS").is_some();
     let bus = classify_host_bus(advertised_a11y_address(), probe_a11y_bus, socket_state);
@@ -221,15 +217,14 @@ pub(crate) enum HostBusState {
         socket: Option<bool>,
         why: String,
     },
-    /// It took the `GetAddress` call and never answered — the one host state this check exists to
-    /// surface, and the one that used to read as a green "no bus running" (glass#455).
+    /// It took the `GetAddress` call and never answered — which used to read as a green "no bus
+    /// running" (glass#455).
     Unresponsive { waited: Duration },
     /// The session bus answered the question with an error that does not mean "nothing serves that
     /// name", so whether a bus is there is unknown.
     Unknown { why: String },
-    /// glass's own probe produced no answer — it never started, or its thread unwound — so
-    /// nothing is claimed about the bus. Only those two [`ProbeFailure`]s reach here; the other
-    /// two are answers about the bus itself.
+    /// glass's own probe produced no answer — it never started, or its thread unwound. Only
+    /// those two [`ProbeFailure`]s reach here; the other two are answers about the bus itself.
     Unaskable(ProbeFailure),
     /// Nothing serves `org.a11y.Bus`, or it owns the name with no bus behind it yet.
     NotRunning,
@@ -264,8 +259,7 @@ fn socket_state(address: &str) -> Option<bool> {
 /// Classify the host bus from what the session bus answered, connecting only if it named an
 /// address to connect to.
 ///
-/// `connect` and `socket` are taken as thunks so the verdict stays pure and testable: neither runs
-/// unless an address is in hand, and a connection nothing attempted can never be reported as one
+/// `connect` and `socket` are thunks: a connection nothing attempted cannot be reported as one
 /// that failed.
 fn classify_host_bus(
     advertised: Result<Option<String>, ProbeFailure>,
@@ -543,7 +537,7 @@ mod tests {
         );
     }
 
-    /// A socket that is still there does not make an unconnectable bus a host without one. That
+    /// A socket that is still there does not make an unconnectable bus a host without one — it
     /// fell to the green arm (glass#455).
     #[test]
     fn an_advertised_bus_is_still_wedged_when_its_socket_is_there() {
@@ -563,8 +557,7 @@ mod tests {
         );
     }
 
-    /// A connection that ran out of time is not one the bus refused — the wording is the
-    /// operator's only way to tell a wedge from a stall.
+    /// A connection that ran out of time is not one the bus refused.
     #[test]
     fn a_connection_that_timed_out_says_so_rather_than_claiming_a_refusal() {
         let state = classify_host_bus(
@@ -593,8 +586,8 @@ mod tests {
         );
     }
 
-    /// The launcher owns `org.a11y.Bus` before it has a bus to name, and answers `""` until then;
-    /// the probe reports that as no bus, and calling it a wedge would name an empty address.
+    /// The launcher answers `""` until it has a bus to name, and calling that a wedge would print
+    /// a detail naming an empty address.
     #[test]
     fn no_address_at_all_is_a_host_without_a_bus() {
         assert_eq!(
@@ -620,7 +613,7 @@ mod tests {
         );
     }
 
-    /// A probe the host refused learned nothing about the bus, so nothing is claimed about it.
+    /// A probe the host refused learned nothing about the bus.
     #[test]
     fn a_probe_that_never_ran_is_not_a_verdict_on_the_host() {
         let refused = ProbeFailure::NotStarted("Resource temporarily unavailable".into());
@@ -793,8 +786,8 @@ mod tests {
         host_bus(&a11y_checks(&found(), false, &facts(bus, 0))).clone()
     }
 
-    /// The unusable states point at the host's at-spi; the check exists to send an operator
-    /// there, and a remedy about glass's own probe would be the wrong half of the diagnosis.
+    /// The unusable states point at the host's at-spi — a remedy about glass's own probe would
+    /// be the wrong half of the diagnosis.
     #[test]
     fn the_states_that_found_an_unusable_bus_prescribe_the_restart() {
         for bus in [
@@ -815,8 +808,7 @@ mod tests {
         }
     }
 
-    /// What was found about the socket is three answers, not two: an abstract or TCP address
-    /// names no file, and reporting one as gone is a finding nothing looked for.
+    /// Three answers, not two: an address that names no file is not a socket that went missing.
     #[test]
     fn a_wedged_bus_says_what_was_found_about_its_socket() {
         let details = [Some(false), Some(true), None]
@@ -841,7 +833,7 @@ mod tests {
     }
 
     /// A host with no a11y bus is the ordinary headless case, and warning at it would make every
-    /// container's doctor run noise. The fix is for the states that learned something is wrong.
+    /// container's doctor run noise.
     #[test]
     fn a_host_that_has_no_a11y_bus_still_reads_green() {
         let h = reported(HostBusState::NotRunning);
@@ -883,8 +875,8 @@ mod tests {
         );
         let remedy = h.remedy.clone().unwrap();
         assert!(!remedy.contains("restart the host's at-spi"), "{remedy}");
-        // Sending an operator to check `/tmp` over an `EAGAIN` would be the same misdirection
-        // one layer down, so the shared not-started remedy is deliberately not reused.
+        // Sending an operator to check `/tmp` over an `EAGAIN` is the same misdirection one
+        // layer down.
         assert!(!remedy.contains("temp dir"), "{remedy}");
     }
 
@@ -919,9 +911,8 @@ mod tests {
         assert_eq!(out, Err(ProbeFailure::Failed("bus said no".into())));
     }
 
-    /// A worker that unwound arrives at once, and is not a wait that elapsed — the distinction
-    /// this seam exists to keep. The panic below is deliberate; its message on stderr is what
-    /// the remedy tells the operator to look for.
+    /// A worker that unwound arrives at once, and is not a wait that elapsed. The panic below is
+    /// deliberate — its message on stderr is what the remedy tells the operator to look for.
     #[test]
     fn a_probe_whose_thread_unwound_is_not_reported_as_a_timeout() {
         let started = std::time::Instant::now();

--- a/crates/glass-a11y-linux/src/doctor.rs
+++ b/crates/glass-a11y-linux/src/doctor.rs
@@ -13,22 +13,31 @@ use glass_core::capability::CapabilityStatus;
 use glass_core::{Check, CheckStatus, ProbeFailure};
 use glass_exec_unix::Resolved;
 
-/// How long either host-bus probe may take before doctor stops waiting on it.
-const PROBE_BUDGET: Duration = Duration::from_secs(3);
+/// How long each host-bus probe may take before doctor stops waiting on it. A bus that answers
+/// nothing costs this once: the connection is attempted only once an address has been answered.
+pub const PROBE_BUDGET: Duration = Duration::from_secs(3);
 
-/// The one action every unhealthy host-bus state calls for. Its diagnosis stays in each check's
-/// detail: "its socket got unlinked" is wrong for a bus that never answered at all.
-const RESTART_AT_SPI: &str = "restart at-spi: kill the at-spi-bus-launcher / at-spi2-registryd / \
-     a11y dbus-daemon processes by PID, then re-activate with any a11y client (`dbus-send \
-     --session --dest=org.a11y.Bus --print-reply /org/a11y/bus org.a11y.Bus.GetAddress`). glass's \
-     own a11y is unaffected (it uses a private bus).";
+/// The action the states that found a bus and could not use it call for. Its diagnosis stays in
+/// each check's detail: "its socket got unlinked" is wrong for a bus that never answered at all.
+/// The PIDs are the host's — glass's own private bus is an `at-spi-bus-launcher` too.
+const RESTART_AT_SPI: &str = "restart the host's at-spi: kill its at-spi-bus-launcher / \
+     at-spi2-registryd / a11y dbus-daemon processes by PID, then re-activate with any a11y client \
+     (`dbus-send --session --dest=org.a11y.Bus --print-reply /org/a11y/bus \
+     org.a11y.Bus.GetAddress`). glass's own a11y is unaffected (it uses a private bus).";
 
-/// What a check that never ran calls for. Not [`ProbeFailure::remedy`]'s text: its "full or
+/// What a question the session bus answered with an error calls for.
+const ASK_FAILED: &str = "the error is the session bus's own — reproduce it with `dbus-send \
+     --session --dest=org.a11y.Bus --print-reply /org/a11y/bus org.a11y.Bus.GetAddress`. An \
+     activation failure there means at-spi-bus-launcher is failing to start. glass's own a11y is \
+     unaffected (it uses a private bus).";
+
+/// What a check that produced no answer of its own calls for — one action, because both ways of
+/// producing none are read the same way. Not [`ProbeFailure::remedy`]'s text: its "full or
 /// read-only temp dir" is a cause for the deep probes that lay one out; this one needs a thread
 /// and a runtime.
-const COULD_NOT_ASK: &str = "nothing here is about your desktop bus — glass never got to ask it, \
-     and the detail says what stopped it: a `pids` cgroup limit low enough to refuse a thread, or \
-     an fd limit low enough to refuse a runtime. A probe that panicked leaves the panic on glass's \
+const COULD_NOT_ASK: &str = "nothing here is about your desktop bus — glass got no answer of its \
+     own. The detail names the cause when the host refused the probe (a `pids` cgroup limit, or an \
+     fd limit low enough to refuse a runtime); a probe that panicked leaves the panic on glass's \
      stderr.";
 
 /// Live: is the AT-SPI bus launcher installed, so glass can spawn its private a11y bus?
@@ -135,36 +144,47 @@ where
     }
 }
 
+/// The D-Bus error for a name nothing serves and nothing can start — the answer a host with no
+/// desktop accessibility stack gives, and the only failure that means "there is no bus".
+const NO_SUCH_SERVICE: &str = "org.freedesktop.DBus.Error.ServiceUnknown";
+
 /// Ask the host session bus what a11y address it advertises (`org.a11y.Bus.GetAddress`).
-fn advertised_a11y_address() -> Result<String, ProbeFailure> {
+///
+/// `Ok(None)` is the settled answer that there is no host bus; an error means the question itself
+/// could not be answered, which is not the same thing (glass#455).
+fn advertised_a11y_address() -> Result<Option<String>, ProbeFailure> {
     probe_on_a_private_runtime(PROBE_BUDGET, || async {
-        let conn = zbus::Connection::session()
-            .await
-            .map_err(|e| e.to_string())?;
+        // No session bus is no desktop a11y bus. The "session bus" check below reports the cause.
+        let Ok(conn) = zbus::Connection::session().await else {
+            return Ok(None);
+        };
         let proxy = zbus::Proxy::new(&conn, "org.a11y.Bus", "/org/a11y/bus", "org.a11y.Bus")
             .await
             .map_err(|e| e.to_string())?;
-        proxy
-            .call_method("GetAddress", &())
-            .await
-            .map_err(|e| e.to_string())?
+        let reply = match proxy.call_method("GetAddress", &()).await {
+            Ok(reply) => reply,
+            Err(zbus::Error::MethodError(name, _, _)) if name.as_str() == NO_SUCH_SERVICE => {
+                return Ok(None);
+            }
+            Err(e) => return Err(e.to_string()),
+        };
+        let address = reply
             .body()
             .deserialize::<String>()
-            .map_err(|e| e.to_string())
+            .map_err(|e| e.to_string())?;
+        // The launcher owns `org.a11y.Bus` before it has a bus to name, and answers "" until then.
+        Ok((!address.is_empty()).then_some(address))
     })
 }
 
 /// Gather host a11y facts (impure: live probe + GetAddress + `/proc`). Read-only — never mutates.
+///
+/// The address is asked for first because `AccessibilityConnection::new` asks for it too before it
+/// connects (atspi-connection 0.14): probing the connection first spends the budget on the same
+/// question, and reports a bus still warming up as one that cannot be connected to.
 fn gather_host_a11y() -> HostA11yFacts {
     let session_bus = std::env::var_os("DBUS_SESSION_BUS_ADDRESS").is_some();
-    let connect = probe_a11y_bus();
-    let advertised = advertised_a11y_address();
-    let socket_present = advertised
-        .as_deref()
-        .ok()
-        .and_then(socket_path_from_address)
-        .is_some_and(|p| std::path::Path::new(p).exists());
-    let bus = classify_host_bus(connect, advertised, socket_present);
+    let bus = classify_host_bus(advertised_a11y_address(), probe_a11y_bus, socket_state);
     let orphaned_daemons = count_orphaned_a11y_daemons(&read_proc_entries());
     HostA11yFacts {
         session_bus,
@@ -193,18 +213,25 @@ fn atspi_launcher_override_set() -> bool {
 pub(crate) enum HostBusState {
     /// glass connected to it.
     Reachable,
-    /// It advertises an address glass could not connect to.
+    /// It advertises an address glass could not use, `why` saying which way the attempt ended.
     Wedged {
         address: String,
-        socket_present: bool,
+        /// Whether the address's socket file exists — `None` when the address names no file to
+        /// look for, which is not the same as looking and finding none.
+        socket: Option<bool>,
+        why: String,
     },
     /// It took the `GetAddress` call and never answered — the one host state this check exists to
     /// surface, and the one that used to read as a green "no bus running" (glass#455).
     Unresponsive { waited: Duration },
-    /// Nothing was learned about the host: the probe never started, or its thread unwound. Only
-    /// those two [`ProbeFailure`]s reach here — the other two are answers about the bus itself.
+    /// The session bus answered the question with an error that does not mean "nothing serves that
+    /// name", so whether a bus is there is unknown.
+    Unknown { why: String },
+    /// glass's own probe produced no answer — it never started, or its thread unwound — so
+    /// nothing is claimed about the bus. Only those two [`ProbeFailure`]s reach here; the other
+    /// two are answers about the bus itself.
     Unaskable(ProbeFailure),
-    /// The session bus answered, and no a11y bus is running.
+    /// Nothing serves `org.a11y.Bus`, or it owns the name with no bus behind it yet.
     NotRunning,
 }
 
@@ -228,36 +255,46 @@ fn socket_path_from_address(addr: &str) -> Option<&str> {
     addr.split(',').find_map(|kv| kv.strip_prefix("unix:path="))
 }
 
-/// Classify the host bus from the connection attempt and what (if anything) the session bus
-/// advertises.
+/// Whether the address's socket file is there. `None` for an address that names no file — an
+/// abstract or TCP address is not one whose socket has gone missing.
+fn socket_state(address: &str) -> Option<bool> {
+    socket_path_from_address(address).map(|p| std::path::Path::new(p).exists())
+}
+
+/// Classify the host bus from what the session bus answered, connecting only if it named an
+/// address to connect to.
 ///
-/// The connection attempt is read first for the two outcomes that are about glass's own host
-/// rather than the bus: an advertised address says nothing about connectivity when nothing got as
-/// far as connecting. A `GetAddress` that answers cleanly then settles it — including the answer
-/// that there is no bus, which is why a connection that merely timed out does not overrule it.
+/// `connect` and `socket` are taken as thunks so the verdict stays pure and testable: neither runs
+/// unless an address is in hand, and a connection nothing attempted can never be reported as one
+/// that failed.
 fn classify_host_bus(
-    connect: Result<(), ProbeFailure>,
-    advertised: Result<String, ProbeFailure>,
-    socket_present: bool,
+    advertised: Result<Option<String>, ProbeFailure>,
+    connect: impl FnOnce() -> Result<(), ProbeFailure>,
+    socket: impl FnOnce(&str) -> Option<bool>,
 ) -> HostBusState {
-    match connect {
+    let address = match advertised {
+        Ok(Some(address)) => address,
+        Ok(None) => return HostBusState::NotRunning,
+        Err(ProbeFailure::TimedOut(waited)) => return HostBusState::Unresponsive { waited },
+        Err(ProbeFailure::Failed(why)) => return HostBusState::Unknown { why },
+        Err(nothing_learned @ (ProbeFailure::NotStarted(_) | ProbeFailure::Vanished)) => {
+            return HostBusState::Unaskable(nothing_learned);
+        }
+    };
+    let why = match connect() {
         Ok(()) => return HostBusState::Reachable,
         Err(nothing_learned @ (ProbeFailure::NotStarted(_) | ProbeFailure::Vanished)) => {
             return HostBusState::Unaskable(nothing_learned);
         }
-        Err(ProbeFailure::Failed(_) | ProbeFailure::TimedOut(_)) => {}
-    }
-    match advertised {
-        // The launcher owns `org.a11y.Bus` before it has a bus to name, and answers "" until then.
-        Ok(address) if !address.is_empty() => HostBusState::Wedged {
-            address,
-            socket_present,
-        },
-        Err(ProbeFailure::TimedOut(waited)) => HostBusState::Unresponsive { waited },
-        Err(nothing_learned @ (ProbeFailure::NotStarted(_) | ProbeFailure::Vanished)) => {
-            HostBusState::Unaskable(nothing_learned)
+        Err(ProbeFailure::Failed(why)) => format!("could not connect to it: {why}"),
+        Err(ProbeFailure::TimedOut(waited)) => {
+            format!("did not finish connecting to it within {waited:?}")
         }
-        Ok(_) | Err(ProbeFailure::Failed(_)) => HostBusState::NotRunning,
+    };
+    HostBusState::Wedged {
+        socket: socket(&address),
+        address,
+        why,
     }
 }
 
@@ -334,16 +371,15 @@ fn a11y_checks(launcher: &Resolved, override_set: bool, facts: &HostA11yFacts) -
         HostBusState::Reachable => {
             Check::new("host desktop a11y", CheckStatus::Ok, "your desktop accessibility bus is healthy")
         }
-        HostBusState::Wedged { address, socket_present } => Check::new(
+        HostBusState::Wedged { address, socket, why } => Check::new(
             "host desktop a11y",
             CheckStatus::Warn,
             format!(
-                "your desktop a11y bus is wedged — it advertises {address} and glass could not \
-                 connect to it: {}",
-                if *socket_present {
-                    "its socket file is still there"
-                } else {
-                    "its socket file is gone — the daemon is alive with its socket unlinked"
+                "your desktop a11y bus advertises {address} and glass {why}{}",
+                match socket {
+                    Some(true) => " — its socket file is there",
+                    Some(false) => " — nothing exists at that socket path",
+                    None => " — its address names no socket file to look for",
                 }
             ),
         )
@@ -352,11 +388,17 @@ fn a11y_checks(launcher: &Resolved, override_set: bool, facts: &HostA11yFacts) -
             "host desktop a11y",
             CheckStatus::Warn,
             format!(
-                "your desktop a11y bus did not answer GetAddress within {waited:?} — something \
-                 owns org.a11y.Bus and is not replying, so host a11y clients hang on it"
+                "nothing answered org.a11y.Bus.GetAddress within {waited:?} — the session bus, or \
+                 whatever owns that name, is not replying, so host a11y clients block on it"
             ),
         )
         .with_remedy(RESTART_AT_SPI),
+        HostBusState::Unknown { why } => Check::new(
+            "host desktop a11y",
+            CheckStatus::Warn,
+            format!("could not tell whether your desktop has an a11y bus: {why}"),
+        )
+        .with_remedy(ASK_FAILED),
         HostBusState::Unaskable(why) => Check::new(
             "host desktop a11y",
             CheckStatus::Warn,
@@ -459,22 +501,36 @@ mod tests {
     }
 
     // ---- classification ----
-    /// An answer from the bus itself, for the cases that turn on what the *other* probe found.
-    fn answered(what: &str) -> ProbeFailure {
-        ProbeFailure::Failed(what.into())
+    /// The two thunks, for the cases that must never reach them: a verdict that runs either has
+    /// classified on something it did not observe.
+    fn never_connects() -> Result<(), ProbeFailure> {
+        panic!("nothing should connect when no address was answered")
     }
 
-    fn wedged(socket_present: bool) -> HostBusState {
+    fn never_stats(_: &str) -> Option<bool> {
+        panic!("nothing should look for a socket when no address was answered")
+    }
+
+    fn refused() -> Result<(), ProbeFailure> {
+        Err(ProbeFailure::Failed("Connection refused".into()))
+    }
+
+    fn address() -> Result<Option<String>, ProbeFailure> {
+        Ok(Some("unix:path=/x".into()))
+    }
+
+    fn wedged(socket: Option<bool>, why: &str) -> HostBusState {
         HostBusState::Wedged {
             address: "unix:path=/x".into(),
-            socket_present,
+            socket,
+            why: why.into(),
         }
     }
 
     #[test]
     fn a_bus_glass_connected_to_is_reachable() {
         assert_eq!(
-            classify_host_bus(Ok(()), Ok("unix:path=/x".into()), true),
+            classify_host_bus(address(), || Ok(()), never_stats),
             HostBusState::Reachable
         );
     }
@@ -482,26 +538,43 @@ mod tests {
     #[test]
     fn an_advertised_bus_that_will_not_connect_is_wedged() {
         assert_eq!(
-            classify_host_bus(
-                Err(answered("Connection refused")),
-                Ok("unix:path=/x".into()),
-                false
-            ),
-            wedged(false)
+            classify_host_bus(address(), refused, |_| Some(false)),
+            wedged(Some(false), "could not connect to it: Connection refused")
         );
     }
 
-    /// A socket that is still there does not make an unconnectable bus a host without one: the
-    /// daemon holds it open and does not serve it. That fell to the green arm (glass#455).
+    /// A socket that is still there does not make an unconnectable bus a host without one. That
+    /// fell to the green arm (glass#455).
     #[test]
     fn an_advertised_bus_is_still_wedged_when_its_socket_is_there() {
         assert_eq!(
-            classify_host_bus(
-                Err(answered("Connection refused")),
-                Ok("unix:path=/x".into()),
-                true
-            ),
-            wedged(true)
+            classify_host_bus(address(), refused, |_| Some(true)),
+            wedged(Some(true), "could not connect to it: Connection refused")
+        );
+    }
+
+    /// An abstract or TCP address names no file, so "its socket is gone" would report a finding
+    /// nothing looked for.
+    #[test]
+    fn an_address_naming_no_file_is_not_a_socket_that_went_missing() {
+        assert_eq!(
+            classify_host_bus(address(), refused, |_| None),
+            wedged(None, "could not connect to it: Connection refused")
+        );
+    }
+
+    /// A connection that ran out of time is not one the bus refused — the wording is the
+    /// operator's only way to tell a wedge from a stall.
+    #[test]
+    fn a_connection_that_timed_out_says_so_rather_than_claiming_a_refusal() {
+        let state = classify_host_bus(
+            address(),
+            || Err(ProbeFailure::TimedOut(Duration::from_millis(1500))),
+            |_| Some(true),
+        );
+        assert_eq!(
+            state,
+            wedged(Some(true), "did not finish connecting to it within 1.5s")
         );
     }
 
@@ -509,47 +582,50 @@ mod tests {
     /// land in the arm that says nothing is wrong (glass#455).
     #[test]
     fn a_bus_that_never_answered_is_not_a_host_without_one() {
+        let waited = Duration::from_millis(1500);
         assert_eq!(
             classify_host_bus(
-                Err(ProbeFailure::TimedOut(PROBE_BUDGET)),
-                Err(ProbeFailure::TimedOut(PROBE_BUDGET)),
-                false
+                Err(ProbeFailure::TimedOut(waited)),
+                never_connects,
+                never_stats
             ),
-            HostBusState::Unresponsive {
-                waited: PROBE_BUDGET
+            HostBusState::Unresponsive { waited }
+        );
+    }
+
+    /// The launcher owns `org.a11y.Bus` before it has a bus to name, and answers `""` until then;
+    /// the probe reports that as no bus, and calling it a wedge would name an empty address.
+    #[test]
+    fn no_address_at_all_is_a_host_without_a_bus() {
+        assert_eq!(
+            classify_host_bus(Ok(None), never_connects, never_stats),
+            HostBusState::NotRunning
+        );
+    }
+
+    /// A question the session bus answered with an error is not the answer "there is no bus" —
+    /// an at-spi launcher that fails to start lands here, and used to read green (glass#455).
+    #[test]
+    fn a_question_that_failed_is_not_an_answer_that_there_is_no_bus() {
+        let state = classify_host_bus(
+            Err(ProbeFailure::Failed("Spawn.ChildExited".into())),
+            never_connects,
+            never_stats,
+        );
+        assert_eq!(
+            state,
+            HostBusState::Unknown {
+                why: "Spawn.ChildExited".into()
             }
         );
     }
 
-    /// The launcher owns `org.a11y.Bus` before it has a bus to name, and answers `""` until then.
-    /// Calling that a wedge prints a remedy about an address that names nothing.
-    #[test]
-    fn an_empty_address_is_no_bus_rather_than_a_wedged_one() {
-        assert_eq!(
-            classify_host_bus(Err(answered("no address")), Ok(String::new()), false),
-            HostBusState::NotRunning
-        );
-    }
-
-    #[test]
-    fn a_session_bus_that_answered_no_a11y_bus_is_not_running_one() {
-        assert_eq!(
-            classify_host_bus(
-                Err(answered("ServiceUnknown")),
-                Err(answered("org.freedesktop.DBus.Error.ServiceUnknown")),
-                false
-            ),
-            HostBusState::NotRunning
-        );
-    }
-
-    /// A probe the host refused learned nothing about the bus, so an advertised address is not
-    /// evidence of a wedge — nothing tried to connect.
+    /// A probe the host refused learned nothing about the bus, so nothing is claimed about it.
     #[test]
     fn a_probe_that_never_ran_is_not_a_verdict_on_the_host() {
         let refused = ProbeFailure::NotStarted("Resource temporarily unavailable".into());
         assert_eq!(
-            classify_host_bus(Err(refused.clone()), Ok("unix:path=/x".into()), true),
+            classify_host_bus(Err(refused.clone()), never_connects, never_stats),
             HostBusState::Unaskable(refused)
         );
     }
@@ -557,12 +633,30 @@ mod tests {
     #[test]
     fn a_getaddress_worker_that_unwound_is_not_a_host_without_a_bus() {
         assert_eq!(
-            classify_host_bus(
-                Err(answered("Connection refused")),
-                Err(ProbeFailure::Vanished),
-                false
-            ),
+            classify_host_bus(Err(ProbeFailure::Vanished), never_connects, never_stats),
             HostBusState::Unaskable(ProbeFailure::Vanished)
+        );
+    }
+
+    /// The same for the second probe: a connect thread that unwound is not a bus that refused.
+    #[test]
+    fn a_connect_worker_that_unwound_is_not_a_bus_that_refused() {
+        assert_eq!(
+            classify_host_bus(address(), || Err(ProbeFailure::Vanished), never_stats),
+            HostBusState::Unaskable(ProbeFailure::Vanished)
+        );
+    }
+
+    /// The socket check reads the address that was answered, not some other one.
+    #[test]
+    fn the_socket_is_looked_for_at_the_address_that_was_answered() {
+        let state = classify_host_bus(address(), refused, |addr| {
+            assert_eq!(addr, "unix:path=/x");
+            Some(true)
+        });
+        assert_eq!(
+            state,
+            wedged(Some(true), "could not connect to it: Connection refused")
         );
     }
 
@@ -699,34 +793,79 @@ mod tests {
         host_bus(&a11y_checks(&found(), false, &facts(bus, 0))).clone()
     }
 
+    /// The unusable states point at the host's at-spi; the check exists to send an operator
+    /// there, and a remedy about glass's own probe would be the wrong half of the diagnosis.
     #[test]
-    fn wedged_host_bus_warns() {
-        let h = reported(wedged(false));
-        assert_eq!(h.status, CheckStatus::Warn);
-        assert!(h.remedy.is_some());
+    fn the_states_that_found_an_unusable_bus_prescribe_the_restart() {
+        for bus in [
+            wedged(Some(false), "could not connect to it: Connection refused"),
+            HostBusState::Unresponsive {
+                waited: Duration::from_millis(1500),
+            },
+        ] {
+            let h = reported(bus);
+            assert_eq!(h.status, CheckStatus::Warn, "{h:#?}");
+            assert!(
+                h.remedy
+                    .clone()
+                    .unwrap()
+                    .contains("restart the host's at-spi"),
+                "{h:#?}"
+            );
+        }
     }
 
-    /// The socket being gone and the socket being held open are different things to have found,
-    /// and the operator reads the detail to tell which one they are looking at.
+    /// What was found about the socket is three answers, not two: an abstract or TCP address
+    /// names no file, and reporting one as gone is a finding nothing looked for.
     #[test]
-    fn a_wedged_bus_says_whether_its_socket_is_still_there() {
-        let gone = reported(wedged(false)).detail;
-        let there = reported(wedged(true)).detail;
-        assert_ne!(gone, there);
-        assert!(gone.contains("unix:path=/x"), "{gone}");
-        assert!(there.contains("unix:path=/x"), "{there}");
+    fn a_wedged_bus_says_what_was_found_about_its_socket() {
+        let details = [Some(false), Some(true), None]
+            .map(|socket| reported(wedged(socket, "could not connect to it: x")).detail);
+        let unique: std::collections::BTreeSet<&String> = details.iter().collect();
+        assert_eq!(unique.len(), 3, "{details:#?}");
+        assert!(
+            details.iter().all(|d| d.contains("unix:path=/x")),
+            "{details:#?}"
+        );
     }
 
-    /// glass#455: reported in green as the state where nothing is wrong, this was the one host
-    /// failure the check was added to catch.
+    /// The host failure the check was added to catch, and the one it reported in green.
     #[test]
     fn a_hung_host_bus_warns_and_says_how_long_it_waited() {
         let h = reported(HostBusState::Unresponsive {
-            waited: Duration::from_secs(3),
+            waited: Duration::from_millis(1500),
         });
         assert_eq!(h.status, CheckStatus::Warn);
-        assert!(h.detail.contains("3s"), "{}", h.detail);
+        assert!(h.detail.contains("1.5s"), "{}", h.detail);
         assert!(h.remedy.is_some());
+    }
+
+    /// A host with no a11y bus is the ordinary headless case, and warning at it would make every
+    /// container's doctor run noise. The fix is for the states that learned something is wrong.
+    #[test]
+    fn a_host_that_has_no_a11y_bus_still_reads_green() {
+        let h = reported(HostBusState::NotRunning);
+        assert_eq!(h.status, CheckStatus::Ok);
+        assert!(h.remedy.is_none(), "{h:#?}");
+    }
+
+    /// A question the session bus refused is not an answer about the host, so its remedy points
+    /// at the error rather than at the operator's at-spi processes.
+    #[test]
+    fn a_question_that_failed_reports_the_error_it_got() {
+        let h = reported(HostBusState::Unknown {
+            why: "org.freedesktop.DBus.Error.Spawn.ChildExited".into(),
+        });
+        assert_eq!(h.status, CheckStatus::Warn);
+        assert!(h.detail.contains("Spawn.ChildExited"), "{}", h.detail);
+        assert!(
+            !h.remedy
+                .clone()
+                .unwrap()
+                .contains("restart the host's at-spi"),
+            "{:?}",
+            h.remedy
+        );
     }
 
     /// A check that never ran says what stopped it, and does not send the operator to restart a
@@ -743,8 +882,9 @@ mod tests {
             h.detail
         );
         let remedy = h.remedy.clone().unwrap();
-        assert!(!remedy.contains("restart at-spi"), "{remedy}");
-        // Sending an operator to check `/tmp` over an `EAGAIN` is this change's own defect.
+        assert!(!remedy.contains("restart the host's at-spi"), "{remedy}");
+        // Sending an operator to check `/tmp` over an `EAGAIN` would be the same misdirection
+        // one layer down, so the shared not-started remedy is deliberately not reused.
         assert!(!remedy.contains("temp dir"), "{remedy}");
     }
 
@@ -753,11 +893,12 @@ mod tests {
     fn every_host_bus_state_says_something_different() {
         let details = [
             HostBusState::Reachable,
-            wedged(false),
-            wedged(true),
+            wedged(Some(false), "could not connect to it: x"),
+            wedged(Some(true), "could not connect to it: x"),
             HostBusState::Unresponsive {
-                waited: Duration::from_secs(3),
+                waited: Duration::from_millis(1500),
             },
+            HostBusState::Unknown { why: "x".into() },
             HostBusState::Unaskable(ProbeFailure::Vanished),
             HostBusState::NotRunning,
         ]
@@ -768,7 +909,7 @@ mod tests {
 
     // ---- the probe seam both host-bus probes run through ----
     /// A call the bus answered with an error is the bus's answer, not a wait that ran out — the
-    /// distinction the old `Err(_) => "timed out"` threw away.
+    /// distinction a single `Err(_)` arm loses.
     #[test]
     fn a_probe_that_failed_is_not_reported_as_one_that_timed_out() {
         let out: Result<(), ProbeFailure> =
@@ -776,6 +917,25 @@ mod tests {
                 Err::<(), String>("bus said no".into())
             });
         assert_eq!(out, Err(ProbeFailure::Failed("bus said no".into())));
+    }
+
+    /// A worker that unwound arrives at once, and is not a wait that elapsed — the distinction
+    /// this seam exists to keep. The panic below is deliberate; its message on stderr is what
+    /// the remedy tells the operator to look for.
+    #[test]
+    fn a_probe_whose_thread_unwound_is_not_reported_as_a_timeout() {
+        let started = std::time::Instant::now();
+        let out: Result<(), ProbeFailure> =
+            probe_on_a_private_runtime(Duration::from_secs(30), || async {
+                panic!("this probe panics on purpose (glass#455)")
+            });
+        assert_eq!(out, Err(ProbeFailure::Vanished));
+        // Reporting it after the budget would claim a wait nobody did.
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "{:?}",
+            started.elapsed()
+        );
     }
 
     /// The budget the wait was given is the one it reports, so "3s" is never a number from a

--- a/crates/glass-a11y-linux/src/doctor.rs
+++ b/crates/glass-a11y-linux/src/doctor.rs
@@ -6,11 +6,30 @@
 //! only once an AT client enables it). Without that probe, doctor would report a
 //! green "ready" while `glass_a11y_*` calls fail at runtime.
 
+use std::sync::mpsc;
 use std::time::Duration;
 
 use glass_core::capability::CapabilityStatus;
-use glass_core::{Check, CheckStatus};
+use glass_core::{Check, CheckStatus, ProbeFailure};
 use glass_exec_unix::Resolved;
+
+/// How long either host-bus probe may take before doctor stops waiting on it.
+const PROBE_BUDGET: Duration = Duration::from_secs(3);
+
+/// The one action every unhealthy host-bus state calls for. Its diagnosis stays in each check's
+/// detail: "its socket got unlinked" is wrong for a bus that never answered at all.
+const RESTART_AT_SPI: &str = "restart at-spi: kill the at-spi-bus-launcher / at-spi2-registryd / \
+     a11y dbus-daemon processes by PID, then re-activate with any a11y client (`dbus-send \
+     --session --dest=org.a11y.Bus --print-reply /org/a11y/bus org.a11y.Bus.GetAddress`). glass's \
+     own a11y is unaffected (it uses a private bus).";
+
+/// What a check that never ran calls for. Not [`ProbeFailure::remedy`]'s text: its "full or
+/// read-only temp dir" is a cause for the deep probes that lay one out; this one needs a thread
+/// and a runtime.
+const COULD_NOT_ASK: &str = "nothing here is about your desktop bus — glass never got to ask it, \
+     and the detail says what stopped it: a `pids` cgroup limit low enough to refuse a thread, or \
+     an fd limit low enough to refuse a runtime. A probe that panicked leaves the panic on glass's \
+     stderr.";
 
 /// Live: is the AT-SPI bus launcher installed, so glass can spawn its private a11y bus?
 /// This is the desktop-a11y capability signal for the Linux backends — the *same* fact the
@@ -79,47 +98,73 @@ fn read_proc_entries() -> Vec<ProcEntry> {
     out
 }
 
-/// Ask the host session bus what a11y address it advertises (`org.a11y.Bus.GetAddress`).
-/// Private thread + current-thread runtime + short timeout, like `probe_a11y_bus`.
-fn advertised_a11y_address() -> Option<String> {
-    let (tx, rx) = std::sync::mpsc::channel();
-    std::thread::spawn(move || {
-        let res = (|| {
-            let rt = tokio::runtime::Builder::new_current_thread()
+/// Run `work` on a private thread with its own current-thread runtime, and wait `budget` for it.
+///
+/// A private thread because the reader drives the same async API and `block_on` panics inside the
+/// caller's runtime, and because a bus that never answers must not hang doctor with it. The thread
+/// is detached: a wait that ends does not end the work, and a worker that died is not a wait that
+/// elapsed (glass#455).
+fn probe_on_a_private_runtime<T, Fut>(
+    budget: Duration,
+    work: impl FnOnce() -> Fut + Send + 'static,
+) -> Result<T, ProbeFailure>
+where
+    T: Send + 'static,
+    Fut: std::future::Future<Output = Result<T, String>>,
+{
+    let (tx, rx) = mpsc::channel();
+    // Builder, not `thread::spawn`: a host that refuses the thread panics the caller there.
+    let spawned = std::thread::Builder::new()
+        .name("glass-doctor-a11y".into())
+        .spawn(move || {
+            let res = match tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
-                .ok()?;
-            rt.block_on(async {
-                let conn = zbus::Connection::session().await.ok()?;
-                let proxy =
-                    zbus::Proxy::new(&conn, "org.a11y.Bus", "/org/a11y/bus", "org.a11y.Bus")
-                        .await
-                        .ok()?;
-                proxy
-                    .call_method("GetAddress", &())
-                    .await
-                    .ok()?
-                    .body()
-                    .deserialize::<String>()
-                    .ok()
-            })
-        })();
-        let _ = tx.send(res);
-    });
-    rx.recv_timeout(Duration::from_secs(3)).ok().flatten()
+            {
+                Ok(rt) => rt.block_on(work()).map_err(ProbeFailure::Failed),
+                Err(e) => Err(ProbeFailure::NotStarted(e.to_string())),
+            };
+            let _ = tx.send(res);
+        });
+    if let Err(e) = spawned {
+        return Err(ProbeFailure::NotStarted(e.to_string()));
+    }
+    match rx.recv_timeout(budget) {
+        Ok(res) => res,
+        Err(e) => Err(ProbeFailure::from_recv(e, budget)),
+    }
+}
+
+/// Ask the host session bus what a11y address it advertises (`org.a11y.Bus.GetAddress`).
+fn advertised_a11y_address() -> Result<String, ProbeFailure> {
+    probe_on_a_private_runtime(PROBE_BUDGET, || async {
+        let conn = zbus::Connection::session()
+            .await
+            .map_err(|e| e.to_string())?;
+        let proxy = zbus::Proxy::new(&conn, "org.a11y.Bus", "/org/a11y/bus", "org.a11y.Bus")
+            .await
+            .map_err(|e| e.to_string())?;
+        proxy
+            .call_method("GetAddress", &())
+            .await
+            .map_err(|e| e.to_string())?
+            .body()
+            .deserialize::<String>()
+            .map_err(|e| e.to_string())
+    })
 }
 
 /// Gather host a11y facts (impure: live probe + GetAddress + `/proc`). Read-only — never mutates.
 fn gather_host_a11y() -> HostA11yFacts {
     let session_bus = std::env::var_os("DBUS_SESSION_BUS_ADDRESS").is_some();
-    let probe_ok = probe_a11y_bus().is_ok();
+    let connect = probe_a11y_bus();
     let advertised = advertised_a11y_address();
     let socket_present = advertised
         .as_deref()
+        .ok()
         .and_then(socket_path_from_address)
-        .map(|p| std::path::Path::new(p).exists())
-        .unwrap_or(false);
-    let bus = classify_host_bus(probe_ok, advertised.as_deref(), socket_present);
+        .is_some_and(|p| std::path::Path::new(p).exists());
+    let bus = classify_host_bus(connect, advertised, socket_present);
     let orphaned_daemons = count_orphaned_a11y_daemons(&read_proc_entries());
     HostA11yFacts {
         session_bus,
@@ -146,8 +191,20 @@ fn atspi_launcher_override_set() -> bool {
 /// Health of the *host* (operator's desktop) AT-SPI bus — distinct from glass's private bus.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum HostBusState {
+    /// glass connected to it.
     Reachable,
-    Wedged { address: String },
+    /// It advertises an address glass could not connect to.
+    Wedged {
+        address: String,
+        socket_present: bool,
+    },
+    /// It took the `GetAddress` call and never answered — the one host state this check exists to
+    /// surface, and the one that used to read as a green "no bus running" (glass#455).
+    Unresponsive { waited: Duration },
+    /// Nothing was learned about the host: the probe never started, or its thread unwound. Only
+    /// those two [`ProbeFailure`]s reach here — the other two are answers about the bus itself.
+    Unaskable(ProbeFailure),
+    /// The session bus answered, and no a11y bus is running.
     NotRunning,
 }
 
@@ -171,20 +228,36 @@ fn socket_path_from_address(addr: &str) -> Option<&str> {
     addr.split(',').find_map(|kv| kv.strip_prefix("unix:path="))
 }
 
-/// Classify the host bus from the probe result + what (if anything) it advertises.
+/// Classify the host bus from the connection attempt and what (if anything) the session bus
+/// advertises.
+///
+/// The connection attempt is read first for the two outcomes that are about glass's own host
+/// rather than the bus: an advertised address says nothing about connectivity when nothing got as
+/// far as connecting. A `GetAddress` that answers cleanly then settles it — including the answer
+/// that there is no bus, which is why a connection that merely timed out does not overrule it.
 fn classify_host_bus(
-    probe_ok: bool,
-    advertised: Option<&str>,
+    connect: Result<(), ProbeFailure>,
+    advertised: Result<String, ProbeFailure>,
     socket_present: bool,
 ) -> HostBusState {
-    if probe_ok {
-        return HostBusState::Reachable;
+    match connect {
+        Ok(()) => return HostBusState::Reachable,
+        Err(nothing_learned @ (ProbeFailure::NotStarted(_) | ProbeFailure::Vanished)) => {
+            return HostBusState::Unaskable(nothing_learned);
+        }
+        Err(ProbeFailure::Failed(_) | ProbeFailure::TimedOut(_)) => {}
     }
     match advertised {
-        Some(addr) if !socket_present => HostBusState::Wedged {
-            address: addr.to_string(),
+        // The launcher owns `org.a11y.Bus` before it has a bus to name, and answers "" until then.
+        Ok(address) if !address.is_empty() => HostBusState::Wedged {
+            address,
+            socket_present,
         },
-        _ => HostBusState::NotRunning,
+        Err(ProbeFailure::TimedOut(waited)) => HostBusState::Unresponsive { waited },
+        Err(nothing_learned @ (ProbeFailure::NotStarted(_) | ProbeFailure::Vanished)) => {
+            HostBusState::Unaskable(nothing_learned)
+        }
+        Ok(_) | Err(ProbeFailure::Failed(_)) => HostBusState::NotRunning,
     }
 }
 
@@ -261,18 +334,35 @@ fn a11y_checks(launcher: &Resolved, override_set: bool, facts: &HostA11yFacts) -
         HostBusState::Reachable => {
             Check::new("host desktop a11y", CheckStatus::Ok, "your desktop accessibility bus is healthy")
         }
-        HostBusState::Wedged { address } => Check::new(
+        HostBusState::Wedged { address, socket_present } => Check::new(
             "host desktop a11y",
             CheckStatus::Warn,
-            format!("your desktop a11y bus is wedged — it advertises {address} but the socket won't connect"),
+            format!(
+                "your desktop a11y bus is wedged — it advertises {address} and glass could not \
+                 connect to it: {}",
+                if *socket_present {
+                    "its socket file is still there"
+                } else {
+                    "its socket file is gone — the daemon is alive with its socket unlinked"
+                }
+            ),
         )
-        .with_remedy(
-            "the a11y daemon is alive but its socket got unlinked. Restart at-spi: kill the \
-             at-spi-bus-launcher / at-spi2-registryd / a11y dbus-daemon processes by PID, then \
-             re-activate with any a11y client (`dbus-send --session --dest=org.a11y.Bus \
-             --print-reply /org/a11y/bus org.a11y.Bus.GetAddress`). glass's own a11y is \
-             unaffected (it uses a private bus).",
-        ),
+        .with_remedy(RESTART_AT_SPI),
+        HostBusState::Unresponsive { waited } => Check::new(
+            "host desktop a11y",
+            CheckStatus::Warn,
+            format!(
+                "your desktop a11y bus did not answer GetAddress within {waited:?} — something \
+                 owns org.a11y.Bus and is not replying, so host a11y clients hang on it"
+            ),
+        )
+        .with_remedy(RESTART_AT_SPI),
+        HostBusState::Unaskable(why) => Check::new(
+            "host desktop a11y",
+            CheckStatus::Warn,
+            why.detail("host a11y bus"),
+        )
+        .with_remedy(COULD_NOT_ASK),
         HostBusState::NotRunning => Check::new(
             "host desktop a11y",
             CheckStatus::Ok,
@@ -308,30 +398,15 @@ fn a11y_checks(launcher: &Resolved, override_set: bool, facts: &HostA11yFacts) -
     checks
 }
 
-/// Try to reach the accessibility bus exactly the way the reader does — on a private
-/// thread + current-thread runtime with a short timeout, so a wedged bus can't hang
-/// doctor. `Ok(())` means a connection was established and dropped.
-fn probe_a11y_bus() -> Result<(), String> {
-    let (tx, rx) = std::sync::mpsc::channel();
-    std::thread::spawn(move || {
-        let res = (|| -> Result<(), String> {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .map_err(|e| e.to_string())?;
-            rt.block_on(async {
-                atspi::connection::AccessibilityConnection::new()
-                    .await
-                    .map(|_| ())
-                    .map_err(|e| e.to_string())
-            })
-        })();
-        let _ = tx.send(res);
-    });
-    match rx.recv_timeout(Duration::from_secs(3)) {
-        Ok(r) => r,
-        Err(_) => Err("timed out connecting to the accessibility bus".into()),
-    }
+/// Try to reach the accessibility bus exactly the way the reader does. `Ok(())` means a
+/// connection was established and dropped.
+fn probe_a11y_bus() -> Result<(), ProbeFailure> {
+    probe_on_a_private_runtime(PROBE_BUDGET, || async {
+        atspi::connection::AccessibilityConnection::new()
+            .await
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    })
 }
 
 #[cfg(test)]
@@ -383,25 +458,111 @@ mod tests {
         assert_eq!(socket_path_from_address("unix:abstract=/tmp/x"), None);
     }
 
+    // ---- classification ----
+    /// An answer from the bus itself, for the cases that turn on what the *other* probe found.
+    fn answered(what: &str) -> ProbeFailure {
+        ProbeFailure::Failed(what.into())
+    }
+
+    fn wedged(socket_present: bool) -> HostBusState {
+        HostBusState::Wedged {
+            address: "unix:path=/x".into(),
+            socket_present,
+        }
+    }
+
     #[test]
-    fn classify_bus_states() {
+    fn a_bus_glass_connected_to_is_reachable() {
         assert_eq!(
-            classify_host_bus(true, Some("unix:path=/x"), false),
+            classify_host_bus(Ok(()), Ok("unix:path=/x".into()), true),
             HostBusState::Reachable
         );
+    }
+
+    #[test]
+    fn an_advertised_bus_that_will_not_connect_is_wedged() {
         assert_eq!(
-            classify_host_bus(false, Some("unix:path=/x"), false),
-            HostBusState::Wedged {
-                address: "unix:path=/x".into()
+            classify_host_bus(
+                Err(answered("Connection refused")),
+                Ok("unix:path=/x".into()),
+                false
+            ),
+            wedged(false)
+        );
+    }
+
+    /// A socket that is still there does not make an unconnectable bus a host without one: the
+    /// daemon holds it open and does not serve it. That fell to the green arm (glass#455).
+    #[test]
+    fn an_advertised_bus_is_still_wedged_when_its_socket_is_there() {
+        assert_eq!(
+            classify_host_bus(
+                Err(answered("Connection refused")),
+                Ok("unix:path=/x".into()),
+                true
+            ),
+            wedged(true)
+        );
+    }
+
+    /// The one this check exists for: a bus that takes `GetAddress` and never answers used to
+    /// land in the arm that says nothing is wrong (glass#455).
+    #[test]
+    fn a_bus_that_never_answered_is_not_a_host_without_one() {
+        assert_eq!(
+            classify_host_bus(
+                Err(ProbeFailure::TimedOut(PROBE_BUDGET)),
+                Err(ProbeFailure::TimedOut(PROBE_BUDGET)),
+                false
+            ),
+            HostBusState::Unresponsive {
+                waited: PROBE_BUDGET
             }
         );
+    }
+
+    /// The launcher owns `org.a11y.Bus` before it has a bus to name, and answers `""` until then.
+    /// Calling that a wedge prints a remedy about an address that names nothing.
+    #[test]
+    fn an_empty_address_is_no_bus_rather_than_a_wedged_one() {
         assert_eq!(
-            classify_host_bus(false, Some("unix:path=/x"), true),
+            classify_host_bus(Err(answered("no address")), Ok(String::new()), false),
             HostBusState::NotRunning
         );
+    }
+
+    #[test]
+    fn a_session_bus_that_answered_no_a11y_bus_is_not_running_one() {
         assert_eq!(
-            classify_host_bus(false, None, false),
+            classify_host_bus(
+                Err(answered("ServiceUnknown")),
+                Err(answered("org.freedesktop.DBus.Error.ServiceUnknown")),
+                false
+            ),
             HostBusState::NotRunning
+        );
+    }
+
+    /// A probe the host refused learned nothing about the bus, so an advertised address is not
+    /// evidence of a wedge — nothing tried to connect.
+    #[test]
+    fn a_probe_that_never_ran_is_not_a_verdict_on_the_host() {
+        let refused = ProbeFailure::NotStarted("Resource temporarily unavailable".into());
+        assert_eq!(
+            classify_host_bus(Err(refused.clone()), Ok("unix:path=/x".into()), true),
+            HostBusState::Unaskable(refused)
+        );
+    }
+
+    #[test]
+    fn a_getaddress_worker_that_unwound_is_not_a_host_without_a_bus() {
+        assert_eq!(
+            classify_host_bus(
+                Err(answered("Connection refused")),
+                Err(ProbeFailure::Vanished),
+                false
+            ),
+            HostBusState::Unaskable(ProbeFailure::Vanished)
         );
     }
 
@@ -526,21 +687,108 @@ mod tests {
         );
     }
 
+    /// The one "host desktop a11y" check, for the states that differ only in what it prints.
+    fn host_bus(checks: &[Check]) -> &Check {
+        checks
+            .iter()
+            .find(|c| c.name == "host desktop a11y")
+            .unwrap()
+    }
+
+    fn reported(bus: HostBusState) -> Check {
+        host_bus(&a11y_checks(&found(), false, &facts(bus, 0))).clone()
+    }
+
     #[test]
     fn wedged_host_bus_warns() {
-        let cs = a11y_checks(
-            &found(),
-            false,
-            &facts(
-                HostBusState::Wedged {
-                    address: "unix:path=/x".into(),
-                },
-                0,
-            ),
-        );
-        let h = cs.iter().find(|c| c.name == "host desktop a11y").unwrap();
+        let h = reported(wedged(false));
         assert_eq!(h.status, CheckStatus::Warn);
         assert!(h.remedy.is_some());
+    }
+
+    /// The socket being gone and the socket being held open are different things to have found,
+    /// and the operator reads the detail to tell which one they are looking at.
+    #[test]
+    fn a_wedged_bus_says_whether_its_socket_is_still_there() {
+        let gone = reported(wedged(false)).detail;
+        let there = reported(wedged(true)).detail;
+        assert_ne!(gone, there);
+        assert!(gone.contains("unix:path=/x"), "{gone}");
+        assert!(there.contains("unix:path=/x"), "{there}");
+    }
+
+    /// glass#455: reported in green as the state where nothing is wrong, this was the one host
+    /// failure the check was added to catch.
+    #[test]
+    fn a_hung_host_bus_warns_and_says_how_long_it_waited() {
+        let h = reported(HostBusState::Unresponsive {
+            waited: Duration::from_secs(3),
+        });
+        assert_eq!(h.status, CheckStatus::Warn);
+        assert!(h.detail.contains("3s"), "{}", h.detail);
+        assert!(h.remedy.is_some());
+    }
+
+    /// A check that never ran says what stopped it, and does not send the operator to restart a
+    /// desktop stack nothing has looked at.
+    #[test]
+    fn a_check_that_could_not_run_does_not_prescribe_a_restart() {
+        let h = reported(HostBusState::Unaskable(ProbeFailure::NotStarted(
+            "Resource temporarily unavailable".into(),
+        )));
+        assert_eq!(h.status, CheckStatus::Warn);
+        assert!(
+            h.detail.contains("Resource temporarily unavailable"),
+            "{}",
+            h.detail
+        );
+        let remedy = h.remedy.clone().unwrap();
+        assert!(!remedy.contains("restart at-spi"), "{remedy}");
+        // Sending an operator to check `/tmp` over an `EAGAIN` is this change's own defect.
+        assert!(!remedy.contains("temp dir"), "{remedy}");
+    }
+
+    /// Each state is a different thing to do about it, so no two may print the same line.
+    #[test]
+    fn every_host_bus_state_says_something_different() {
+        let details = [
+            HostBusState::Reachable,
+            wedged(false),
+            wedged(true),
+            HostBusState::Unresponsive {
+                waited: Duration::from_secs(3),
+            },
+            HostBusState::Unaskable(ProbeFailure::Vanished),
+            HostBusState::NotRunning,
+        ]
+        .map(|bus| reported(bus).detail);
+        let unique: std::collections::BTreeSet<&String> = details.iter().collect();
+        assert_eq!(unique.len(), details.len(), "{details:#?}");
+    }
+
+    // ---- the probe seam both host-bus probes run through ----
+    /// A call the bus answered with an error is the bus's answer, not a wait that ran out — the
+    /// distinction the old `Err(_) => "timed out"` threw away.
+    #[test]
+    fn a_probe_that_failed_is_not_reported_as_one_that_timed_out() {
+        let out: Result<(), ProbeFailure> =
+            probe_on_a_private_runtime(Duration::from_secs(30), || async {
+                Err::<(), String>("bus said no".into())
+            });
+        assert_eq!(out, Err(ProbeFailure::Failed("bus said no".into())));
+    }
+
+    /// The budget the wait was given is the one it reports, so "3s" is never a number from a
+    /// constant somewhere else.
+    #[test]
+    fn a_probe_that_outlives_its_budget_times_out_against_that_budget() {
+        let budget = Duration::from_millis(50);
+        let out: Result<(), ProbeFailure> =
+            probe_on_a_private_runtime(budget, move || async move {
+                tokio::time::sleep(Duration::from_secs(30)).await;
+                Ok(())
+            });
+        assert_eq!(out, Err(ProbeFailure::TimedOut(budget)));
     }
 
     #[test]

--- a/crates/glass-a11y-linux/tests/host_bus_unresponsive.rs
+++ b/crates/glass-a11y-linux/tests/host_bus_unresponsive.rs
@@ -1,11 +1,10 @@
-//! glass#455: a desktop a11y bus that takes `org.a11y.Bus.GetAddress` and never answers is the one
-//! host state this check exists to surface, and the one that was reported in green as "no desktop
-//! a11y bus running" — the state where nothing is wrong. Nothing had ever driven it: the unit tests
-//! classify facts, and no test had produced the fact.
+//! glass#455: a desktop a11y bus that takes `org.a11y.Bus.GetAddress` and never answers was
+//! reported in green as "no desktop a11y bus running". Nothing had driven that state: the unit
+//! tests classify facts, and no test had produced the fact.
 //!
-//! Its own test binary, holding this one test, because it repoints `DBUS_SESSION_BUS_ADDRESS` for
-//! the whole process — the variable every other test's glass session reads. The operator's real
-//! a11y bus is never touched; the bus wedged here is spawned, wedged and killed by this file.
+//! Its own test binary because it repoints `DBUS_SESSION_BUS_ADDRESS` for the whole process — the
+//! variable every other test's glass session reads. The operator's real a11y bus is never touched:
+//! the one wedged here is spawned and killed by this file.
 
 #![cfg(target_os = "linux")]
 
@@ -18,8 +17,8 @@ use std::time::{Duration, Instant};
 use glass_a11y_linux::doctor::PROBE_BUDGET;
 use glass_core::CheckStatus;
 
-/// How long the private bus gets to print its address, and its wedge to own the name. Generous:
-/// it bounds a setup failure, and the thing under test has its own much tighter budget.
+/// How long the private bus gets to print its address, and its wedge to own the name — a bound on
+/// setup failure, not the one under test.
 const SETUP_BUDGET: Duration = Duration::from_secs(10);
 
 /// Restores the variable's prior value, not "unset" — this suite runs inside a desktop session
@@ -69,8 +68,7 @@ impl PrivateBus {
             .expect("spawn dbus-daemon");
         let stdout = child.stdout.take().expect("dbus-daemon stdout");
         let bus = PrivateBus(child);
-        // Bounded: a daemon that starts and prints nothing would otherwise hang the suite, in a
-        // test whose whole subject is not waiting on something that never answers.
+        // Bounded: a daemon that starts and prints nothing would otherwise hang the suite.
         let (tx, rx) = mpsc::channel();
         let reader = std::thread::spawn(move || {
             let mut line = String::new();
@@ -159,8 +157,7 @@ fn a_host_bus_that_never_answers_is_not_reported_as_a_host_without_one() {
         host.remedy.is_some(),
         "a warning about a bus that answers nothing has to say what to do about it"
     );
-    // One budget, not two: the connection is only attempted once an address has been answered,
-    // and here nothing ever answers. Doctor waiting with the bus is the other way this fails.
+    // One budget, not two: the connection is only attempted once an address has been answered.
     assert!(
         waited < PROBE_BUDGET + PROBE_BUDGET / 2,
         "doctor waited {waited:?} on a bus that never answers"

--- a/crates/glass-a11y-linux/tests/host_bus_unresponsive.rs
+++ b/crates/glass-a11y-linux/tests/host_bus_unresponsive.rs
@@ -1,0 +1,153 @@
+//! glass#455: a desktop a11y bus that takes `org.a11y.Bus.GetAddress` and never answers is the one
+//! host state this check exists to surface, and the one that was reported in green as "no desktop
+//! a11y bus running" — the state where nothing is wrong. Nothing had ever driven it: the unit
+//! tests classify facts, and no test had produced the fact.
+//!
+//! Its own test binary, holding this one test: it points `DBUS_SESSION_BUS_ADDRESS` at a private
+//! bus of its own, which every other test's session reads. The operator's real a11y bus is only
+//! ever read from, never touched — this one is spawned, wedged and killed here.
+
+#![cfg(target_os = "linux")]
+
+use std::ffi::OsString;
+use std::io::{BufRead as _, BufReader};
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use glass_core::CheckStatus;
+
+/// Restores each variable's prior value, not "unset" — this suite runs inside a desktop session
+/// that has its own.
+struct EnvGuard(Vec<(&'static str, Option<OsString>)>);
+
+#[allow(unsafe_code)]
+impl EnvGuard {
+    /// `DBUS_SESSION_BUS_ADDRESS` points the probes at the wedged bus; `AT_SPI_BUS_ADDRESS` is
+    /// cleared so the connection probe has to ask it rather than a bus named in the environment.
+    fn set(address: &str) -> EnvGuard {
+        let prior = ["DBUS_SESSION_BUS_ADDRESS", "AT_SPI_BUS_ADDRESS"]
+            .map(|k| (k, std::env::var_os(k)))
+            .to_vec();
+        // SAFETY: this binary holds exactly one test, so nothing else in the process is reading
+        // the environment while it is mutated.
+        unsafe {
+            std::env::set_var("DBUS_SESSION_BUS_ADDRESS", address);
+            std::env::remove_var("AT_SPI_BUS_ADDRESS");
+        }
+        EnvGuard(prior)
+    }
+}
+
+#[allow(unsafe_code)]
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (key, value) in self.0.drain(..) {
+            // SAFETY: as above — one test in this binary.
+            match value {
+                Some(v) => unsafe { std::env::set_var(key, v) },
+                None => unsafe { std::env::remove_var(key) },
+            }
+        }
+    }
+}
+
+/// A private `dbus-daemon --session`, killed when the test ends — a panic included.
+struct PrivateBus(Child);
+
+impl Drop for PrivateBus {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+impl PrivateBus {
+    fn start() -> (PrivateBus, String) {
+        let mut child = Command::new("dbus-daemon")
+            .args(["--session", "--nofork", "--print-address"])
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn dbus-daemon");
+        let stdout = child.stdout.take().expect("dbus-daemon stdout");
+        let bus = PrivateBus(child);
+        let mut address = String::new();
+        BufReader::new(stdout)
+            .read_line(&mut address)
+            .expect("read the bus address");
+        let address = address.trim().to_string();
+        assert!(!address.is_empty(), "dbus-daemon printed no address");
+        (bus, address)
+    }
+}
+
+/// Owns `org.a11y.Bus` and answers `GetAddress` never — a launcher wedged mid-call, which is what
+/// an operator whose AT-SPI reads hang actually has.
+struct NeverAnswers;
+
+#[zbus::interface(name = "org.a11y.Bus")]
+impl NeverAnswers {
+    async fn get_address(&self) -> String {
+        std::future::pending::<()>().await;
+        unreachable!("the call is taken and never answered")
+    }
+}
+
+/// Wedge `bus`, returning once the name is owned — so a probe that gets "no such name" is a
+/// failure of the code under test rather than of the setup.
+fn wedge(address: &str) {
+    let address = address.to_string();
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        rt.block_on(async {
+            let conn = zbus::connection::Builder::address(address.as_str())
+                .expect("address")
+                .serve_at("/org/a11y/bus", NeverAnswers)
+                .expect("serve")
+                .name("org.a11y.Bus")
+                .expect("request the name")
+                .build()
+                .await
+                .expect("own org.a11y.Bus");
+            tx.send(()).expect("signal the test");
+            // Holds the connection — and the name — for as long as the test process lives.
+            std::future::pending::<()>().await;
+            drop(conn);
+        });
+    });
+    rx.recv_timeout(Duration::from_secs(10))
+        .expect("org.a11y.Bus was never owned");
+}
+
+#[test]
+#[ignore = "spawns a private session bus and mutates the process environment; run via scripts/test-a11y.sh"]
+fn a_host_bus_that_never_answers_is_not_reported_as_a_host_without_one() {
+    let (_bus, address) = PrivateBus::start();
+    wedge(&address);
+    let _env = EnvGuard::set(&address);
+
+    let started = Instant::now();
+    let checks = glass_a11y_linux::doctor::checks();
+    let waited = started.elapsed();
+
+    let host = checks
+        .iter()
+        .find(|c| c.name == "host desktop a11y")
+        .expect("a host desktop a11y check");
+    assert_eq!(host.status, CheckStatus::Warn, "{host:#?}");
+    assert!(host.detail.contains("did not answer"), "{}", host.detail);
+    assert!(
+        host.remedy.is_some(),
+        "a warning about a wedged bus has to say what to do about it"
+    );
+    // Each probe gives up after its own budget; doctor waiting with the bus is the other way this
+    // check fails an operator.
+    assert!(
+        waited < Duration::from_secs(30),
+        "doctor waited {waited:?} on a bus that never answers"
+    );
+}

--- a/crates/glass-a11y-linux/tests/host_bus_unresponsive.rs
+++ b/crates/glass-a11y-linux/tests/host_bus_unresponsive.rs
@@ -1,11 +1,11 @@
 //! glass#455: a desktop a11y bus that takes `org.a11y.Bus.GetAddress` and never answers is the one
 //! host state this check exists to surface, and the one that was reported in green as "no desktop
-//! a11y bus running" — the state where nothing is wrong. Nothing had ever driven it: the unit
-//! tests classify facts, and no test had produced the fact.
+//! a11y bus running" — the state where nothing is wrong. Nothing had ever driven it: the unit tests
+//! classify facts, and no test had produced the fact.
 //!
-//! Its own test binary, holding this one test: it points `DBUS_SESSION_BUS_ADDRESS` at a private
-//! bus of its own, which every other test's session reads. The operator's real a11y bus is only
-//! ever read from, never touched — this one is spawned, wedged and killed here.
+//! Its own test binary, holding this one test, because it repoints `DBUS_SESSION_BUS_ADDRESS` for
+//! the whole process — the variable every other test's glass session reads. The operator's real
+//! a11y bus is never touched; the bus wedged here is spawned, wedged and killed by this file.
 
 #![cfg(target_os = "linux")]
 
@@ -15,26 +15,24 @@ use std::process::{Child, Command, Stdio};
 use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
+use glass_a11y_linux::doctor::PROBE_BUDGET;
 use glass_core::CheckStatus;
 
-/// Restores each variable's prior value, not "unset" — this suite runs inside a desktop session
+/// How long the private bus gets to print its address, and its wedge to own the name. Generous:
+/// it bounds a setup failure, and the thing under test has its own much tighter budget.
+const SETUP_BUDGET: Duration = Duration::from_secs(10);
+
+/// Restores the variable's prior value, not "unset" — this suite runs inside a desktop session
 /// that has its own.
-struct EnvGuard(Vec<(&'static str, Option<OsString>)>);
+struct EnvGuard(Option<OsString>);
 
 #[allow(unsafe_code)]
 impl EnvGuard {
-    /// `DBUS_SESSION_BUS_ADDRESS` points the probes at the wedged bus; `AT_SPI_BUS_ADDRESS` is
-    /// cleared so the connection probe has to ask it rather than a bus named in the environment.
     fn set(address: &str) -> EnvGuard {
-        let prior = ["DBUS_SESSION_BUS_ADDRESS", "AT_SPI_BUS_ADDRESS"]
-            .map(|k| (k, std::env::var_os(k)))
-            .to_vec();
-        // SAFETY: this binary holds exactly one test, so nothing else in the process is reading
-        // the environment while it is mutated.
-        unsafe {
-            std::env::set_var("DBUS_SESSION_BUS_ADDRESS", address);
-            std::env::remove_var("AT_SPI_BUS_ADDRESS");
-        }
+        let prior = std::env::var_os("DBUS_SESSION_BUS_ADDRESS");
+        // SAFETY: this binary holds one test, and this runs before it starts a thread — the
+        // process is single-threaded here, so nothing can be reading the environment.
+        unsafe { std::env::set_var("DBUS_SESSION_BUS_ADDRESS", address) };
         EnvGuard(prior)
     }
 }
@@ -42,23 +40,23 @@ impl EnvGuard {
 #[allow(unsafe_code)]
 impl Drop for EnvGuard {
     fn drop(&mut self) {
-        for (key, value) in self.0.drain(..) {
-            // SAFETY: as above — one test in this binary.
-            match value {
-                Some(v) => unsafe { std::env::set_var(key, v) },
-                None => unsafe { std::env::remove_var(key) },
-            }
+        // SAFETY: doctor's probe threads are detached and still parked on the wedged bus, but
+        // they read this variable once, when connecting, which they are long past — zbus resolves
+        // the address before the call that hangs them. Nothing else in the process reads it.
+        match self.0.take() {
+            Some(v) => unsafe { std::env::set_var("DBUS_SESSION_BUS_ADDRESS", v) },
+            None => unsafe { std::env::remove_var("DBUS_SESSION_BUS_ADDRESS") },
         }
     }
 }
 
-/// A private `dbus-daemon --session`, killed when the test ends — a panic included.
+/// A private `dbus-daemon --session`, reaped when the test ends — a panic included.
 struct PrivateBus(Child);
 
 impl Drop for PrivateBus {
     fn drop(&mut self) {
-        let _ = self.0.kill();
-        let _ = self.0.wait();
+        // SIGTERM first, so the daemon unlinks its own socket rather than leaving one behind.
+        glass_proc_linux::reap_graceful(&mut self.0, glass_proc_linux::REAP_GRACE);
     }
 }
 
@@ -71,12 +69,23 @@ impl PrivateBus {
             .expect("spawn dbus-daemon");
         let stdout = child.stdout.take().expect("dbus-daemon stdout");
         let bus = PrivateBus(child);
-        let mut address = String::new();
-        BufReader::new(stdout)
-            .read_line(&mut address)
-            .expect("read the bus address");
-        let address = address.trim().to_string();
-        assert!(!address.is_empty(), "dbus-daemon printed no address");
+        // Bounded: a daemon that starts and prints nothing would otherwise hang the suite, in a
+        // test whose whole subject is not waiting on something that never answers.
+        let (tx, rx) = mpsc::channel();
+        let reader = std::thread::spawn(move || {
+            let mut line = String::new();
+            let read = BufReader::new(stdout).read_line(&mut line);
+            let _ = tx.send(read.map(|_| line));
+        });
+        let address = rx
+            .recv_timeout(SETUP_BUDGET)
+            .expect("dbus-daemon printed no address")
+            .expect("read the bus address")
+            .trim()
+            .to_string();
+        // Joined, so the process is single-threaded again before the test mutates its environment.
+        reader.join().expect("the address reader");
+        assert!(!address.is_empty(), "dbus-daemon printed an empty address");
         (bus, address)
     }
 }
@@ -93,7 +102,7 @@ impl NeverAnswers {
     }
 }
 
-/// Wedge `bus`, returning once the name is owned — so a probe that gets "no such name" is a
+/// Wedge `address`, returning once the name is owned — so a probe that gets "no such name" is a
 /// failure of the code under test rather than of the setup.
 fn wedge(address: &str) {
     let address = address.to_string();
@@ -119,7 +128,7 @@ fn wedge(address: &str) {
             drop(conn);
         });
     });
-    rx.recv_timeout(Duration::from_secs(10))
+    rx.recv_timeout(SETUP_BUDGET)
         .expect("org.a11y.Bus was never owned");
 }
 
@@ -127,8 +136,8 @@ fn wedge(address: &str) {
 #[ignore = "spawns a private session bus and mutates the process environment; run via scripts/test-a11y.sh"]
 fn a_host_bus_that_never_answers_is_not_reported_as_a_host_without_one() {
     let (_bus, address) = PrivateBus::start();
-    wedge(&address);
     let _env = EnvGuard::set(&address);
+    wedge(&address);
 
     let started = Instant::now();
     let checks = glass_a11y_linux::doctor::checks();
@@ -139,15 +148,21 @@ fn a_host_bus_that_never_answers_is_not_reported_as_a_host_without_one() {
         .find(|c| c.name == "host desktop a11y")
         .expect("a host desktop a11y check");
     assert_eq!(host.status, CheckStatus::Warn, "{host:#?}");
-    assert!(host.detail.contains("did not answer"), "{}", host.detail);
+    // The phrase belongs to this state alone, so a `Warn` from any other one fails here.
+    assert!(
+        host.detail
+            .contains("nothing answered org.a11y.Bus.GetAddress"),
+        "{}",
+        host.detail
+    );
     assert!(
         host.remedy.is_some(),
-        "a warning about a wedged bus has to say what to do about it"
+        "a warning about a bus that answers nothing has to say what to do about it"
     );
-    // Each probe gives up after its own budget; doctor waiting with the bus is the other way this
-    // check fails an operator.
+    // One budget, not two: the connection is only attempted once an address has been answered,
+    // and here nothing ever answers. Doctor waiting with the bus is the other way this fails.
     assert!(
-        waited < Duration::from_secs(30),
+        waited < PROBE_BUDGET + PROBE_BUDGET / 2,
         "doctor waited {waited:?} on a bus that never answers"
     );
 }

--- a/scripts/test-a11y.sh
+++ b/scripts/test-a11y.sh
@@ -53,3 +53,5 @@ cargo test -p glass-dbus-linux --lib -- --ignored --test-threads=1 "$TEST_FILTER
 cargo test -p glass-a11y-linux --test integration -- --ignored --test-threads=1 "${SKIP_ARGS[@]}" "$TEST_FILTER"
 # Its own binary, so the environment it mutates is nothing else's (see the file's header).
 cargo test -p glass-a11y-linux --test launcher_override -- --ignored "$TEST_FILTER"
+# Likewise: it points DBUS_SESSION_BUS_ADDRESS at a private bus it wedges on purpose.
+cargo test -p glass-a11y-linux --test host_bus_unresponsive -- --ignored "$TEST_FILTER"

--- a/scripts/test-a11y.sh
+++ b/scripts/test-a11y.sh
@@ -53,5 +53,5 @@ cargo test -p glass-dbus-linux --lib -- --ignored --test-threads=1 "$TEST_FILTER
 cargo test -p glass-a11y-linux --test integration -- --ignored --test-threads=1 "${SKIP_ARGS[@]}" "$TEST_FILTER"
 # Its own binary, so the environment it mutates is nothing else's (see the file's header).
 cargo test -p glass-a11y-linux --test launcher_override -- --ignored "$TEST_FILTER"
-# Likewise: it points DBUS_SESSION_BUS_ADDRESS at a private bus it wedges on purpose.
-cargo test -p glass-a11y-linux --test host_bus_unresponsive -- --ignored "$TEST_FILTER"
+# Likewise, and --test-threads=1 so the environment it repoints stays this test's alone.
+cargo test -p glass-a11y-linux --test host_bus_unresponsive -- --ignored --test-threads=1 "$TEST_FILTER"


### PR DESCRIPTION
`glass doctor`'s host desktop a11y check reported a wedged desktop bus as a clean bill of health.
`advertised_a11y_address` ended in `.ok().flatten()`, so a bus that never answered `GetAddress`, a
worker thread that panicked, and a bus that answered nothing all became one `None` — and
`classify_host_bus` could only reach `Wedged` with an address in hand, so every one of them fell to
the arm that prints green as "no desktop a11y bus running". The one host state the check exists to
surface read as the state where nothing is wrong.

Both probes now run through one seam returning `glass_core::ProbeFailure` — the taxonomy #452
added — and the verdict follows what the session bus actually answered:

| what happened | check |
|---|---|
| glass connected | ✓ your desktop accessibility bus is healthy |
| nothing serves the name, no address yet, or no session bus | ✓ no desktop a11y bus running |
| `GetAddress` never answered | ⚠ nothing answered … within 3s |
| an address glass could not use | ⚠ advertises …, and what the attempt did |
| the question came back an error | ⚠ could not tell whether your desktop has an a11y bus |
| glass's own probe never ran, or unwound | ⚠ what stopped it |

The address is asked for before the connection is attempted, because `AccessibilityConnection::new`
asks for it too: probing the connection first spent the budget twice on a bus that answers nothing,
and reported a bus still warming up from a lazy activation as one that cannot be connected to.

Closes #455.

## Verification

`crates/glass-a11y-linux/tests/host_bus_unresponsive.rs` wedges a private session bus — a service
that owns `org.a11y.Bus` and answers `GetAddress` never — and asserts doctor warns and gives up
within one budget. Against the pre-fix classifier it reports `Ok`: #455 reproduced end to end.

Checked live on a Linux desktop: a healthy bus reads green, a bus whose config has no service dirs
reads green in 0.2s, and a wedged bus warns in 3s.