### PR TITLE
fix(doctor): the deep sway probe verifies the stop, and says what failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,13 @@ internal refactors, CI, or test-only changes.
   backend failing, and each gets the remedy for that, rather than the backend's. On the Wayland
   backend a headless sway that exits immediately is reported as an exit, not as an eight-second
   wait it never made.
+- `glass doctor --deep` no longer reports the Wayland probe's compositor as "started and stopped"
+  without checking the stopping half. A probe whose compositor outlives its teardown now warns and
+  names the processes that are still running, and keeps their runtime dir rather than deleting the
+  sockets out from under them. When the probe fails, the check carries sway's own stderr — its
+  account of what went wrong, which previously went to glass's stderr and never to the report —
+  and a compositor that is up but whose IPC never answers now says what the last connection
+  attempt was told.
 
 ## [1.4.0] - 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,12 +41,14 @@ internal refactors, CI, or test-only changes.
   backend a headless sway that exits immediately is reported as an exit, not as an eight-second
   wait it never made.
 - `glass doctor --deep` no longer reports the Wayland probe's compositor as "started and stopped"
-  without checking the stopping half. A probe whose compositor outlives its teardown now warns and
-  names the processes that are still running, and keeps their runtime dir rather than deleting the
-  sockets out from under them. When the probe fails, the check carries sway's own stderr — its
-  account of what went wrong, which previously went to glass's stderr and never to the report —
-  and a compositor that is up but whose IPC never answers now says what the last connection
-  attempt was told.
+  without checking the stopping half. The probe now looks for anything still running out of the
+  private runtime directory it created — which is how a compositor's Xwayland and the app it starts
+  are found at all, since neither stays in sway's process tree — warns and names what is left, and
+  keeps that directory rather than deleting the sockets out from under it. When the probe fails the
+  check carries sway's own stderr, quoted and clipped, instead of leaving it on glass's stderr where
+  no MCP client reads it; a compositor whose IPC never answered now says whether its socket never
+  appeared or refused the connection; and a probe that lost track of what it started warns, rather
+  than reporting it as sway failing and pointing at the host's graphics stack.
 
 ## [1.4.0] - 2026-08-17
 

--- a/crates/glass-proc-linux/src/lib.rs
+++ b/crates/glass-proc-linux/src/lib.rs
@@ -50,14 +50,6 @@ pub const CLOSE_GRACE: Duration = Duration::from_millis(1500);
 /// making sure it is gone.
 pub const APP_REAP_GRACE: Duration = Duration::from_millis(1000);
 
-/// How long [`reap_launch`] waits for a signalled process to actually leave before naming it a
-/// survivor.
-///
-/// A signal lands when its target is next scheduled, so a `/proc` check taken straight after one
-/// still sees pids that are already dying. Each backend counts this into the ladder it asserts
-/// against `glass_core::TEARDOWN_BUDGET`.
-pub const KILL_CONFIRM: Duration = Duration::from_millis(50);
-
 /// How a launched app actually went away, so the backend can say so rather than reporting
 /// every teardown as an unqualified success. Signalling an app that was never asked destroys
 /// whatever it would have flushed on exit, and the user only learns of it the next time the
@@ -204,18 +196,35 @@ pub fn await_condition(grace: Duration, mut done: impl FnMut() -> bool) -> bool 
     }
 }
 
-/// Which of `pids` are still live processes — [`any_alive`]'s answer, named.
-pub fn still_alive(pids: &[u32]) -> Vec<u32> {
-    pids.iter()
-        .copied()
-        .filter(|pid| std::path::Path::new(&format!("/proc/{pid}")).exists())
-        .collect()
+/// Whether `pid` is a live process.
+///
+/// A zombie is not: it has a `/proc` entry until its parent reaps it, but it holds nothing and no
+/// signal reaches it, so counting one would make a teardown look unfinished. Its state is field 3
+/// of `/proc/<pid>/stat`, read after the last `)` because the comm field before it can itself
+/// contain spaces and parens.
+fn alive(pid: u32) -> bool {
+    if !std::path::Path::new(&format!("/proc/{pid}")).exists() {
+        return false;
+    }
+    let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) else {
+        // It answered the first question and not the second, which is what exiting looks like
+        // from here. Reported as alive, the direction that costs a caller a second look rather
+        // than a missed survivor.
+        return true;
+    };
+    !stat
+        .rsplit_once(')')
+        .is_some_and(|(_, rest)| rest.trim_start().starts_with('Z'))
+}
+
+/// Which of `pids` are live processes.
+pub fn live_pids(pids: &[u32]) -> Vec<u32> {
+    pids.iter().copied().filter(|pid| alive(*pid)).collect()
 }
 
 /// Whether any of `pids` is still a live process.
 pub fn any_alive(pids: &[u32]) -> bool {
-    pids.iter()
-        .any(|pid| std::path::Path::new(&format!("/proc/{pid}")).exists())
+    pids.iter().copied().any(alive)
 }
 
 /// Reap a whole launch: the child glass spawned, its process group, and every pid in `tree` — a
@@ -235,9 +244,11 @@ pub fn any_alive(pids: &[u32]) -> bool {
 /// way every `kill`-based reaper on Linux does; the alternative is leaking the app's children on
 /// every teardown.
 ///
-/// Returns the pids still running [`KILL_CONFIRM`] after the ladder ran — empty on the ordinary
-/// path, and what a caller reporting the teardown has to report too (glass#380).
-#[must_use = "a launch that outlived its reap is what the caller has to report"]
+/// Returns the pids of `tree` still alive once the ladder has run — empty on the ordinary path.
+/// Two things it is not: an answer about the process GROUP, which is signalled but not
+/// enumerated, and a confirmation, because a signal lands only when its target is next scheduled.
+/// A caller that reports what survived polls this until it settles (glass#380).
+#[must_use = "the survivors are the caller's to report, or to ignore on purpose"]
 pub fn reap_launch(child: &mut Child, tree: &[u32], grace: Duration) -> Vec<u32> {
     let leader = Pid::from_raw(child.id() as i32);
     let signal_all = |signal| {
@@ -245,7 +256,7 @@ pub fn reap_launch(child: &mut Child, tree: &[u32], grace: Duration) -> Vec<u32>
             let _ = kill_process_group(leader, signal);
         }
         for &pid in tree {
-            if std::path::Path::new(&format!("/proc/{pid}")).exists()
+            if alive(pid)
                 && let Some(pid) = Pid::from_raw(pid as i32)
             {
                 let _ = kill_process(pid, signal);
@@ -262,8 +273,7 @@ pub fn reap_launch(child: &mut Child, tree: &[u32], grace: Duration) -> Vec<u32>
     }
     let _ = child.wait();
     // Asked after the wait, because until the child is reaped its own zombie is still in /proc.
-    await_condition(KILL_CONFIRM, || !any_alive(tree));
-    still_alive(tree)
+    live_pids(tree)
 }
 
 /// Gracefully reap a single child: SIGTERM, poll for exit up to `grace`, then
@@ -386,7 +396,8 @@ pub fn spawn_reader<S: Copy + Send + 'static, R: Read + Send + 'static>(
 #[cfg(test)]
 mod reap_tests {
     use super::{
-        Asked, CLOSE_GRACE, Closed, REAP_GRACE, reap_graceful, reap_group, teardown_notice,
+        Asked, CLOSE_GRACE, Closed, REAP_GRACE, await_condition, reap_graceful, reap_group,
+        teardown_notice,
     };
     use std::io::{BufRead, BufReader};
     use std::os::unix::process::CommandExt;
@@ -619,16 +630,53 @@ mod reap_tests {
     /// glass#380: the reaper computed whether the launch went away and discarded the answer, so
     /// its callers could only report the stop they asked for.
     #[test]
-    fn still_alive_names_the_processes_that_are_there() {
-        let mut child = Command::new("sleep").arg("5").spawn().expect("spawn sleep");
+    fn live_pids_names_the_processes_that_are_there() {
+        let mut child = Command::new("sleep")
+            .arg("5")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn sleep");
         let pid = child.id();
-        assert_eq!(super::still_alive(&[pid]), vec![pid]);
+        assert_eq!(super::live_pids(&[pid]), vec![pid]);
         child.kill().expect("kill");
         child.wait().expect("wait");
         assert!(
-            super::still_alive(&[pid]).is_empty(),
+            super::live_pids(&[pid]).is_empty(),
             "a child that was killed and reaped is not alive"
         );
+    }
+
+    /// A zombie keeps its `/proc` entry until its parent reaps it, so an existence test calls one
+    /// a survivor — and then a teardown that reached everything reports a process to go and kill.
+    #[test]
+    fn a_zombie_is_not_a_live_process() {
+        let mut child = Command::new("sleep")
+            .arg("5")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn sleep");
+        let pid = child.id();
+        child.kill().expect("kill");
+        // Deliberately not waited: that is what makes it a zombie rather than gone.
+        assert!(
+            await_condition(Duration::from_secs(5), || std::fs::read_to_string(format!(
+                "/proc/{pid}/stat"
+            ))
+            .is_ok_and(|s| s
+                .rsplit_once(')')
+                .is_some_and(|(_, rest)| rest.trim_start().starts_with('Z')))),
+            "the fixture has to reach the state under test"
+        );
+        assert!(std::path::Path::new(&format!("/proc/{pid}")).exists());
+        assert!(
+            super::live_pids(&[pid]).is_empty(),
+            "a zombie holds nothing and takes no signal, so it is not a survivor"
+        );
+        child.wait().expect("reap the fixture");
     }
 
     #[test]

--- a/crates/glass-proc-linux/src/lib.rs
+++ b/crates/glass-proc-linux/src/lib.rs
@@ -54,9 +54,8 @@ pub const APP_REAP_GRACE: Duration = Duration::from_millis(1000);
 /// survivor.
 ///
 /// A signal lands when its target is next scheduled, so a `/proc` check taken straight after one
-/// still sees pids that are already dying. Small because it is spent only where something is
-/// still there — a launch that went away is confirmed gone on the first look — and because each
-/// backend counts it into the ladder it asserts against `glass_core::TEARDOWN_BUDGET`.
+/// still sees pids that are already dying. Each backend counts this into the ladder it asserts
+/// against `glass_core::TEARDOWN_BUDGET`.
 pub const KILL_CONFIRM: Duration = Duration::from_millis(50);
 
 /// How a launched app actually went away, so the backend can say so rather than reporting
@@ -206,9 +205,6 @@ pub fn await_condition(grace: Duration, mut done: impl FnMut() -> bool) -> bool 
 }
 
 /// Which of `pids` are still live processes — [`any_alive`]'s answer, named.
-///
-/// A caller that reports a teardown needs the list rather than the bool: an operator can kill a
-/// pid, and cannot act on "something survived".
 pub fn still_alive(pids: &[u32]) -> Vec<u32> {
     pids.iter()
         .copied()
@@ -240,8 +236,7 @@ pub fn any_alive(pids: &[u32]) -> bool {
 /// every teardown.
 ///
 /// Returns the pids still running [`KILL_CONFIRM`] after the ladder ran — empty on the ordinary
-/// path. A caller that reports the teardown must report these too, or it claims a stop that did
-/// not happen (glass#380).
+/// path, and what a caller reporting the teardown has to report too (glass#380).
 #[must_use = "a launch that outlived its reap is what the caller has to report"]
 pub fn reap_launch(child: &mut Child, tree: &[u32], grace: Duration) -> Vec<u32> {
     let leader = Pid::from_raw(child.id() as i32);
@@ -622,8 +617,7 @@ mod reap_tests {
     }
 
     /// glass#380: the reaper computed whether the launch went away and discarded the answer, so
-    /// its callers could only report the stop they asked for. A list rather than a bool because
-    /// naming a survivor is what an operator can act on.
+    /// its callers could only report the stop they asked for.
     #[test]
     fn still_alive_names_the_processes_that_are_there() {
         let mut child = Command::new("sleep").arg("5").spawn().expect("spawn sleep");

--- a/crates/glass-proc-linux/src/lib.rs
+++ b/crates/glass-proc-linux/src/lib.rs
@@ -645,8 +645,7 @@ mod reap_tests {
         );
     }
 
-    /// A zombie keeps its `/proc` entry until its parent reaps it, so an existence test calls one
-    /// a survivor.
+    /// An existence test calls a zombie a survivor.
     #[test]
     fn a_zombie_is_not_a_live_process() {
         let mut child = Command::new("sleep")

--- a/crates/glass-proc-linux/src/lib.rs
+++ b/crates/glass-proc-linux/src/lib.rs
@@ -50,6 +50,15 @@ pub const CLOSE_GRACE: Duration = Duration::from_millis(1500);
 /// making sure it is gone.
 pub const APP_REAP_GRACE: Duration = Duration::from_millis(1000);
 
+/// How long [`reap_launch`] waits for a signalled process to actually leave before naming it a
+/// survivor.
+///
+/// A signal lands when its target is next scheduled, so a `/proc` check taken straight after one
+/// still sees pids that are already dying. Small because it is spent only where something is
+/// still there — a launch that went away is confirmed gone on the first look — and because each
+/// backend counts it into the ladder it asserts against `glass_core::TEARDOWN_BUDGET`.
+pub const KILL_CONFIRM: Duration = Duration::from_millis(50);
+
 /// How a launched app actually went away, so the backend can say so rather than reporting
 /// every teardown as an unqualified success. Signalling an app that was never asked destroys
 /// whatever it would have flushed on exit, and the user only learns of it the next time the
@@ -196,6 +205,17 @@ pub fn await_condition(grace: Duration, mut done: impl FnMut() -> bool) -> bool 
     }
 }
 
+/// Which of `pids` are still live processes — [`any_alive`]'s answer, named.
+///
+/// A caller that reports a teardown needs the list rather than the bool: an operator can kill a
+/// pid, and cannot act on "something survived".
+pub fn still_alive(pids: &[u32]) -> Vec<u32> {
+    pids.iter()
+        .copied()
+        .filter(|pid| std::path::Path::new(&format!("/proc/{pid}")).exists())
+        .collect()
+}
+
 /// Whether any of `pids` is still a live process.
 pub fn any_alive(pids: &[u32]) -> bool {
     pids.iter()
@@ -218,7 +238,12 @@ pub fn any_alive(pids: &[u32]) -> bool {
 /// A pid is only signalled while `/proc/<pid>` still exists. That check races pid reuse the same
 /// way every `kill`-based reaper on Linux does; the alternative is leaking the app's children on
 /// every teardown.
-pub fn reap_launch(child: &mut Child, tree: &[u32], grace: Duration) {
+///
+/// Returns the pids still running [`KILL_CONFIRM`] after the ladder ran — empty on the ordinary
+/// path. A caller that reports the teardown must report these too, or it claims a stop that did
+/// not happen (glass#380).
+#[must_use = "a launch that outlived its reap is what the caller has to report"]
+pub fn reap_launch(child: &mut Child, tree: &[u32], grace: Duration) -> Vec<u32> {
     let leader = Pid::from_raw(child.id() as i32);
     let signal_all = |signal| {
         if let Some(leader) = leader {
@@ -241,6 +266,9 @@ pub fn reap_launch(child: &mut Child, tree: &[u32], grace: Duration) {
         let _ = child.kill();
     }
     let _ = child.wait();
+    // Asked after the wait, because until the child is reaped its own zombie is still in /proc.
+    await_condition(KILL_CONFIRM, || !any_alive(tree));
+    still_alive(tree)
 }
 
 /// Gracefully reap a single child: SIGTERM, poll for exit up to `grace`, then
@@ -593,6 +621,22 @@ mod reap_tests {
         assert!(super::CLOSE_GRACE > super::APP_REAP_GRACE);
     }
 
+    /// glass#380: the reaper computed whether the launch went away and discarded the answer, so
+    /// its callers could only report the stop they asked for. A list rather than a bool because
+    /// naming a survivor is what an operator can act on.
+    #[test]
+    fn still_alive_names_the_processes_that_are_there() {
+        let mut child = Command::new("sleep").arg("5").spawn().expect("spawn sleep");
+        let pid = child.id();
+        assert_eq!(super::still_alive(&[pid]), vec![pid]);
+        child.kill().expect("kill");
+        child.wait().expect("wait");
+        assert!(
+            super::still_alive(&[pid]).is_empty(),
+            "a child that was killed and reaped is not alive"
+        );
+    }
+
     #[test]
     fn reap_launch_reaps_a_child_that_left_the_process_group() {
         // sway does exactly this to every app it execs: `setsid` puts the app in its own group
@@ -616,7 +660,11 @@ mod reap_tests {
             !escaped.is_empty(),
             "the launch should have a child to reap"
         );
-        super::reap_launch(&mut leader, &tree, Duration::from_secs(5));
+        let left = super::reap_launch(&mut leader, &tree, Duration::from_secs(5));
+        assert!(
+            left.is_empty(),
+            "a launch that was reaped has no survivors to report: {left:?}"
+        );
         std::thread::sleep(Duration::from_millis(100));
         assert!(
             !super::any_alive(&escaped),

--- a/crates/glass-proc-linux/src/lib.rs
+++ b/crates/glass-proc-linux/src/lib.rs
@@ -198,18 +198,15 @@ pub fn await_condition(grace: Duration, mut done: impl FnMut() -> bool) -> bool 
 
 /// Whether `pid` is a live process.
 ///
-/// A zombie is not: it has a `/proc` entry until its parent reaps it, but it holds nothing and no
-/// signal reaches it, so counting one would make a teardown look unfinished. Its state is field 3
-/// of `/proc/<pid>/stat`, read after the last `)` because the comm field before it can itself
-/// contain spaces and parens.
+/// A zombie is not: it keeps a `/proc` entry until its parent reaps it, and holds nothing. Its
+/// state is field 3 of `/proc/<pid>/stat`, read after the last `)` because the comm field before
+/// it can itself contain spaces and parens.
 fn alive(pid: u32) -> bool {
     if !std::path::Path::new(&format!("/proc/{pid}")).exists() {
         return false;
     }
     let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) else {
-        // It answered the first question and not the second, which is what exiting looks like
-        // from here. Reported as alive, the direction that costs a caller a second look rather
-        // than a missed survivor.
+        // Reported as alive: a caller looking twice costs less than a survivor missed.
         return true;
     };
     !stat
@@ -649,7 +646,7 @@ mod reap_tests {
     }
 
     /// A zombie keeps its `/proc` entry until its parent reaps it, so an existence test calls one
-    /// a survivor — and then a teardown that reached everything reports a process to go and kill.
+    /// a survivor.
     #[test]
     fn a_zombie_is_not_a_live_process() {
         let mut child = Command::new("sleep")

--- a/crates/glass-wayland/src/doctor.rs
+++ b/crates/glass-wayland/src/doctor.rs
@@ -38,7 +38,7 @@ pub fn checks(deep: bool) -> Vec<Check> {
 #[derive(Debug)]
 struct SwaySpawn {
     came_up: CameUp,
-    /// What the last IPC connect attempt was told, phrased by the caller that made it.
+    /// What the last IPC connect attempt was told.
     last_ipc: Option<String>,
     /// What sway wrote to stderr, captured rather than inherited — its own account of a failure.
     said: Option<String>,
@@ -67,7 +67,8 @@ struct Leaked {
 }
 
 impl Leaked {
-    /// `rt` is consumed either way: deleted when nothing survived, kept when something did.
+    /// `rt` is consumed either way: deleted when nothing survived, kept when something did,
+    /// because deleting it would take that process's sockets with it.
     fn after_reap(pids: Vec<u32>, rt: tempfile::TempDir) -> Option<Leaked> {
         (!pids.is_empty()).then(|| Leaked {
             pids,
@@ -195,7 +196,7 @@ struct Survivors {
     remedy: String,
 }
 
-/// Describe what was left running, in what was observed rather than why.
+/// Describe what was left running.
 fn leak_notice(leaked: &Leaked) -> Survivors {
     let pids: Vec<String> = leaked.pids.iter().map(u32::to_string).collect();
     let (count, label) = match pids.len() {
@@ -458,9 +459,6 @@ const LEAK_GRACE: Duration = Duration::from_millis(500);
 
 /// Tear the launch down and account for it: what the probe started that is still running, and the
 /// runtime dir kept for it.
-///
-/// `rt` is consumed either way — deleted when nothing survived, kept when something did, because
-/// deleting it would take that process's sockets with it.
 fn reap_and_account(child: &mut Child, rt: tempfile::TempDir) -> Option<Leaked> {
     // Snapshot the launch before any of it exits: once sway is reaped its descendants are
     // reparented to init and can no longer be found from its pid.
@@ -472,10 +470,8 @@ fn reap_and_account(child: &mut Child, rt: tempfile::TempDir) -> Option<Leaked> 
 /// Everything of the probe's own still running after `grace`, by both of the answers available —
 /// neither is the set on its own.
 ///
-/// `after_reap` is what the reaper could still see of the tree it signalled; the session sweep is
-/// what carries the probe's private `XDG_RUNTIME_DIR`, which is how a compositor's Xwayland and
-/// the app it `exec`s are found at all — sway reparents one and `setsid`s the other out of the
-/// tree (glass#380).
+/// `after_reap` is what the reaper could still see of the tree it signalled; only
+/// [`session_processes`] finds a compositor's Xwayland or the app it `exec`s (glass#380).
 fn left_running(runtime_dir: &Path, after_reap: &[u32], grace: Duration) -> Vec<u32> {
     let look = || {
         let mut left = crate::xwayland::session_processes(runtime_dir);
@@ -532,8 +528,7 @@ fn probe_sway_within(sway: &Path, budget: Duration) -> SwaySpawn {
     let said = match child.stderr.take().map(SwaySaid::drain) {
         Some(Ok(said)) => Some(said),
         // A refused thread leaves sway's stderr undrained, so the compositor is taken back down
-        // rather than run blind — and this path accounts for it like any other, because a host
-        // that refuses threads is where a teardown is likeliest to leave something behind.
+        // rather than run blind — and accounted for like any other path.
         Some(Err(e)) => {
             return SwaySpawn {
                 came_up: CameUp::Unknown(format!(
@@ -557,9 +552,8 @@ fn probe_sway_within(sway: &Path, budget: Duration) -> SwaySpawn {
     }
 }
 
-/// One attempt at sway's IPC, phrased for the check that may have to quote it: a socket that never
-/// appeared and one that is there and refusing are different diagnoses, and `Ipc::connect` answers
-/// both with a `Backend` error.
+/// One attempt at sway's IPC, phrased for the check that quotes it: `Ipc::connect` answers both
+/// "no socket" and "refused" with a `Backend` error, and those are different diagnoses.
 fn connect_ipc(runtime_dir: &Path) -> Result<(), String> {
     match Ipc::connect(runtime_dir) {
         Ok(_) => Ok(()),
@@ -956,7 +950,7 @@ mod tests {
         assert!(attempts.get() > 1, "the wait made one attempt only");
     }
 
-    /// And it has to reach the check, which is the only surface an MCP client reads.
+    /// And it has to reach the check.
     #[test]
     fn the_check_shows_what_the_ipc_connect_said() {
         let refused = "its IPC socket refused the connection: Connection refused (os error 111)";

--- a/crates/glass-wayland/src/doctor.rs
+++ b/crates/glass-wayland/src/doctor.rs
@@ -5,8 +5,9 @@
 
 use std::io::Read as _;
 use std::path::{Path, PathBuf};
-use std::process::{ChildStderr, Stdio};
-use std::sync::mpsc;
+use std::process::{Child, ChildStderr, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, PoisonError};
 use std::time::{Duration, Instant};
 
 use glass_core::{AppSpec, Check, CheckStatus, ProbeFailure};
@@ -30,24 +31,49 @@ pub fn checks(deep: bool) -> Vec<Check> {
     wayland_checks(&sway, gl, deep_spawn)
 }
 
-/// What the deep probe learned: whether the compositor came up, and what its teardown left
-/// running.
+/// What the deep probe learned: whether the compositor came up, and what it left running.
 ///
 /// A compositor that came up and was not torn down is a working sway and a leaked process at
 /// once; reporting only the first is what claimed a stop nobody had checked (glass#380).
+#[derive(Debug)]
 struct SwaySpawn {
-    /// Whether sway's IPC answered inside the probe's budget.
-    came_up: Result<(), ProbeFailure>,
-    /// What the last IPC connect attempt said — a socket that never appeared, or one that is
-    /// there and refusing.
-    last_ipc_error: Option<String>,
+    came_up: CameUp,
+    /// What the last IPC connect attempt was told, phrased by the caller that made it.
+    last_ipc: Option<String>,
     /// What sway wrote to stderr, captured rather than inherited — its own account of a failure.
     said: Option<String>,
-    /// Pids of the probe's own launch still running once its teardown was done.
-    left_behind: Vec<u32>,
-    /// The probe's private runtime dir, kept only when something is still running out of it —
-    /// deleting it would take that process's sockets with it.
-    kept_runtime_dir: Option<PathBuf>,
+    /// What the probe started and did not manage to stop.
+    leaked: Option<Leaked>,
+}
+
+/// Whether sway's IPC answered inside the probe's budget.
+#[derive(Debug)]
+enum CameUp {
+    Yes,
+    /// It did not, for a reason the shared vocabulary names.
+    No(ProbeFailure),
+    /// Neither: the probe ran and glass lost track of what it had started, so nothing here is
+    /// about sway (glass#373's mis-attribution, one door along).
+    Unknown(String),
+}
+
+/// What the probe started and did not stop. Non-empty by construction — the absence is `None`.
+#[derive(Debug)]
+struct Leaked {
+    /// Processes of the probe's own session still running.
+    pids: Vec<u32>,
+    /// The probe's runtime dir, kept because those processes still have sockets in it.
+    runtime_dir: PathBuf,
+}
+
+impl Leaked {
+    /// `rt` is consumed either way: deleted when nothing survived, kept when something did.
+    fn after_reap(pids: Vec<u32>, rt: tempfile::TempDir) -> Option<Leaked> {
+        (!pids.is_empty()).then(|| Leaked {
+            pids,
+            runtime_dir: rt.keep(),
+        })
+    }
 }
 
 /// Pure: build the Wayland checks from gathered facts.
@@ -79,85 +105,120 @@ fn wayland_checks(
         )
         .with_remedy("install Mesa software GL: `apt install libegl1 libgl1-mesa-dri`")
     });
-    if let Some(res) = deep_spawn {
-        checks.push(deep_spawn_check(res));
+    if let Some(spawn) = deep_spawn {
+        checks.push(deep_spawn_check(spawn));
     }
     checks
 }
 
-/// The `sway spawn (deep)` check: whether the compositor came up, and whether the probe's own
-/// teardown reached everything it started.
+/// What glass can do about a probe whose own machinery failed — never the backend's advice, which
+/// nothing here established (glass#373).
+const NOTHING_ABOUT_SWAY: &str = "the compositor was started and then lost track of, so nothing \
+     here is about sway or the host's GL stack. Re-run `glass doctor --deep`; a host that refuses \
+     threads (a low `pids` cgroup limit) does this repeatably";
+
+/// The `sway spawn (deep)` check: whether the compositor came up, and whether the probe stopped
+/// everything it started.
 fn deep_spawn_check(spawn: SwaySpawn) -> Check {
     const NAME: &str = "sway spawn (deep)";
-    let left = survivors(&spawn.left_behind, spawn.kept_runtime_dir.as_deref());
-    match (spawn.came_up, left) {
-        (Ok(()), None) => Check::new(NAME, CheckStatus::Ok, "headless sway started and stopped"),
-        // The start half stands, so the check keeps it and warns about the half that does not.
-        (Ok(()), Some(left)) => Check::new(
-            NAME,
-            CheckStatus::Warn,
-            format!("headless sway started, but {}", left.detail),
-        )
-        .with_remedy(left.remedy),
-        // The remedy comes from the failure itself, which withholds `SWAY_START_HINT` from
-        // the outcomes that never reached sway (glass#373).
-        (Err(failure), left) => {
+    let leak = spawn.leaked.as_ref().map(leak_notice);
+    let (status, mut detail, remedy) = match spawn.came_up {
+        CameUp::Yes => match &leak {
+            None => {
+                return Check::new(NAME, CheckStatus::Ok, "headless sway started and stopped");
+            }
+            // The start half stands, so the check keeps it and warns about the half that does not.
+            Some(leak) => (
+                CheckStatus::Warn,
+                format!("headless sway started, but {}", leak.detail),
+                leak.remedy.clone(),
+            ),
+        },
+        // The remedy comes from the failure itself, which withholds `SWAY_START_HINT` from the
+        // outcomes that never reached sway (glass#373).
+        CameUp::No(failure) => {
             let mut detail = failure.detail("headless sway");
-            // Only on the timeout: after an exit the missing socket has a reason the detail
+            // Only on the timeout: after an exit, the missing socket has a reason the detail
             // already gives.
-            if let (ProbeFailure::TimedOut(_), Some(why)) = (&failure, &spawn.last_ipc_error) {
-                detail.push_str(&format!(" — its IPC socket last said: {why}"));
+            if let (ProbeFailure::TimedOut(_), Some(why)) = (&failure, &spawn.last_ipc) {
+                detail.push_str(&format!(" — {why}"));
             }
-            if let Some(said) = &spawn.said {
-                detail.push_str(&format!(" — sway said: {said}"));
-            }
-            let mut remedy = failure.remedy(SWAY_START_HINT);
-            if let Some(left) = left {
-                detail.push_str(&format!(" — and {}", left.detail));
-                remedy.push_str(&format!(". {}", left.remedy));
-            }
-            Check::new(NAME, CheckStatus::Fail, detail).with_remedy(remedy)
+            with_leak(
+                CheckStatus::Fail,
+                detail,
+                failure.remedy(SWAY_START_HINT),
+                leak.as_ref(),
+            )
         }
+        // `Warn`, not `Fail`: a probe that established nothing is not evidence against the
+        // backend, and `Skip` would say the check did not apply.
+        CameUp::Unknown(why) => with_leak(
+            CheckStatus::Warn,
+            format!("glass lost track of the headless sway it started: {why}"),
+            NOTHING_ABOUT_SWAY.to_string(),
+            leak.as_ref(),
+        ),
+    };
+    // Sway's own words go last and quoted: they are the one span of this line glass did not
+    // write, and undelimited they can imitate the clauses around them (glass#348).
+    if let Some(said) = &spawn.said {
+        detail.push_str(&format!(" — sway said: {said:?}"));
+    }
+    Check::new(NAME, status, detail).with_remedy(remedy)
+}
+
+/// Fold what the probe left running into a verdict already described.
+fn with_leak(
+    status: CheckStatus,
+    mut detail: String,
+    remedy: String,
+    leak: Option<&Survivors>,
+) -> (CheckStatus, String, String) {
+    let Some(leak) = leak else {
+        return (status, detail, remedy);
+    };
+    detail.push_str(&format!(" — and {}", leak.detail));
+    (status, detail, join_remedies(&remedy, &leak.remedy))
+}
+
+/// Two remedies as one, dropping either if it is empty.
+fn join_remedies(first: &str, second: &str) -> String {
+    match (first.trim(), second.trim()) {
+        ("", other) | (other, "") => other.to_string(),
+        (first, second) => format!("{first}. {second}"),
     }
 }
 
-/// What the check says about processes the probe's teardown did not reach.
+/// What the check says about what the probe left running.
 struct Survivors {
     detail: String,
     remedy: String,
 }
 
-/// Describe `left_behind`, or `None` when the teardown reached everything.
-fn survivors(left_behind: &[u32], kept_runtime_dir: Option<&Path>) -> Option<Survivors> {
-    let (first, rest) = left_behind.split_first()?;
-    let list = |sep: &str| {
-        std::iter::once(first.to_string())
-            .chain(rest.iter().map(u32::to_string))
-            .collect::<Vec<_>>()
-            .join(sep)
+/// Describe what was left running, in what was observed rather than why.
+fn leak_notice(leaked: &Leaked) -> Survivors {
+    let pids: Vec<String> = leaked.pids.iter().map(u32::to_string).collect();
+    let (count, label) = match pids.len() {
+        1 => ("1 process".to_string(), "pid"),
+        n => (format!("{n} processes"), "pids"),
     };
-    let (count, pids, whose) = match rest.len() {
-        0 => ("1 process".to_string(), format!("pid {first}"), "its"),
-        n => (
-            format!("{} processes", n + 1),
-            format!("pids {}", list(", ")),
-            "their",
+    let dir = leaked.runtime_dir.display();
+    Survivors {
+        detail: format!(
+            "{count} it started was still running {LEAK_GRACE:?} after the probe signalled it \
+             ({label} {}); the probe's runtime dir is kept at {dir} rather than deleted, so \
+             whatever is still using it keeps its sockets",
+            pids.join(", ")
         ),
-    };
-    let dir = kept_runtime_dir
-        .map(|d| format!("; {whose} runtime dir is kept at {}", d.display()))
-        .unwrap_or_default();
-    Some(Survivors {
-        detail: format!("{count} of its launch outlived the probe's SIGKILL ({pids}){dir}"),
+        // No cause is named: the same observation is produced by a process on its way out, one
+        // the kernel cannot kill, and a pid that has been reused since.
         remedy: format!(
-            "kill {} by hand{}; a process that outlives SIGKILL is usually stuck in the kernel \
-             (uninterruptible I/O), which only its device or a reboot clears",
-            list(" "),
-            kept_runtime_dir
-                .map(|d| format!(", then remove {}", d.display()))
-                .unwrap_or_default()
+            "look first — `ps -p {} -o pid,stat,args` says whether they are still the probe's \
+             sway; if they are, `kill -9 {}` and remove {dir}",
+            pids.join(","),
+            pids.join(" ")
         ),
-    })
+    }
 }
 
 /// Resolve sway (path) and ask it its version.
@@ -247,115 +308,185 @@ fn probe_sway(sway: &Path) -> SwaySpawn {
     probe_sway_within(sway, IPC_READY_BUDGET)
 }
 
-/// How much of sway's stderr the probe keeps — the front, where a failed start explains itself,
-/// and no more than a check's detail can carry.
-const STDERR_KEPT: u64 = 2 * 1024;
+/// How much of sway's stderr the probe keeps, and how much of that a check quotes.
+///
+/// Two numbers because they answer different questions: the pipe must be drained faster than sway
+/// writes, and a check's detail is one line an operator reads.
+const STDERR_KEPT: usize = 8 * 1024;
+const STDERR_SHOWN: usize = 512;
 
-/// How long the probe waits for the stderr pipe to end after the compositor has been reaped.
+/// How long the probe waits for the stderr pipe to close after the compositor has been reaped.
 const SAID_GRACE: Duration = Duration::from_millis(200);
 
 /// Sway's own stderr, read on a helper thread for as long as the pipe is open.
 ///
-/// Not a read at the end: a compositor whose stderr nobody drains stalls on a full pipe, which
-/// the probe would report as one that never came up.
-struct SwaySaid(mpsc::Receiver<String>);
+/// Not a read at the end: a compositor whose stderr nobody drains stalls on a full pipe, which the
+/// probe would report as one that never came up.
+struct SwaySaid {
+    kept: Arc<Mutex<Vec<u8>>>,
+    closed: Arc<AtomicBool>,
+}
 
 impl SwaySaid {
     /// Start reading. `Err` is the host refusing the thread: `Builder`, where `thread::spawn`
     /// panics (glass#454).
     fn drain(mut stderr: ChildStderr) -> std::io::Result<SwaySaid> {
-        let (tx, rx) = mpsc::channel();
+        let said = SwaySaid {
+            kept: Arc::default(),
+            closed: Arc::default(),
+        };
+        let (kept, closed) = (Arc::clone(&said.kept), Arc::clone(&said.closed));
         std::thread::Builder::new()
             .name("glass-doctor-sway-stderr".into())
             .spawn(move || {
-                let mut kept = Vec::new();
-                let _ = stderr.by_ref().take(STDERR_KEPT).read_to_end(&mut kept);
-                // Past the cap the pipe is still drained, so sway is never blocked writing to it.
-                let _ = std::io::copy(&mut stderr, &mut std::io::sink());
-                // One line: a check's detail is a line, and a compositor's stderr is not.
-                let text = String::from_utf8_lossy(&kept);
-                let said = text
-                    .lines()
-                    .map(str::trim)
-                    .filter(|line| !line.is_empty())
-                    .collect::<Vec<_>>()
-                    .join("; ");
-                let _ = tx.send(said);
+                let mut chunk = [0u8; 1024];
+                loop {
+                    match stderr.read(&mut chunk) {
+                        Ok(0) | Err(_) => break,
+                        Ok(n) => {
+                            let mut kept = kept.lock().unwrap_or_else(PoisonError::into_inner);
+                            // Past the cap the pipe is still drained, so sway is never blocked
+                            // writing to it.
+                            let room = STDERR_KEPT.saturating_sub(kept.len());
+                            kept.extend_from_slice(&chunk[..n.min(room)]);
+                        }
+                    }
+                }
+                closed.store(true, Ordering::Release);
             })?;
-        Ok(SwaySaid(rx))
+        Ok(said)
     }
 
-    /// What it said, once its pipe has ended. `None` when it said nothing, or when a survivor of
-    /// the teardown still holds the pipe open.
-    fn snapshot(self, grace: Duration) -> Option<String> {
-        self.0.recv_timeout(grace).ok().filter(|s| !s.is_empty())
+    /// What it said, after `grace` for the pipe to close — call once the compositor is reaped.
+    ///
+    /// Read whether or not the pipe closed, because it stays open while anything the probe left
+    /// running holds it, which is the case whose stderr matters most.
+    fn snapshot(&self, grace: Duration) -> Option<String> {
+        glass_proc_linux::await_condition(grace, || self.closed.load(Ordering::Acquire));
+        let kept = self.kept.lock().unwrap_or_else(PoisonError::into_inner);
+        said_line(&kept)
     }
 }
 
-/// What ended a wait for sway's IPC, and the last thing a connect attempt said.
+/// Sway's stderr as one line of a check: lines joined, clipped to [`STDERR_SHOWN`] with the cut
+/// disclosed. `None` when it said nothing.
+fn said_line(kept: &[u8]) -> Option<String> {
+    let text = String::from_utf8_lossy(kept);
+    let said = text
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join("; ");
+    if said.is_empty() {
+        return None;
+    }
+    if said.len() <= STDERR_SHOWN {
+        return Some(said);
+    }
+    let cut = said.floor_char_boundary(STDERR_SHOWN);
+    Some(format!(
+        "{}… (first {cut} bytes of {})",
+        &said[..cut],
+        said.len()
+    ))
+}
+
+/// What ended a wait for sway's IPC, and what the last connect attempt was told.
+#[derive(Debug)]
 struct IpcWait {
-    outcome: Result<(), ProbeFailure>,
-    last_ipc_error: Option<String>,
+    came_up: CameUp,
+    last_ipc: Option<String>,
 }
 
 /// Wait for `connect` to answer, giving up at `budget`, and stopping early when `exited` reports
 /// the compositor gone.
 ///
-/// A deadline, not a poll count: the failure names the wait it made, and a count times `poll` is
-/// not that wait — each turn also spends a connect attempt (glass#373).
+/// A deadline, not a poll count: the failure names the wait it made, and a count times
+/// [`IPC_POLL`] is not that wait — each turn also spends a connect attempt (glass#373).
 ///
 /// Both halves are closures so the classification can be driven without a compositor.
 fn await_ipc(
     budget: Duration,
-    poll: Duration,
     mut exited: impl FnMut() -> std::io::Result<Option<std::process::ExitStatus>>,
     mut connect: impl FnMut() -> Result<(), String>,
 ) -> IpcWait {
     let deadline = Instant::now() + budget;
-    let mut last_ipc_error = None;
-    let outcome = loop {
+    let mut last_ipc = None;
+    let came_up = loop {
         match exited() {
             // sway exited before its IPC came up — its own answer, and immediate: quoting the
             // budget below would claim a wait nobody made.
             Ok(Some(status)) => {
-                break Err(ProbeFailure::Failed(format!(
+                break CameUp::No(ProbeFailure::Failed(format!(
                     "sway exited before its IPC came up ({status})"
                 )));
             }
             // Whether sway is running can no longer be established — something else reaped it, so
             // `waitpid` answers ECHILD. Dropped, this read as "still running", so the wait spent
             // its whole budget and blamed a timeout.
-            Err(e) => {
-                break Err(ProbeFailure::Failed(format!(
-                    "glass could not wait on sway, so its exit could not be observed: {e}"
-                )));
-            }
+            Err(e) => break CameUp::Unknown(format!("waiting on it failed: {e}")),
             Ok(None) => {}
         }
         match connect() {
-            Ok(()) => break Ok(()),
-            Err(e) => last_ipc_error = Some(e),
+            Ok(()) => break CameUp::Yes,
+            Err(e) => last_ipc = Some(e),
         }
         if Instant::now() >= deadline {
-            break Err(ProbeFailure::TimedOut(budget));
+            break CameUp::No(ProbeFailure::TimedOut(budget));
         }
-        std::thread::sleep(poll);
+        std::thread::sleep(IPC_POLL);
     };
-    IpcWait {
-        outcome,
-        last_ipc_error,
-    }
+    IpcWait { came_up, last_ipc }
 }
 
 /// A probe that ended before it spawned anything: nothing ran, so nothing was left behind.
 fn never_ran(why: ProbeFailure) -> SwaySpawn {
     SwaySpawn {
-        came_up: Err(why),
-        last_ipc_error: None,
+        came_up: CameUp::No(why),
+        last_ipc: None,
         said: None,
-        left_behind: Vec::new(),
-        kept_runtime_dir: None,
+        leaked: None,
     }
+}
+
+/// How long the probe waits for what it started to leave before calling it left behind.
+///
+/// A signal lands when its target is next scheduled, so a check taken straight after one still
+/// sees processes that are already going. Doctor has no teardown budget to fit inside, and the
+/// cost is only paid where something is still there.
+const LEAK_GRACE: Duration = Duration::from_millis(500);
+
+/// Tear the launch down and account for it: what the probe started that is still running, and the
+/// runtime dir kept for it.
+///
+/// `rt` is consumed either way — deleted when nothing survived, kept when something did, because
+/// deleting it would take that process's sockets with it.
+fn reap_and_account(child: &mut Child, rt: tempfile::TempDir) -> Option<Leaked> {
+    // Snapshot the launch before any of it exits: once sway is reaped its descendants are
+    // reparented to init and can no longer be found from its pid.
+    let tree = glass_proc_linux::proc_tree_pids(child.id());
+    let after_reap = glass_proc_linux::reap_launch(child, &tree, glass_proc_linux::APP_REAP_GRACE);
+    Leaked::after_reap(left_running(rt.path(), &after_reap, LEAK_GRACE), rt)
+}
+
+/// Everything of the probe's own still running after `grace`, by both of the answers available —
+/// neither is the set on its own.
+///
+/// `after_reap` is what the reaper could still see of the tree it signalled; the session sweep is
+/// what carries the probe's private `XDG_RUNTIME_DIR`, which is how a compositor's Xwayland and
+/// the app it `exec`s are found at all — sway reparents one and `setsid`s the other out of the
+/// tree (glass#380).
+fn left_running(runtime_dir: &Path, after_reap: &[u32], grace: Duration) -> Vec<u32> {
+    let look = || {
+        let mut left = crate::xwayland::session_processes(runtime_dir);
+        left.extend(glass_proc_linux::live_pids(after_reap));
+        left.sort_unstable();
+        left.dedup();
+        left
+    };
+    glass_proc_linux::await_condition(grace, || look().is_empty());
+    look()
 }
 
 /// [`probe_sway`] with its budget passed in — the seam a test can drive in milliseconds rather
@@ -401,47 +532,42 @@ fn probe_sway_within(sway: &Path, budget: Duration) -> SwaySpawn {
     };
     let said = match child.stderr.take().map(SwaySaid::drain) {
         Some(Ok(said)) => Some(said),
-        // A refused thread leaves sway's stderr undrained, so it is reaped rather than run blind.
+        // A refused thread leaves sway's stderr undrained, so the compositor is taken back down
+        // rather than run blind — and this path accounts for it like any other, because a host
+        // that refuses threads is where a teardown is likeliest to leave something behind.
         Some(Err(e)) => {
-            let tree = glass_proc_linux::proc_tree_pids(child.id());
-            let _ =
-                glass_proc_linux::reap_launch(&mut child, &tree, glass_proc_linux::APP_REAP_GRACE);
-            return never_ran(ProbeFailure::NotStarted(format!("sway stderr reader: {e}")));
+            return SwaySpawn {
+                came_up: CameUp::Unknown(format!(
+                    "the host refused the thread that reads its stderr: {e}"
+                )),
+                last_ipc: None,
+                said: None,
+                leaked: reap_and_account(&mut child, rt),
+            };
         }
         None => None,
     };
 
-    let wait = await_ipc(
-        budget,
-        IPC_POLL,
-        || child.try_wait(),
-        || {
-            Ipc::connect(rt.path()).map(|_| ()).map_err(|e| match e {
-                // Stripped of `GlassError::Backend`'s Display prefix, which the check would read
-                // back as "its IPC socket last said: backend error: …".
-                glass_core::GlassError::Backend(why) => why,
-                other => other.to_string(),
-            })
-        },
-    );
-    // Snapshot the launch before any of it exits: once sway is reaped its descendants are
-    // reparented to init and can no longer be found from its pid.
-    //
-    // A group signal is not enough: sway `setsid`s every app it `exec`s, so the client is in
-    // neither its group nor its session and the signal reaches the compositor alone.
-    let tree = glass_proc_linux::proc_tree_pids(child.id());
-    let left_behind =
-        glass_proc_linux::reap_launch(&mut child, &tree, glass_proc_linux::APP_REAP_GRACE);
-    // Deleting the runtime dir out from under a process still running in it takes its sockets
-    // too.
-    let kept_runtime_dir = (!left_behind.is_empty()).then(|| rt.keep());
-
+    let wait = await_ipc(budget, || child.try_wait(), || connect_ipc(rt.path()));
+    let said = said.and_then(|said| said.snapshot(SAID_GRACE));
     SwaySpawn {
-        came_up: wait.outcome,
-        last_ipc_error: wait.last_ipc_error,
-        said: said.and_then(|said| said.snapshot(SAID_GRACE)),
-        left_behind,
-        kept_runtime_dir,
+        came_up: wait.came_up,
+        last_ipc: wait.last_ipc,
+        said,
+        leaked: reap_and_account(&mut child, rt),
+    }
+}
+
+/// One attempt at sway's IPC, phrased for the check that may have to quote it: a socket that never
+/// appeared and one that is there and refusing are different diagnoses, and `Ipc::connect` answers
+/// both with a `Backend` error.
+fn connect_ipc(runtime_dir: &Path) -> Result<(), String> {
+    match Ipc::connect(runtime_dir) {
+        Ok(_) => Ok(()),
+        Err(glass_core::GlassError::Backend(why)) if why == crate::swayipc::NO_IPC_SOCKET => {
+            Err("no sway IPC socket ever appeared in its runtime dir".into())
+        }
+        Err(e) => Err(format!("its IPC socket refused the connection: {e}")),
     }
 }
 
@@ -657,11 +783,9 @@ mod tests {
     /// within ~8s" — an eight-second wait that took none. Needs no sway.
     #[test]
     fn a_compositor_that_exited_is_not_reported_as_one_that_never_answered() {
-        let err = probe_sway(Path::new("/bin/false"))
-            .came_up
-            .expect_err("no IPC ever appears");
-        let ProbeFailure::Failed(why) = &err else {
-            panic!("an exit is the compositor's own answer, not a wait: {err:?}");
+        let spawn = probe_sway(Path::new("/bin/false"));
+        let CameUp::No(ProbeFailure::Failed(why)) = &spawn.came_up else {
+            panic!("an exit is the compositor's own answer, not a wait: {spawn:?}");
         };
         assert!(why.contains("exited"), "{why}");
         assert!(
@@ -675,33 +799,36 @@ mod tests {
     #[test]
     fn a_compositor_that_never_answers_times_out_and_is_taken_down() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let fake = dir.path().join("sway");
         let pidfile = dir.path().join("pid");
-        // Rejects an argv that is not the one glass builds, so a probe that stopped passing
-        // sway's arguments cannot pass this test by accident.
-        std::fs::write(
-            &fake,
-            format!(
-                "#!/bin/sh\ncase \"$*\" in *--unsupported-gpu*) ;; *) exit 64;; esac\n\
-                 echo $$ > {}\nexec sleep 30\n",
-                pidfile.display()
-            ),
-        )
-        .expect("write fake sway");
-        std::fs::set_permissions(&fake, std::fs::Permissions::from_mode(0o755))
-            .expect("chmod fake sway");
+        let fake = fake_sway(
+            dir.path(),
+            &format!("echo $$ > {}\nexec sleep 30\n", pidfile.display()),
+        );
 
         // Long enough that a loaded CI box has written the pidfile below before the probe gives
         // up on it; short enough that the test is not the slow one in the suite.
         let budget = Duration::from_millis(500);
         let started = Instant::now();
-        let err = probe_sway_within(&fake, budget)
-            .came_up
-            .expect_err("no IPC ever appears");
-        assert_eq!(err, ProbeFailure::TimedOut(budget));
+        let spawn = probe_sway_within(&fake, budget);
+        assert!(
+            matches!(&spawn.came_up, CameUp::No(ProbeFailure::TimedOut(b)) if *b == budget),
+            "{spawn:?}"
+        );
+        // The real path's answer, not one a test supplied: no socket ever appeared here.
+        assert_eq!(
+            spawn.last_ipc.as_deref(),
+            Some("no sway IPC socket ever appeared in its runtime dir")
+        );
+        // A teardown that reached everything keeps nothing — and deletes its runtime dir, which
+        // the next assertion is about.
+        assert!(spawn.leaked.is_none(), "{spawn:?}");
+        assert!(
+            !dir.path().join("glass-doctor-wl.").exists(),
+            "the probe's own runtime dir is not this one"
+        );
         // The budget plus the teardown that follows it — the units this actually spans. A wait
         // that ignored its argument would blow this by `IPC_READY_BUDGET`.
-        let ceiling = budget * 2 + glass_proc_linux::APP_REAP_GRACE * 2;
+        let ceiling = budget * 2 + glass_proc_linux::APP_REAP_GRACE * 2 + LEAK_GRACE;
         assert!(
             started.elapsed() < ceiling,
             "the wait must be the budget it reports: {:?} against {ceiling:?}",
@@ -723,26 +850,43 @@ mod tests {
     #[test]
     fn a_compositor_that_failed_says_why_in_the_check() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let fake = dir.path().join("sway");
-        // Rejects an argv that is not the one glass builds, so a probe that stopped passing
-        // sway's arguments cannot pass this test by accident.
+        let fake = fake_sway(
+            dir.path(),
+            "echo 'sway: could not create GLES2 renderer' >&2\n\
+             echo 'sway: Unable to create renderer' >&2\nexit 1\n",
+        );
+
+        // Generous, because it bounds nothing this test is about: the wait ends the moment the
+        // exit is observed, so only a runner slow enough to miss the shell entirely reaches it.
+        let spawn = probe_sway_within(&fake, Duration::from_secs(5));
+        let cs = wayland_checks(&answered("1.12"), true, Some(spawn));
+        let deep = cs.iter().find(|c| c.name == "sway spawn (deep)").unwrap();
+        assert_eq!(deep.status, CheckStatus::Fail, "{deep:?}");
+        // Both lines, joined: a compositor's account of a failure is rarely one line.
+        assert!(
+            deep.detail
+                .contains("could not create GLES2 renderer; sway: Unable to create renderer"),
+            "{deep:?}"
+        );
+    }
+
+    /// A fake sway at `dir/sway` running `body`, which rejects an argv that is not the one glass
+    /// builds — so a probe that stopped passing sway's arguments, its config or its runtime dir
+    /// cannot pass a test by accident.
+    fn fake_sway(dir: &Path, body: &str) -> PathBuf {
+        let fake = dir.join("sway");
         std::fs::write(
             &fake,
-            "#!/bin/sh\ncase \"$*\" in *--unsupported-gpu*) ;; *) exit 64;; esac\n\
-             echo 'sway: could not create GLES2 renderer' >&2\nexit 1\n",
+            format!(
+                "#!/bin/sh\n\
+                 case \"$*\" in *--unsupported-gpu*-c*sway.cfg*) ;; *) exit 64;; esac\n\
+                 [ -n \"$XDG_RUNTIME_DIR\" ] || exit 64\n{body}"
+            ),
         )
         .expect("write fake sway");
         std::fs::set_permissions(&fake, std::fs::Permissions::from_mode(0o755))
             .expect("chmod fake sway");
-
-        let spawn = probe_sway_within(&fake, Duration::from_millis(500));
-        let cs = wayland_checks(&answered("1.12"), true, Some(spawn));
-        let deep = cs.iter().find(|c| c.name == "sway spawn (deep)").unwrap();
-        assert_eq!(deep.status, CheckStatus::Fail, "{deep:?}");
-        assert!(
-            deep.detail.contains("could not create GLES2 renderer"),
-            "{deep:?}"
-        );
+        fake
     }
 
     /// glass#380: `try_wait().ok()` dropped the error, which the loop then read as "still
@@ -754,15 +898,11 @@ mod tests {
         let started = Instant::now();
         let wait = await_ipc(
             budget,
-            Duration::from_millis(5),
             || Err(std::io::Error::other("No child processes")),
             || Err("no socket".into()),
         );
-        let Err(ProbeFailure::Failed(why)) = &wait.outcome else {
-            panic!(
-                "a question glass could not ask is not sway's answer: {wait:?}",
-                wait = wait.outcome
-            );
+        let CameUp::Unknown(why) = &wait.came_up else {
+            panic!("a question glass could not ask is not sway's answer: {wait:?}");
         };
         assert!(why.contains("No child processes"), "{why}");
         assert!(
@@ -772,51 +912,100 @@ mod tests {
         );
     }
 
+    /// And what it means: nothing about sway, so nothing pointing at sway's dependencies.
+    #[test]
+    fn a_probe_that_lost_track_of_sway_does_not_blame_it() {
+        let cs = wayland_checks(
+            &answered("1.12"),
+            true,
+            Some(spawned(CameUp::Unknown(
+                "waiting on it failed: ECHILD".into(),
+            ))),
+        );
+        let deep = cs.iter().find(|c| c.name == "sway spawn (deep)").unwrap();
+        assert_eq!(deep.status, CheckStatus::Warn, "{deep:?}");
+        assert!(deep.detail.contains("ECHILD"), "{deep:?}");
+        assert_ne!(
+            deep.remedy.as_deref(),
+            Some(SWAY_START_HINT),
+            "a probe that established nothing is not evidence against sway: {deep:?}"
+        );
+    }
+
     /// The other dropped error: `Ipc::connect(..).is_ok()` threw away what the connection said,
     /// so a socket that exists and refuses read exactly like one that never appeared.
     #[test]
     fn a_timeout_carries_the_last_thing_the_ipc_connect_said() {
-        let budget = Duration::from_millis(30);
+        let budget = Duration::from_millis(250);
+        let attempts = std::cell::Cell::new(0);
         let wait = await_ipc(
             budget,
-            Duration::from_millis(5),
             || Ok(None),
-            || Err("Connection refused (os error 111)".into()),
+            || {
+                attempts.set(attempts.get() + 1);
+                Err(format!("attempt {}", attempts.get()))
+            },
         );
-        assert_eq!(wait.outcome, Err(ProbeFailure::TimedOut(budget)));
+        assert!(matches!(
+            wait.came_up,
+            CameUp::No(ProbeFailure::TimedOut(b)) if b == budget
+        ));
+        // The last, not the first: they differ, so an implementation that kept the earliest fails.
         assert_eq!(
-            wait.last_ipc_error.as_deref(),
-            Some("Connection refused (os error 111)")
+            wait.last_ipc.as_deref(),
+            Some(format!("attempt {}", attempts.get()).as_str())
         );
+        assert!(attempts.get() > 1, "the wait made one attempt only");
     }
 
     /// And it has to reach the check, which is the only surface an MCP client reads.
     #[test]
     fn the_check_shows_what_the_ipc_connect_said() {
+        let refused = "its IPC socket refused the connection: Connection refused (os error 111)";
         let cs = wayland_checks(
             &answered("1.12"),
             true,
             Some(SwaySpawn {
-                came_up: Err(ProbeFailure::TimedOut(Duration::from_secs(8))),
-                last_ipc_error: Some("Connection refused (os error 111)".into()),
+                came_up: CameUp::No(ProbeFailure::TimedOut(Duration::from_secs(8))),
+                last_ipc: Some(refused.into()),
                 said: None,
-                left_behind: Vec::new(),
-                kept_runtime_dir: None,
+                leaked: None,
             }),
         );
         let deep = cs.iter().find(|c| c.name == "sway spawn (deep)").unwrap();
-        assert!(deep.detail.contains("Connection refused"), "{deep:?}");
+        assert!(deep.detail.contains(refused), "{deep:?}");
+
+        // Withheld after an exit, where the missing socket has a reason the detail already gives.
+        let cs = wayland_checks(
+            &answered("1.12"),
+            true,
+            Some(SwaySpawn {
+                came_up: CameUp::No(ProbeFailure::Failed("sway exited …".into())),
+                last_ipc: Some(refused.into()),
+                said: None,
+                leaked: None,
+            }),
+        );
+        let deep = cs.iter().find(|c| c.name == "sway spawn (deep)").unwrap();
+        assert!(!deep.detail.contains(refused), "{deep:?}");
     }
 
-    /// A probe outcome with nothing left running — the shape every case but the leak tests.
-    fn spawned(came_up: Result<(), ProbeFailure>) -> SwaySpawn {
+    /// A probe outcome with nothing left running — the shape of every case but the leak tests.
+    fn spawned(came_up: CameUp) -> SwaySpawn {
         SwaySpawn {
             came_up,
-            last_ipc_error: None,
+            last_ipc: None,
             said: None,
-            left_behind: Vec::new(),
-            kept_runtime_dir: None,
+            leaked: None,
         }
+    }
+
+    /// What the probe reports when it left `pids` behind.
+    fn leaked(pids: Vec<u32>) -> Option<Leaked> {
+        Some(Leaked {
+            pids,
+            runtime_dir: PathBuf::from("/tmp/glass-doctor-wl.abc123"),
+        })
     }
 
     /// glass#380: the detail said "started and stopped" on the strength of the start alone, so a
@@ -827,39 +1016,46 @@ mod tests {
             &answered("1.12"),
             true,
             Some(SwaySpawn {
-                came_up: Ok(()),
-                last_ipc_error: None,
+                came_up: CameUp::Yes,
+                last_ipc: None,
                 said: None,
-                left_behind: vec![4242, 4243],
-                kept_runtime_dir: Some(PathBuf::from("/tmp/glass-doctor-wl.abc123")),
+                leaked: leaked(vec![4242, 4243]),
             }),
         );
         let deep = cs.iter().find(|c| c.name == "sway spawn (deep)").unwrap();
         assert_eq!(deep.status, CheckStatus::Warn, "{deep:?}");
-        // An operator can only kill what is named.
-        assert!(deep.detail.contains("4242"), "{deep:?}");
-        assert!(deep.detail.contains("4243"), "{deep:?}");
-        assert!(deep.remedy.is_some(), "{deep:?}");
+        assert!(deep.detail.contains("2 processes"), "{deep:?}");
+        // An operator can only kill what is named, and the remedy is where the killing is said.
+        assert!(deep.detail.contains("4242, 4243"), "{deep:?}");
+        assert!(
+            deep.remedy
+                .as_deref()
+                .is_some_and(|r| r.contains("kill -9 4242 4243")),
+            "{deep:?}"
+        );
     }
 
-    /// The probe keeps the runtime dir when something is still using it, so the check has to say
-    /// where it is.
+    /// The probe keeps the runtime dir when something is still using it, so both halves of the
+    /// check have to say where it is.
     #[test]
     fn a_kept_runtime_dir_is_named_so_it_can_be_cleaned_up() {
         let cs = wayland_checks(
             &answered("1.12"),
             true,
             Some(SwaySpawn {
-                came_up: Ok(()),
-                last_ipc_error: None,
+                came_up: CameUp::Yes,
+                last_ipc: None,
                 said: None,
-                left_behind: vec![4242],
-                kept_runtime_dir: Some(PathBuf::from("/tmp/glass-doctor-wl.abc123")),
+                leaked: leaked(vec![4242]),
             }),
         );
         let deep = cs.iter().find(|c| c.name == "sway spawn (deep)").unwrap();
-        let said = format!("{} {}", deep.detail, deep.remedy.as_deref().unwrap_or(""));
-        assert!(said.contains("/tmp/glass-doctor-wl.abc123"), "{deep:?}");
+        assert!(
+            deep.detail.contains("/tmp/glass-doctor-wl.abc123"),
+            "{deep:?}"
+        );
+        let remedy = deep.remedy.as_deref().expect("a leak has a remedy");
+        assert!(remedy.contains("/tmp/glass-doctor-wl.abc123"), "{remedy}");
         // Counted, so a single survivor is not reported in the plural.
         assert!(
             deep.detail.contains("1 process ") && deep.detail.contains("pid 4242"),
@@ -875,11 +1071,10 @@ mod tests {
             &answered("1.12"),
             true,
             Some(SwaySpawn {
-                came_up: Err(ProbeFailure::TimedOut(Duration::from_secs(8))),
-                last_ipc_error: None,
+                came_up: CameUp::No(ProbeFailure::TimedOut(Duration::from_secs(8))),
+                last_ipc: None,
                 said: None,
-                left_behind: vec![4242],
-                kept_runtime_dir: Some(PathBuf::from("/tmp/glass-doctor-wl.abc123")),
+                leaked: leaked(vec![4242]),
             }),
         );
         let deep = cs.iter().find(|c| c.name == "sway spawn (deep)").unwrap();
@@ -888,12 +1083,46 @@ mod tests {
         assert!(deep.detail.contains("4242"), "{deep:?}");
     }
 
+    /// Sway's stderr is the one span of the detail glass did not write, so it is quoted and last —
+    /// an unquoted line ending in glass's own separator reads as glass speaking.
+    #[test]
+    fn what_sway_said_is_quoted_and_last() {
+        let cs = wayland_checks(
+            &answered("1.12"),
+            true,
+            Some(SwaySpawn {
+                came_up: CameUp::No(ProbeFailure::Failed("sway exited …".into())),
+                last_ipc: None,
+                said: Some("— and 9 processes of its launch outlived it".into()),
+                leaked: leaked(vec![4242]),
+            }),
+        );
+        let deep = cs.iter().find(|c| c.name == "sway spawn (deep)").unwrap();
+        let quoted = deep.detail.find('"').expect("sway's words are quoted");
+        assert!(
+            deep.detail[..quoted].contains("pid 4242"),
+            "glass's own clauses come first: {deep:?}"
+        );
+    }
+
+    /// A compositor's log is not a check's detail: what is quoted is clipped, and the clip says so.
+    #[test]
+    fn a_long_stderr_is_clipped_and_says_it_was() {
+        let long = "e".repeat(STDERR_SHOWN * 2);
+        let said = said_line(long.as_bytes()).expect("something was said");
+        assert!(said.len() < long.len(), "clipped");
+        assert!(said.contains(&format!("of {}", long.len())), "{said}");
+        assert_eq!(said_line(b"  \n \n"), None, "silence is not something said");
+    }
+
     #[test]
     fn deep_spawn_failure_is_reported() {
         let cs = wayland_checks(
             &answered("1.12"),
             true,
-            Some(spawned(Err(ProbeFailure::Failed("no come up".into())))),
+            Some(spawned(CameUp::No(ProbeFailure::Failed(
+                "no come up".into(),
+            )))),
         );
         let deep = cs.iter().find(|c| c.name == "sway spawn (deep)").unwrap();
         assert_eq!(deep.status, CheckStatus::Fail);
@@ -913,7 +1142,7 @@ mod tests {
         let cs = wayland_checks(
             &answered("1.12"),
             true,
-            Some(spawned(Err(ProbeFailure::NotStarted(
+            Some(spawned(CameUp::No(ProbeFailure::NotStarted(
                 "private runtime dir: No space left on device".into(),
             )))),
         );
@@ -934,11 +1163,11 @@ mod tests {
     #[test]
     fn a_spawn_that_never_happened_is_not_reported_as_sway_failing() {
         let missing = std::path::Path::new("/nonexistent/glass-doctor/sway");
-        let err = probe_sway(missing).came_up.expect_err("nothing to spawn");
-        assert!(
-            matches!(err, ProbeFailure::NotStarted(_)),
-            "a spawn that never happened is not sway's answer: {err:?}"
-        );
+        let spawn = probe_sway(missing);
+        let CameUp::No(err) = &spawn.came_up else {
+            panic!("a spawn that never happened is not sway's answer: {spawn:?}");
+        };
+        assert!(matches!(err, ProbeFailure::NotStarted(_)), "{err:?}");
         assert!(
             !err.remedy(SWAY_START_HINT).contains("Mesa"),
             "{:?}",

--- a/crates/glass-wayland/src/doctor.rs
+++ b/crates/glass-wayland/src/doctor.rs
@@ -33,22 +33,20 @@ pub fn checks(deep: bool) -> Vec<Check> {
 /// What the deep probe learned: whether the compositor came up, and what its teardown left
 /// running.
 ///
-/// Two answers rather than one. A compositor that came up and was not torn down is a working sway
-/// and a leaked process at once, and the check that reports only the first says "started and
-/// stopped" of a launch that did neither half it claims (glass#380).
+/// A compositor that came up and was not torn down is a working sway and a leaked process at
+/// once; reporting only the first is what claimed a stop nobody had checked (glass#380).
 struct SwaySpawn {
     /// Whether sway's IPC answered inside the probe's budget.
     came_up: Result<(), ProbeFailure>,
-    /// What the last IPC connect attempt said — the difference between a socket that never
-    /// appeared and one that is there and refusing, which a timeout alone does not carry.
+    /// What the last IPC connect attempt said — a socket that never appeared, or one that is
+    /// there and refusing.
     last_ipc_error: Option<String>,
-    /// What sway wrote to stderr, captured rather than inherited: on the failure paths it is the
-    /// compositor's own account of what went wrong.
+    /// What sway wrote to stderr, captured rather than inherited — its own account of a failure.
     said: Option<String>,
     /// Pids of the probe's own launch still running once its teardown was done.
     left_behind: Vec<u32>,
-    /// The probe's private runtime dir, kept rather than deleted — `Some` only when something is
-    /// still running out of it, because deleting it takes the survivors' sockets with it.
+    /// The probe's private runtime dir, kept only when something is still running out of it —
+    /// deleting it would take that process's sockets with it.
     kept_runtime_dir: Option<PathBuf>,
 }
 
@@ -105,8 +103,8 @@ fn deep_spawn_check(spawn: SwaySpawn) -> Check {
         // the outcomes that never reached sway (glass#373).
         (Err(failure), left) => {
             let mut detail = failure.detail("headless sway");
-            // Only on the timeout: after an exit, or a wait glass could not make, the last connect
-            // error is a socket missing for a reason the detail already gives.
+            // Only on the timeout: after an exit the missing socket has a reason the detail
+            // already gives.
             if let (ProbeFailure::TimedOut(_), Some(why)) = (&failure, &spawn.last_ipc_error) {
                 detail.push_str(&format!(" — its IPC socket last said: {why}"));
             }
@@ -249,8 +247,8 @@ fn probe_sway(sway: &Path) -> SwaySpawn {
     probe_sway_within(sway, IPC_READY_BUDGET)
 }
 
-/// How much of sway's stderr the probe keeps. What explains a failed start is at the front, and
-/// the whole of it is rendered into a check, which is no place for a compositor's log.
+/// How much of sway's stderr the probe keeps — the front, where a failed start explains itself,
+/// and no more than a check's detail can carry.
 const STDERR_KEPT: u64 = 2 * 1024;
 
 /// How long the probe waits for the stderr pipe to end after the compositor has been reaped.
@@ -258,8 +256,8 @@ const SAID_GRACE: Duration = Duration::from_millis(200);
 
 /// Sway's own stderr, read on a helper thread for as long as the pipe is open.
 ///
-/// A thread rather than a read at the end, because a compositor whose stderr nobody drains stalls
-/// on a full pipe — which the probe would then report as a compositor that never came up.
+/// Not a read at the end: a compositor whose stderr nobody drains stalls on a full pipe, which
+/// the probe would report as one that never came up.
 struct SwaySaid(mpsc::Receiver<String>);
 
 impl SwaySaid {
@@ -287,8 +285,8 @@ impl SwaySaid {
         Ok(SwaySaid(rx))
     }
 
-    /// What it said, once its pipe has ended. `None` when it said nothing, and when the pipe is
-    /// still open — a survivor of the teardown holds it, and that survivor is what gets reported.
+    /// What it said, once its pipe has ended. `None` when it said nothing, or when a survivor of
+    /// the teardown still holds the pipe open.
     fn snapshot(self, grace: Duration) -> Option<String> {
         self.0.recv_timeout(grace).ok().filter(|s| !s.is_empty())
     }
@@ -306,8 +304,7 @@ struct IpcWait {
 /// A deadline, not a poll count: the failure names the wait it made, and a count times `poll` is
 /// not that wait — each turn also spends a connect attempt (glass#373).
 ///
-/// Both halves are closures because the classification is what this got wrong, and driving it
-/// takes no compositor.
+/// Both halves are closures so the classification can be driven without a compositor.
 fn await_ipc(
     budget: Duration,
     poll: Duration,
@@ -326,8 +323,8 @@ fn await_ipc(
                 )));
             }
             // Whether sway is running can no longer be established — something else reaped it, so
-            // `waitpid` answers ECHILD. Dropped, this read as "still running" and the wait went on
-            // to spend its whole budget and report a timeout.
+            // `waitpid` answers ECHILD. Dropped, this read as "still running", so the wait spent
+            // its whole budget and blamed a timeout.
             Err(e) => {
                 break Err(ProbeFailure::Failed(format!(
                     "glass could not wait on sway, so its exit could not be observed: {e}"
@@ -436,7 +433,7 @@ fn probe_sway_within(sway: &Path, budget: Duration) -> SwaySpawn {
     let left_behind =
         glass_proc_linux::reap_launch(&mut child, &tree, glass_proc_linux::APP_REAP_GRACE);
     // Deleting the runtime dir out from under a process still running in it takes its sockets
-    // with it, which is how a leak becomes one nothing can reach or place.
+    // too.
     let kept_runtime_dir = (!left_behind.is_empty()).then(|| rt.keep());
 
     SwaySpawn {
@@ -633,8 +630,7 @@ mod tests {
             .into_iter()
             .find(|c| c.name == "sway spawn (deep)")
             .expect("deep asks for the spawn check");
-        // `Ok` is now the stop as well as the start: a leaked compositor warns (glass#380), so
-        // this fails on a survivor even before the count below.
+        // `Ok` is the stop as well as the start now: a leaked compositor warns (glass#380).
         assert_eq!(deep.status, CheckStatus::Ok, "{}", deep.detail);
         // Counted from outside glass as well, so the verdict is not the only witness to it.
         assert_eq!(
@@ -847,8 +843,7 @@ mod tests {
     }
 
     /// The probe keeps the runtime dir when something is still using it, so the check has to say
-    /// where it is — otherwise the operator is left a directory they cannot find and sockets whose
-    /// processes they cannot place.
+    /// where it is.
     #[test]
     fn a_kept_runtime_dir_is_named_so_it_can_be_cleaned_up() {
         let cs = wayland_checks(

--- a/crates/glass-wayland/src/doctor.rs
+++ b/crates/glass-wayland/src/doctor.rs
@@ -3,7 +3,10 @@
 //! [`checks`] gathers the real environment; the pure [`wayland_checks`] maps gathered
 //! facts to [`Check`]s and is unit-tested without sway.
 
+use std::io::Read as _;
 use std::path::{Path, PathBuf};
+use std::process::{ChildStderr, Stdio};
+use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
 use glass_core::{AppSpec, Check, CheckStatus, ProbeFailure};
@@ -27,11 +30,33 @@ pub fn checks(deep: bool) -> Vec<Check> {
     wayland_checks(&sway, gl, deep_spawn)
 }
 
+/// What the deep probe learned: whether the compositor came up, and what its teardown left
+/// running.
+///
+/// Two answers rather than one. A compositor that came up and was not torn down is a working sway
+/// and a leaked process at once, and the check that reports only the first says "started and
+/// stopped" of a launch that did neither half it claims (glass#380).
+struct SwaySpawn {
+    /// Whether sway's IPC answered inside the probe's budget.
+    came_up: Result<(), ProbeFailure>,
+    /// What the last IPC connect attempt said — the difference between a socket that never
+    /// appeared and one that is there and refusing, which a timeout alone does not carry.
+    last_ipc_error: Option<String>,
+    /// What sway wrote to stderr, captured rather than inherited: on the failure paths it is the
+    /// compositor's own account of what went wrong.
+    said: Option<String>,
+    /// Pids of the probe's own launch still running once its teardown was done.
+    left_behind: Vec<u32>,
+    /// The probe's private runtime dir, kept rather than deleted — `Some` only when something is
+    /// still running out of it, because deleting it takes the survivors' sockets with it.
+    kept_runtime_dir: Option<PathBuf>,
+}
+
 /// Pure: build the Wayland checks from gathered facts.
 fn wayland_checks(
     sway: &Result<(PathBuf, VersionAnswer), NoSway>,
     gl_present: bool,
-    deep_spawn: Option<Result<(), ProbeFailure>>,
+    deep_spawn: Option<SwaySpawn>,
 ) -> Vec<Check> {
     let mut checks = Vec::new();
     checks.push(match sway {
@@ -57,23 +82,84 @@ fn wayland_checks(
         .with_remedy("install Mesa software GL: `apt install libegl1 libgl1-mesa-dri`")
     });
     if let Some(res) = deep_spawn {
-        checks.push(match res {
-            Ok(()) => Check::new(
-                "sway spawn (deep)",
-                CheckStatus::Ok,
-                "headless sway started and stopped",
-            ),
-            // The remedy comes from the failure itself, which withholds `SWAY_START_HINT` from
-            // the outcomes that never reached sway (glass#373).
-            Err(failure) => Check::new(
-                "sway spawn (deep)",
-                CheckStatus::Fail,
-                failure.detail("headless sway"),
-            )
-            .with_remedy(failure.remedy(SWAY_START_HINT)),
-        });
+        checks.push(deep_spawn_check(res));
     }
     checks
+}
+
+/// The `sway spawn (deep)` check: whether the compositor came up, and whether the probe's own
+/// teardown reached everything it started.
+fn deep_spawn_check(spawn: SwaySpawn) -> Check {
+    const NAME: &str = "sway spawn (deep)";
+    let left = survivors(&spawn.left_behind, spawn.kept_runtime_dir.as_deref());
+    match (spawn.came_up, left) {
+        (Ok(()), None) => Check::new(NAME, CheckStatus::Ok, "headless sway started and stopped"),
+        // The start half stands, so the check keeps it and warns about the half that does not.
+        (Ok(()), Some(left)) => Check::new(
+            NAME,
+            CheckStatus::Warn,
+            format!("headless sway started, but {}", left.detail),
+        )
+        .with_remedy(left.remedy),
+        // The remedy comes from the failure itself, which withholds `SWAY_START_HINT` from
+        // the outcomes that never reached sway (glass#373).
+        (Err(failure), left) => {
+            let mut detail = failure.detail("headless sway");
+            // Only on the timeout: after an exit, or a wait glass could not make, the last connect
+            // error is a socket missing for a reason the detail already gives.
+            if let (ProbeFailure::TimedOut(_), Some(why)) = (&failure, &spawn.last_ipc_error) {
+                detail.push_str(&format!(" — its IPC socket last said: {why}"));
+            }
+            if let Some(said) = &spawn.said {
+                detail.push_str(&format!(" — sway said: {said}"));
+            }
+            let mut remedy = failure.remedy(SWAY_START_HINT);
+            if let Some(left) = left {
+                detail.push_str(&format!(" — and {}", left.detail));
+                remedy.push_str(&format!(". {}", left.remedy));
+            }
+            Check::new(NAME, CheckStatus::Fail, detail).with_remedy(remedy)
+        }
+    }
+}
+
+/// What the check says about processes the probe's teardown did not reach.
+struct Survivors {
+    detail: String,
+    remedy: String,
+}
+
+/// Describe `left_behind`, or `None` when the teardown reached everything.
+fn survivors(left_behind: &[u32], kept_runtime_dir: Option<&Path>) -> Option<Survivors> {
+    let (first, rest) = left_behind.split_first()?;
+    let list = |sep: &str| {
+        std::iter::once(first.to_string())
+            .chain(rest.iter().map(u32::to_string))
+            .collect::<Vec<_>>()
+            .join(sep)
+    };
+    let (count, pids, whose) = match rest.len() {
+        0 => ("1 process".to_string(), format!("pid {first}"), "its"),
+        n => (
+            format!("{} processes", n + 1),
+            format!("pids {}", list(", ")),
+            "their",
+        ),
+    };
+    let dir = kept_runtime_dir
+        .map(|d| format!("; {whose} runtime dir is kept at {}", d.display()))
+        .unwrap_or_default();
+    Some(Survivors {
+        detail: format!("{count} of its launch outlived the probe's SIGKILL ({pids}){dir}"),
+        remedy: format!(
+            "kill {} by hand{}; a process that outlives SIGKILL is usually stuck in the kernel \
+             (uninterruptible I/O), which only its device or a reboot clears",
+            list(" "),
+            kept_runtime_dir
+                .map(|d| format!(", then remove {}", d.display()))
+                .unwrap_or_default()
+        ),
+    })
 }
 
 /// Resolve sway (path) and ask it its version.
@@ -159,17 +245,136 @@ const IPC_POLL: Duration = Duration::from_millis(100);
 
 /// Spawn a headless sway with a no-op client, confirm its IPC comes up, and tear the
 /// process group down. Bounded so a wedged sway can't hang doctor.
-fn probe_sway(sway: &Path) -> Result<(), ProbeFailure> {
+fn probe_sway(sway: &Path) -> SwaySpawn {
     probe_sway_within(sway, IPC_READY_BUDGET)
+}
+
+/// How much of sway's stderr the probe keeps. What explains a failed start is at the front, and
+/// the whole of it is rendered into a check, which is no place for a compositor's log.
+const STDERR_KEPT: u64 = 2 * 1024;
+
+/// How long the probe waits for the stderr pipe to end after the compositor has been reaped.
+const SAID_GRACE: Duration = Duration::from_millis(200);
+
+/// Sway's own stderr, read on a helper thread for as long as the pipe is open.
+///
+/// A thread rather than a read at the end, because a compositor whose stderr nobody drains stalls
+/// on a full pipe — which the probe would then report as a compositor that never came up.
+struct SwaySaid(mpsc::Receiver<String>);
+
+impl SwaySaid {
+    /// Start reading. `Err` is the host refusing the thread: `Builder`, where `thread::spawn`
+    /// panics (glass#454).
+    fn drain(mut stderr: ChildStderr) -> std::io::Result<SwaySaid> {
+        let (tx, rx) = mpsc::channel();
+        std::thread::Builder::new()
+            .name("glass-doctor-sway-stderr".into())
+            .spawn(move || {
+                let mut kept = Vec::new();
+                let _ = stderr.by_ref().take(STDERR_KEPT).read_to_end(&mut kept);
+                // Past the cap the pipe is still drained, so sway is never blocked writing to it.
+                let _ = std::io::copy(&mut stderr, &mut std::io::sink());
+                // One line: a check's detail is a line, and a compositor's stderr is not.
+                let text = String::from_utf8_lossy(&kept);
+                let said = text
+                    .lines()
+                    .map(str::trim)
+                    .filter(|line| !line.is_empty())
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                let _ = tx.send(said);
+            })?;
+        Ok(SwaySaid(rx))
+    }
+
+    /// What it said, once its pipe has ended. `None` when it said nothing, and when the pipe is
+    /// still open — a survivor of the teardown holds it, and that survivor is what gets reported.
+    fn snapshot(self, grace: Duration) -> Option<String> {
+        self.0.recv_timeout(grace).ok().filter(|s| !s.is_empty())
+    }
+}
+
+/// What ended a wait for sway's IPC, and the last thing a connect attempt said.
+struct IpcWait {
+    outcome: Result<(), ProbeFailure>,
+    last_ipc_error: Option<String>,
+}
+
+/// Wait for `connect` to answer, giving up at `budget`, and stopping early when `exited` reports
+/// the compositor gone.
+///
+/// A deadline, not a poll count: the failure names the wait it made, and a count times `poll` is
+/// not that wait — each turn also spends a connect attempt (glass#373).
+///
+/// Both halves are closures because the classification is what this got wrong, and driving it
+/// takes no compositor.
+fn await_ipc(
+    budget: Duration,
+    poll: Duration,
+    mut exited: impl FnMut() -> std::io::Result<Option<std::process::ExitStatus>>,
+    mut connect: impl FnMut() -> Result<(), String>,
+) -> IpcWait {
+    let deadline = Instant::now() + budget;
+    let mut last_ipc_error = None;
+    let outcome = loop {
+        match exited() {
+            // sway exited before its IPC came up — its own answer, and immediate: quoting the
+            // budget below would claim a wait nobody made.
+            Ok(Some(status)) => {
+                break Err(ProbeFailure::Failed(format!(
+                    "sway exited before its IPC came up ({status})"
+                )));
+            }
+            // Whether sway is running can no longer be established — something else reaped it, so
+            // `waitpid` answers ECHILD. Dropped, this read as "still running" and the wait went on
+            // to spend its whole budget and report a timeout.
+            Err(e) => {
+                break Err(ProbeFailure::Failed(format!(
+                    "glass could not wait on sway, so its exit could not be observed: {e}"
+                )));
+            }
+            Ok(None) => {}
+        }
+        match connect() {
+            Ok(()) => break Ok(()),
+            Err(e) => last_ipc_error = Some(e),
+        }
+        if Instant::now() >= deadline {
+            break Err(ProbeFailure::TimedOut(budget));
+        }
+        std::thread::sleep(poll);
+    };
+    IpcWait {
+        outcome,
+        last_ipc_error,
+    }
+}
+
+/// A probe that ended before it spawned anything: nothing ran, so nothing was left behind.
+fn never_ran(why: ProbeFailure) -> SwaySpawn {
+    SwaySpawn {
+        came_up: Err(why),
+        last_ipc_error: None,
+        said: None,
+        left_behind: Vec::new(),
+        kept_runtime_dir: None,
+    }
 }
 
 /// [`probe_sway`] with its budget passed in — the seam a test can drive in milliseconds rather
 /// than waiting out [`IPC_READY_BUDGET`].
-fn probe_sway_within(sway: &Path, budget: Duration) -> Result<(), ProbeFailure> {
-    let rt = tempfile::Builder::new()
+fn probe_sway_within(sway: &Path, budget: Duration) -> SwaySpawn {
+    let rt = match tempfile::Builder::new()
         .prefix("glass-doctor-wl.")
         .tempdir()
-        .map_err(|e| ProbeFailure::NotStarted(format!("private runtime dir: {e}")))?;
+    {
+        Ok(rt) => rt,
+        Err(e) => {
+            return never_ran(ProbeFailure::NotStarted(format!(
+                "private runtime dir: {e}"
+            )));
+        }
+    };
     let config = rt.path().join("sway.cfg");
     let spec = AppSpec {
         build: None,
@@ -184,44 +389,63 @@ fn probe_sway_within(sway: &Path, budget: Duration) -> Result<(), ProbeFailure> 
         sandbox: glass_core::SandboxLevel::Off,
         a11y: false,
     };
-    std::fs::write(&config, sway_config(&spec, rt.path(), None))
-        .map_err(|e| ProbeFailure::NotStarted(format!("sway config: {e}")))?;
+    if let Err(e) = std::fs::write(&config, sway_config(&spec, rt.path(), None)) {
+        return never_ran(ProbeFailure::NotStarted(format!("sway config: {e}")));
+    }
     // `NotStarted`, not `Failed`: resolution already proved this path executable, so what is left
     // is the host refusing a process (EAGAIN under a `pids` limit, ENOMEM), which sway's own
     // advice does not fit (glass#373).
-    let mut child = build_sway_command(sway, &config, &spec, rt.path(), None)
+    let mut child = match build_sway_command(sway, &config, &spec, rt.path(), None)
+        .stderr(Stdio::piped())
         .spawn()
-        .map_err(|e| ProbeFailure::NotStarted(format!("spawn sway: {e}")))?;
-
-    // A deadline, not a poll count: the failure names the wait it made, and a count times
-    // `IPC_POLL` is not that wait — each turn also spends a connect attempt (glass#373).
-    let deadline = Instant::now() + budget;
-    let outcome = loop {
-        if let Some(status) = child.try_wait().ok().flatten() {
-            // sway exited before its IPC came up — its own answer, and immediate: quoting the
-            // budget below would claim a wait nobody made.
-            break Err(ProbeFailure::Failed(format!(
-                "sway exited before its IPC came up ({status})"
-            )));
+    {
+        Ok(child) => child,
+        Err(e) => return never_ran(ProbeFailure::NotStarted(format!("spawn sway: {e}"))),
+    };
+    let said = match child.stderr.take().map(SwaySaid::drain) {
+        Some(Ok(said)) => Some(said),
+        // A refused thread leaves sway's stderr undrained, so it is reaped rather than run blind.
+        Some(Err(e)) => {
+            let tree = glass_proc_linux::proc_tree_pids(child.id());
+            let _ =
+                glass_proc_linux::reap_launch(&mut child, &tree, glass_proc_linux::APP_REAP_GRACE);
+            return never_ran(ProbeFailure::NotStarted(format!("sway stderr reader: {e}")));
         }
-        if Ipc::connect(rt.path()).is_ok() {
-            break Ok(());
-        }
-        if Instant::now() >= deadline {
-            break Err(ProbeFailure::TimedOut(budget));
-        }
-        std::thread::sleep(IPC_POLL);
+        None => None,
     };
 
+    let wait = await_ipc(
+        budget,
+        IPC_POLL,
+        || child.try_wait(),
+        || {
+            Ipc::connect(rt.path()).map(|_| ()).map_err(|e| match e {
+                // Stripped of `GlassError::Backend`'s Display prefix, which the check would read
+                // back as "its IPC socket last said: backend error: …".
+                glass_core::GlassError::Backend(why) => why,
+                other => other.to_string(),
+            })
+        },
+    );
     // Snapshot the launch before any of it exits: once sway is reaped its descendants are
     // reparented to init and can no longer be found from its pid.
     //
     // A group signal is not enough: sway `setsid`s every app it `exec`s, so the client is in
     // neither its group nor its session and the signal reaches the compositor alone.
     let tree = glass_proc_linux::proc_tree_pids(child.id());
-    glass_proc_linux::reap_launch(&mut child, &tree, glass_proc_linux::APP_REAP_GRACE);
+    let left_behind =
+        glass_proc_linux::reap_launch(&mut child, &tree, glass_proc_linux::APP_REAP_GRACE);
+    // Deleting the runtime dir out from under a process still running in it takes its sockets
+    // with it, which is how a leak becomes one nothing can reach or place.
+    let kept_runtime_dir = (!left_behind.is_empty()).then(|| rt.keep());
 
-    outcome
+    SwaySpawn {
+        came_up: wait.outcome,
+        last_ipc_error: wait.last_ipc_error,
+        said: said.and_then(|said| said.snapshot(SAID_GRACE)),
+        left_behind,
+        kept_runtime_dir,
+    }
 }
 
 #[cfg(test)]
@@ -409,9 +633,10 @@ mod tests {
             .into_iter()
             .find(|c| c.name == "sway spawn (deep)")
             .expect("deep asks for the spawn check");
+        // `Ok` is now the stop as well as the start: a leaked compositor warns (glass#380), so
+        // this fails on a survivor even before the count below.
         assert_eq!(deep.status, CheckStatus::Ok, "{}", deep.detail);
-        // The detail claims "started and stopped" and nothing else asserts the second half: a
-        // probe that leaks its compositor still answers Ok, and each survivor holds a display.
+        // Counted from outside glass as well, so the verdict is not the only witness to it.
         assert_eq!(
             compositors_running(),
             before,
@@ -436,7 +661,9 @@ mod tests {
     /// within ~8s" — an eight-second wait that took none. Needs no sway.
     #[test]
     fn a_compositor_that_exited_is_not_reported_as_one_that_never_answered() {
-        let err = probe_sway(Path::new("/bin/false")).expect_err("no IPC ever appears");
+        let err = probe_sway(Path::new("/bin/false"))
+            .came_up
+            .expect_err("no IPC ever appears");
         let ProbeFailure::Failed(why) = &err else {
             panic!("an exit is the compositor's own answer, not a wait: {err:?}");
         };
@@ -472,7 +699,9 @@ mod tests {
         // up on it; short enough that the test is not the slow one in the suite.
         let budget = Duration::from_millis(500);
         let started = Instant::now();
-        let err = probe_sway_within(&fake, budget).expect_err("no IPC ever appears");
+        let err = probe_sway_within(&fake, budget)
+            .came_up
+            .expect_err("no IPC ever appears");
         assert_eq!(err, ProbeFailure::TimedOut(budget));
         // The budget plus the teardown that follows it — the units this actually spans. A wait
         // that ignored its argument would blow this by `IPC_READY_BUDGET`.
@@ -493,12 +722,183 @@ mod tests {
         );
     }
 
+    /// glass#380: sway's stderr was inherited, so what it said about its own failure went to
+    /// glass's stderr and never to the check — the only surface an MCP client reads.
+    #[test]
+    fn a_compositor_that_failed_says_why_in_the_check() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let fake = dir.path().join("sway");
+        // Rejects an argv that is not the one glass builds, so a probe that stopped passing
+        // sway's arguments cannot pass this test by accident.
+        std::fs::write(
+            &fake,
+            "#!/bin/sh\ncase \"$*\" in *--unsupported-gpu*) ;; *) exit 64;; esac\n\
+             echo 'sway: could not create GLES2 renderer' >&2\nexit 1\n",
+        )
+        .expect("write fake sway");
+        std::fs::set_permissions(&fake, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod fake sway");
+
+        let spawn = probe_sway_within(&fake, Duration::from_millis(500));
+        let cs = wayland_checks(&answered("1.12"), true, Some(spawn));
+        let deep = cs.iter().find(|c| c.name == "sway spawn (deep)").unwrap();
+        assert_eq!(deep.status, CheckStatus::Fail, "{deep:?}");
+        assert!(
+            deep.detail.contains("could not create GLES2 renderer"),
+            "{deep:?}"
+        );
+    }
+
+    /// glass#380: `try_wait().ok()` dropped the error, which the loop then read as "still
+    /// running" — so a wait glass could not make spent the whole budget and was reported as a
+    /// compositor that took too long.
+    #[test]
+    fn a_wait_that_could_not_be_made_is_not_reported_as_a_slow_compositor() {
+        let budget = Duration::from_secs(2);
+        let started = Instant::now();
+        let wait = await_ipc(
+            budget,
+            Duration::from_millis(5),
+            || Err(std::io::Error::other("No child processes")),
+            || Err("no socket".into()),
+        );
+        let Err(ProbeFailure::Failed(why)) = &wait.outcome else {
+            panic!(
+                "a question glass could not ask is not sway's answer: {wait:?}",
+                wait = wait.outcome
+            );
+        };
+        assert!(why.contains("No child processes"), "{why}");
+        assert!(
+            started.elapsed() < budget / 2,
+            "the wait ended on the error, so none of the budget is spent: {:?}",
+            started.elapsed()
+        );
+    }
+
+    /// The other dropped error: `Ipc::connect(..).is_ok()` threw away what the connection said,
+    /// so a socket that exists and refuses read exactly like one that never appeared.
+    #[test]
+    fn a_timeout_carries_the_last_thing_the_ipc_connect_said() {
+        let budget = Duration::from_millis(30);
+        let wait = await_ipc(
+            budget,
+            Duration::from_millis(5),
+            || Ok(None),
+            || Err("Connection refused (os error 111)".into()),
+        );
+        assert_eq!(wait.outcome, Err(ProbeFailure::TimedOut(budget)));
+        assert_eq!(
+            wait.last_ipc_error.as_deref(),
+            Some("Connection refused (os error 111)")
+        );
+    }
+
+    /// And it has to reach the check, which is the only surface an MCP client reads.
+    #[test]
+    fn the_check_shows_what_the_ipc_connect_said() {
+        let cs = wayland_checks(
+            &answered("1.12"),
+            true,
+            Some(SwaySpawn {
+                came_up: Err(ProbeFailure::TimedOut(Duration::from_secs(8))),
+                last_ipc_error: Some("Connection refused (os error 111)".into()),
+                said: None,
+                left_behind: Vec::new(),
+                kept_runtime_dir: None,
+            }),
+        );
+        let deep = cs.iter().find(|c| c.name == "sway spawn (deep)").unwrap();
+        assert!(deep.detail.contains("Connection refused"), "{deep:?}");
+    }
+
+    /// A probe outcome with nothing left running — the shape every case but the leak tests.
+    fn spawned(came_up: Result<(), ProbeFailure>) -> SwaySpawn {
+        SwaySpawn {
+            came_up,
+            last_ipc_error: None,
+            said: None,
+            left_behind: Vec::new(),
+            kept_runtime_dir: None,
+        }
+    }
+
+    /// glass#380: the detail said "started and stopped" on the strength of the start alone, so a
+    /// probe that leaked its compositor reported the same green line as one that tore it down.
+    #[test]
+    fn a_probe_that_left_its_compositor_running_is_not_reported_as_stopped() {
+        let cs = wayland_checks(
+            &answered("1.12"),
+            true,
+            Some(SwaySpawn {
+                came_up: Ok(()),
+                last_ipc_error: None,
+                said: None,
+                left_behind: vec![4242, 4243],
+                kept_runtime_dir: Some(PathBuf::from("/tmp/glass-doctor-wl.abc123")),
+            }),
+        );
+        let deep = cs.iter().find(|c| c.name == "sway spawn (deep)").unwrap();
+        assert_eq!(deep.status, CheckStatus::Warn, "{deep:?}");
+        // An operator can only kill what is named.
+        assert!(deep.detail.contains("4242"), "{deep:?}");
+        assert!(deep.detail.contains("4243"), "{deep:?}");
+        assert!(deep.remedy.is_some(), "{deep:?}");
+    }
+
+    /// The probe keeps the runtime dir when something is still using it, so the check has to say
+    /// where it is — otherwise the operator is left a directory they cannot find and sockets whose
+    /// processes they cannot place.
+    #[test]
+    fn a_kept_runtime_dir_is_named_so_it_can_be_cleaned_up() {
+        let cs = wayland_checks(
+            &answered("1.12"),
+            true,
+            Some(SwaySpawn {
+                came_up: Ok(()),
+                last_ipc_error: None,
+                said: None,
+                left_behind: vec![4242],
+                kept_runtime_dir: Some(PathBuf::from("/tmp/glass-doctor-wl.abc123")),
+            }),
+        );
+        let deep = cs.iter().find(|c| c.name == "sway spawn (deep)").unwrap();
+        let said = format!("{} {}", deep.detail, deep.remedy.as_deref().unwrap_or(""));
+        assert!(said.contains("/tmp/glass-doctor-wl.abc123"), "{deep:?}");
+        // Counted, so a single survivor is not reported in the plural.
+        assert!(
+            deep.detail.contains("1 process ") && deep.detail.contains("pid 4242"),
+            "{deep:?}"
+        );
+    }
+
+    /// A failed probe that also leaked is worse than one that only failed, so the survivors ride
+    /// on the failure rather than replacing it.
+    #[test]
+    fn survivors_are_named_on_the_failure_path_too() {
+        let cs = wayland_checks(
+            &answered("1.12"),
+            true,
+            Some(SwaySpawn {
+                came_up: Err(ProbeFailure::TimedOut(Duration::from_secs(8))),
+                last_ipc_error: None,
+                said: None,
+                left_behind: vec![4242],
+                kept_runtime_dir: Some(PathBuf::from("/tmp/glass-doctor-wl.abc123")),
+            }),
+        );
+        let deep = cs.iter().find(|c| c.name == "sway spawn (deep)").unwrap();
+        assert_eq!(deep.status, CheckStatus::Fail, "{deep:?}");
+        assert!(deep.detail.contains("8s"), "the failure survives: {deep:?}");
+        assert!(deep.detail.contains("4242"), "{deep:?}");
+    }
+
     #[test]
     fn deep_spawn_failure_is_reported() {
         let cs = wayland_checks(
             &answered("1.12"),
             true,
-            Some(Err(ProbeFailure::Failed("no come up".into()))),
+            Some(spawned(Err(ProbeFailure::Failed("no come up".into())))),
         );
         let deep = cs.iter().find(|c| c.name == "sway spawn (deep)").unwrap();
         assert_eq!(deep.status, CheckStatus::Fail);
@@ -518,9 +918,9 @@ mod tests {
         let cs = wayland_checks(
             &answered("1.12"),
             true,
-            Some(Err(ProbeFailure::NotStarted(
+            Some(spawned(Err(ProbeFailure::NotStarted(
                 "private runtime dir: No space left on device".into(),
-            ))),
+            )))),
         );
         let deep = cs.iter().find(|c| c.name == "sway spawn (deep)").unwrap();
         assert_eq!(deep.status, CheckStatus::Fail);
@@ -539,7 +939,7 @@ mod tests {
     #[test]
     fn a_spawn_that_never_happened_is_not_reported_as_sway_failing() {
         let missing = std::path::Path::new("/nonexistent/glass-doctor/sway");
-        let err = probe_sway(missing).expect_err("nothing to spawn");
+        let err = probe_sway(missing).came_up.expect_err("nothing to spawn");
         assert!(
             matches!(err, ProbeFailure::NotStarted(_)),
             "a spawn that never happened is not sway's answer: {err:?}"

--- a/crates/glass-wayland/src/doctor.rs
+++ b/crates/glass-wayland/src/doctor.rs
@@ -52,8 +52,8 @@ enum CameUp {
     Yes,
     /// It did not, for a reason the shared vocabulary names.
     No(ProbeFailure),
-    /// Neither: the probe ran and glass lost track of what it had started, so nothing here is
-    /// about sway (glass#373's mis-attribution, one door along).
+    /// Neither: the probe ran and glass lost track of what it started, so nothing here is about
+    /// sway (glass#373).
     Unknown(String),
 }
 
@@ -159,8 +159,8 @@ fn deep_spawn_check(spawn: SwaySpawn) -> Check {
             leak.as_ref(),
         ),
     };
-    // Sway's own words go last and quoted: they are the one span of this line glass did not
-    // write, and undelimited they can imitate the clauses around them (glass#348).
+    // Sway's own words go last and quoted: undelimited, the one span glass did not write can
+    // imitate the clauses around it (glass#348).
     if let Some(said) = &spawn.said {
         detail.push_str(&format!(" — sway said: {said:?}"));
     }
@@ -310,8 +310,8 @@ fn probe_sway(sway: &Path) -> SwaySpawn {
 
 /// How much of sway's stderr the probe keeps, and how much of that a check quotes.
 ///
-/// Two numbers because they answer different questions: the pipe must be drained faster than sway
-/// writes, and a check's detail is one line an operator reads.
+/// The pipe must be drained faster than sway writes; a check's detail is one line an operator
+/// reads.
 const STDERR_KEPT: usize = 8 * 1024;
 const STDERR_SHOWN: usize = 512;
 
@@ -359,8 +359,7 @@ impl SwaySaid {
 
     /// What it said, after `grace` for the pipe to close — call once the compositor is reaped.
     ///
-    /// Read whether or not the pipe closed, because it stays open while anything the probe left
-    /// running holds it, which is the case whose stderr matters most.
+    /// Read whether or not the pipe closed — anything the probe left running holds it open.
     fn snapshot(&self, grace: Duration) -> Option<String> {
         glass_proc_linux::await_condition(grace, || self.closed.load(Ordering::Acquire));
         let kept = self.kept.lock().unwrap_or_else(PoisonError::into_inner);
@@ -453,8 +452,8 @@ fn never_ran(why: ProbeFailure) -> SwaySpawn {
 /// How long the probe waits for what it started to leave before calling it left behind.
 ///
 /// A signal lands when its target is next scheduled, so a check taken straight after one still
-/// sees processes that are already going. Doctor has no teardown budget to fit inside, and the
-/// cost is only paid where something is still there.
+/// sees processes that are already going. Longer than a teardown's, because doctor has no budget
+/// to fit inside.
 const LEAK_GRACE: Duration = Duration::from_millis(500);
 
 /// Tear the launch down and account for it: what the probe started that is still running, and the
@@ -819,8 +818,7 @@ mod tests {
             spawn.last_ipc.as_deref(),
             Some("no sway IPC socket ever appeared in its runtime dir")
         );
-        // A teardown that reached everything keeps nothing — and deletes its runtime dir, which
-        // the next assertion is about.
+        // A teardown that reached everything keeps nothing, and deletes its runtime dir.
         assert!(spawn.leaked.is_none(), "{spawn:?}");
         assert!(
             !dir.path().join("glass-doctor-wl.").exists(),
@@ -856,8 +854,8 @@ mod tests {
              echo 'sway: Unable to create renderer' >&2\nexit 1\n",
         );
 
-        // Generous, because it bounds nothing this test is about: the wait ends the moment the
-        // exit is observed, so only a runner slow enough to miss the shell entirely reaches it.
+        // Generous: the wait ends the moment the exit is observed, so this bounds nothing the
+        // test is about.
         let spawn = probe_sway_within(&fake, Duration::from_secs(5));
         let cs = wayland_checks(&answered("1.12"), true, Some(spawn));
         let deep = cs.iter().find(|c| c.name == "sway spawn (deep)").unwrap();
@@ -1025,7 +1023,7 @@ mod tests {
         let deep = cs.iter().find(|c| c.name == "sway spawn (deep)").unwrap();
         assert_eq!(deep.status, CheckStatus::Warn, "{deep:?}");
         assert!(deep.detail.contains("2 processes"), "{deep:?}");
-        // An operator can only kill what is named, and the remedy is where the killing is said.
+        // An operator can only kill what is named.
         assert!(deep.detail.contains("4242, 4243"), "{deep:?}");
         assert!(
             deep.remedy

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -48,7 +48,10 @@ use crate::swayipc::{Ipc, Window as SwayWindow};
 // reaps at `REAP_GRACE`, so a helper that ignores SIGTERM can take the whole teardown past the
 // budget; that is pre-existing and not what this assertion is about.
 const _: () = assert!(
-    CLOSE_GRACE.as_millis() + APP_REAP_GRACE.as_millis() < TEARDOWN_BUDGET.as_millis(),
+    CLOSE_GRACE.as_millis()
+        + APP_REAP_GRACE.as_millis()
+        + glass_proc_linux::KILL_CONFIRM.as_millis()
+        < TEARDOWN_BUDGET.as_millis(),
     "the close request + compositor reap must finish inside glass_core::TEARDOWN_BUDGET"
 );
 
@@ -127,7 +130,13 @@ impl WaylandPlatform {
                     !glass_proc_linux::any_alive(&app)
                 }
             });
-            glass_proc_linux::reap_launch(&mut s.child, &tree, glass_proc_linux::APP_REAP_GRACE);
+            // Teardown reports what it asked, not what survived — doctor's deep probe is the
+            // caller that reads this (glass#380).
+            let _ = glass_proc_linux::reap_launch(
+                &mut s.child,
+                &tree,
+                glass_proc_linux::APP_REAP_GRACE,
+            );
             glass_proc_linux::disclose_teardown(&asked.outcome(closed_itself));
         }
         self.dbus = None;

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -48,10 +48,7 @@ use crate::swayipc::{Ipc, Window as SwayWindow};
 // reaps at `REAP_GRACE`, so a helper that ignores SIGTERM can take the whole teardown past the
 // budget; that is pre-existing and not what this assertion is about.
 const _: () = assert!(
-    CLOSE_GRACE.as_millis()
-        + APP_REAP_GRACE.as_millis()
-        + glass_proc_linux::KILL_CONFIRM.as_millis()
-        < TEARDOWN_BUDGET.as_millis(),
+    CLOSE_GRACE.as_millis() + APP_REAP_GRACE.as_millis() < TEARDOWN_BUDGET.as_millis(),
     "the close request + compositor reap must finish inside glass_core::TEARDOWN_BUDGET"
 );
 

--- a/crates/glass-wayland/src/swayipc.rs
+++ b/crates/glass-wayland/src/swayipc.rs
@@ -124,11 +124,15 @@ pub struct Ipc {
     broken: bool,
 }
 
+/// No socket in the runtime dir at all, as opposed to one that answered badly — doctor tells the
+/// two apart when it reports why a compositor never became reachable.
+pub(crate) const NO_IPC_SOCKET: &str = "sway IPC socket not found";
+
 impl Ipc {
     /// Find the `sway-ipc.*.sock` in the private runtime dir and connect.
     pub fn connect(runtime_dir: &Path) -> Result<Ipc> {
         let path = find_ipc_socket(runtime_dir)
-            .ok_or_else(|| GlassError::Backend("sway IPC socket not found".into()))?;
+            .ok_or_else(|| GlassError::Backend(NO_IPC_SOCKET.into()))?;
         let sock = UnixStream::connect(&path)
             .map_err(|e| GlassError::Backend(format!("connect sway IPC: {e}")))?;
         let mut ipc = Ipc::from_stream(sock)?;

--- a/crates/glass-wayland/src/xwayland.rs
+++ b/crates/glass-wayland/src/xwayland.rs
@@ -334,6 +334,25 @@ fn xwayland_pids() -> Vec<u32> {
         .collect()
 }
 
+/// Every process on the machine that belongs to the session `runtime_dir` was created for.
+///
+/// By what a process inherited, not by parentage: sway reparents Xwayland out of its own tree and
+/// `setsid`s every app it `exec`s, so a walk of sway's descendants finds neither. This is what
+/// answers whether a launch is really gone (glass#380).
+pub(crate) fn session_processes(runtime_dir: &Path) -> Vec<u32> {
+    let Ok(entries) = std::fs::read_dir("/proc") else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .filter_map(|e| e.file_name().to_str()?.parse::<u32>().ok())
+        .filter(|pid| {
+            std::fs::read(format!("/proc/{pid}/environ"))
+                .is_ok_and(|environ| serves_session(&environ, runtime_dir))
+        })
+        .collect()
+}
+
 /// Whether a process's environment (`/proc/<pid>/environ`: NUL-separated `KEY=VALUE`) says it
 /// belongs to the session glass created `runtime_dir` for.
 fn serves_session(environ: &[u8], runtime_dir: &Path) -> bool {
@@ -737,6 +756,33 @@ mod session_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// glass#380: what the probe started is found by what it inherited, because sway reparents
+    /// Xwayland out of its own tree and `setsid`s the app it `exec`s — a walk of sway's
+    /// descendants finds neither, so a teardown that missed one would look complete.
+    #[test]
+    fn a_process_is_matched_to_the_session_it_was_started_for() {
+        let rt = tempfile::tempdir().expect("tempdir");
+        let mut child = std::process::Command::new("sleep")
+            .arg("5")
+            .env("XDG_RUNTIME_DIR", rt.path())
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn sleep");
+        let pid = child.id();
+        assert!(
+            session_processes(rt.path()).contains(&pid),
+            "a process carrying the session's runtime dir belongs to it"
+        );
+        // Another session's dir must not match it — the whole point is telling them apart.
+        let other = tempfile::tempdir().expect("tempdir");
+        assert!(!session_processes(other.path()).contains(&pid));
+        child.kill().expect("kill");
+        child.wait().expect("reap");
+        assert!(!session_processes(rt.path()).contains(&pid));
+    }
 
     fn toplevel() -> WindowFacts {
         WindowFacts {

--- a/crates/glass-wayland/src/xwayland.rs
+++ b/crates/glass-wayland/src/xwayland.rs
@@ -757,9 +757,9 @@ mod session_tests {
 mod tests {
     use super::*;
 
-    /// glass#380: what the probe started is found by what it inherited, because sway reparents
-    /// Xwayland out of its own tree and `setsid`s the app it `exec`s — a walk of sway's
-    /// descendants finds neither, so a teardown that missed one would look complete.
+    /// glass#380: what the probe started is found by what it inherited — sway reparents Xwayland
+    /// out of its own tree and `setsid`s the app it `exec`s, so a walk of its descendants finds
+    /// neither.
     #[test]
     fn a_process_is_matched_to_the_session_it_was_started_for() {
         let rt = tempfile::tempdir().expect("tempdir");

--- a/crates/glass-wayland/src/xwayland.rs
+++ b/crates/glass-wayland/src/xwayland.rs
@@ -757,9 +757,7 @@ mod session_tests {
 mod tests {
     use super::*;
 
-    /// glass#380: what the probe started is found by what it inherited — sway reparents Xwayland
-    /// out of its own tree and `setsid`s the app it `exec`s, so a walk of its descendants finds
-    /// neither.
+    /// glass#380: this is what tells a teardown whether what it started is really gone.
     #[test]
     fn a_process_is_matched_to_the_session_it_was_started_for() {
         let rt = tempfile::tempdir().expect("tempdir");

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -24,10 +24,7 @@ use x11rb::wrapper::ConnectionExt as _;
 // private Xvfb — still reaps at `REAP_GRACE` each, so a helper that ignores SIGTERM can take the
 // whole teardown past the budget; that is pre-existing and not what this assertion is about.
 const _: () = assert!(
-    ASK_BUDGET.as_millis()
-        + CLOSE_GRACE.as_millis()
-        + APP_REAP_GRACE.as_millis()
-        + glass_proc_linux::KILL_CONFIRM.as_millis()
+    ASK_BUDGET.as_millis() + CLOSE_GRACE.as_millis() + APP_REAP_GRACE.as_millis()
         < TEARDOWN_BUDGET.as_millis(),
     "sending the close request, waiting it out and the signal ladder must all finish inside \
      glass_core::TEARDOWN_BUDGET"

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -24,7 +24,10 @@ use x11rb::wrapper::ConnectionExt as _;
 // private Xvfb — still reaps at `REAP_GRACE` each, so a helper that ignores SIGTERM can take the
 // whole teardown past the budget; that is pre-existing and not what this assertion is about.
 const _: () = assert!(
-    ASK_BUDGET.as_millis() + CLOSE_GRACE.as_millis() + APP_REAP_GRACE.as_millis()
+    ASK_BUDGET.as_millis()
+        + CLOSE_GRACE.as_millis()
+        + APP_REAP_GRACE.as_millis()
+        + glass_proc_linux::KILL_CONFIRM.as_millis()
         < TEARDOWN_BUDGET.as_millis(),
     "sending the close request, waiting it out and the signal ladder must all finish inside \
      glass_core::TEARDOWN_BUDGET"
@@ -475,7 +478,9 @@ impl X11Platform {
             // The sweep runs either way: an app that closed itself can still have forked children
             // it never cleaned up, and on the graceful path the signals land on processes that
             // are already gone and cost nothing.
-            glass_proc_linux::reap_launch(&mut child, &tree, APP_REAP_GRACE);
+            // Teardown reports what it asked, not what survived — doctor's deep probe is the
+            // caller that reads this (glass#380).
+            let _ = glass_proc_linux::reap_launch(&mut child, &tree, APP_REAP_GRACE);
             glass_proc_linux::disclose_teardown(&asked.outcome(closed_itself));
         }
         self.window = None;


### PR DESCRIPTION
Closes #380.

`glass doctor --deep` reported `sway spawn (deep)` as "headless sway started and stopped" on the strength of the start alone, and said less than it knew when the start failed.

## What it checks now

The stop is verified by **session membership**: which processes carry the private `XDG_RUNTIME_DIR` the probe created, polled until it settles. That is the question that discriminates — sway reparents Xwayland out of its own process tree and `setsid`s every app it `exec`s, so a walk of sway's descendants finds neither. `session_processes` is the observation `session_display` already relied on for the same reason.

When something is left, the check warns, names the pids, and keeps the runtime dir rather than deleting the sockets out from under it. The text states what was observed ("still running 500ms after the probe signalled it") and the remedy looks before it kills, because the same observation is produced by a process on its way out, a zombie, or a pid the kernel has reused.

## What it says now

| what happened | before | now |
|---|---|---|
| sway exited | `sway exited before its IPC came up (exit status: 1)` | + `— sway said: "…Failed to create EGL context; …Unable to create renderer"` |
| IPC never answered | `still not ready 8s later` | + `— no sway IPC socket ever appeared in its runtime dir` (or `— its IPC socket refused the connection: …`) |
| `waitpid` answered ECHILD | `headless sway failed to come up` + the host-GL remedy | `⚠ glass lost track of the headless sway it started` + a remedy that does not blame sway |
| the host refused the stderr thread | — | the same, and the compositor is reaped and accounted for |

sway's stderr was inherited, so its own account of a failure went to glass's stderr and never to the check — the only surface an MCP client reads. It is captured, clipped, quoted, and placed last so it cannot imitate glass's own clauses.

## Elsewhere

- `glass_proc_linux::reap_launch` returns the pids of the launch still alive once its ladder has run, instead of computing that and discarding it. Both production callers currently ignore it — #470.
- `live_pids`/`any_alive` exclude zombies, which keep a `/proc` entry but hold nothing and take no signal, and the three open-coded liveness checks share one predicate.
- No teardown timing changed: the reaper keeps no confirmation window, so both backends' `TEARDOWN_BUDGET` assertions stand as they were.

## Verification

TDD throughout; every new assertion was seen red first, and the ones that went green on arrival were ablated — the session sweep, the zombie filter, the reaper's answer, the recorded connect error, and the live deep-probe test, which flips to `Warn` when the leak check is made to claim a survivor.

Run locally: `cargo fmt`, clippy `-D warnings`, `cargo test --workspace`, `cargo test -p glass-wayland -- --include-ignored` (241), `scripts/test-x11.sh` (51), `scripts/test-wayland.sh` (25), and all three product paths end to end against a real sway and two fixtures. Nothing left in `/tmp`.

## Review

A six-lens panel ran before this PR was opened. It refuted the first cut — `reap_launch` ends in `child.wait()`, so the compositor itself was already provably reaped, which is why the check now asks a different question — and found that the stderr-reader-refused path had reproduced #380 inside the fix. Both are addressed in `b5770d5`. Three findings were verified and deferred as their own issues: #469, #470, #471.

🤖 Generated with [Claude Code](https://claude.com/claude-code)