### PR TITLE
fix(ios): resolve idb_companion to a binary glass can run, not one that is merely there

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ internal refactors, CI, or test-only changes.
 ## [Unreleased]
 
 ### Fixed
+- iOS: an `idb_companion` that is installed but cannot be executed — no execute bit, a `noexec`
+  mount, permissions this user is not in — no longer reads as available. glass now asks the kernel
+  whether it may run the binary, so a runnable copy later on `PATH` or in a Homebrew prefix is
+  preferred over an unrunnable one earlier, and starting a session names the file and the `chmod +x`
+  that fixes it instead of failing at spawn. `glass doctor` and the iOS input and accessibility
+  capabilities report the same resolution: one that cannot run says so rather than reading as
+  present, one that could not be looked up at all (no `PATH` — the stripped environment MCP clients
+  routinely hand a server) says that rather than "not found", and a `GLASS_IDB_COMPANION` naming
+  nothing points at the variable rather than at another `brew install`.
 - `glass doctor` no longer reports a desktop accessibility bus that has hung as a green "no
   desktop a11y bus running". A bus that takes `GetAddress` and never answers, one that advertises
   an address glass cannot use, a question the session bus answered with an error, and a check that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,12 +23,14 @@ internal refactors, CI, or test-only changes.
 - iOS: an `idb_companion` that is installed but cannot be executed — no execute bit, a `noexec`
   mount, permissions this user is not in — no longer reads as available. glass now asks the kernel
   whether it may run the binary, so a runnable copy later on `PATH` or in a Homebrew prefix is
-  preferred over an unrunnable one earlier, and starting a session names the file and the `chmod +x`
-  that fixes it instead of failing at spawn. `glass doctor` and the iOS input and accessibility
-  capabilities report the same resolution: one that cannot run says so rather than reading as
-  present, one that could not be looked up at all (no `PATH` — the stripped environment MCP clients
-  routinely hand a server) says that rather than "not found", and a `GLASS_IDB_COMPANION` naming
-  nothing points at the variable rather than at another `brew install`.
+  preferred over an unrunnable one earlier, and the iOS input and accessibility capabilities go
+  unavailable exactly when a launch would fail. Starting a session refuses with the file and the
+  `chmod +x` that fixes it instead of failing at spawn, and `glass doctor` gives that same reason
+  its own line: a companion that could not be looked up at all (no `PATH` — the stripped
+  environment MCP clients routinely hand a server) says so rather than "not found", and a
+  `GLASS_IDB_COMPANION` naming nothing points at the variable rather than at another
+  `brew install`. The install glass prints now taps `facebook/fb` first, which a plain
+  `brew install idb-companion` needs and did not have.
 - `glass doctor` no longer reports a desktop accessibility bus that has hung as a green "no
   desktop a11y bus running". A bus that takes `GetAddress` and never answers, one that advertises
   an address glass cannot use, a question the session bus answered with an error, and a check that

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1217,6 +1217,7 @@ name = "glass-ios"
 version = "0.0.0"
 dependencies = [
  "glass-core",
+ "glass-exec-unix",
  "hyper-util",
  "image",
  "prost",

--- a/crates/glass-exec-unix/src/lib.rs
+++ b/crates/glass-exec-unix/src/lib.rs
@@ -8,9 +8,9 @@
 //! directory, and so does the walk here.
 //!
 //! Consumers: the X11 and Wayland backends (`glass-x11`, `glass-wayland`), the AT-SPI bus launcher
-//! and its doctor check (`glass-dbus-linux`, `glass-a11y-linux`), and the sandbox backends
-//! (`glass-sandbox-linux`, `glass-sandbox-macos`). `glass-android` and `glass-ios` resolve their
-//! device tooling themselves.
+//! and its doctor check (`glass-dbus-linux`, `glass-a11y-linux`), the sandbox backends
+//! (`glass-sandbox-linux`, `glass-sandbox-macos`), and the iOS Simulator backend's
+//! `idb_companion` (`glass-ios`). `glass-android` resolves its device tooling itself.
 //!
 //! Which host paths a launch touches is a different question, answered by `glass-sandbox-unix`.
 //!

--- a/crates/glass-ios/Cargo.toml
+++ b/crates/glass-ios/Cargo.toml
@@ -13,6 +13,7 @@ bench = false
 # too — mirrors glass-x11/glass-wayland, the workspace's other fully-gated crates.
 [target.'cfg(unix)'.dependencies]
 glass-core.workspace = true
+glass-exec-unix.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
 image = { version = "0.25", default-features = false, features = ["png"] }

--- a/crates/glass-ios/src/doctor.rs
+++ b/crates/glass-ios/src/doctor.rs
@@ -442,10 +442,10 @@ fn probe_companion(bin: &Path) -> CompanionProbe {
 }
 
 /// The human cause from a failed [`IdbCompanion::spawn`], stripped of `GlassError::Backend`'s
-/// `"backend error: "` Display prefix — the doctor already frames it as "failed to start: …",
-/// so the prefix would read redundantly in user-facing output. Any other variant falls back
-/// to its full Display.
-fn spawn_cause(e: GlassError) -> String {
+/// `"backend error: "` Display prefix — every caller frames the cause itself ("failed to start:
+/// …", "input and the accessibility tree are disabled: …"), so the prefix reads redundantly in
+/// user-facing output. Any other variant falls back to its full Display.
+pub(crate) fn spawn_cause(e: GlassError) -> String {
     match e {
         GlassError::Backend(msg) => msg,
         other => other.to_string(),

--- a/crates/glass-ios/src/doctor.rs
+++ b/crates/glass-ios/src/doctor.rs
@@ -10,9 +10,10 @@ use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
 use glass_core::{Check, CheckStatus, GlassError};
+use glass_exec_unix::Resolved;
 
 use crate::device::{Resolve, SimDevice, parse_devices, resolve};
-use crate::idb::companion::{IdbCompanion, companion_bin, companion_present_with};
+use crate::idb::companion::{CompanionFacts, IdbCompanion};
 use crate::simctl::Simctl;
 use crate::target::wants;
 
@@ -228,14 +229,13 @@ pub fn checks(_deep: bool) -> Vec<Check> {
     })
 }
 
-/// Outcome of the `--deep` iOS `idb_companion` health probe (see [`probe_companion`]). Pure
-/// data — the aggregator (`glass-mcp`) maps it to a `Check`. `NotFound` means the binary is
-/// unresolvable; `Started`/`FailedToStart` come from a real spawn against an already-booted
-/// simulator; `SelfTestOk`/`SelfTestFailed` come from the bounded `--version` fallback used
-/// when no simulator is booted.
+/// Outcome of the `--deep` `idb_companion` health probe (see [`probe_companion`]).
+/// `Started`/`FailedToStart` come from a real spawn against an already-booted simulator;
+/// `SelfTestOk`/`SelfTestFailed` from the bounded `--version` fallback used when none is booted.
+/// A binary that never resolved is not among them — [`companion_check`] answers that from the
+/// resolution, without spawning.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum CompanionProbe {
-    NotFound,
+enum CompanionProbe {
     Started,
     FailedToStart(String),
     SelfTestOk,
@@ -252,17 +252,10 @@ const SELF_TEST_TIMEOUT: Duration = Duration::from_secs(5);
 /// Poll interval while waiting for the self-test child to exit.
 const SELF_TEST_POLL: Duration = Duration::from_millis(50);
 
-/// Run the companion's bounded `--version` self-test: does the binary actually execute? Used
-/// only when no simulator is booted (so a real spawn isn't possible without booting one).
-/// Captures stderr to a temp file — a file can't fill and block, mirroring `IdbCompanion` —
-/// and surfaces it as the cause on failure. Success ⇒ [`CompanionProbe::SelfTestOk`].
-fn self_test() -> CompanionProbe {
-    self_test_with(&companion_bin(&|k| std::env::var(k).ok()))
-}
-
-/// [`self_test`] against an explicit binary path — the testable seam (no env / no real
-/// companion needed).
-fn self_test_with(bin: &str) -> CompanionProbe {
+/// The companion's bounded `--version` self-test: does the binary actually execute? Used only
+/// when no simulator is booted. Captures stderr to a temp file — a file can't fill and block,
+/// mirroring `IdbCompanion` — and surfaces it as the cause on failure.
+fn self_test_with(bin: &Path) -> CompanionProbe {
     // A uniquely-named temp file (rather than a name keyed on this process's pid) — several
     // self-tests can run concurrently in one process, e.g. this module's own tests running in
     // parallel, and a pid-only name would let them collide on the same log file.
@@ -283,7 +276,10 @@ fn self_test_with(bin: &str) -> CompanionProbe {
     {
         Ok(c) => c,
         Err(e) => {
-            return CompanionProbe::SelfTestFailed(format!("spawn {bin} {SELF_TEST_ARG}: {e}"));
+            return CompanionProbe::SelfTestFailed(format!(
+                "spawn {} {SELF_TEST_ARG}: {e}",
+                bin.display()
+            ));
         }
     };
     let deadline = Instant::now() + SELF_TEST_TIMEOUT;
@@ -318,25 +314,146 @@ fn read_trimmed(path: &Path) -> Option<String> {
         .map(|s| s.trim().to_string())
 }
 
-/// Is the companion binary resolvable — `GLASS_IDB_COMPANION` naming an existing file, or
-/// `idb_companion` found on `PATH` or in Homebrew's standard prefixes? The passive
-/// (non-`--deep`) presence signal, and the `NotFound` gate for [`probe_companion`]. Uses the
-/// same [`companion_bin`] resolution the runtime spawn does.
-pub fn companion_present() -> bool {
-    companion_present_with(&|k| std::env::var(k).ok(), &|p| p.is_file())
+/// Whether this host has an `idb_companion` glass can actually run — the gate on the iOS
+/// input and accessibility capabilities.
+pub(crate) fn companion_runnable() -> bool {
+    matches!(gather().resolved, Resolved::Found(_))
 }
 
-/// The `--deep` iOS companion health probe: does `idb_companion` actually start? Reuses the
-/// real runtime spawn path against an *already-booted* simulator — never booting one, so it
-/// stays bounded (the spawn carries its own 10s socket deadline) and non-mutating. When no
-/// simulator is booted, falls back to the bounded [`self_test`] so `--deep` still yields a
-/// signal. Only the aggregator's macOS-only ios section calls this.
-pub fn probe_companion() -> CompanionProbe {
-    if !companion_present() {
-        return CompanionProbe::NotFound;
+/// What this host has, read from the real environment.
+fn gather() -> CompanionFacts {
+    CompanionFacts::gather(&|k| std::env::var(k).ok())
+}
+
+/// The `idb_companion` line for `glass doctor`, and — with `deep` — the health probe behind it.
+///
+/// `deep` costs a real companion start, which is why the aggregator gates it on iOS being the
+/// selected backend while emitting the line either way.
+pub fn companion_check(deep: bool) -> Check {
+    check_for(&gather(), deep, probe_companion)
+}
+
+/// [`companion_check`] over gathered facts, with the probe injected — the seam that pins which
+/// resolutions are worth a real companion start without one running here.
+fn check_for(
+    facts: &CompanionFacts,
+    deep: bool,
+    probe: impl FnOnce(&Path) -> CompanionProbe,
+) -> Check {
+    match &facts.resolved {
+        // Only a runnable binary is worth starting: probing any other outcome would report a
+        // spawn failure whose cause is the resolution the check already has in hand.
+        Resolved::Found(bin) if deep => deep_check(&probe(bin)),
+        _ => resolution_check(facts),
     }
+}
+
+/// The shared `idb_companion` install remedy.
+const INSTALL_REMEDY: &str =
+    "brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion";
+
+/// Pure: what a resolution means for the operator.
+///
+/// A companion glass cannot run is a **Fail**, not a Warn: unlike android, which keeps barebones
+/// function without its companions, iOS cannot drive apps at all without this one. The aggregator
+/// softens that to a Warn when iOS is not the selected backend.
+fn resolution_check(facts: &CompanionFacts) -> Check {
+    match &facts.resolved {
+        Resolved::Found(p) => Check::new(
+            "idb_companion",
+            CheckStatus::Ok,
+            format!("{} — input + accessibility are available", p.display()),
+        ),
+        // It is installed; what it needs is permission, not another `brew install`.
+        Resolved::NotExecutable(p) => Check::new(
+            "idb_companion",
+            CheckStatus::Fail,
+            format!(
+                "{} — not executable; input + accessibility are unavailable (iOS cannot drive apps)",
+                p.display()
+            ),
+        )
+        .with_remedy(format!(
+            "chmod +x {}, or point GLASS_IDB_COMPANION at a runnable binary",
+            p.display()
+        )),
+        // An override skips discovery, so the variable — not what this host has installed —
+        // is what left glass with nothing.
+        Resolved::Absent if facts.override_set => Check::new(
+            "idb_companion",
+            CheckStatus::Fail,
+            "GLASS_IDB_COMPANION does not name a runnable idb_companion — input + accessibility \
+             are unavailable (iOS cannot drive apps)",
+        )
+        .with_remedy(
+            "point GLASS_IDB_COMPANION at a runnable idb_companion, or unset it to search PATH \
+             and Homebrew's standard prefixes",
+        ),
+        Resolved::Absent => not_found_check(),
+        // Nothing was looked up, so "not found" would be a claim this check never established
+        // (glass#373).
+        Resolved::NoSearchPath => Check::new(
+            "idb_companion",
+            CheckStatus::Fail,
+            "idb_companion could not be looked up — PATH is unset in glass's environment",
+        )
+        .with_remedy(format!(
+            "set GLASS_IDB_COMPANION to its absolute path, give glass a PATH to search, or \
+             install it: {INSTALL_REMEDY}"
+        )),
+    }
+}
+
+/// The Fail for a companion that is nowhere to be found.
+fn not_found_check() -> Check {
+    Check::new(
+        "idb_companion",
+        CheckStatus::Fail,
+        "idb_companion not found — input + accessibility are unavailable (iOS cannot drive apps)",
+    )
+    .with_remedy(INSTALL_REMEDY)
+}
+
+/// Pure: what a `--deep` probe proved. Broken (`FailedToStart`/`SelfTestFailed`) ⇒ Fail: iOS
+/// cannot drive apps without the companion. Unverified (`SelfTestOk` — the binary runs but no
+/// booted simulator was available to exercise a real start) ⇒ Warn.
+fn deep_check(probe: &CompanionProbe) -> Check {
+    match probe {
+        CompanionProbe::Started => Check::new(
+            "idb_companion",
+            CheckStatus::Ok,
+            "started and served its gRPC socket — input + accessibility are available",
+        ),
+        CompanionProbe::SelfTestOk => Check::new(
+            "idb_companion",
+            CheckStatus::Warn,
+            "binary runs, but no booted simulator was available to verify a real start — \
+             boot one and re-run with --deep to exercise the companion",
+        ),
+        CompanionProbe::FailedToStart(cause) => Check::new(
+            "idb_companion",
+            CheckStatus::Fail,
+            format!(
+                "failed to start: {cause} — input + accessibility are unavailable (iOS is observe-only)"
+            ),
+        )
+        .with_remedy(INSTALL_REMEDY),
+        CompanionProbe::SelfTestFailed(cause) => Check::new(
+            "idb_companion",
+            CheckStatus::Fail,
+            format!("binary failed to execute: {cause} — input + accessibility are unavailable"),
+        )
+        .with_remedy(INSTALL_REMEDY),
+    }
+}
+
+/// The `--deep` companion health probe: does `bin` actually start? Reuses the real runtime spawn
+/// path against an *already-booted* simulator — never booting one, so it stays bounded (the spawn
+/// carries its own socket deadline) and non-mutating. With no simulator booted, falls back to the
+/// bounded [`self_test_with`] so `--deep` still yields a signal.
+fn probe_companion(bin: &Path) -> CompanionProbe {
     match booted_udid() {
-        Some(udid) => match IdbCompanion::spawn(&udid) {
+        Some(udid) => match IdbCompanion::spawn_bin(&udid, bin) {
             // Dropping the companion kills+reaps the child and removes its socket.
             Ok(companion) => {
                 drop(companion);
@@ -346,7 +463,7 @@ pub fn probe_companion() -> CompanionProbe {
             // `GlassError::Backend` Display prefix (the mapping frames it "failed to start: …").
             Err(e) => CompanionProbe::FailedToStart(spawn_cause(e)),
         },
-        None => self_test(),
+        None => self_test_with(bin),
     }
 }
 
@@ -453,6 +570,8 @@ fn booted_from(devices: &[SimDevice]) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
+
     use crate::device::SimDevice;
 
     #[test]
@@ -848,11 +967,189 @@ mod tests {
         );
     }
 
+    /// Gathered facts for a resolution that discovery reached (no `GLASS_IDB_COMPANION`).
+    fn discovered(resolved: Resolved) -> CompanionFacts {
+        CompanionFacts {
+            resolved,
+            override_set: false,
+        }
+    }
+
+    #[test]
+    fn a_runnable_companion_reads_ok_and_names_the_binary() {
+        let c = resolution_check(&discovered(Resolved::Found(PathBuf::from(
+            "/opt/homebrew/bin/idb_companion",
+        ))));
+        assert_eq!(c.status, CheckStatus::Ok);
+        assert!(
+            c.detail.contains("/opt/homebrew/bin/idb_companion"),
+            "the operator needs to know which binary answered: {}",
+            c.detail
+        );
+        assert_eq!(c.remedy, None);
+    }
+
+    /// glass#393: an `idb_companion` that is installed and unrunnable used to read as missing,
+    /// sending the user to reinstall a package that is already there. It has to name the file
+    /// and the permission fix instead.
+    #[test]
+    fn a_companion_that_cannot_be_executed_is_told_apart_from_a_missing_one() {
+        let c = resolution_check(&discovered(Resolved::NotExecutable(PathBuf::from(
+            "/usr/local/bin/idb_companion",
+        ))));
+        assert_eq!(c.status, CheckStatus::Fail);
+        let remedy = c
+            .remedy
+            .as_deref()
+            .expect("an unrunnable binary has a remedy");
+        assert!(
+            remedy.contains("chmod +x /usr/local/bin/idb_companion"),
+            "remedy must name the permission fix on the real path: {remedy}"
+        );
+        assert_ne!(
+            remedy, INSTALL_REMEDY,
+            "the companion is installed — reinstalling it changes nothing"
+        );
+    }
+
+    #[test]
+    fn a_companion_that_is_nowhere_points_at_the_install() {
+        let c = resolution_check(&discovered(Resolved::Absent));
+        assert_eq!(c.status, CheckStatus::Fail);
+        assert_eq!(c.remedy.as_deref(), Some(INSTALL_REMEDY));
+    }
+
+    /// glass#373: MCP clients routinely spawn glass-mcp with a stripped environment. "Not found"
+    /// there is a claim the check never established.
+    #[test]
+    fn a_companion_that_could_not_be_looked_up_says_so_rather_than_not_found() {
+        let c = resolution_check(&discovered(Resolved::NoSearchPath));
+        assert_eq!(c.status, CheckStatus::Fail);
+        assert!(
+            c.detail.contains("PATH"),
+            "detail must name the unset PATH: {}",
+            c.detail
+        );
+        let remedy = c
+            .remedy
+            .as_deref()
+            .expect("a stripped environment has a remedy");
+        assert!(
+            remedy.contains("GLASS_IDB_COMPANION"),
+            "remedy must name the override that needs no PATH: {remedy}"
+        );
+    }
+
+    /// An override skips discovery, so "not found — brew install" would prescribe a fix that
+    /// changes nothing: glass would still read only the variable.
+    #[test]
+    fn an_override_that_names_nothing_blames_the_variable_not_the_install() {
+        let c = resolution_check(&CompanionFacts {
+            resolved: Resolved::Absent,
+            override_set: true,
+        });
+        assert_eq!(c.status, CheckStatus::Fail);
+        assert!(
+            c.detail.contains("GLASS_IDB_COMPANION"),
+            "detail must name the variable that decided this: {}",
+            c.detail
+        );
+        assert_ne!(
+            c.remedy.as_deref(),
+            Some(INSTALL_REMEDY),
+            "installing another copy would not be looked at while the override stands"
+        );
+    }
+
+    #[test]
+    fn a_deep_check_probes_the_binary_the_resolution_found() {
+        let probed = std::cell::Cell::new(String::new());
+        let c = check_for(
+            &discovered(Resolved::Found(PathBuf::from(
+                "/opt/homebrew/bin/idb_companion",
+            ))),
+            true,
+            |bin| {
+                probed.set(bin.display().to_string());
+                CompanionProbe::Started
+            },
+        );
+        assert_eq!(
+            probed.take(),
+            "/opt/homebrew/bin/idb_companion",
+            "the probe must start the binary the check reported, not resolve a second time"
+        );
+        assert_eq!(c.status, CheckStatus::Ok);
+    }
+
+    /// A binary glass cannot execute needs no spawn to prove it: probing would report a
+    /// permission failure as if the companion were broken, burying the fix.
+    #[test]
+    fn a_deep_check_never_probes_a_binary_it_already_knows_it_cannot_run() {
+        let c = check_for(
+            &discovered(Resolved::NotExecutable(PathBuf::from(
+                "/usr/local/bin/idb_companion",
+            ))),
+            true,
+            |_| panic!("an unrunnable binary must not be spawned"),
+        );
+        assert_eq!(c.status, CheckStatus::Fail);
+        assert!(
+            c.remedy
+                .as_deref()
+                .is_some_and(|r| r.contains("chmod +x /usr/local/bin/idb_companion")),
+            "remedy must still be the permission fix: {:?}",
+            c.remedy
+        );
+    }
+
+    #[test]
+    fn a_shallow_check_never_probes_at_all() {
+        let c = check_for(
+            &discovered(Resolved::Found(PathBuf::from(
+                "/opt/homebrew/bin/idb_companion",
+            ))),
+            false,
+            |_| panic!("a check without --deep must not spawn the companion"),
+        );
+        assert_eq!(c.status, CheckStatus::Ok);
+    }
+
+    #[test]
+    fn deep_check_maps_every_probe_outcome() {
+        let started = deep_check(&CompanionProbe::Started);
+        assert_eq!(started.status, CheckStatus::Ok);
+        assert_eq!(started.remedy, None);
+
+        let unverified = deep_check(&CompanionProbe::SelfTestOk);
+        assert_eq!(unverified.status, CheckStatus::Warn);
+
+        let broken = deep_check(&CompanionProbe::FailedToStart("exited 1: boom".into()));
+        assert_eq!(broken.status, CheckStatus::Fail);
+        assert!(
+            broken.detail.contains("boom"),
+            "cause must surface: {}",
+            broken.detail
+        );
+        assert_eq!(broken.remedy.as_deref(), Some(INSTALL_REMEDY));
+
+        let unrunnable = deep_check(&CompanionProbe::SelfTestFailed("spawn: nope".into()));
+        assert_eq!(unrunnable.status, CheckStatus::Fail);
+        assert!(
+            unrunnable.detail.contains("nope"),
+            "cause must surface: {}",
+            unrunnable.detail
+        );
+    }
+
     #[test]
     fn self_test_ok_when_binary_exits_zero() {
         // `/bin/echo --version` prints and exits 0 regardless of args — stands in for a
         // healthy idb_companion whose real `--version` also exits 0.
-        assert_eq!(self_test_with("/bin/echo"), CompanionProbe::SelfTestOk);
+        assert_eq!(
+            self_test_with(Path::new("/bin/echo")),
+            CompanionProbe::SelfTestOk
+        );
     }
 
     #[test]
@@ -866,7 +1163,7 @@ mod tests {
         let script = dir.path().join("fake_companion");
         std::fs::write(&script, "#!/bin/sh\necho 'boom-from-stderr' >&2\nexit 3\n").expect("write");
         std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).expect("chmod");
-        let bin = script.to_str().unwrap();
+        let bin = script.as_path();
 
         // Retry past a transient ETXTBSY ("Text file busy", os error 26): `cargo test` runs
         // tests on parallel threads, and a sibling thread's `Command::spawn` (fork) can
@@ -897,7 +1194,7 @@ mod tests {
 
     #[test]
     fn self_test_fails_when_binary_is_unspawnable() {
-        match self_test_with("/nonexistent/definitely-not-a-binary") {
+        match self_test_with(Path::new("/nonexistent/definitely-not-a-binary")) {
             CompanionProbe::SelfTestFailed(cause) => {
                 assert!(
                     cause.contains("spawn"),

--- a/crates/glass-ios/src/doctor.rs
+++ b/crates/glass-ios/src/doctor.rs
@@ -322,9 +322,8 @@ fn read_trimmed(path: &Path) -> Option<String> {
         .map(|s| s.trim().to_string())
 }
 
-/// Whether this host has an `idb_companion` glass can actually run — the gate on the iOS
-/// input and accessibility capabilities. The launch path's own verdict, not a second reading of
-/// the resolution that could disagree with it.
+/// Whether this host has an `idb_companion` glass can actually run — the launch path's own
+/// verdict, gating the iOS input and accessibility capabilities.
 pub(crate) fn companion_runnable() -> bool {
     gather().spawn_target().is_ok()
 }
@@ -342,8 +341,8 @@ pub fn companion_check(deep: bool) -> Check {
     check_for(&gather(), deep, probe_companion)
 }
 
-/// [`companion_check`] over gathered facts, with the probe injected — the seam that pins which
-/// resolutions are worth a real companion start without one running here.
+/// [`companion_check`] over gathered facts, with the probe injected — the seam a test drives
+/// without a companion running here.
 fn check_for(
     facts: &CompanionFacts,
     deep: bool,
@@ -358,7 +357,7 @@ fn check_for(
 }
 
 /// Pure: what a resolution means for the operator, rendering the launch path's own
-/// [`NoCompanion`] so the two cannot drift about the same file.
+/// `NoCompanion`.
 ///
 /// A companion glass cannot run is a **Fail**, not a Warn: unlike android, which keeps barebones
 /// function without its companions, iOS cannot drive apps at all without this one. The aggregator
@@ -964,9 +963,7 @@ mod tests {
         assert_eq!(c.remedy, None);
     }
 
-    /// glass#393: an `idb_companion` that is installed and unrunnable used to read as missing,
-    /// sending the user to reinstall a package that is already there. It has to name the file
-    /// and the permission fix instead.
+    /// glass#393 at the message layer: the file and the permission fix, not another install.
     #[test]
     fn a_companion_that_cannot_be_executed_is_told_apart_from_a_missing_one() {
         let c = resolution_check(&discovered(Resolved::NotExecutable(PathBuf::from(

--- a/crates/glass-ios/src/doctor.rs
+++ b/crates/glass-ios/src/doctor.rs
@@ -1,9 +1,10 @@
-//! `glass doctor` checks for the iOS Simulator backend: is a full Xcode install active,
-//! does `xcrun simctl` work, is at least one iOS runtime downloaded, and is the target glass would
-//! resolve at start actually driveable?
+//! `glass doctor` checks for the iOS Simulator backend: is a full Xcode install active, does
+//! `xcrun simctl` work, is at least one iOS runtime downloaded, is the target glass would resolve
+//! at start actually driveable, and is there an `idb_companion` glass can run?
 //!
-//! Pure `build_checks(&Probe)` over observed state, plus the thin subprocess-probing
-//! `checks(deep)` entry point the aggregator calls.
+//! Two entry points for the aggregator: `checks(deep)`, the thin subprocess-probing wrapper over
+//! the pure `build_checks(&Probe)`, and `companion_check(deep)`, which carries the iOS backend's
+//! only expensive probe.
 
 use std::path::Path;
 use std::process::{Command, Stdio};
@@ -13,7 +14,7 @@ use glass_core::{Check, CheckStatus, GlassError};
 use glass_exec_unix::Resolved;
 
 use crate::device::{Resolve, SimDevice, parse_devices, resolve};
-use crate::idb::companion::{CompanionFacts, IdbCompanion};
+use crate::idb::companion::{CompanionFacts, INSTALL_REMEDY, IdbCompanion};
 use crate::simctl::Simctl;
 use crate::target::wants;
 
@@ -185,7 +186,8 @@ const PROBE_BUDGET: Duration = Duration::from_secs(10);
 /// Build the iOS doctor checks by probing the host with real `xcrun`/`xcode-select`
 /// calls. Best-effort: a missing tool simply makes the corresponding check report
 /// not-ok with a remedy, rather than failing this function. `_deep` is accepted for
-/// signature parity with the other backends' doctors; iOS has no expensive deep probe.
+/// signature parity with the other backends' doctors; iOS's only deep probe is
+/// [`companion_check`].
 pub fn checks(_deep: bool) -> Vec<Check> {
     // Bounded like every other one-shot: doctor's job is to report, and a doctor that hangs on a
     // wedged tool reports nothing at all. A timeout lands in the same `None` as a missing tool,
@@ -301,7 +303,13 @@ fn self_test_with(bin: &Path) -> CompanionProbe {
                 ));
             }
             Ok(None) => std::thread::sleep(SELF_TEST_POLL),
-            Err(e) => break CompanionProbe::SelfTestFailed(format!("try_wait: {e}")),
+            // Reap before giving up: a wait glass could not make is no reason to leave the
+            // child running for the life of the server.
+            Err(e) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                break CompanionProbe::SelfTestFailed(format!("try_wait: {e}"));
+            }
         }
     }
     // `log` (a `NamedTempFile`) removes its file on drop here.
@@ -315,19 +323,20 @@ fn read_trimmed(path: &Path) -> Option<String> {
 }
 
 /// Whether this host has an `idb_companion` glass can actually run — the gate on the iOS
-/// input and accessibility capabilities.
+/// input and accessibility capabilities. The launch path's own verdict, not a second reading of
+/// the resolution that could disagree with it.
 pub(crate) fn companion_runnable() -> bool {
-    matches!(gather().resolved, Resolved::Found(_))
+    gather().spawn_target().is_ok()
 }
 
 /// What this host has, read from the real environment.
 fn gather() -> CompanionFacts {
-    CompanionFacts::gather(&|k| std::env::var(k).ok())
+    CompanionFacts::gather(&|k| std::env::var_os(k))
 }
 
 /// The `idb_companion` line for `glass doctor`, and — with `deep` — the health probe behind it.
 ///
-/// `deep` costs a real companion start, which is why the aggregator gates it on iOS being the
+/// `deep` can cost a real companion start, which is why the aggregator gates it on iOS being the
 /// selected backend while emitting the line either way.
 pub fn companion_check(deep: bool) -> Check {
     check_for(&gather(), deep, probe_companion)
@@ -343,92 +352,58 @@ fn check_for(
     match &facts.resolved {
         // Only a runnable binary is worth starting: probing any other outcome would report a
         // spawn failure whose cause is the resolution the check already has in hand.
-        Resolved::Found(bin) if deep => deep_check(&probe(bin)),
+        Resolved::Found(bin) if deep => deep_check(bin, &probe(bin)),
         _ => resolution_check(facts),
     }
 }
 
-/// The shared `idb_companion` install remedy.
-const INSTALL_REMEDY: &str =
-    "brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion";
-
-/// Pure: what a resolution means for the operator.
+/// Pure: what a resolution means for the operator, rendering the launch path's own
+/// [`NoCompanion`] so the two cannot drift about the same file.
 ///
 /// A companion glass cannot run is a **Fail**, not a Warn: unlike android, which keeps barebones
 /// function without its companions, iOS cannot drive apps at all without this one. The aggregator
 /// softens that to a Warn when iOS is not the selected backend.
 fn resolution_check(facts: &CompanionFacts) -> Check {
-    match &facts.resolved {
-        Resolved::Found(p) => Check::new(
+    match facts.spawn_target() {
+        Ok(p) => Check::new(
             "idb_companion",
             CheckStatus::Ok,
             format!("{} — input + accessibility are available", p.display()),
         ),
-        // It is installed; what it needs is permission, not another `brew install`.
-        Resolved::NotExecutable(p) => Check::new(
+        Err(no) => Check::new(
             "idb_companion",
             CheckStatus::Fail,
             format!(
-                "{} — not executable; input + accessibility are unavailable (iOS cannot drive apps)",
-                p.display()
+                "{} — input + accessibility are unavailable (iOS cannot drive apps)",
+                no.cause
             ),
         )
-        .with_remedy(format!(
-            "chmod +x {}, or point GLASS_IDB_COMPANION at a runnable binary",
-            p.display()
-        )),
-        // An override skips discovery, so the variable — not what this host has installed —
-        // is what left glass with nothing.
-        Resolved::Absent if facts.override_set => Check::new(
-            "idb_companion",
-            CheckStatus::Fail,
-            "GLASS_IDB_COMPANION does not name a runnable idb_companion — input + accessibility \
-             are unavailable (iOS cannot drive apps)",
-        )
-        .with_remedy(
-            "point GLASS_IDB_COMPANION at a runnable idb_companion, or unset it to search PATH \
-             and Homebrew's standard prefixes",
-        ),
-        Resolved::Absent => not_found_check(),
-        // Nothing was looked up, so "not found" would be a claim this check never established
-        // (glass#373).
-        Resolved::NoSearchPath => Check::new(
-            "idb_companion",
-            CheckStatus::Fail,
-            "idb_companion could not be looked up — PATH is unset in glass's environment",
-        )
-        .with_remedy(format!(
-            "set GLASS_IDB_COMPANION to its absolute path, give glass a PATH to search, or \
-             install it: {INSTALL_REMEDY}"
-        )),
+        .with_remedy(no.remedy),
     }
-}
-
-/// The Fail for a companion that is nowhere to be found.
-fn not_found_check() -> Check {
-    Check::new(
-        "idb_companion",
-        CheckStatus::Fail,
-        "idb_companion not found — input + accessibility are unavailable (iOS cannot drive apps)",
-    )
-    .with_remedy(INSTALL_REMEDY)
 }
 
 /// Pure: what a `--deep` probe proved. Broken (`FailedToStart`/`SelfTestFailed`) ⇒ Fail: iOS
 /// cannot drive apps without the companion. Unverified (`SelfTestOk` — the binary runs but no
 /// booted simulator was available to exercise a real start) ⇒ Warn.
-fn deep_check(probe: &CompanionProbe) -> Check {
+fn deep_check(bin: &Path, probe: &CompanionProbe) -> Check {
     match probe {
+        // The failure arms name the binary through their cause, which the spawn error carries.
         CompanionProbe::Started => Check::new(
             "idb_companion",
             CheckStatus::Ok,
-            "started and served its gRPC socket — input + accessibility are available",
+            format!(
+                "{} started and served its gRPC socket — input + accessibility are available",
+                bin.display()
+            ),
         ),
         CompanionProbe::SelfTestOk => Check::new(
             "idb_companion",
             CheckStatus::Warn,
-            "binary runs, but no booted simulator was available to verify a real start — \
-             boot one and re-run with --deep to exercise the companion",
+            format!(
+                "{} runs, but no booted simulator was available to verify a real start — boot \
+                 one and re-run with --deep to exercise the companion",
+                bin.display()
+            ),
         ),
         CompanionProbe::FailedToStart(cause) => Check::new(
             "idb_companion",
@@ -998,13 +973,18 @@ mod tests {
             "/usr/local/bin/idb_companion",
         ))));
         assert_eq!(c.status, CheckStatus::Fail);
+        assert!(
+            c.detail.contains("/usr/local/bin/idb_companion"),
+            "detail must name the file the operator has to fix: {}",
+            c.detail
+        );
         let remedy = c
             .remedy
             .as_deref()
             .expect("an unrunnable binary has a remedy");
         assert!(
-            remedy.contains("chmod +x /usr/local/bin/idb_companion"),
-            "remedy must name the permission fix on the real path: {remedy}"
+            remedy.contains("chmod +x"),
+            "remedy must name the permission fix: {remedy}"
         );
         assert_ne!(
             remedy, INSTALL_REMEDY,
@@ -1054,10 +1034,39 @@ mod tests {
             "detail must name the variable that decided this: {}",
             c.detail
         );
+        let remedy = c.remedy.as_deref().expect("a Fail names its fix");
+        assert!(
+            remedy.contains("unset it"),
+            "remedy must offer the way back to discovery: {remedy}"
+        );
         assert_ne!(
-            c.remedy.as_deref(),
-            Some(INSTALL_REMEDY),
+            remedy, INSTALL_REMEDY,
             "installing another copy would not be looked at while the override stands"
+        );
+    }
+
+    /// A bare-name override with no `$PATH` — the one way an override reaches `NoSearchPath`.
+    /// The discovery-flavoured "set GLASS_IDB_COMPANION" would be what they already did.
+    #[test]
+    fn a_bare_name_override_with_no_path_is_told_apart_from_a_stripped_environment() {
+        let c = resolution_check(&CompanionFacts {
+            resolved: Resolved::NoSearchPath,
+            override_set: true,
+        });
+        assert_eq!(c.status, CheckStatus::Fail);
+        assert!(
+            c.detail.contains("GLASS_IDB_COMPANION"),
+            "detail must name the variable it searched for: {}",
+            c.detail
+        );
+        let remedy = c.remedy.as_deref().expect("a Fail names its fix");
+        assert!(
+            remedy.contains("absolute path"),
+            "remedy must ask for an absolute path: {remedy}"
+        );
+        assert!(
+            !remedy.contains("brew install"),
+            "an override in force means another install would not be read: {remedy}"
         );
     }
 
@@ -1095,9 +1104,7 @@ mod tests {
         );
         assert_eq!(c.status, CheckStatus::Fail);
         assert!(
-            c.remedy
-                .as_deref()
-                .is_some_and(|r| r.contains("chmod +x /usr/local/bin/idb_companion")),
+            c.remedy.as_deref().is_some_and(|r| r.contains("chmod +x")),
             "remedy must still be the permission fix: {:?}",
             c.remedy
         );
@@ -1117,14 +1124,16 @@ mod tests {
 
     #[test]
     fn deep_check_maps_every_probe_outcome() {
-        let started = deep_check(&CompanionProbe::Started);
+        let bin = Path::new("/opt/homebrew/bin/idb_companion");
+
+        let started = deep_check(bin, &CompanionProbe::Started);
         assert_eq!(started.status, CheckStatus::Ok);
         assert_eq!(started.remedy, None);
 
-        let unverified = deep_check(&CompanionProbe::SelfTestOk);
+        let unverified = deep_check(bin, &CompanionProbe::SelfTestOk);
         assert_eq!(unverified.status, CheckStatus::Warn);
 
-        let broken = deep_check(&CompanionProbe::FailedToStart("exited 1: boom".into()));
+        let broken = deep_check(bin, &CompanionProbe::FailedToStart("exited 1: boom".into()));
         assert_eq!(broken.status, CheckStatus::Fail);
         assert!(
             broken.detail.contains("boom"),
@@ -1133,13 +1142,33 @@ mod tests {
         );
         assert_eq!(broken.remedy.as_deref(), Some(INSTALL_REMEDY));
 
-        let unrunnable = deep_check(&CompanionProbe::SelfTestFailed("spawn: nope".into()));
+        let unrunnable = deep_check(bin, &CompanionProbe::SelfTestFailed("spawn: nope".into()));
         assert_eq!(unrunnable.status, CheckStatus::Fail);
         assert!(
             unrunnable.detail.contains("nope"),
             "cause must surface: {}",
             unrunnable.detail
         );
+        assert_eq!(
+            unrunnable.remedy.as_deref(),
+            Some(INSTALL_REMEDY),
+            "a binary that will not execute still needs a way out"
+        );
+    }
+
+    /// The shallow line names the binary that answered; a green `--deep` line has no less reason
+    /// to. The failure arms name it through the spawn error they quote.
+    #[test]
+    fn a_green_deep_check_names_the_binary_it_started() {
+        let bin = Path::new("/opt/homebrew/bin/idb_companion");
+        for probe in [CompanionProbe::Started, CompanionProbe::SelfTestOk] {
+            let c = deep_check(bin, &probe);
+            assert!(
+                c.detail.contains("/opt/homebrew/bin/idb_companion"),
+                "{probe:?} must name the binary: {}",
+                c.detail
+            );
+        }
     }
 
     #[test]

--- a/crates/glass-ios/src/idb/companion.rs
+++ b/crates/glass-ios/src/idb/companion.rs
@@ -1,7 +1,7 @@
 //! Spawns and owns the `idb_companion` process bound to one simulator UDID, and
 //! exposes the Unix socket it serves gRPC on. Killing the child on Drop reaps it
 //! (Child::drop does NOT kill), mirroring glass-android's AgentRegistry lifetime.
-use std::ffi::OsStr;
+use std::ffi::OsString;
 use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
@@ -21,7 +21,7 @@ const SOCKET_POLL_INTERVAL: Duration = Duration::from_millis(200);
 /// How long to wait for the companion to open its socket before giving up.
 const SOCKET_READY_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// Standard Homebrew `idb_companion` locations, probed when it is not on `PATH`. A `.app` or
+/// Standard Homebrew `idb_companion` locations, probed when `$PATH` yields no runnable copy. A `.app` or
 /// LaunchAgent glass is launched by launchd with a minimal `PATH` that omits Homebrew's bindir,
 /// so a `brew install idb-companion` would otherwise be invisible and input/accessibility would
 /// go dark with no way for the user to fix it short of setting an env var. Apple-silicon prefix
@@ -35,10 +35,74 @@ const HOMEBREW_COMPANION_PATHS: [&str; 2] = [
 const COMPANION_ENV: &str = "GLASS_IDB_COMPANION";
 /// The companion's program name, looked up on `$PATH` when nothing names it outright.
 const COMPANION_BIN: &str = "idb_companion";
+/// The install, tap first — `idb_companion` is not in Homebrew core.
+pub(crate) const INSTALL_REMEDY: &str =
+    "brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion";
 
-/// What glass knows about this host's `idb_companion`: the resolution, and whether
-/// `GLASS_IDB_COMPANION` decided it. A struct rather than loose arguments so the two cannot be
-/// handed over in the wrong order.
+/// Why there is no companion to run. Two fields: the doctor prints cause and fix in separate
+/// columns, the launch path joins them into one message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NoCompanion {
+    pub(crate) cause: String,
+    pub(crate) remedy: String,
+}
+
+impl NoCompanion {
+    fn not_executable(p: &Path) -> NoCompanion {
+        NoCompanion {
+            cause: format!("idb_companion at {} is not executable", p.display()),
+            remedy: "restore its execute bit (`chmod +x`), or point GLASS_IDB_COMPANION at a \
+                     runnable binary"
+                .into(),
+        }
+    }
+
+    /// An override skips discovery, so another install would not be looked at either.
+    fn override_names_nothing() -> NoCompanion {
+        NoCompanion {
+            cause: "GLASS_IDB_COMPANION does not name a runnable idb_companion".into(),
+            remedy: "point GLASS_IDB_COMPANION at a runnable idb_companion, or unset it to \
+                     search PATH and Homebrew's standard prefixes"
+                .into(),
+        }
+    }
+
+    fn absent() -> NoCompanion {
+        NoCompanion {
+            cause: "idb_companion not found".into(),
+            remedy: INSTALL_REMEDY.into(),
+        }
+    }
+
+    /// A bare name is all `$PATH` can resolve, and there is no `$PATH`.
+    fn override_needs_a_path() -> NoCompanion {
+        NoCompanion {
+            cause: "GLASS_IDB_COMPANION names a bare command, and PATH is unset in glass's \
+                    environment"
+                .into(),
+            remedy: "set GLASS_IDB_COMPANION to an absolute path".into(),
+        }
+    }
+
+    fn no_search_path() -> NoCompanion {
+        NoCompanion {
+            cause: "idb_companion could not be looked up — PATH is unset in glass's environment"
+                .into(),
+            remedy: format!(
+                "set GLASS_IDB_COMPANION to its absolute path, give glass a PATH to search, or \
+                 install it: {INSTALL_REMEDY}"
+            ),
+        }
+    }
+
+    /// Cause and fix in one string, for the launch path's single error message.
+    fn message(&self) -> String {
+        format!("{} — {}", self.cause, self.remedy)
+    }
+}
+
+/// What glass knows about this host's `idb_companion`, from one read of the environment.
+#[derive(Debug)]
 pub(crate) struct CompanionFacts {
     /// This host's `idb_companion`, or why there is none.
     pub(crate) resolved: Resolved,
@@ -48,72 +112,57 @@ pub(crate) struct CompanionFacts {
 }
 
 impl CompanionFacts {
-    /// Read the environment once, and resolve from it.
-    pub(crate) fn gather(get: &dyn Fn(&str) -> Option<String>) -> CompanionFacts {
+    /// Resolve from one read of the environment, so the two fields cannot describe different
+    /// moments — `override_set` is true exactly when the resolution took the override branch.
+    pub(crate) fn gather(get: &dyn Fn(&str) -> Option<OsString>) -> CompanionFacts {
+        // An override set to "" is how a wrapper clears it, and a non-UTF-8 value cannot be a
+        // program token `exec` would take; neither is an override.
+        let over = get(COMPANION_ENV)
+            .and_then(|v| v.into_string().ok())
+            .filter(|s| !s.is_empty());
         CompanionFacts {
-            resolved: resolve_companion(get),
-            override_set: get(COMPANION_ENV).is_some_and(|s| !s.is_empty()),
+            override_set: over.is_some(),
+            resolved: resolve_companion_with(over, get("PATH"), &HOMEBREW_COMPANION_PATHS),
         }
     }
 
     /// The binary to hand `Command::new`, or why there is none.
     ///
     /// A binary glass cannot run is refused here, not exec'd: `exec` comes back with a bare
-    /// `EACCES` where the resolution already knows the file and the fix. One mapping, so the
-    /// preflight and the bring-up cannot disagree.
-    pub(crate) fn spawn_target(&self) -> std::result::Result<&Path, String> {
+    /// `EACCES` where the resolution already knows the file and the fix. The doctor renders the
+    /// same [`NoCompanion`], so the preflight and the bring-up cannot disagree.
+    pub(crate) fn spawn_target(&self) -> std::result::Result<&Path, NoCompanion> {
         match &self.resolved {
             Resolved::Found(p) => Ok(p),
-            Resolved::NotExecutable(p) => Err(format!(
-                "idb_companion at {} is not executable — chmod +x it, or point \
-                 GLASS_IDB_COMPANION at a runnable binary",
-                p.display()
-            )),
-            // An override skips discovery, so installing another copy would not be read either.
-            Resolved::Absent if self.override_set => Err(
-                "GLASS_IDB_COMPANION does not name a runnable idb_companion — point it at one, \
-                 or unset it to search PATH and Homebrew's standard prefixes"
-                    .into(),
-            ),
-            Resolved::Absent => Err(
-                "idb_companion not found (install: brew install idb-companion), or set \
-                 GLASS_IDB_COMPANION to its path"
-                    .into(),
-            ),
-            Resolved::NoSearchPath => Err(
-                "idb_companion could not be looked up — PATH is unset in glass's environment; \
-                 set GLASS_IDB_COMPANION to its path"
-                    .into(),
-            ),
+            Resolved::NotExecutable(p) => Err(NoCompanion::not_executable(p)),
+            Resolved::Absent if self.override_set => Err(NoCompanion::override_names_nothing()),
+            Resolved::Absent => Err(NoCompanion::absent()),
+            Resolved::NoSearchPath if self.override_set => {
+                Err(NoCompanion::override_needs_a_path())
+            }
+            Resolved::NoSearchPath => Err(NoCompanion::no_search_path()),
         }
     }
 }
 
-/// This host's `idb_companion`, or why there is none.
-///
-/// One resolution, shared by the runtime spawn and `glass doctor`: a second lookup would let
-/// one run answer both "present" and "not found" about one file (glass#391).
-fn resolve_companion(get: &dyn Fn(&str) -> Option<String>) -> Resolved {
-    resolve_companion_with(get(COMPANION_ENV), get("PATH"), &HOMEBREW_COMPANION_PATHS)
-}
-
-/// [`resolve_companion`] against explicit inputs — the testable seam. The Homebrew prefixes are
-/// injected too, so a test cannot be answered by the developer's own `brew install`.
+/// [`CompanionFacts::gather`]'s resolution against explicit inputs — the testable seam. The
+/// Homebrew prefixes are injected too, so a test cannot be answered by the developer's own
+/// `brew install`. `override_value` is already normalised: `Some` means an override is in force.
 ///
 /// `GLASS_IDB_COMPANION` names the companion outright and is never searched for among
 /// `fallbacks`, though a bare name still goes through `$PATH`; discovery walks `$PATH` first and
 /// `fallbacks` only once it runs dry.
 fn resolve_companion_with(
     override_value: Option<String>,
-    path: Option<String>,
+    path: Option<OsString>,
     fallbacks: &[&str],
 ) -> Resolved {
-    if let Some(bin) = override_value.filter(|s| !s.is_empty()) {
-        return resolve_bin(&bin, path.as_deref().map(OsStr::new));
+    if let Some(bin) = override_value {
+        return resolve_bin(&bin, path.as_deref());
     }
     let mut first_unrunnable = None;
     let mut nothing_to_search = false;
-    for resolved in std::iter::once(resolve_bin(COMPANION_BIN, path.as_deref().map(OsStr::new)))
+    for resolved in std::iter::once(resolve_bin(COMPANION_BIN, path.as_deref()))
         .chain(fallbacks.iter().map(|c| resolve_path(Path::new(c))))
     {
         match resolved {
@@ -127,6 +176,8 @@ fn resolve_companion_with(
         }
     }
     match (first_unrunnable, nothing_to_search) {
+        // A file the user can act on outranks the missing search list, and the remedy's second
+        // clause covers a copy that a `$PATH` would have found.
         (Some(p), _) => Resolved::NotExecutable(p),
         // No `$PATH` to walk and nothing in the standard prefixes: the companion may well be
         // installed somewhere glass was never told to look (glass#373).
@@ -173,8 +224,10 @@ impl IdbCompanion {
     /// or a socket that never comes up leaves no child behind: both paths
     /// kill + reap before returning `Err`.
     pub fn spawn(udid: &str) -> Result<IdbCompanion> {
-        let facts = CompanionFacts::gather(&|k| std::env::var(k).ok());
-        let bin = facts.spawn_target().map_err(GlassError::Backend)?;
+        let facts = CompanionFacts::gather(&|k| std::env::var_os(k));
+        let bin = facts
+            .spawn_target()
+            .map_err(|no| GlassError::Backend(no.message()))?;
         Self::spawn_bin(udid, bin)
     }
 
@@ -225,9 +278,14 @@ impl IdbCompanion {
             .spawn()
             .map_err(|e| {
                 let _ = std::fs::remove_file(&stderr_log);
-                // No install hint: resolution already refused a companion that is missing or
-                // unrunnable, so what lands here is a binary that changed underneath it.
-                GlassError::Backend(format!("spawn {}: {e}", bin.display()))
+                // Resolution asked `access(X_OK)`, which answers permission and not whether
+                // the file is a loadable image — an x86_64 companion from the Intel prefix on an
+                // arm64 Mac without Rosetta resolves and fails here — so this keeps a remedy.
+                GlassError::Backend(format!(
+                    "spawn {}: {e} — the binary resolved but did not start; check it matches \
+                     this Mac's architecture, or reinstall it: {INSTALL_REMEDY}",
+                    bin.display()
+                ))
             })?;
         let mut this = IdbCompanion {
             child,
@@ -334,6 +392,7 @@ fn socket_ready(sock: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsStr;
     use std::os::unix::fs::PermissionsExt;
 
     /// A directory holding `name` at `mode`. Real files at real modes, because resolution asks
@@ -347,14 +406,19 @@ mod tests {
         dir
     }
 
-    /// A `$PATH`-style value naming `dirs`, in the `String` shape the env getter yields.
-    fn path_of(dirs: &[&Path]) -> Option<String> {
-        Some(
-            std::env::join_paths(dirs)
-                .expect("join paths")
-                .into_string()
-                .expect("utf-8 temp paths"),
-        )
+    /// A `$PATH`-style value naming `dirs`.
+    fn path_of(dirs: &[&Path]) -> Option<OsString> {
+        Some(std::env::join_paths(dirs).expect("join paths"))
+    }
+
+    /// An env getter over a fixed set of pairs, in the shape [`CompanionFacts::gather`] reads.
+    fn env<'a>(pairs: &'a [(&'a str, &'a OsStr)]) -> impl Fn(&str) -> Option<OsString> + 'a {
+        move |k: &str| {
+            pairs
+                .iter()
+                .find(|(name, _)| *name == k)
+                .map(|(_, v)| v.to_os_string())
+        }
     }
 
     /// The `fallbacks` entry naming `dir`'s companion.
@@ -465,12 +529,53 @@ mod tests {
         );
     }
 
-    /// An unset `GLASS_IDB_COMPANION` and one set to the empty string mean the same thing.
+    /// An unset `GLASS_IDB_COMPANION` and one set to the empty string mean the same thing — and
+    /// both fields have to say so, or the doctor blames a variable that decided nothing.
     #[test]
-    fn an_empty_override_falls_through_to_discovery() {
+    fn an_empty_override_is_not_an_override() {
         let dir = dir_with(COMPANION_BIN, 0o755);
+        let facts = CompanionFacts::gather(&env(&[
+            (COMPANION_ENV, OsStr::new("")),
+            ("PATH", dir.path().as_os_str()),
+        ]));
+        assert!(!facts.override_set, "an empty override is not one");
         assert_eq!(
-            resolve_companion_with(Some(String::new()), path_of(&[dir.path()]), &[]),
+            facts.resolved,
+            Resolved::Found(dir.path().join(COMPANION_BIN)),
+            "discovery must have run"
+        );
+    }
+
+    /// The gathering wiring: `$PATH` really is the list discovery walks, and a set override
+    /// really does record itself.
+    #[test]
+    fn gather_walks_the_path_it_was_given_and_records_a_set_override() {
+        let dir = dir_with(COMPANION_BIN, 0o755);
+        let found = CompanionFacts::gather(&env(&[("PATH", dir.path().as_os_str())]));
+        assert_eq!(
+            found.resolved,
+            Resolved::Found(dir.path().join(COMPANION_BIN))
+        );
+        assert!(!found.override_set);
+
+        let bin = dir.path().join(COMPANION_BIN);
+        let overridden = CompanionFacts::gather(&env(&[(COMPANION_ENV, bin.as_os_str())]));
+        assert!(overridden.override_set);
+        assert_eq!(overridden.resolved, Resolved::Found(bin));
+    }
+
+    /// A `$PATH` that is not UTF-8 is still a search list. Reading it as a `String` would drop it
+    /// and report "PATH is unset", a claim the walk never established.
+    #[test]
+    fn a_non_utf8_path_is_still_searched() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let dir = dir_with(COMPANION_BIN, 0o755);
+        let mut raw = dir.path().as_os_str().to_os_string();
+        raw.push(OsStr::from_bytes(b":/\xff\xfe"));
+        let facts = CompanionFacts::gather(&env(&[("PATH", &raw)]));
+        assert_eq!(
+            facts.resolved,
             Resolved::Found(dir.path().join(COMPANION_BIN))
         );
     }
@@ -532,6 +637,18 @@ mod tests {
         );
     }
 
+    /// Both facts are observed at once: no `$PATH` to search AND an unrunnable copy in a prefix.
+    /// The file the user can act on wins — reporting "PATH is unset" would send them to fix an
+    /// environment when there is a companion right there to `chmod`.
+    #[test]
+    fn an_unrunnable_prefix_copy_outranks_a_missing_search_list() {
+        let brew = dir_with(COMPANION_BIN, 0o644);
+        assert_eq!(
+            resolve_companion_with(None, None, &[&candidate(&brew)]),
+            Resolved::NotExecutable(brew.path().join(COMPANION_BIN))
+        );
+    }
+
     /// A companion found in a prefix answers the question outright, so a missing `$PATH` is not
     /// worth reporting.
     #[test]
@@ -551,6 +668,14 @@ mod tests {
         }
     }
 
+    /// Gathered facts for a resolution `GLASS_IDB_COMPANION` decided.
+    fn overridden(resolved: Resolved) -> CompanionFacts {
+        CompanionFacts {
+            resolved,
+            override_set: true,
+        }
+    }
+
     #[test]
     fn the_spawn_runs_the_binary_resolution_found() {
         let bin = PathBuf::from("/opt/homebrew/bin/idb_companion");
@@ -564,53 +689,98 @@ mod tests {
     /// resolution already knows the file and the fix.
     #[test]
     fn a_companion_it_cannot_run_is_refused_by_name_rather_than_spawned() {
-        let why = discovered(Resolved::NotExecutable(PathBuf::from(
+        let no = discovered(Resolved::NotExecutable(PathBuf::from(
             "/usr/local/bin/idb_companion",
         )))
         .spawn_target()
         .expect_err("an unrunnable companion must not be spawned");
         assert!(
-            why.contains("/usr/local/bin/idb_companion") && why.contains("chmod +x"),
-            "must name the file and the permission fix: {why}"
+            no.cause.contains("/usr/local/bin/idb_companion"),
+            "the cause must name the file: {}",
+            no.cause
+        );
+        assert!(
+            no.remedy.contains("chmod +x"),
+            "the remedy must be the permission fix: {}",
+            no.remedy
         );
     }
 
     #[test]
     fn a_companion_that_is_nowhere_is_refused_with_the_install() {
-        let why = discovered(Resolved::Absent)
+        let no = discovered(Resolved::Absent)
             .spawn_target()
             .expect_err("a missing companion cannot be spawned");
+        assert_eq!(no.remedy, INSTALL_REMEDY);
+    }
+
+    /// The tap comes first — `idb_companion` is not in Homebrew core, so a bare
+    /// `brew install idb-companion` fails. The launch path and the doctor must not differ on it.
+    #[test]
+    fn the_install_the_launch_path_names_is_the_one_the_doctor_names() {
         assert!(
-            why.contains("brew install idb-companion"),
-            "must name the install: {why}"
+            INSTALL_REMEDY.contains("brew tap facebook/fb"),
+            "the install must tap first: {INSTALL_REMEDY}"
         );
     }
 
     /// An override skips discovery, so an install the user has not pointed it at is not the fix.
     #[test]
     fn an_override_that_names_nothing_is_refused_by_naming_the_variable() {
-        let why = CompanionFacts {
-            resolved: Resolved::Absent,
-            override_set: true,
-        }
-        .spawn_target()
-        .expect_err("an override naming nothing cannot be spawned");
+        let no = overridden(Resolved::Absent)
+            .spawn_target()
+            .expect_err("an override naming nothing cannot be spawned");
         assert!(
-            why.contains("GLASS_IDB_COMPANION"),
-            "must name the variable that decided this: {why}"
+            no.cause.contains("GLASS_IDB_COMPANION"),
+            "must name the variable that decided this: {}",
+            no.cause
         );
         assert!(
-            !why.contains("brew install"),
-            "installing another copy would not be read while the override stands: {why}"
+            !no.remedy.contains("brew install"),
+            "installing another copy would not be read while the override stands: {}",
+            no.remedy
         );
     }
 
     #[test]
     fn a_companion_that_could_not_be_looked_up_is_refused_by_naming_path() {
-        let why = discovered(Resolved::NoSearchPath)
+        let no = discovered(Resolved::NoSearchPath)
             .spawn_target()
             .expect_err("nothing was looked up, so nothing can be spawned");
-        assert!(why.contains("PATH"), "must name the unset PATH: {why}");
+        assert!(
+            no.cause.contains("PATH"),
+            "must name the unset PATH: {}",
+            no.cause
+        );
+    }
+
+    /// A bare-name override with no `$PATH` is the one way an override reaches `NoSearchPath`.
+    /// "Set GLASS_IDB_COMPANION" is what they already did; an absolute path is the fix.
+    #[test]
+    fn a_bare_name_override_with_no_path_asks_for_an_absolute_path() {
+        let no = overridden(Resolved::NoSearchPath)
+            .spawn_target()
+            .expect_err("a bare name with no PATH resolves to nothing");
+        assert!(
+            no.cause.contains("GLASS_IDB_COMPANION"),
+            "must name the variable it searched for: {}",
+            no.cause
+        );
+        assert!(
+            no.remedy.contains("absolute path"),
+            "must ask for an absolute path, not for the variable they already set: {}",
+            no.remedy
+        );
+    }
+
+    /// The launch path gets one string, so it has to carry the fix as well as the cause.
+    #[test]
+    fn the_launch_message_joins_the_cause_to_its_remedy() {
+        let no = discovered(Resolved::Absent)
+            .spawn_target()
+            .expect_err("a missing companion cannot be spawned");
+        let msg = no.message();
+        assert!(msg.contains(&no.cause) && msg.contains(&no.remedy), "{msg}");
     }
 
     #[test]
@@ -663,9 +833,8 @@ mod tests {
         .expect("write stub");
         std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755)).expect("chmod");
 
-        // Name the stub directly — never through this process's real env, which would race
-        // parallel tests. A short ready deadline keeps the never-served socket from costing the
-        // full production timeout.
+        // A short ready deadline keeps the never-served socket from costing the full
+        // production timeout.
         const READY: Duration = Duration::from_millis(500);
         // A unique udid keeps this test's socket file name from colliding with another test
         // in the same process (the socket path is keyed on the udid prefix + this pid).

--- a/crates/glass-ios/src/idb/companion.rs
+++ b/crates/glass-ios/src/idb/companion.rs
@@ -1,12 +1,14 @@
 //! Spawns and owns the `idb_companion` process bound to one simulator UDID, and
 //! exposes the Unix socket it serves gRPC on. Killing the child on Drop reaps it
 //! (Child::drop does NOT kill), mirroring glass-android's AgentRegistry lifetime.
+use std::ffi::OsStr;
 use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
 use glass_core::{GlassError, Result};
+use glass_exec_unix::{Resolved, resolve_bin, resolve_path};
 
 /// macOS caps a Unix-domain socket path (`sun_path`) at 104 bytes; a longer one makes the
 /// companion refuse to bind with an opaque `unixDomainSocketPathTooLong`.
@@ -29,69 +31,107 @@ const HOMEBREW_COMPANION_PATHS: [&str; 2] = [
     "/usr/local/bin/idb_companion",
 ];
 
-/// The program to hand `Command::new` for the companion spawn. `GLASS_IDB_COMPANION` wins
-/// verbatim (an explicit override is trusted — a wrong path surfaces a clear spawn error);
-/// otherwise `idb_companion` is auto-discovered on `PATH`, then in Homebrew's standard prefixes;
-/// failing all that, the bare name is returned so the spawn fails with the actionable
-/// "install idb_companion" error rather than a silent no-op.
-pub fn companion_bin(get: &dyn Fn(&str) -> Option<String>) -> String {
-    companion_program(get, &|p| p.is_file())
+/// Env var naming the companion binary outright, bypassing discovery.
+const COMPANION_ENV: &str = "GLASS_IDB_COMPANION";
+/// The companion's program name, looked up on `$PATH` when nothing names it outright.
+const COMPANION_BIN: &str = "idb_companion";
+
+/// What glass knows about this host's `idb_companion`: the resolution, and whether
+/// `GLASS_IDB_COMPANION` decided it. A struct rather than loose arguments so the two cannot be
+/// handed over in the wrong order.
+pub(crate) struct CompanionFacts {
+    /// This host's `idb_companion`, or why there is none.
+    pub(crate) resolved: Resolved,
+    /// `GLASS_IDB_COMPANION` named it outright, so discovery never ran — which changes what a
+    /// resolution that found nothing says.
+    pub(crate) override_set: bool,
 }
 
-/// [`companion_bin`] with the filesystem-existence check injected, so tests can drive resolution
-/// without touching the real environment.
-fn companion_program(
-    get: &dyn Fn(&str) -> Option<String>,
-    exists: &dyn Fn(&Path) -> bool,
-) -> String {
-    if let Some(explicit) = get("GLASS_IDB_COMPANION").filter(|s| !s.is_empty()) {
-        return explicit;
+impl CompanionFacts {
+    /// Read the environment once, and resolve from it.
+    pub(crate) fn gather(get: &dyn Fn(&str) -> Option<String>) -> CompanionFacts {
+        CompanionFacts {
+            resolved: resolve_companion(get),
+            override_set: get(COMPANION_ENV).is_some_and(|s| !s.is_empty()),
+        }
     }
-    discover_companion(get, exists)
-        .map(|p| p.to_string_lossy().into_owned())
-        .unwrap_or_else(|| "idb_companion".to_string())
+
+    /// The binary to hand `Command::new`, or why there is none.
+    ///
+    /// A binary glass cannot run is refused here, not exec'd: `exec` comes back with a bare
+    /// `EACCES` where the resolution already knows the file and the fix. One mapping, so the
+    /// preflight and the bring-up cannot disagree.
+    pub(crate) fn spawn_target(&self) -> std::result::Result<&Path, String> {
+        match &self.resolved {
+            Resolved::Found(p) => Ok(p),
+            Resolved::NotExecutable(p) => Err(format!(
+                "idb_companion at {} is not executable — chmod +x it, or point \
+                 GLASS_IDB_COMPANION at a runnable binary",
+                p.display()
+            )),
+            // An override skips discovery, so installing another copy would not be read either.
+            Resolved::Absent if self.override_set => Err(
+                "GLASS_IDB_COMPANION does not name a runnable idb_companion — point it at one, \
+                 or unset it to search PATH and Homebrew's standard prefixes"
+                    .into(),
+            ),
+            Resolved::Absent => Err(
+                "idb_companion not found (install: brew install idb-companion), or set \
+                 GLASS_IDB_COMPANION to its path"
+                    .into(),
+            ),
+            Resolved::NoSearchPath => Err(
+                "idb_companion could not be looked up — PATH is unset in glass's environment; \
+                 set GLASS_IDB_COMPANION to its path"
+                    .into(),
+            ),
+        }
+    }
 }
 
-/// Auto-discover `idb_companion` when `GLASS_IDB_COMPANION` is unset: on `PATH` first, then in
-/// the standard Homebrew prefixes ([`HOMEBREW_COMPANION_PATHS`]). `None` if it is nowhere to be
-/// found. `get`/`exists` are seams so tests drive it deterministically.
-fn discover_companion(
-    get: &dyn Fn(&str) -> Option<String>,
-    exists: &dyn Fn(&Path) -> bool,
-) -> Option<PathBuf> {
-    on_path("idb_companion", get, exists).or_else(|| {
-        HOMEBREW_COMPANION_PATHS
-            .iter()
-            .copied()
-            .map(PathBuf::from)
-            .find(|p| exists(p))
-    })
+/// This host's `idb_companion`, or why there is none.
+///
+/// One resolution, shared by the runtime spawn and `glass doctor`: a second lookup would let
+/// one run answer both "present" and "not found" about one file (glass#391).
+fn resolve_companion(get: &dyn Fn(&str) -> Option<String>) -> Resolved {
+    resolve_companion_with(get(COMPANION_ENV), get("PATH"), &HOMEBREW_COMPANION_PATHS)
 }
 
-/// The first `PATH` entry containing a file named `name`, if any.
-fn on_path(
-    name: &str,
-    get: &dyn Fn(&str) -> Option<String>,
-    exists: &dyn Fn(&Path) -> bool,
-) -> Option<PathBuf> {
-    let path = get("PATH")?;
-    std::env::split_paths(&path)
-        .map(|dir| dir.join(name))
-        .find(|p| exists(p))
-}
-
-/// Whether the companion resolves to an existing binary — the testable core of the doctor's
-/// presence check, mirroring [`companion_bin`]'s resolution so the two never drift: an explicit
-/// `GLASS_IDB_COMPANION` path must exist (a bare name must be on `PATH`); otherwise auto-discovery
-/// (`PATH`, then Homebrew prefixes) must find one. `get`/`exists` are seams for tests.
-pub(crate) fn companion_present_with(
-    get: &dyn Fn(&str) -> Option<String>,
-    exists: &dyn Fn(&Path) -> bool,
-) -> bool {
-    match get("GLASS_IDB_COMPANION").filter(|s| !s.is_empty()) {
-        Some(bin) if bin.contains('/') => exists(Path::new(&bin)),
-        Some(bin) => on_path(&bin, get, exists).is_some(),
-        None => discover_companion(get, exists).is_some(),
+/// [`resolve_companion`] against explicit inputs — the testable seam. The Homebrew prefixes are
+/// injected too, so a test cannot be answered by the developer's own `brew install`.
+///
+/// `GLASS_IDB_COMPANION` names the companion outright and is never searched for among
+/// `fallbacks`, though a bare name still goes through `$PATH`; discovery walks `$PATH` first and
+/// `fallbacks` only once it runs dry.
+fn resolve_companion_with(
+    override_value: Option<String>,
+    path: Option<String>,
+    fallbacks: &[&str],
+) -> Resolved {
+    if let Some(bin) = override_value.filter(|s| !s.is_empty()) {
+        return resolve_bin(&bin, path.as_deref().map(OsStr::new));
+    }
+    let mut first_unrunnable = None;
+    let mut nothing_to_search = false;
+    for resolved in std::iter::once(resolve_bin(COMPANION_BIN, path.as_deref().map(OsStr::new)))
+        .chain(fallbacks.iter().map(|c| resolve_path(Path::new(c))))
+    {
+        match resolved {
+            Resolved::Found(p) => return Resolved::Found(p),
+            Resolved::NotExecutable(p) => {
+                first_unrunnable.get_or_insert(p);
+            }
+            // Only the `$PATH` walk can lack a search list; a fallback is one fixed path.
+            Resolved::NoSearchPath => nothing_to_search = true,
+            Resolved::Absent => {}
+        }
+    }
+    match (first_unrunnable, nothing_to_search) {
+        (Some(p), _) => Resolved::NotExecutable(p),
+        // No `$PATH` to walk and nothing in the standard prefixes: the companion may well be
+        // installed somewhere glass was never told to look (glass#373).
+        (None, true) => Resolved::NoSearchPath,
+        (None, false) => Resolved::Absent,
     }
 }
 
@@ -133,20 +173,22 @@ impl IdbCompanion {
     /// or a socket that never comes up leaves no child behind: both paths
     /// kill + reap before returning `Err`.
     pub fn spawn(udid: &str) -> Result<IdbCompanion> {
-        Self::spawn_with(udid, &|k| std::env::var(k).ok(), SOCKET_READY_TIMEOUT)
+        let facts = CompanionFacts::gather(&|k| std::env::var(k).ok());
+        let bin = facts.spawn_target().map_err(GlassError::Backend)?;
+        Self::spawn_bin(udid, bin)
     }
 
-    /// [`spawn`](Self::spawn) with the companion-binary env resolution and the socket-ready
-    /// deadline injected — the seam that makes the failure-cleanup path testable without a
-    /// real simulator. A test points `GLASS_IDB_COMPANION` at a stub through `get_env`
-    /// *without* mutating this process's environment (which would race parallel tests), and
-    /// passes a short `ready_timeout` so a stub that never serves its socket fails fast.
-    fn spawn_with(
-        udid: &str,
-        get_env: &dyn Fn(&str) -> Option<String>,
-        ready_timeout: Duration,
-    ) -> Result<IdbCompanion> {
-        let bin = companion_bin(get_env);
+    /// [`spawn`](Self::spawn) against an already-resolved binary, for a caller that resolved it
+    /// once and must not resolve again — a second lookup can answer differently from the first
+    /// (glass#391), so the doctor would report one binary and start another.
+    pub(crate) fn spawn_bin(udid: &str, bin: &Path) -> Result<IdbCompanion> {
+        Self::spawn_with(udid, bin, SOCKET_READY_TIMEOUT)
+    }
+
+    /// [`spawn_bin`](Self::spawn_bin) with the socket-ready deadline injected — the seam that
+    /// makes the failure-cleanup path testable without a real simulator. A test points it at a
+    /// stub and passes a short `ready_timeout`, so a stub that never serves its socket fails fast.
+    fn spawn_with(udid: &str, bin: &Path, ready_timeout: Duration) -> Result<IdbCompanion> {
         let dir = std::env::temp_dir();
         let pid = std::process::id();
         let sock = socket_path(&dir, udid, pid);
@@ -174,7 +216,7 @@ impl IdbCompanion {
             ))
         })?;
 
-        let child = Command::new(&bin)
+        let child = Command::new(bin)
             .args(["--udid", udid, "--grpc-domain-sock"])
             .arg(&sock)
             .stdout(Stdio::null())
@@ -183,9 +225,9 @@ impl IdbCompanion {
             .spawn()
             .map_err(|e| {
                 let _ = std::fs::remove_file(&stderr_log);
-                GlassError::Backend(format!(
-                    "spawn {bin}: {e} (install: brew install idb-companion)"
-                ))
+                // No install hint: resolution already refused a companion that is missing or
+                // unrunnable, so what lands here is a binary that changed underneath it.
+                GlassError::Backend(format!("spawn {}: {e}", bin.display()))
             })?;
         let mut this = IdbCompanion {
             child,
@@ -292,99 +334,283 @@ fn socket_ready(sock: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
+    use std::os::unix::fs::PermissionsExt;
 
-    /// Build an env getter from a fixed set of pairs.
-    fn env(pairs: &[(&'static str, &'static str)]) -> impl Fn(&str) -> Option<String> + use<> {
-        let m: HashMap<&'static str, &'static str> = pairs.iter().copied().collect();
-        move |k: &str| m.get(k).map(|s| s.to_string())
+    /// A directory holding `name` at `mode`. Real files at real modes, because resolution asks
+    /// the kernel whether this process may execute one and no injected predicate stands in for
+    /// that answer.
+    fn dir_with(name: &str, mode: u32) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bin = dir.path().join(name);
+        std::fs::write(&bin, b"").expect("write");
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(mode)).expect("chmod");
+        dir
+    }
+
+    /// A `$PATH`-style value naming `dirs`, in the `String` shape the env getter yields.
+    fn path_of(dirs: &[&Path]) -> Option<String> {
+        Some(
+            std::env::join_paths(dirs)
+                .expect("join paths")
+                .into_string()
+                .expect("utf-8 temp paths"),
+        )
+    }
+
+    /// The `fallbacks` entry naming `dir`'s companion.
+    fn candidate(dir: &tempfile::TempDir) -> String {
+        dir.path()
+            .join(COMPANION_BIN)
+            .to_str()
+            .expect("utf-8 temp path")
+            .to_string()
     }
 
     #[test]
-    fn companion_program_uses_the_env_override_verbatim() {
-        // An explicit override is trusted even when the file is absent — the spawn surfaces the error.
+    fn a_runnable_companion_on_path_resolves_to_it() {
+        let dir = dir_with(COMPANION_BIN, 0o755);
         assert_eq!(
-            companion_program(
-                &env(&[("GLASS_IDB_COMPANION", "/opt/idb_companion")]),
-                &|_: &Path| false,
+            resolve_companion_with(None, path_of(&[dir.path()]), &[]),
+            Resolved::Found(dir.path().join(COMPANION_BIN))
+        );
+    }
+
+    /// glass#393. A companion that is installed and cannot be executed — no execute bit, a
+    /// `noexec` mount, a permission class this user is not in — must not read as available:
+    /// the spawn would fail, and "not found" sends the user to reinstall what is already there.
+    #[test]
+    fn a_companion_that_cannot_be_executed_is_reported_as_present_not_missing() {
+        let dir = dir_with(COMPANION_BIN, 0o644);
+        assert_eq!(
+            resolve_companion_with(None, path_of(&[dir.path()]), &[]),
+            Resolved::NotExecutable(dir.path().join(COMPANION_BIN))
+        );
+    }
+
+    /// The same defect on the override path: an explicit `GLASS_IDB_COMPANION` is still a
+    /// binary glass has to exec.
+    #[test]
+    fn an_override_naming_a_non_executable_binary_is_not_executable() {
+        let dir = dir_with("my_idb", 0o644);
+        let bin = dir.path().join("my_idb");
+        assert_eq!(
+            resolve_companion_with(
+                Some(bin.to_str().expect("utf-8 temp path").to_string()),
+                None,
+                &[]
             ),
-            "/opt/idb_companion"
+            Resolved::NotExecutable(bin)
         );
     }
 
+    /// A runnable companion later in the order beats an unrunnable one earlier: resolving to the
+    /// unrunnable one would spawn a binary the user's own shell would have walked past.
     #[test]
-    fn companion_program_falls_back_to_the_bare_name_when_nothing_resolves() {
+    fn a_non_executable_companion_on_path_does_not_shadow_a_runnable_homebrew_one() {
+        let on_path = dir_with(COMPANION_BIN, 0o644);
+        let brew = dir_with(COMPANION_BIN, 0o755);
         assert_eq!(
-            companion_program(&env(&[("PATH", "/usr/bin:/bin")]), &|_: &Path| false),
-            "idb_companion"
+            resolve_companion_with(None, path_of(&[on_path.path()]), &[&candidate(&brew)]),
+            Resolved::Found(brew.path().join(COMPANION_BIN))
         );
     }
 
+    /// Nothing runnable anywhere: the first unrunnable file walked past is the one the user can
+    /// act on, so it is reported rather than a flat "not found".
     #[test]
-    fn discover_prefers_path_over_homebrew() {
-        let exists = |p: &Path| {
-            p == Path::new("/usr/bin/idb_companion")
-                || p == Path::new("/opt/homebrew/bin/idb_companion")
-        };
+    fn with_nothing_runnable_the_first_unrunnable_companion_is_reported() {
+        let on_path = dir_with(COMPANION_BIN, 0o644);
+        let brew = dir_with(COMPANION_BIN, 0o600);
         assert_eq!(
-            discover_companion(&env(&[("PATH", "/usr/bin")]), &exists),
-            Some(PathBuf::from("/usr/bin/idb_companion"))
+            resolve_companion_with(None, path_of(&[on_path.path()]), &[&candidate(&brew)]),
+            Resolved::NotExecutable(on_path.path().join(COMPANION_BIN))
         );
     }
 
     #[test]
-    fn discover_finds_homebrew_when_off_path() {
-        // launchd's minimal PATH omits Homebrew's bindir; discovery still finds the brew install.
-        let exists = |p: &Path| p == Path::new("/opt/homebrew/bin/idb_companion");
+    fn an_override_naming_a_runnable_binary_resolves_to_it() {
+        let dir = dir_with("my_idb", 0o755);
+        let bin = dir.path().join("my_idb");
         assert_eq!(
-            discover_companion(&env(&[("PATH", "/usr/bin:/bin")]), &exists),
-            Some(PathBuf::from("/opt/homebrew/bin/idb_companion"))
+            resolve_companion_with(
+                Some(bin.to_str().expect("utf-8 temp path").to_string()),
+                None,
+                &[]
+            ),
+            Resolved::Found(bin)
         );
     }
 
     #[test]
-    fn discover_prefers_apple_silicon_over_intel_prefix() {
-        // Both prefixes "exist"; the arm64 prefix is chosen first.
+    fn a_bare_name_override_is_looked_up_on_path() {
+        let dir = dir_with("my_idb", 0o755);
         assert_eq!(
-            discover_companion(&env(&[]), &|_: &Path| true),
-            Some(PathBuf::from("/opt/homebrew/bin/idb_companion"))
+            resolve_companion_with(Some("my_idb".to_string()), path_of(&[dir.path()]), &[]),
+            Resolved::Found(dir.path().join("my_idb"))
         );
     }
 
+    /// An override is taken at its word and never searched for among the Homebrew prefixes: a
+    /// user who named a build wants that build, not whichever one `brew` installed.
     #[test]
-    fn discover_is_none_when_absent_everywhere() {
+    fn an_override_that_resolves_to_nothing_is_absent_even_when_homebrew_has_one() {
+        let brew = dir_with(COMPANION_BIN, 0o755);
         assert_eq!(
-            discover_companion(&env(&[("PATH", "/usr/bin:/bin")]), &|_: &Path| false),
-            None
+            resolve_companion_with(
+                Some("/nonexistent/my_idb".to_string()),
+                None,
+                &[&candidate(&brew)]
+            ),
+            Resolved::Absent
+        );
+    }
+
+    /// An unset `GLASS_IDB_COMPANION` and one set to the empty string mean the same thing.
+    #[test]
+    fn an_empty_override_falls_through_to_discovery() {
+        let dir = dir_with(COMPANION_BIN, 0o755);
+        assert_eq!(
+            resolve_companion_with(Some(String::new()), path_of(&[dir.path()]), &[]),
+            Resolved::Found(dir.path().join(COMPANION_BIN))
         );
     }
 
     #[test]
-    fn present_with_validates_that_an_override_path_exists() {
-        let get = env(&[("GLASS_IDB_COMPANION", "/opt/idb_companion")]);
-        assert!(companion_present_with(&get, &|p: &Path| p == Path::new("/opt/idb_companion")));
-        assert!(!companion_present_with(&get, &|_: &Path| false));
+    fn discovery_prefers_path_over_the_homebrew_prefixes() {
+        let on_path = dir_with(COMPANION_BIN, 0o755);
+        let brew = dir_with(COMPANION_BIN, 0o755);
+        assert_eq!(
+            resolve_companion_with(None, path_of(&[on_path.path()]), &[&candidate(&brew)]),
+            Resolved::Found(on_path.path().join(COMPANION_BIN))
+        );
+    }
+
+    /// launchd hands a `.app` a minimal `PATH` that omits Homebrew's bindir; discovery still
+    /// finds the `brew install`.
+    #[test]
+    fn discovery_finds_a_homebrew_prefix_when_the_companion_is_off_path() {
+        let empty = tempfile::tempdir().expect("tempdir");
+        let brew = dir_with(COMPANION_BIN, 0o755);
+        assert_eq!(
+            resolve_companion_with(None, path_of(&[empty.path()]), &[&candidate(&brew)]),
+            Resolved::Found(brew.path().join(COMPANION_BIN))
+        );
+    }
+
+    /// The prefixes are ordered (Apple silicon before Intel), so the first match wins.
+    #[test]
+    fn discovery_takes_the_first_homebrew_prefix_that_matches() {
+        let first = dir_with(COMPANION_BIN, 0o755);
+        let second = dir_with(COMPANION_BIN, 0o755);
+        assert_eq!(
+            resolve_companion_with(None, None, &[&candidate(&first), &candidate(&second)]),
+            Resolved::Found(first.path().join(COMPANION_BIN))
+        );
     }
 
     #[test]
-    fn present_with_resolves_a_bare_name_override_on_path() {
-        let get = env(&[("GLASS_IDB_COMPANION", "my_idb"), ("PATH", "/usr/bin:/bin")]);
-        assert!(companion_present_with(&get, &|p: &Path| p == Path::new("/bin/my_idb")));
+    fn a_companion_that_is_nowhere_is_absent() {
+        let empty = tempfile::tempdir().expect("tempdir");
+        assert_eq!(
+            resolve_companion_with(
+                None,
+                path_of(&[empty.path()]),
+                &["/nonexistent/idb_companion"]
+            ),
+            Resolved::Absent
+        );
+    }
+
+    /// glass#373: MCP clients routinely spawn glass-mcp with a stripped environment. With no
+    /// `$PATH` the standard prefixes are still checked, but an install anywhere else could not
+    /// be looked up — which is a different remedy from "install it".
+    #[test]
+    fn no_path_and_no_companion_in_the_prefixes_says_it_could_not_be_looked_up() {
+        assert_eq!(
+            resolve_companion_with(None, None, &["/nonexistent/idb_companion"]),
+            Resolved::NoSearchPath
+        );
+    }
+
+    /// A companion found in a prefix answers the question outright, so a missing `$PATH` is not
+    /// worth reporting.
+    #[test]
+    fn no_path_still_resolves_a_companion_in_a_prefix() {
+        let brew = dir_with(COMPANION_BIN, 0o755);
+        assert_eq!(
+            resolve_companion_with(None, None, &[&candidate(&brew)]),
+            Resolved::Found(brew.path().join(COMPANION_BIN))
+        );
+    }
+
+    /// Gathered facts for a resolution that discovery reached (no `GLASS_IDB_COMPANION`).
+    fn discovered(resolved: Resolved) -> CompanionFacts {
+        CompanionFacts {
+            resolved,
+            override_set: false,
+        }
     }
 
     #[test]
-    fn present_with_finds_homebrew_when_off_path() {
-        let get = env(&[("PATH", "/usr/bin:/bin")]);
-        assert!(companion_present_with(&get, &|p: &Path| p
-            == Path::new("/opt/homebrew/bin/idb_companion")));
+    fn the_spawn_runs_the_binary_resolution_found() {
+        let bin = PathBuf::from("/opt/homebrew/bin/idb_companion");
+        assert_eq!(
+            discovered(Resolved::Found(bin.clone())).spawn_target(),
+            Ok(bin.as_path())
+        );
+    }
+
+    /// glass#393: exec'ing it anyway costs a spawn and comes back with a bare `EACCES`, where the
+    /// resolution already knows the file and the fix.
+    #[test]
+    fn a_companion_it_cannot_run_is_refused_by_name_rather_than_spawned() {
+        let why = discovered(Resolved::NotExecutable(PathBuf::from(
+            "/usr/local/bin/idb_companion",
+        )))
+        .spawn_target()
+        .expect_err("an unrunnable companion must not be spawned");
+        assert!(
+            why.contains("/usr/local/bin/idb_companion") && why.contains("chmod +x"),
+            "must name the file and the permission fix: {why}"
+        );
     }
 
     #[test]
-    fn present_with_is_false_when_absent_everywhere() {
-        assert!(!companion_present_with(
-            &env(&[("PATH", "/usr/bin")]),
-            &|_: &Path| false
-        ));
+    fn a_companion_that_is_nowhere_is_refused_with_the_install() {
+        let why = discovered(Resolved::Absent)
+            .spawn_target()
+            .expect_err("a missing companion cannot be spawned");
+        assert!(
+            why.contains("brew install idb-companion"),
+            "must name the install: {why}"
+        );
+    }
+
+    /// An override skips discovery, so an install the user has not pointed it at is not the fix.
+    #[test]
+    fn an_override_that_names_nothing_is_refused_by_naming_the_variable() {
+        let why = CompanionFacts {
+            resolved: Resolved::Absent,
+            override_set: true,
+        }
+        .spawn_target()
+        .expect_err("an override naming nothing cannot be spawned");
+        assert!(
+            why.contains("GLASS_IDB_COMPANION"),
+            "must name the variable that decided this: {why}"
+        );
+        assert!(
+            !why.contains("brew install"),
+            "installing another copy would not be read while the override stands: {why}"
+        );
+    }
+
+    #[test]
+    fn a_companion_that_could_not_be_looked_up_is_refused_by_naming_path() {
+        let why = discovered(Resolved::NoSearchPath)
+            .spawn_target()
+            .expect_err("nothing was looked up, so nothing can be spawned");
+        assert!(why.contains("PATH"), "must name the unset PATH: {why}");
     }
 
     #[test]
@@ -424,8 +650,6 @@ mod tests {
 
     #[test]
     fn spawn_reaps_the_child_when_the_socket_never_opens() {
-        use std::os::unix::fs::PermissionsExt;
-
         let dir = tempfile::tempdir().expect("tempdir");
         let stub = dir.path().join("stub_companion");
         let pidfile = dir.path().join("child.pid");
@@ -439,11 +663,9 @@ mod tests {
         .expect("write stub");
         std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755)).expect("chmod");
 
-        // Point GLASS_IDB_COMPANION at the stub through the injected getter — never through
-        // this process's real env, which would race parallel tests. A short ready deadline
-        // keeps the never-served socket from costing the full production timeout.
-        let stub_path = stub.to_str().expect("utf-8 stub path").to_string();
-        let get_env = |k: &str| (k == "GLASS_IDB_COMPANION").then(|| stub_path.clone());
+        // Name the stub directly — never through this process's real env, which would race
+        // parallel tests. A short ready deadline keeps the never-served socket from costing the
+        // full production timeout.
         const READY: Duration = Duration::from_millis(500);
         // A unique udid keeps this test's socket file name from colliding with another test
         // in the same process (the socket path is keyed on the udid prefix + this pid).
@@ -454,7 +676,7 @@ mod tests {
         // just-written fixture, never the installed idb_companion (same rationale as doctor).
         let mut err = None;
         for _ in 0..100 {
-            match IdbCompanion::spawn_with(UDID, &get_env, READY) {
+            match IdbCompanion::spawn_with(UDID, &stub, READY) {
                 Ok(_) => panic!("stub never opens a socket, so spawn_with must fail"),
                 Err(GlassError::Backend(m)) if m.contains("Text file busy") => {
                     std::thread::sleep(Duration::from_millis(10));

--- a/crates/glass-ios/src/idb/companion.rs
+++ b/crates/glass-ios/src/idb/companion.rs
@@ -57,7 +57,7 @@ impl NoCompanion {
         }
     }
 
-    /// An override skips discovery, so another install would not be looked at either.
+    /// Another install would not be looked at while the override stands.
     fn override_names_nothing() -> NoCompanion {
         NoCompanion {
             cause: "GLASS_IDB_COMPANION does not name a runnable idb_companion".into(),
@@ -231,9 +231,8 @@ impl IdbCompanion {
         Self::spawn_bin(udid, bin)
     }
 
-    /// [`spawn`](Self::spawn) against an already-resolved binary, for a caller that resolved it
-    /// once and must not resolve again — a second lookup can answer differently from the first
-    /// (glass#391), so the doctor would report one binary and start another.
+    /// [`spawn`](Self::spawn) against an already-resolved binary, for a caller holding one from
+    /// [`resolve_companion`] that must not resolve again.
     pub(crate) fn spawn_bin(udid: &str, bin: &Path) -> Result<IdbCompanion> {
         Self::spawn_with(udid, bin, SOCKET_READY_TIMEOUT)
     }

--- a/crates/glass-ios/src/lib.rs
+++ b/crates/glass-ios/src/lib.rs
@@ -36,8 +36,8 @@ use glass_core::capability::{CapabilityMap, CapabilityStatus, Support};
 pub const BACKEND: &str = "ios";
 
 /// This backend's live capability map. `input`/`accessibility` need `idb_companion` — gated on
-/// [`doctor::companion_runnable`], the same resolution the runtime spawn runs, so a companion
-/// that is installed but cannot be executed reads here as it does at spawn time.
+/// `doctor::companion_runnable`, which is the launch path's own verdict, so a companion that is
+/// installed but cannot be executed is unavailable here exactly as it would be at spawn time.
 pub fn capabilities() -> CapabilityMap {
     capabilities_with(crate::doctor::companion_runnable())
 }
@@ -57,7 +57,10 @@ fn capabilities_with(companion: bool) -> CapabilityMap {
         accessibility: if companion {
             CapabilityStatus::supported()
         } else {
-            CapabilityStatus::requires_setup("idb_companion not found (needed for accessibility)")
+            CapabilityStatus::requires_setup(
+                "needs a runnable idb_companion; `glass doctor` says whether it is missing, \
+                 not executable, or unresolvable",
+            )
         },
         window_move_resize: CapabilityStatus::unsupported(Some("apps are full-screen")),
     }

--- a/crates/glass-ios/src/lib.rs
+++ b/crates/glass-ios/src/lib.rs
@@ -35,11 +35,11 @@ use glass_core::capability::{CapabilityMap, CapabilityStatus, Support};
 /// This backend's canonical name (matches the `glass_capabilities` / `GLASS_BACKEND` value).
 pub const BACKEND: &str = "ios";
 
-/// This backend's live capability map. `input`/`accessibility` need `idb_companion` —
-/// gated on [`doctor::companion_present`], the same presence signal the runtime spawn
-/// resolves.
+/// This backend's live capability map. `input`/`accessibility` need `idb_companion` — gated on
+/// [`doctor::companion_runnable`], the same resolution the runtime spawn runs, so a companion
+/// that is installed but cannot be executed reads here as it does at spawn time.
 pub fn capabilities() -> CapabilityMap {
-    capabilities_with(crate::doctor::companion_present())
+    capabilities_with(crate::doctor::companion_runnable())
 }
 
 fn capabilities_with(companion: bool) -> CapabilityMap {

--- a/crates/glass-ios/src/platform.rs
+++ b/crates/glass-ios/src/platform.rs
@@ -309,7 +309,7 @@ impl IosPlatform {
         let (driver, driver_error) = match IdbDriver::start(target.udid()) {
             Ok(driver) => (Some(driver), None),
             Err(e) => {
-                let cause = e.to_string();
+                let cause = crate::doctor::spawn_cause(e);
                 eprintln!(
                     "glass-ios: idb_companion unavailable — running observe-only \
                      (capture/logs/clipboard); input and the accessibility tree are \

--- a/crates/glass-ios/src/platform.rs
+++ b/crates/glass-ios/src/platform.rs
@@ -330,9 +330,9 @@ impl IosPlatform {
         self.app.as_ref().ok_or(GlassError::NoActiveSession)
     }
 
-    /// The input/accessibility driver, or a clear `Unsupported` when the companion is
-    /// absent (observe-only mode). The message carries the recorded cause so a caller sees
-    /// *why* input is disabled (not installed vs. installed-but-crashed).
+    /// The input/accessibility driver, or a clear `Unsupported` when there is no companion to
+    /// run (observe-only mode). The message carries the recorded cause, so a caller sees *why*
+    /// input is disabled rather than only that it is.
     fn driver(&self) -> Result<&IdbDriver> {
         self.driver.as_ref().ok_or_else(|| {
             GlassError::Unsupported(match &self.driver_error {

--- a/crates/glass-mcp/src/doctor.rs
+++ b/crates/glass-mcp/src/doctor.rs
@@ -243,11 +243,7 @@ fn diagnose_inner(deep: bool, audit: Option<&crate::audit::AuditReport>) -> Diag
         // The companion gates all iOS input + accessibility, so its status is *always*
         // surfaced — an operator driving iOS per-call from a macos-default server still needs
         // to see it. Only the expensive --deep spawn probe is gated to the selected backend.
-        let companion = if ios_selected && deep {
-            companion_deep_check(glass_ios::doctor::probe_companion())
-        } else {
-            idb_companion_check(glass_ios::doctor::companion_present())
-        };
+        let companion = glass_ios::doctor::companion_check(ios_selected && deep);
         let ios_checks = ios_checks_assembled(base, companion, ios_selected);
         sections.push(Section::new("ios", Some("ios".into()), ios_checks));
     }
@@ -335,84 +331,6 @@ fn ios_checks_assembled(mut base: Vec<Check>, companion: Check, ios_selected: bo
         soften_inactive_fails(&mut base, "ios");
     }
     base
-}
-
-/// The shared `idb_companion` install remedy.
-#[cfg_attr(not(any(target_os = "macos", test)), allow(dead_code))]
-const IDB_COMPANION_REMEDY: &str =
-    "brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion";
-
-/// The check for a resolvable/unresolvable `idb_companion` on the *passive* (non-`--deep`)
-/// path — takes the already-resolved presence fact so it's unit-tested without touching
-/// PATH/env; `glass_ios::doctor::companion_present` gathers the real fact on macOS. A missing
-/// companion is a **Fail**, not a Warn: unlike android — which keeps barebones function
-/// without its companions — the iOS companion is required to drive apps at all, so without it
-/// iOS is observe-only (unusable for development). Because this check is only added when iOS
-/// is the *selected* backend, the Fail reddens the verdict only for someone actually driving
-/// iOS. Kept out of `#[cfg]` (only its caller is macOS-only) so the test still runs on every
-/// host.
-#[cfg_attr(not(any(target_os = "macos", test)), allow(dead_code))]
-pub(crate) fn idb_companion_check(found: bool) -> Check {
-    if found {
-        Check::new(
-            "idb_companion",
-            CheckStatus::Ok,
-            "idb_companion found — input + accessibility are available",
-        )
-    } else {
-        idb_companion_not_found_check()
-    }
-}
-
-/// The Fail check for an absent `idb_companion`, shared by the passive presence path and the
-/// `--deep` probe's `CompanionProbe::NotFound` mapping.
-#[cfg_attr(not(any(target_os = "macos", test)), allow(dead_code))]
-fn idb_companion_not_found_check() -> Check {
-    Check::new(
-        "idb_companion",
-        CheckStatus::Fail,
-        "idb_companion not found — input + accessibility are unavailable (iOS cannot drive apps)",
-    )
-    .with_remedy(IDB_COMPANION_REMEDY)
-}
-
-/// Map a `--deep` iOS companion probe ([`glass_ios::doctor::probe_companion`]) to a `Check`.
-/// Pure — the probe's I/O is done by the caller — so it's unit-tested per variant without a
-/// real companion. Broken (`FailedToStart`/`SelfTestFailed`) or missing (`NotFound`) ⇒ Fail:
-/// iOS cannot drive apps without the companion. Unverified (`SelfTestOk` — the binary runs but
-/// no booted simulator was available to exercise a real start) ⇒ Warn. macOS-gated: it names a
-/// `glass-ios` type, and glass-mcp only depends on glass-ios on macOS (mirrors `macos_checks_from`).
-#[cfg(target_os = "macos")]
-pub(crate) fn companion_deep_check(probe: glass_ios::doctor::CompanionProbe) -> Check {
-    use glass_ios::doctor::CompanionProbe;
-    match probe {
-        CompanionProbe::Started => Check::new(
-            "idb_companion",
-            CheckStatus::Ok,
-            "started and served its gRPC socket — input + accessibility are available",
-        ),
-        CompanionProbe::SelfTestOk => Check::new(
-            "idb_companion",
-            CheckStatus::Warn,
-            "binary runs, but no booted simulator was available to verify a real start — \
-             boot one and re-run with --deep to exercise the companion",
-        ),
-        CompanionProbe::FailedToStart(cause) => Check::new(
-            "idb_companion",
-            CheckStatus::Fail,
-            format!(
-                "failed to start: {cause} — input + accessibility are unavailable (iOS is observe-only)"
-            ),
-        )
-        .with_remedy(IDB_COMPANION_REMEDY),
-        CompanionProbe::SelfTestFailed(cause) => Check::new(
-            "idb_companion",
-            CheckStatus::Fail,
-            format!("binary failed to execute: {cause} — input + accessibility are unavailable"),
-        )
-        .with_remedy(IDB_COMPANION_REMEDY),
-        CompanionProbe::NotFound => idb_companion_not_found_check(),
-    }
 }
 
 /// macOS checks: the two TCC grants (Screen Recording, Accessibility), the console session's
@@ -658,18 +576,15 @@ mod tests {
         assert_eq!(glass.detail, crate::VERSION);
     }
 
-    #[test]
-    fn idb_companion_check_fails_when_absent_and_oks_when_present() {
-        // The iOS companion is *required* to drive apps (unlike android's optional companions);
-        // without it iOS is observe-only, which is not a usable dev workflow — so absent is a
-        // Fail, not a Warn.
-        let absent = idb_companion_check(false);
-        assert_eq!(absent.status, CheckStatus::Fail);
-        assert_eq!(absent.remedy.as_deref(), Some(IDB_COMPANION_REMEDY));
-        let present = idb_companion_check(true);
-        assert_eq!(present.status, CheckStatus::Ok);
-        assert_eq!(present.remedy, None);
+    /// A stand-in for the `idb_companion` check `glass-ios` builds. These tests are about where
+    /// the aggregator puts that check and what softening does to it, not about its wording, which
+    /// is `glass-ios`'s to test.
+    fn companion_fixture(status: CheckStatus) -> Check {
+        Check::new("idb_companion", status, "idb_companion").with_remedy(COMPANION_REMEDY)
     }
+
+    /// The fixture's remedy — any string, asserted only to survive softening.
+    const COMPANION_REMEDY: &str = "brew install idb-companion";
 
     #[test]
     fn inactive_android_fails_soften_to_warn() {
@@ -731,7 +646,7 @@ mod tests {
             ),
             Check::new("device", CheckStatus::Ok, "1 iPhone simulator(s) available"),
         ];
-        let checks = ios_checks_assembled(base, idb_companion_check(false), false);
+        let checks = ios_checks_assembled(base, companion_fixture(CheckStatus::Fail), false);
         let companion = checks
             .iter()
             .find(|c| c.name == "idb_companion")
@@ -744,7 +659,7 @@ mod tests {
             "{}",
             companion.detail
         );
-        assert_eq!(companion.remedy.as_deref(), Some(IDB_COMPANION_REMEDY)); // remedy preserved
+        assert_eq!(companion.remedy.as_deref(), Some(COMPANION_REMEDY)); // remedy preserved
     }
 
     #[test]
@@ -756,13 +671,13 @@ mod tests {
             CheckStatus::Ok,
             "1 iPhone simulator(s) available",
         )];
-        let checks = ios_checks_assembled(base, idb_companion_check(false), true);
+        let checks = ios_checks_assembled(base, companion_fixture(CheckStatus::Fail), true);
         let companion = checks
             .iter()
             .find(|c| c.name == "idb_companion")
             .expect("idb_companion line");
         assert_eq!(companion.status, CheckStatus::Fail);
-        assert_eq!(companion.remedy.as_deref(), Some(IDB_COMPANION_REMEDY));
+        assert_eq!(companion.remedy.as_deref(), Some(COMPANION_REMEDY));
     }
 
     #[test]
@@ -775,7 +690,7 @@ mod tests {
                 .with_remedy("install Xcode from the App Store"),
             Check::new("device", CheckStatus::Ok, "1 iPhone simulator(s) available"),
         ];
-        let checks = ios_checks_assembled(base, idb_companion_check(true), false);
+        let checks = ios_checks_assembled(base, companion_fixture(CheckStatus::Ok), false);
         let xcode = checks.iter().find(|c| c.name == "xcode").unwrap();
         assert_eq!(xcode.status, CheckStatus::Warn); // Fail → Warn
         assert!(
@@ -942,7 +857,11 @@ mod tests {
     fn missing_companion_fails_the_ios_verdict() {
         // A Fail companion check in the ios section must escalate the overall verdict to Fail
         // (exit code 1) when ios is the backend — iOS is unusable without the companion.
-        let ios = Section::new("ios", Some("ios".into()), vec![idb_companion_check(false)]);
+        let ios = Section::new(
+            "ios",
+            Some("ios".into()),
+            vec![companion_fixture(CheckStatus::Fail)],
+        );
         let d = Diagnosis::new(vec![ios]);
         assert_eq!(d.overall("ios"), CheckStatus::Fail);
         assert_eq!(d.exit_code("ios"), 1);
@@ -1243,41 +1162,6 @@ mod tests {
                 c.remedy_action.as_deref(),
                 Some(format!("open {}", glass_macos::accessibility_pane_url()).as_str())
             );
-        }
-
-        #[test]
-        fn companion_deep_check_maps_every_probe_outcome() {
-            use glass_ios::doctor::CompanionProbe;
-
-            let started = companion_deep_check(CompanionProbe::Started);
-            assert_eq!(started.status, CheckStatus::Ok);
-            assert_eq!(started.remedy, None);
-
-            let unverified = companion_deep_check(CompanionProbe::SelfTestOk);
-            assert_eq!(unverified.status, CheckStatus::Warn);
-
-            let broken =
-                companion_deep_check(CompanionProbe::FailedToStart("exited 1: boom".into()));
-            assert_eq!(broken.status, CheckStatus::Fail);
-            assert!(
-                broken.detail.contains("boom"),
-                "cause must surface: {}",
-                broken.detail
-            );
-            assert_eq!(broken.remedy.as_deref(), Some(IDB_COMPANION_REMEDY));
-
-            let unrunnable =
-                companion_deep_check(CompanionProbe::SelfTestFailed("spawn: nope".into()));
-            assert_eq!(unrunnable.status, CheckStatus::Fail);
-            assert!(
-                unrunnable.detail.contains("nope"),
-                "cause must surface: {}",
-                unrunnable.detail
-            );
-
-            let missing = companion_deep_check(CompanionProbe::NotFound);
-            assert_eq!(missing.status, CheckStatus::Fail);
-            assert_eq!(missing.remedy.as_deref(), Some(IDB_COMPANION_REMEDY));
         }
     }
 }

--- a/crates/glass-mcp/src/doctor.rs
+++ b/crates/glass-mcp/src/doctor.rs
@@ -580,7 +580,14 @@ mod tests {
     /// the aggregator puts that check and what softening does to it, not about its wording, which
     /// is `glass-ios`'s to test.
     fn companion_fixture(status: CheckStatus) -> Check {
-        Check::new("idb_companion", status, "idb_companion").with_remedy(COMPANION_REMEDY)
+        let c = Check::new("idb_companion", status, "idb_companion");
+        // Production never puts a remedy on an Ok check, and these tests assert remedies survive
+        // softening — so the fixture carries one only where production would.
+        if status == CheckStatus::Ok {
+            c
+        } else {
+            c.with_remedy(COMPANION_REMEDY)
+        }
     }
 
     /// The fixture's remedy — any string, asserted only to survive softening.
@@ -854,9 +861,10 @@ mod tests {
     }
 
     #[test]
-    fn missing_companion_fails_the_ios_verdict() {
-        // A Fail companion check in the ios section must escalate the overall verdict to Fail
-        // (exit code 1) when ios is the backend — iOS is unusable without the companion.
+    fn a_failing_ios_check_fails_the_verdict() {
+        // A Fail in the ios section must escalate the overall verdict to Fail (exit code 1) when
+        // ios is the backend. That an absent companion IS such a Fail is glass-ios's to prove
+        // (`a_companion_that_is_nowhere_points_at_the_install`); this pins only the escalation.
         let ios = Section::new(
             "ios",
             Some("ios".into()),

--- a/docs/how-to/setup-ios.md
+++ b/docs/how-to/setup-ios.md
@@ -102,9 +102,10 @@ unsupported error, while capture, logs, and clipboard keep working.
 
 glass finds `idb_companion` on `PATH`, and — because a `.app` / LaunchAgent launch runs with a
 minimal `PATH` that omits Homebrew's bindir — also probes the standard Homebrew locations
-(`/opt/homebrew/bin`, `/usr/local/bin`), so a `brew install` is picked up with no extra setup. Set
-`GLASS_IDB_COMPANION` to the binary's path only to override that — an install elsewhere, or to pin a
-specific build.
+(`/opt/homebrew/bin`, `/usr/local/bin`), so a `brew install` is picked up with no extra setup. It
+takes the first copy it can actually execute, and reports one it cannot (`doctor` then asks for a
+`chmod +x` rather than another install). Set `GLASS_IDB_COMPANION` to the binary's path only to
+override that — an install elsewhere, or to pin a specific build.
 
 ## Clipboard
 

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -111,7 +111,7 @@ override that with an explicit path. Full setup is in [how-to/setup-android.md](
 | `GLASS_IOS_UDID` | Exact Simulator UDID to drive when several are available | the newest booted/available iPhone simulator | iOS |
 | `GLASS_IOS_DEVICE` | Device name to boot when none is running, e.g. `iPhone 17` or `iPad Pro 13-inch` (ignored if `GLASS_IOS_UDID` is set) | the newest available iPhone simulator | iOS |
 | `GLASS_SIMULATOR_KEEP` | Leave a glass-booted iOS Simulator running at shutdown instead of stopping it | stop it | iOS |
-| `GLASS_IDB_COMPANION` | Path to the `idb_companion` binary (input + accessibility for the Simulator backend) | `idb_companion` (found on `PATH`) | iOS |
+| `GLASS_IDB_COMPANION` | Path to the `idb_companion` binary (input + accessibility for the Simulator backend) | the first runnable `idb_companion` on `PATH`, then Homebrew's standard prefixes | iOS |
 
 Attach-or-boot works the same way as the Android group above: glass attaches to an already-booted
 Simulator, or boots the newest available iPhone simulator itself. `GLASS_IOS_DEVICE` names any


### PR DESCRIPTION
`glass-ios` accepted `idb_companion` on `is_file()`, in both the runtime resolution and the doctor's presence signal. A companion that is installed and cannot be executed — no execute bit, a `noexec` mount, a permission class this user is not in — was reported as available, and the spawn then failed. Same defect class as #374, in the one crate that was outside its scope.

Resolution now goes through `glass-exec-unix`, whose `is_executable_file` asks the kernel rather than reading mode bits, and the hand-rolled `$PATH` walk is replaced by `resolve_bin`. Discovery walks past an unrunnable candidate to a runnable one later on `$PATH` or in a Homebrew prefix, as the user's shell would.

One resolution answers for both surfaces (#391). `NoCompanion { cause, remedy }` renders it two ways — the doctor's columns and the launch path's single message — so the preflight and the bring-up cannot drift, on the `NoSway` precedent in `glass-wayland`. Four outcomes, each with the remedy for that outcome:

| resolution | what the user is told |
|---|---|
| unrunnable | the file, and `chmod +x` — not another `brew install` of what is already there |
| absent | the install (tap first, which the launch path previously got wrong) |
| `GLASS_IDB_COMPANION` names nothing | the variable — an override skips discovery, so another install would not be read |
| no `$PATH` | it could not be looked up (#373); a bare-name override gets "set an absolute path" |

The launch refuses an unrunnable companion with that reason instead of exec'ing it for a bare `EACCES`, and the iOS `input`/`accessibility` capabilities read the same verdict, so they go unavailable exactly when a launch would fail.

The companion's checks move to `glass-ios`, next to the resolution they describe, leaving `glass-mcp` with the placement and softening that are its own — the arrangement `glass-android` and the desktop backends already have. Their per-outcome tests come along and now run on the Linux runner instead of only on macOS.

## Verification

`cargo test --workspace` (85 binaries), `clippy --all-targets`, and `fmt --check` clean, plus `--target x86_64-apple-darwin` and `--target x86_64-pc-windows-gnu` for the code Linux does not compile.

Resolution is tested against real files at real modes — no injected predicate can stand in for the kernel's answer, and an injected one is what hid the original bug. The four assertions encoding the fix were watched failing against the old behaviour, and every new guard was ablated and fails exactly the test written for it.

A five-lens review ran before this was opened; its findings are the second commit. The user-visible symptom still wants a macOS host with a Simulator to confirm end to end — the code paths here were exercised on Linux.

Closes #393.