### PR TITLE
fix(proc-linux): one child-stderr reader, and it can stop without waiting for EOF

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,6 +269,8 @@ jobs:
           if-no-files-found: warn
 
   mutants:
+    # The ruleset matches this check by name, so it stays as written even as the list below
+    # grows — glass-proc-linux is gated too, and deliberately unnamed here.
     name: Mutation shard ${{ matrix.shard }} (glass-core, glass-android, glass-x11, glass-exec-unix, glass-dbus-linux)
     runs-on: ubuntu-latest
     # A push carries no base ref to diff against; this gate is a pull-request check.
@@ -306,7 +308,8 @@ jobs:
                ':(glob)crates/glass-android/src/**/*.rs' \
                ':(glob)crates/glass-x11/src/**/*.rs' \
                ':(glob)crates/glass-exec-unix/src/**/*.rs' \
-               ':(glob)crates/glass-dbus-linux/src/**/*.rs' > "$RUNNER_TEMP/pr.diff"
+               ':(glob)crates/glass-dbus-linux/src/**/*.rs' \
+               ':(glob)crates/glass-proc-linux/src/**/*.rs' > "$RUNNER_TEMP/pr.diff"
           wc -l "$RUNNER_TEMP/pr.diff"
           if [ -s "$RUNNER_TEMP/pr.diff" ]; then
             echo "touched=true" >> "$GITHUB_OUTPUT"
@@ -340,6 +343,7 @@ jobs:
             --test-tool nextest \
             --package glass-core --package glass-android --package glass-x11 \
             --package glass-exec-unix --package glass-dbus-linux \
+            --package glass-proc-linux \
             --shard ${{ matrix.shard }}/8 --sharding round-robin \
             --in-diff "$RUNNER_TEMP/pr.diff"
 

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -15,6 +15,8 @@ env:
 
 jobs:
   sweep:
+    # Named crates plus glass-proc-linux; the name matches the PR gate's, which the ruleset
+    # requires by name.
     name: Mutation sweep shard ${{ matrix.shard }} (glass-core, glass-android, glass-x11, glass-exec-unix, glass-dbus-linux)
     runs-on: ubuntu-latest
     strategy:
@@ -43,6 +45,7 @@ jobs:
             --test-tool nextest \
             --package glass-core --package glass-android --package glass-x11 \
             --package glass-exec-unix --package glass-dbus-linux \
+            --package glass-proc-linux \
             --shard ${{ matrix.shard }}/8 --sharding round-robin
       - name: Upload the outcome
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ internal refactors, CI, or test-only changes.
 ## [Unreleased]
 
 ### Fixed
+- Linux: a deep `glass doctor` probe no longer leaves a stuck thread and an open pipe behind for
+  the rest of the process's life. The X11 and Wayland probes each read their child's stderr on a
+  helper thread, and that thread could only stop at end-of-file — which anything the probe left
+  running holds off indefinitely, since it inherited the pipe. A long-lived `glass-mcp serve
+  --http` accumulated one thread and one file descriptor per such probe. The reader is now told to
+  stop and waited for, so it always ends and always closes its end; the private headless X
+  server's reader ends with the display it was reading. A host that refuses glass that
+  thread is now its own start failure, naming what the host said instead of sending the user to
+  reinstall an Xvfb that is already there and working.
 - iOS: an `idb_companion` that is installed but cannot be executed — no execute bit, a `noexec`
   mount, permissions this user is not in — no longer reads as available. glass now asks the kernel
   whether it may run the binary, so a runnable copy later on `PATH` or in a Homebrew prefix is

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1391,6 +1391,7 @@ dependencies = [
  "glass-exec-unix",
  "glass-proc-linux",
  "glass-sandbox-linux",
+ "rustix",
  "tempfile",
  "x11rb",
 ]

--- a/crates/glass-proc-linux/src/lib.rs
+++ b/crates/glass-proc-linux/src/lib.rs
@@ -14,8 +14,16 @@
 //! the sandbox crate (it is generic process introspection, unrelated to
 //! bubblewrap). The Windows peer (`descendant_pids`, Toolhelp-based) lives with
 //! the Windows backend for the same reason — the OS APIs can't share an impl.
+//!
+//! It also holds what both backends need *around* a spawned process: reaping it and its
+//! descendants, and reading what it wrote — its stderr under a cap and a stop
+//! ([`StderrTail`]), or its output line-by-line until EOF ([`spawn_reader`]).
 
 #![cfg(target_os = "linux")]
+
+mod stderr;
+
+pub use stderr::{STDERR_KEPT, StderrTail};
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::io::{BufRead, BufReader, Read};

--- a/crates/glass-proc-linux/src/stderr.rs
+++ b/crates/glass-proc-linux/src/stderr.rs
@@ -1,0 +1,410 @@
+//! Bounded capture of a child's stderr, shared by the Linux backends.
+
+use std::io::{ErrorKind, Read};
+use std::os::fd::OwnedFd;
+use std::process::ChildStderr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, PoisonError};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use rustix::event::{EventfdFlags, PollFd, PollFlags, Timespec, eventfd, poll};
+use rustix::fs::{OFlags, fcntl_getfl, fcntl_setfl};
+
+/// How much of a child's stderr is kept for diagnostics.
+///
+/// An X server dumps its option table (~5 KiB) *after* the fatal line and sway's complaints come
+/// first, so the head is what is kept.
+pub const STDERR_KEPT: usize = 8 * 1024;
+
+/// How long an idle reader sleeps before looking at the stop flag again.
+///
+/// Also the ceiling on [`StderrTail::finish`]'s join if the wakeup is lost — the flag is what
+/// stops the reader.
+const HEARD_BY: Timespec = Timespec {
+    tv_sec: 5,
+    tv_nsec: 0,
+};
+
+/// A child's stderr, read on a helper thread until the pipe closes or the tail ends it.
+///
+/// Not a read at the end: a child whose stderr nobody drains stalls on a full pipe, which the
+/// caller reads as a process that never came up.
+///
+/// The write end is inherited by everything the child spawned, so a process outliving the
+/// teardown holds the pipe open, and a reader that could only stop at EOF would park there
+/// holding an fd — one per deep probe, for the life of a `glass-mcp serve --http` (glass#471).
+pub struct StderrTail {
+    kept: Arc<Mutex<Vec<u8>>>,
+    /// Set by the reader on its way out, so [`StderrTail::finish`] can end its wait as soon as
+    /// the pipe closes on its own.
+    done: Arc<AtomicBool>,
+    /// What actually stops the reader. A flag rather than the wakeup below, so a wakeup that
+    /// never arrives costs [`HEARD_BY`] rather than the life of the process.
+    stopping: Arc<AtomicBool>,
+    /// Wakes a reader asleep in `poll` so it reads the flag now instead of at [`HEARD_BY`].
+    /// Nobody drains the counter, so one write stays readable and the next poll is certain to
+    /// see it.
+    wake: OwnedFd,
+    /// Taken by whichever of [`StderrTail::finish`] and `drop` runs first.
+    reader: Option<JoinHandle<()>>,
+}
+
+impl StderrTail {
+    /// Start reading.
+    ///
+    /// `Err` is the host refusing a resource the bounded read is built from: the thread —
+    /// `Builder`, where `thread::spawn` panics (glass#454) — the wakeup fd or its dup, or the
+    /// non-blocking mode. `stderr` is consumed either way, so on `Err` the read end is already
+    /// closed and the child will take `EPIPE` rather than stall.
+    pub fn drain(stderr: ChildStderr) -> std::io::Result<StderrTail> {
+        // Blocking, a read with nothing to read parks past every look at the flag. Safe for the
+        // child: `pipe(2)` gives the two ends separate open file descriptions, so a status flag
+        // set here never reaches the write end it inherited.
+        fcntl_setfl(&stderr, fcntl_getfl(&stderr)?.union(OFlags::NONBLOCK))?;
+        // CLOEXEC or this fd lands in every process the host spawns afterwards. No NONBLOCK:
+        // `end` writes to it once, and only a saturated counter would block that.
+        let wake = eventfd(0, EventfdFlags::CLOEXEC)?;
+        // A dup, not a second eventfd: both fds name one counter, so `end`'s write is what this
+        // reader's poll sees.
+        let woken = wake.try_clone()?;
+        let kept: Arc<Mutex<Vec<u8>>> = Arc::default();
+        let done: Arc<AtomicBool> = Arc::default();
+        let stopping: Arc<AtomicBool> = Arc::default();
+        let (keeping, ended, stop) = (Arc::clone(&kept), Arc::clone(&done), Arc::clone(&stopping));
+        let reader = std::thread::Builder::new()
+            .name("glass-stderr-tail".into())
+            .spawn(move || {
+                read_until_stopped(stderr, &woken, &stop, &keeping);
+                ended.store(true, Ordering::Release);
+            })?;
+        Ok(StderrTail {
+            kept,
+            done,
+            stopping,
+            wake,
+            reader: Some(reader),
+        })
+    }
+
+    /// What it said, at most [`STDERR_KEPT`] bytes, after `grace` for the pipe to close — call
+    /// once the child is reaped.
+    ///
+    /// Collected whether or not the pipe closed: anything the child left running holds it open,
+    /// and the reader is ended either way.
+    pub fn finish(mut self, grace: Duration) -> String {
+        crate::await_condition(grace, || self.done.load(Ordering::Acquire));
+        self.end();
+        let kept = self.kept.lock().unwrap_or_else(PoisonError::into_inner);
+        String::from_utf8_lossy(&kept).into_owned()
+    }
+
+    /// Stop the reader and wait for it to go, which is what makes the pipe closed rather than
+    /// assumed closed. Idempotent, because `finish` runs it and then drops.
+    fn end(&mut self) {
+        let Some(reader) = self.reader.take() else {
+            return;
+        };
+        // Set before the wake, or a reader the write pulls out of `poll` finds the flag still
+        // false and goes back to sleep for another `HEARD_BY`.
+        self.stopping.store(true, Ordering::Release);
+        let _ = rustix::io::write(&self.wake, &1u64.to_ne_bytes());
+        let _ = reader.join();
+    }
+}
+
+impl Drop for StderrTail {
+    /// A tail nobody reads still ends its reader.
+    fn drop(&mut self) {
+        self.end();
+    }
+}
+
+/// Hides the capture: derived, it renders up to [`STDERR_KEPT`] decimal byte values into
+/// whatever printed the struct holding it.
+impl std::fmt::Debug for StderrTail {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let kept = self.kept.lock().unwrap_or_else(PoisonError::into_inner);
+        f.debug_struct("StderrTail")
+            .field("kept", &format_args!("{} bytes", kept.len()))
+            .field("done", &self.done.load(Ordering::Acquire))
+            .finish_non_exhaustive()
+    }
+}
+
+/// Read `stderr` until it ends or `stopping` says to, keeping the first [`STDERR_KEPT`] bytes.
+fn read_until_stopped(
+    mut stderr: ChildStderr,
+    wake: &OwnedFd,
+    stopping: &AtomicBool,
+    keeping: &Mutex<Vec<u8>>,
+) {
+    let mut chunk = [0u8; 4096];
+    // The flag is read before every read, not only when the pipe runs dry, so a child that
+    // never stops writing cannot keep the reader here either.
+    while !stopping.load(Ordering::Acquire) {
+        match stderr.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(n) => {
+                let mut kept = keeping.lock().unwrap_or_else(PoisonError::into_inner);
+                // Past the cap the pipe is still drained, so the child is never blocked writing
+                // to it.
+                let room = STDERR_KEPT.saturating_sub(kept.len());
+                kept.extend_from_slice(&chunk[..n.min(room)]);
+            }
+            Err(e) => match e.kind() {
+                // Nothing to read yet, or the read was interrupted: back to the wait.
+                ErrorKind::WouldBlock | ErrorKind::Interrupted => wait_for_more(&stderr, wake),
+                // Anything else will not read better next time.
+                _ => break,
+            },
+        }
+    }
+}
+
+/// Sleep until the pipe has more to say, the wakeup is rung, or [`HEARD_BY`] elapses. The caller
+/// re-reads whichever it was, so none of the three needs telling apart.
+///
+/// A poll that errors sleeps instead of returning at once: a persistent one — `EINVAL` under an
+/// `RLIMIT_NOFILE` below two — would otherwise spin this loop on an `EAGAIN` read and burn a core.
+fn wait_for_more(stderr: &ChildStderr, wake: &OwnedFd) {
+    let mut waiting = [
+        PollFd::new(stderr, PollFlags::IN),
+        PollFd::new(wake, PollFlags::IN),
+    ];
+    if poll(&mut waiting, Some(&HEARD_BY)).is_err() {
+        std::thread::sleep(crate::POLL_INTERVAL);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{BufRead, BufReader};
+    use std::os::fd::AsRawFd;
+    use std::process::{Child, Command, Stdio};
+    use std::sync::mpsc;
+    use std::time::{Duration, Instant};
+
+    use rustix::process::{Pid, Signal, kill_process};
+
+    /// How long a test waits for a `finish` that is supposed to be bounded — twice the longest
+    /// grace a test passes, and a third of the survivor's life, which must not be what ends it.
+    const NEVER_RETURNS: Duration = Duration::from_secs(10);
+
+    /// A process holding a child's stderr after the child is gone, killed when the test ends,
+    /// panic included. It outlives [`NEVER_RETURNS`] three times over, so a reader that only
+    /// stops at EOF stays parked for the whole test, and self-limits if the guard cannot run.
+    ///
+    /// Load-bearing for the fd assertions, not only for cleanup: while it holds the write end
+    /// the pipe's inode cannot be freed, so no sibling test thread can be handed the same
+    /// `pipe:[n]` and read as a false failure.
+    struct Survivor(Option<u32>);
+
+    impl Drop for Survivor {
+        fn drop(&mut self) {
+            if let Some(pid) = self.0.and_then(|p| Pid::from_raw(p as i32)) {
+                let _ = kill_process(pid, Signal::KILL);
+            }
+        }
+    }
+
+    /// Spawn `sh -c script` with its stderr piped.
+    fn child(script: &str) -> Child {
+        Command::new("sh")
+            .arg("-c")
+            .arg(script)
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("sh is runnable")
+    }
+
+    /// A child that says `said`, leaves a process holding its stderr, and exits.
+    fn child_with_survivor(said: &str) -> (Child, Survivor) {
+        let mut c = Command::new("sh")
+            .arg("-c")
+            .arg(format!("printf '{said}\\n' >&2; sleep 30 & echo $!"))
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("sh is runnable");
+        let mut pid = String::new();
+        let read = BufReader::new(c.stdout.take().expect("piped stdout")).read_line(&mut pid);
+        // Guarded before anything that can panic: the sleeper exists from the moment `sh` runs.
+        let survivor = Survivor(pid.trim().parse().ok());
+        read.expect("sh reports the pid it backgrounded");
+        assert!(survivor.0.is_some(), "sh reported {pid:?}, not a pid");
+        c.wait().expect("the child exits, the survivor does not");
+        (c, survivor)
+    }
+
+    /// What `finish` produced, and how long it took. Runs off-thread so a reader with no exit
+    /// fails the test rather than hanging the suite.
+    fn finish_within(tail: StderrTail, grace: Duration) -> (String, Duration) {
+        let (tx, rx) = mpsc::channel();
+        let t0 = Instant::now();
+        std::thread::spawn(move || tx.send(tail.finish(grace)));
+        let said = rx
+            .recv_timeout(NEVER_RETURNS)
+            .expect("finish must return; a reader parked in read() never does");
+        (said, t0.elapsed())
+    }
+
+    #[test]
+    fn the_read_end_is_non_blocking() {
+        // Blocking, a read with nothing to read parks past every look at the stop flag, and the
+        // wakeup cannot reach a thread that is no longer in `poll`. `Xvfb` holds its tail for
+        // the server's lifetime, and a healthy X server is silent, so that is `drop` hanging.
+        let (mut c, _survivor) = child_with_survivor("the fatal line");
+        let stderr = c.stderr.take().expect("piped stderr");
+        let fd = stderr.as_raw_fd();
+        // Held for the whole assertion, so this reads our own pipe and not a reused number.
+        let _tail = StderrTail::drain(stderr).expect("a reader");
+
+        let fdinfo = std::fs::read_to_string(format!("/proc/self/fdinfo/{fd}")).expect("fdinfo");
+        let flags = fdinfo
+            .lines()
+            .find_map(|l| l.strip_prefix("flags:"))
+            .expect("fdinfo reports the open file description's flags");
+        let bits = u32::from_str_radix(flags.trim(), 8).expect("octal");
+        assert!(
+            bits & 0o4000 != 0,
+            "the read end must carry O_NONBLOCK, but fdinfo says flags:{flags}"
+        );
+    }
+
+    #[test]
+    fn debug_summarises_the_capture_instead_of_dumping_it() {
+        // Derived, this renders every kept byte as a decimal — into `Xvfb`'s own derived `Debug`,
+        // and from there into whatever printed the struct holding it.
+        let (mut c, _survivor) = child_with_survivor("the fatal line");
+        let tail = StderrTail::drain(c.stderr.take().expect("piped stderr")).expect("a reader");
+        assert!(
+            crate::await_condition(Duration::from_secs(5), || !format!("{tail:?}")
+                .contains("0 bytes")),
+            "nothing was captured, so a dump would have had nothing to show either"
+        );
+
+        let rendered = format!("{tail:?}");
+        assert!(
+            rendered.contains("15 bytes"),
+            "a count, not a dump: {rendered}"
+        );
+        assert!(
+            !rendered.contains("116"),
+            "the bytes themselves must not be in it: {rendered}"
+        );
+    }
+
+    #[test]
+    fn finish_returns_what_was_said_while_a_survivor_holds_the_pipe() {
+        // The write end is inherited by everything the child spawned, so EOF is not a deadline
+        // the reader can count on reaching (glass#471).
+        let (mut c, _survivor) = child_with_survivor("the fatal line");
+        let tail = StderrTail::drain(c.stderr.take().expect("piped stderr")).expect("a reader");
+
+        let (said, took) = finish_within(tail, Duration::from_millis(200));
+
+        assert_eq!(said.trim(), "the fatal line");
+        assert!(
+            took < Duration::from_secs(2),
+            "the grace is the wait, not a floor: took {took:?}"
+        );
+    }
+
+    #[test]
+    fn finish_releases_the_pipe_a_survivor_holds_open() {
+        // A `finish` that gives up on a still-open pipe without ending its reader leaves the
+        // fd held for the process's life.
+        let (mut c, _survivor) = child_with_survivor("the fatal line");
+        let stderr = c.stderr.take().expect("piped stderr");
+        let link = format!("/proc/self/fd/{}", stderr.as_raw_fd());
+        let held = std::fs::read_link(&link).expect("the read end is open");
+        let tail = StderrTail::drain(stderr).expect("a reader");
+
+        finish_within(tail, Duration::from_millis(200));
+
+        // The survivor still holds the write end, so this pipe cannot be reopened by anything
+        // else: finding the same target again means the same fd, still ours.
+        assert!(
+            std::fs::read_link(&link).ok().is_none_or(|now| now != held),
+            "the reader must close its end, but {link} still points at {held:?}"
+        );
+    }
+
+    #[test]
+    fn dropping_a_tail_instead_of_finishing_it_still_releases_the_pipe() {
+        // `finish` is how the capture is read, not how the reader is ended.
+        let (mut c, _survivor) = child_with_survivor("the fatal line");
+        let stderr = c.stderr.take().expect("piped stderr");
+        let link = format!("/proc/self/fd/{}", stderr.as_raw_fd());
+        let held = std::fs::read_link(&link).expect("the read end is open");
+
+        drop(StderrTail::drain(stderr).expect("a reader"));
+
+        assert!(
+            std::fs::read_link(&link).ok().is_none_or(|now| now != held),
+            "a dropped tail must end its reader too, but {link} still points at {held:?}"
+        );
+    }
+
+    #[test]
+    fn the_reader_stops_keeping_bytes_at_the_documented_cap() {
+        // A child dumping megabytes must cost bounded memory. The range is half the assertion:
+        // against the constant alone, shrinking the cap to a byte would read as agreement.
+        assert!(
+            (5 * 1024..64 * 1024).contains(&STDERR_KEPT),
+            "the cap must hold an X server's option table without holding a log: {STDERR_KEPT}"
+        );
+        let mut c = child("dd if=/dev/zero bs=1024 count=64 2>/dev/null | tr '\\0' e >&2");
+        let tail = StderrTail::drain(c.stderr.take().expect("piped stderr")).expect("a reader");
+        // Not `wait`: the child writes exactly one pipe buffer, so a reader that stopped
+        // draining would hang the suite here instead of failing it.
+        assert!(
+            crate::await_condition(Duration::from_secs(10), || matches!(
+                c.try_wait(),
+                Ok(Some(_))
+            )),
+            "the child must not block writing 64 KiB into a drained pipe"
+        );
+        assert_eq!(
+            finish_within(tail, Duration::from_secs(5)).0.len(),
+            STDERR_KEPT
+        );
+    }
+
+    #[test]
+    fn a_child_that_floods_stderr_past_the_cap_is_never_blocked_writing() {
+        // Past the cap the pipe must still be drained. Stop reading and the child blocks in
+        // write() once the 64 KiB pipe buffer fills, which every caller reads as a hang.
+        let mut c = child("dd if=/dev/zero bs=1024 count=1024 2>/dev/null | tr '\\0' e >&2");
+        let tail = StderrTail::drain(c.stderr.take().expect("piped stderr")).expect("a reader");
+        let exited = crate::await_condition(Duration::from_secs(10), || {
+            matches!(c.try_wait(), Ok(Some(_)))
+        });
+        assert!(
+            exited,
+            "1 MiB of stderr must not block the child writing it"
+        );
+        assert!(c.wait().expect("already exited").success());
+        finish_within(tail, Duration::from_secs(5));
+    }
+
+    #[test]
+    fn finish_waits_out_the_grace_for_a_line_that_has_not_arrived_yet() {
+        // The diagnostics arrive after the caller asks for them. Read without waiting and a
+        // failed start reports an empty stderr — the only clue it had.
+        let mut c = child("sleep 0.3; printf 'the fatal line\\n' >&2");
+        let tail = StderrTail::drain(c.stderr.take().expect("piped stderr")).expect("a reader");
+        let (said, took) = finish_within(tail, Duration::from_secs(5));
+        c.wait().expect("the child exits");
+        assert_eq!(said.trim(), "the fatal line");
+        // The other half: a `finish` that always burned its whole grace would satisfy the line
+        // above and cost every caller the ceiling on every call.
+        assert!(
+            took < Duration::from_secs(2),
+            "the grace is a ceiling, not a floor: took {took:?}"
+        );
+    }
+}

--- a/crates/glass-proc-linux/tests/idle_reader_sleeps.rs
+++ b/crates/glass-proc-linux/tests/idle_reader_sleeps.rs
@@ -1,0 +1,60 @@
+//! glass#471: the reader sleeps between reads.
+//!
+//! Nothing in the unit tests reaches this. A reader that turned every empty read straight into
+//! another empty read would pass all of them — and `Xvfb` holds one for the whole life of a
+//! server that is normally silent, so it would pin a core for the session.
+//!
+//! Its own test binary: the measurement is this process's CPU time, which a sibling test running
+//! in parallel would add to.
+
+#![cfg(target_os = "linux")]
+
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+/// How long the reader is watched. Long enough that a spinning one is unmistakable, short enough
+/// that the survivor below outlives it many times over.
+const WATCHED_FOR: Duration = Duration::from_millis(300);
+
+/// This process's CPU time in clock ticks: `utime` + `stime`, read after the last `)` because the
+/// comm field before it can itself contain spaces and parens.
+fn cpu_ticks() -> u64 {
+    let stat = std::fs::read_to_string("/proc/self/stat").expect("/proc/self/stat");
+    let after_comm = &stat[stat.rfind(')').expect("comm is parenthesised") + 1..];
+    let fields: Vec<&str> = after_comm.split_whitespace().collect();
+    // `state` is the first field left, which puts utime and stime at 11 and 12.
+    fields[11].parse::<u64>().expect("utime") + fields[12].parse::<u64>().expect("stime")
+}
+
+#[test]
+fn an_idle_reader_costs_no_cpu() {
+    // The survivor keeps the pipe open with nothing to say, which is the state a healthy server
+    // spends its life in. It outlives the watch and then goes on its own.
+    let mut child = Command::new("sh")
+        .arg("-c")
+        .arg("printf 'the fatal line\\n' >&2; sleep 5 &")
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("sh is runnable");
+    let tail = glass_proc_linux::StderrTail::drain(child.stderr.take().expect("piped stderr"))
+        .expect("a reader");
+    child
+        .wait()
+        .expect("the child exits, the survivor does not");
+
+    let before = cpu_ticks();
+    std::thread::sleep(WATCHED_FOR);
+    let spent = cpu_ticks() - before;
+
+    // Clock ticks are 100/s on Linux, so a reader spinning through the watch bills ~30 and one
+    // asleep in `poll` bills none. Ten is far above the noise and far below a spin.
+    assert!(
+        spent < 10,
+        "an idle reader must sleep, not spin: {spent} ticks of CPU in {WATCHED_FOR:?}"
+    );
+    assert_eq!(
+        tail.finish(Duration::from_millis(200)).trim(),
+        "the fatal line"
+    );
+}

--- a/crates/glass-wayland/src/doctor.rs
+++ b/crates/glass-wayland/src/doctor.rs
@@ -3,14 +3,12 @@
 //! [`checks`] gathers the real environment; the pure [`wayland_checks`] maps gathered
 //! facts to [`Check`]s and is unit-tested without sway.
 
-use std::io::Read as _;
 use std::path::{Path, PathBuf};
-use std::process::{Child, ChildStderr, Stdio};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex, PoisonError};
+use std::process::{Child, Stdio};
 use std::time::{Duration, Instant};
 
 use glass_core::{AppSpec, Check, CheckStatus, ProbeFailure};
+use glass_proc_linux::StderrTail;
 
 use crate::command::{build_sway_command, sway_config};
 use crate::platform::{
@@ -115,8 +113,8 @@ fn wayland_checks(
 /// What glass can do about a probe whose own machinery failed — never the backend's advice, which
 /// nothing here established (glass#373).
 const NOTHING_ABOUT_SWAY: &str = "the compositor was started and then lost track of, so nothing \
-     here is about sway or the host's GL stack. Re-run `glass doctor --deep`; a host that refuses \
-     threads (a low `pids` cgroup limit) does this repeatably";
+     here is about sway or the host's GL stack. Re-run `glass doctor --deep`; a host out of \
+     threads (a low `pids` cgroup limit) or file descriptors does this repeatably";
 
 /// The `sway spawn (deep)` check: whether the compositor came up, and whether the probe stopped
 /// everything it started.
@@ -309,69 +307,16 @@ fn probe_sway(sway: &Path) -> SwaySpawn {
     probe_sway_within(sway, IPC_READY_BUDGET)
 }
 
-/// How much of sway's stderr the probe keeps, and how much of that a check quotes.
-///
-/// The pipe must be drained faster than sway writes; a check's detail is one line an operator
-/// reads.
-const STDERR_KEPT: usize = 8 * 1024;
+/// How much of the kept stderr a check quotes: a check's detail is one line an operator reads,
+/// where what was kept is [`glass_proc_linux::STDERR_KEPT`].
 const STDERR_SHOWN: usize = 512;
 
 /// How long the probe waits for the stderr pipe to close after the compositor has been reaped.
 const SAID_GRACE: Duration = Duration::from_millis(200);
 
-/// Sway's own stderr, read on a helper thread for as long as the pipe is open.
-///
-/// Not a read at the end: a compositor whose stderr nobody drains stalls on a full pipe, which the
-/// probe would report as one that never came up.
-struct SwaySaid {
-    kept: Arc<Mutex<Vec<u8>>>,
-    closed: Arc<AtomicBool>,
-}
-
-impl SwaySaid {
-    /// Start reading. `Err` is the host refusing the thread: `Builder`, where `thread::spawn`
-    /// panics (glass#454).
-    fn drain(mut stderr: ChildStderr) -> std::io::Result<SwaySaid> {
-        let said = SwaySaid {
-            kept: Arc::default(),
-            closed: Arc::default(),
-        };
-        let (kept, closed) = (Arc::clone(&said.kept), Arc::clone(&said.closed));
-        std::thread::Builder::new()
-            .name("glass-doctor-sway-stderr".into())
-            .spawn(move || {
-                let mut chunk = [0u8; 1024];
-                loop {
-                    match stderr.read(&mut chunk) {
-                        Ok(0) | Err(_) => break,
-                        Ok(n) => {
-                            let mut kept = kept.lock().unwrap_or_else(PoisonError::into_inner);
-                            // Past the cap the pipe is still drained, so sway is never blocked
-                            // writing to it.
-                            let room = STDERR_KEPT.saturating_sub(kept.len());
-                            kept.extend_from_slice(&chunk[..n.min(room)]);
-                        }
-                    }
-                }
-                closed.store(true, Ordering::Release);
-            })?;
-        Ok(said)
-    }
-
-    /// What it said, after `grace` for the pipe to close — call once the compositor is reaped.
-    ///
-    /// Read whether or not the pipe closed — anything the probe left running holds it open.
-    fn snapshot(&self, grace: Duration) -> Option<String> {
-        glass_proc_linux::await_condition(grace, || self.closed.load(Ordering::Acquire));
-        let kept = self.kept.lock().unwrap_or_else(PoisonError::into_inner);
-        said_line(&kept)
-    }
-}
-
 /// Sway's stderr as one line of a check: lines joined, clipped to [`STDERR_SHOWN`] with the cut
 /// disclosed. `None` when it said nothing.
-fn said_line(kept: &[u8]) -> Option<String> {
-    let text = String::from_utf8_lossy(kept);
+fn said_line(text: &str) -> Option<String> {
     let said = text
         .lines()
         .map(str::trim)
@@ -525,30 +470,31 @@ fn probe_sway_within(sway: &Path, budget: Duration) -> SwaySpawn {
         Ok(child) => child,
         Err(e) => return never_ran(ProbeFailure::NotStarted(format!("spawn sway: {e}"))),
     };
-    let said = match child.stderr.take().map(SwaySaid::drain) {
-        Some(Ok(said)) => Some(said),
-        // A refused thread leaves sway's stderr undrained, so the compositor is taken back down
-        // rather than run blind — and accounted for like any other path.
-        Some(Err(e)) => {
+    let said = match StderrTail::drain(child.stderr.take().expect("piped stderr")) {
+        Ok(said) => said,
+        // `drain` consumed the pipe, so the read end is already closed and sway's next words
+        // take SIGPIPE.
+        Err(e) => {
             return SwaySpawn {
                 came_up: CameUp::Unknown(format!(
-                    "the host refused the thread that reads its stderr: {e}"
+                    "glass could not set up the reader for its stderr: {e}"
                 )),
                 last_ipc: None,
                 said: None,
                 leaked: reap_and_account(&mut child, rt),
             };
         }
-        None => None,
     };
 
     let wait = await_ipc(budget, || child.try_wait(), || connect_ipc(rt.path()));
-    let said = said.and_then(|said| said.snapshot(SAID_GRACE));
+    // Reap first: closing the read end under a live compositor would EPIPE the writes being
+    // collected.
+    let leaked = reap_and_account(&mut child, rt);
     SwaySpawn {
         came_up: wait.came_up,
         last_ipc: wait.last_ipc,
-        said,
-        leaked: reap_and_account(&mut child, rt),
+        said: said_line(&said.finish(SAID_GRACE)),
+        leaked,
     }
 }
 
@@ -744,7 +690,8 @@ mod tests {
     #[test]
     #[ignore = "starts a real compositor or X server; needs sway, Mesa, Xwayland or Xvfb"]
     fn the_deep_check_really_starts_and_stops_a_compositor() {
-        let before = compositors_running();
+        let (sway, _) = discover_sway().expect("this box has a discoverable sway");
+        let before = compositors_running(&sway);
         let deep = checks(true)
             .into_iter()
             .find(|c| c.name == "sway spawn (deep)")
@@ -753,22 +700,24 @@ mod tests {
         assert_eq!(deep.status, CheckStatus::Ok, "{}", deep.detail);
         // Counted from outside glass as well, so the verdict is not the only witness to it.
         assert_eq!(
-            compositors_running(),
+            compositors_running(&sway),
             before,
             "the deep probe left a compositor behind"
         );
     }
 
-    /// How many of the deep probe's own compositors are running, matched on its private
-    /// runtime-dir prefix so another test's session or a real sway is never counted.
-    fn compositors_running() -> usize {
+    /// How many of the deep probe's own compositors are running, matched on both the probe's
+    /// runtime-dir prefix and `sway` itself so a real session is never counted — nor a sibling
+    /// test's fixture compositor, which the prefix alone does not tell apart.
+    fn compositors_running(sway: &Path) -> usize {
+        let sway = sway.display().to_string();
         let out = std::process::Command::new("ps")
             .args(["-eo", "args"])
             .output()
             .expect("ps");
         String::from_utf8_lossy(&out.stdout)
             .lines()
-            .filter(|l| l.contains("glass-doctor-wl."))
+            .filter(|l| l.contains("glass-doctor-wl.") && l.contains(&sway))
             .count()
     }
 
@@ -860,6 +809,88 @@ mod tests {
                 .contains("could not create GLES2 renderer; sway: Unable to create renderer"),
             "{deep:?}"
         );
+    }
+
+    /// glass#471: the write end of sway's stderr is inherited by anything it leaves outside its
+    /// own process tree — an Xwayland, an `exec`ed client — so EOF is not a deadline the reader
+    /// can count on reaching.
+    #[test]
+    fn a_compositor_that_left_something_holding_its_stderr_still_reports_what_it_said() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pidfile = dir.path().join("survivor");
+        let fake = fake_sway(
+            dir.path(),
+            // `setsid` puts it in its own session, so the pid-tree snapshot cannot see it and
+            // the reap cannot signal it. The `exec` keeps the pid the shell reported, so the
+            // guard can reach it, and the sleep self-limits if it cannot.
+            &format!(
+                "echo 'sway: Unable to create renderer' >&2\n\
+                 setsid sh -c 'echo $$ > {}; exec sleep 30' &\n\
+                 exit 1\n",
+                pidfile.display()
+            ),
+        );
+
+        // Off-thread: a reader with no exit of its own must fail this test, not hang the suite.
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(probe_sway_within(&fake, Duration::from_secs(5)));
+        });
+        let spawn = rx
+            .recv_timeout(Duration::from_secs(30))
+            .expect("the probe must return; a reader parked in read() never does");
+        let _reap = Survivor(&pidfile);
+
+        assert!(
+            spawn
+                .said
+                .as_deref()
+                .is_some_and(|said| said.contains("Unable to create renderer")),
+            "what sway said must survive a survivor holding its stderr: {spawn:?}"
+        );
+    }
+
+    /// glass#471: `finish` closes the read end, so collecting before the reap takes sway's
+    /// stderr away from it while it is still running.
+    #[test]
+    fn a_compositor_says_what_it_said_on_the_way_out_too() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let fake = fake_sway(
+            dir.path(),
+            // `sleep &` + `wait`, not `sleep`: a foreground child defers the trap until it
+            // returns, so the compositor would ride out the whole reap grace instead of
+            // answering the SIGTERM.
+            "trap 'echo \"sway: caught SIGTERM\" >&2; exit 0' TERM\n\
+             sleep 30 &\n\
+             wait\n",
+        );
+
+        // Short: the compositor never brings its IPC up, so this budget is pure waiting.
+        let spawn = probe_sway_within(&fake, Duration::from_secs(1));
+
+        assert!(
+            spawn
+                .said
+                .as_deref()
+                .is_some_and(|said| said.contains("caught SIGTERM")),
+            "the reader must outlive the reap it is reporting on: {spawn:?}"
+        );
+    }
+
+    /// Kills what a fixture left running, however the test ends. The pid is read at drop time:
+    /// the fixture writes it asynchronously, and a test that failed early may never have looked.
+    struct Survivor<'a>(&'a Path);
+
+    impl Drop for Survivor<'_> {
+        fn drop(&mut self) {
+            let pid = std::fs::read_to_string(self.0)
+                .ok()
+                .and_then(|p| p.trim().parse::<i32>().ok())
+                .and_then(rustix::process::Pid::from_raw);
+            if let Some(pid) = pid {
+                let _ = rustix::process::kill_process(pid, rustix::process::Signal::KILL);
+            }
+        }
     }
 
     /// A fake sway at `dir/sway` running `body`, which rejects an argv that is not the one glass
@@ -1101,10 +1132,10 @@ mod tests {
     #[test]
     fn a_long_stderr_is_clipped_and_says_it_was() {
         let long = "e".repeat(STDERR_SHOWN * 2);
-        let said = said_line(long.as_bytes()).expect("something was said");
+        let said = said_line(&long).expect("something was said");
         assert!(said.len() < long.len(), "clipped");
         assert!(said.contains(&format!("of {}", long.len())), "{said}");
-        assert_eq!(said_line(b"  \n \n"), None, "silence is not something said");
+        assert_eq!(said_line("  \n \n"), None, "silence is not something said");
     }
 
     #[test]

--- a/crates/glass-x11/Cargo.toml
+++ b/crates/glass-x11/Cargo.toml
@@ -27,6 +27,8 @@ x11rb.workspace = true
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 criterion = { workspace = true }
+# Signalling a fixture's leftover process directly, so a test cleans up what it started.
+rustix = { workspace = true }
 tempfile = { workspace = true }
 
 [[bench]]

--- a/crates/glass-x11/src/xvfb.rs
+++ b/crates/glass-x11/src/xvfb.rs
@@ -3,12 +3,13 @@
 //! Uses `-displayfd`: the server picks a free display and reports it once ready,
 //! avoiding display-number and readiness races.
 
-use std::io::{BufRead, BufReader, Read};
-use std::process::{Child, ChildStderr, ChildStdout, Command, Stdio};
-use std::sync::{Arc, Condvar, Mutex, mpsc};
+use std::io::{BufRead, BufReader};
+use std::process::{Child, ChildStdout, Command, Stdio};
+use std::sync::mpsc;
 use std::time::Duration;
 
 use glass_core::{GlassError, Result};
+use glass_proc_linux::StderrTail;
 
 /// How long to wait for Xvfb to report its display before treating it as wedged.
 /// Readiness is normally well under a second; this ceiling is generous so a
@@ -18,16 +19,20 @@ use glass_core::{GlassError, Result};
 const READY_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Upper bound on how long `Xvfb::start` can take before it returns (both
-/// attempts wedge, each reaped): callers that put their own timeout around a
-/// start (doctor's deep probe) must budget at least this or they'll misreport
-/// a start that would have succeeded on the retry.
+/// attempts wedge, each reaped and each collected): callers that put their own
+/// timeout around a start (doctor's deep probe) must budget at least this or
+/// they'll misreport a start that would have succeeded on the retry.
+///
+/// Excludes the reader's own backstop, which only runs if a wakeup is lost.
 pub(crate) fn start_deadline() -> Duration {
-    2 * (READY_TIMEOUT + glass_proc_linux::REAP_GRACE)
+    2 * (READY_TIMEOUT + glass_proc_linux::REAP_GRACE + SAID_GRACE)
 }
 
-/// How much of Xvfb's stderr to keep for error messages. Failures print early;
-/// past the cap the pipe is still drained (see `StderrTail`) but bytes are dropped.
-const STDERR_CAP: usize = 8 * 1024;
+/// How long a failed start waits for Xvfb's stderr pipe to close before rendering what it has.
+///
+/// The server is already reaped, so the pipe EOFs within moments — unless the server left
+/// something holding it, and then this is what the message costs instead of everything.
+const SAID_GRACE: Duration = Duration::from_millis(500);
 
 #[derive(Debug)]
 pub struct Xvfb {
@@ -40,6 +45,14 @@ pub struct Xvfb {
         reason = "RAII: held open for the server's lifetime so the fd never SIGPIPEs"
     )]
     displayfd: ChildStdout,
+    /// Kept draining for the server's lifetime — a chatty server must never stall on a full
+    /// pipe. Fields drop after `Drop::drop` returns, so the reader ends only once the server
+    /// has been reaped.
+    #[expect(
+        dead_code,
+        reason = "RAII: drained for the server's lifetime, and its reader ends when this drops"
+    )]
+    stderr: StderrTail,
 }
 
 impl Xvfb {
@@ -63,6 +76,10 @@ impl Xvfb {
 enum StartErr {
     /// `exec` itself failed — the binary is missing/not runnable.
     Spawn(String),
+    /// The server started, but the host refused something the stderr reader is built from —
+    /// the thread, an fd. Not `Spawn`: nothing is wrong with the binary, so its remedy would
+    /// misdirect.
+    NoReader(String),
     /// Xvfb exited before reporting a display.
     Exited { stderr: String },
     /// A line arrived on `-displayfd` but wasn't a display number.
@@ -76,7 +93,8 @@ enum StartErr {
 /// transient failure class (seen under heavy host load), and on a user's first
 /// run a single quiet retry is the difference between working and giving up.
 /// Exit/garbage failures are deterministic (bad binary/args/env); retrying those
-/// would only double the time to the same error.
+/// would only double the time to the same error. A refused reader is not retried
+/// either: the host is out of a resource, and a second server would ask for more.
 fn start_binary(xvfb: &str, screen: &str, ready_timeout: Duration) -> Result<Xvfb> {
     match start_once(xvfb, screen, ready_timeout) {
         Ok(x) => Ok(x),
@@ -107,20 +125,28 @@ fn start_once(
         .spawn()
         .map_err(|e| StartErr::Spawn(e.to_string()))?;
 
-    let stderr_tail = StderrTail::drain(child.stderr.take().expect("piped stderr"));
+    let stderr_tail = match StderrTail::drain(child.stderr.take().expect("piped stderr")) {
+        Ok(tail) => tail,
+        // `drain` consumed the pipe, so the read end is already closed and the server's next
+        // complaint takes SIGPIPE — reap it rather than leave a display glass cannot hear.
+        Err(e) => {
+            glass_proc_linux::reap_graceful(&mut child, glass_proc_linux::REAP_GRACE);
+            return Err(StartErr::NoReader(e.to_string()));
+        }
+    };
     let stdout = child.stdout.take().expect("piped stdout");
     match read_displayfd(stdout, ready_timeout) {
         Ok((num, displayfd)) => Ok(Xvfb {
             child,
             display: format!(":{num}"),
             displayfd,
+            stderr: stderr_tail,
         }),
         Err(e) => {
             glass_proc_linux::reap_graceful(&mut child, glass_proc_linux::REAP_GRACE);
-            // The child is dead, so its stderr pipe has EOF'd (or will within
-            // moments); wait briefly for the drain to finish so the message is
-            // complete rather than racing the reader thread.
-            let stderr = stderr_tail.snapshot(Duration::from_millis(500));
+            // Reaped first, so what is left is the reader catching up: collecting before that
+            // races it and reports an empty stderr, the only diagnostics a failed start has.
+            let stderr = stderr_tail.finish(SAID_GRACE).trim().to_string();
             Err(match e {
                 ReadErr::Closed => StartErr::Exited { stderr },
                 ReadErr::Garbage(line) => StartErr::Garbage { line, stderr },
@@ -137,6 +163,12 @@ fn into_glass_error(xvfb: &str, e: StartErr, ready_timeout: Duration) -> GlassEr
         StartErr::Spawn(e) => format!(
             "could not spawn {xvfb} ({e}); install it (e.g. `apt install xvfb`), \
              set GLASS_XVFB to its path, or set GLASS_DISPLAY=:N to attach to an \
+             existing display"
+        ),
+        StartErr::NoReader(e) => format!(
+            "started {xvfb} but could not set up the reader for its stderr ({e}); the server \
+             was stopped rather than left to stall on a pipe nobody drains — free up threads \
+             and file descriptors on the host, or set GLASS_DISPLAY=:N to attach to an \
              existing display"
         ),
         StartErr::Exited { stderr } => with_stderr(
@@ -171,7 +203,7 @@ const STDERR_SHOWN: usize = 512;
 
 fn with_stderr(msg: String, stderr: &str) -> String {
     if stderr.is_empty() {
-        return format!("{msg} (Xvfb printed nothing to stderr)");
+        return format!("{msg} (nothing arrived on Xvfb's stderr)");
     }
     if stderr.len() <= STDERR_SHOWN {
         return format!("{msg}; Xvfb stderr: {stderr}");
@@ -182,64 +214,6 @@ fn with_stderr(msg: String, stderr: &str) -> String {
         stderr.len(),
         &stderr[..cut]
     )
-}
-
-/// Drains a child's stderr on a helper thread for the child's whole lifetime
-/// (so a chatty server can never stall on a full pipe), keeping the first
-/// `STDERR_CAP` bytes for diagnostics.
-struct StderrTail(Arc<TailState>);
-
-struct TailState {
-    buf: Mutex<TailBuf>,
-    eof: Condvar,
-}
-
-struct TailBuf {
-    bytes: Vec<u8>,
-    done: bool,
-}
-
-impl StderrTail {
-    fn drain(mut stderr: ChildStderr) -> StderrTail {
-        let state = Arc::new(TailState {
-            buf: Mutex::new(TailBuf {
-                bytes: Vec::new(),
-                done: false,
-            }),
-            eof: Condvar::new(),
-        });
-        let s = state.clone();
-        std::thread::spawn(move || {
-            let mut chunk = [0u8; 4096];
-            loop {
-                match stderr.read(&mut chunk) {
-                    Ok(0) | Err(_) => break,
-                    Ok(n) => {
-                        let mut g = s.buf.lock().unwrap();
-                        let room = STDERR_CAP.saturating_sub(g.bytes.len());
-                        g.bytes.extend_from_slice(&chunk[..n.min(room)]);
-                        // keep looping past the cap — the pipe must stay drained
-                    }
-                }
-            }
-            let mut g = s.buf.lock().unwrap();
-            g.done = true;
-            s.eof.notify_all();
-        });
-        StderrTail(state)
-    }
-
-    /// The captured stderr, waiting up to `timeout` for the pipe to EOF first
-    /// (call after the child is reaped). Lossy UTF-8, trimmed.
-    fn snapshot(&self, timeout: Duration) -> String {
-        let g = self.0.buf.lock().unwrap();
-        let (g, _) = self
-            .0
-            .eof
-            .wait_timeout_while(g, timeout, |b| !b.done)
-            .unwrap();
-        String::from_utf8_lossy(&g.bytes).trim().to_string()
-    }
 }
 
 /// Why reading the `-displayfd` line failed.
@@ -288,6 +262,7 @@ impl Drop for Xvfb {
     /// leftover costs nothing — while unlinking it cuts off whoever reclaimed the number.
     fn drop(&mut self) {
         glass_proc_linux::reap_graceful(&mut self.child, glass_proc_linux::REAP_GRACE);
+        // `stderr` drops on the way out of here, ending its reader.
     }
 }
 
@@ -319,42 +294,6 @@ mod tests {
         panic!("ETXTBSY persisted after 100 retries: {last:?}")
     }
 
-    /// Spawn a fixture script directly with its stderr piped, for the tests that drive
-    /// `StderrTail` rather than a whole start. Retries past ETXTBSY for the same reason
-    /// `start_fixture` does.
-    fn spawn_fixture(script: &std::path::Path) -> std::process::Child {
-        for _ in 0..100 {
-            match Command::new(script)
-                .stdout(Stdio::null())
-                .stderr(Stdio::piped())
-                .spawn()
-            {
-                Ok(child) => return child,
-                Err(e) if e.kind() == std::io::ErrorKind::ExecutableFileBusy => {
-                    std::thread::sleep(Duration::from_millis(10));
-                }
-                Err(e) => panic!("the fixture {} is not runnable: {e}", script.display()),
-            }
-        }
-        panic!("the fixture stayed ETXTBSY after 100 retries")
-    }
-
-    fn running(pid: u32) -> bool {
-        std::path::Path::new(&format!("/proc/{pid}")).exists()
-    }
-
-    /// Write an executable fake-Xvfb shell script into a unique temp dir and
-    /// return its path. `$0.ran` is the script's own scratch marker.
-    fn fixture(name: &str, body: &str) -> std::path::PathBuf {
-        use std::os::unix::fs::PermissionsExt;
-        let dir = std::env::temp_dir().join(format!("glass-xvfb-fixture-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let p = dir.join(name);
-        std::fs::write(&p, format!("#!/bin/sh\n{body}")).unwrap();
-        std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).unwrap();
-        p
-    }
-
     #[test]
     fn the_start_deadline_covers_both_attempts_and_both_reaps() {
         // doctor's deep probe puts its own timeout around `Xvfb::start`. Budget less than
@@ -381,35 +320,6 @@ mod tests {
     }
 
     #[test]
-    fn the_drain_stops_keeping_bytes_at_the_documented_cap() {
-        // A server dumping megabytes must cost bounded memory, while the kept head stays
-        // large enough for a real Xvfb option table (~5KB).
-        let script = fixture(
-            "flood.sh",
-            "dd if=/dev/zero bs=1024 count=64 2>/dev/null | tr '\\0' e >&2\n",
-        );
-        let mut child = spawn_fixture(&script);
-        let tail = super::StderrTail::drain(child.stderr.take().expect("piped stderr"));
-        child.wait().expect("fixture exits");
-        assert_eq!(tail.snapshot(Duration::from_secs(5)).len(), 8 * 1024);
-    }
-
-    #[test]
-    fn a_snapshot_waits_for_the_pipe_to_close_before_reading() {
-        // The diagnostics arrive after the caller asks for them. Read without waiting for
-        // EOF and a failed start reports an empty stderr — the only clue it had.
-        let script = fixture(
-            "late-stderr.sh",
-            "sleep 0.3\nprintf 'the fatal line\\n' >&2\n",
-        );
-        let mut child = spawn_fixture(&script);
-        let tail = super::StderrTail::drain(child.stderr.take().expect("piped stderr"));
-        let captured = tail.snapshot(Duration::from_secs(5));
-        child.wait().expect("fixture exits");
-        assert_eq!(captured, "the fatal line");
-    }
-
-    #[test]
     fn the_reported_pid_is_the_server_itself() {
         // A test that SIGSTOPs this pid to make the display unresponsive stops something
         // else entirely if it is wrong.
@@ -428,6 +338,117 @@ mod tests {
             parent,
             std::process::id().to_string(),
             "the reported pid must be the server this test spawned, not another process"
+        );
+    }
+
+    /// Kills a fixture's leftover process however the test ends, panic included.
+    struct Survivor(u32);
+
+    impl Drop for Survivor {
+        fn drop(&mut self) {
+            if let Some(pid) = rustix::process::Pid::from_raw(self.0 as i32) {
+                let _ = rustix::process::kill_process(pid, rustix::process::Signal::KILL);
+            }
+        }
+    }
+
+    #[test]
+    fn a_server_that_complains_after_reporting_its_display_is_still_drained() {
+        // The tail is held for the server's lifetime, not the start's. End the reader when the
+        // start returns and the server blocks on a full 64KiB pipe or takes SIGPIPE on its next
+        // complaint — a display that vanishes mid-session either way.
+        let script = fixture(
+            "chatty-after.sh",
+            "echo 4321\n\
+             dd if=/dev/zero bs=1024 count=1024 2>/dev/null | tr '\\0' e >&2\n\
+             echo 'still here' >&2\n\
+             touch \"$0.flushed\"\n\
+             exec sleep 30\n",
+        );
+        let flushed = format!("{}.flushed", script.display());
+        let _ = std::fs::remove_file(&flushed);
+        let server = start_fixture(&script, Duration::from_secs(5)).expect("must start");
+
+        // One marker catches both failures: a closed read end kills the shell at the `echo`
+        // before the `touch`, and an undrained pipe blocks `tr` after 64 KiB so it never runs.
+        assert!(
+            glass_proc_linux::await_condition(Duration::from_secs(10), || {
+                std::path::Path::new(&flushed).exists()
+            }),
+            "1MiB of stderr written after the display report must not stall or kill the server"
+        );
+        assert!(running(server.pid()), "the server must survive complaining");
+    }
+
+    #[test]
+    fn dropping_the_server_releases_a_stderr_pipe_its_survivor_holds_open() {
+        // A reader that can only stop at EOF is held open by whatever the server left behind,
+        // and doctor's deep probe starts a server per call (glass#471).
+        let script = fixture(
+            "survivor.sh",
+            "sleep 30 &\necho $! > \"$0.survivor\"\necho 4321\nexec sleep 30\n",
+        );
+        let server = start_fixture(&script, Duration::from_secs(5)).expect("must start");
+        let survivor: u32 = std::fs::read_to_string(format!("{}.survivor", script.display()))
+            .expect("the fixture reports what it left running")
+            .trim()
+            .parse()
+            .expect("a pid");
+        let _reap = Survivor(survivor);
+        // The survivor inherited the write end, so this names the one pipe — no other process
+        // can hold it, and nothing else in this one can reopen it.
+        let pipe = std::fs::read_link(format!("/proc/{survivor}/fd/2"))
+            .expect("the survivor holds the server's stderr");
+
+        drop(server);
+
+        let held: Vec<_> = std::fs::read_dir("/proc/self/fd")
+            .expect("/proc/self/fd")
+            .filter_map(|e| e.ok())
+            .filter(|e| std::fs::read_link(e.path()).is_ok_and(|target| target == pipe))
+            .map(|e| e.file_name())
+            .collect();
+        assert!(
+            held.is_empty(),
+            "a reaped server must leave no reader on its stderr, but {pipe:?} is still open on {held:?}"
+        );
+    }
+
+    fn running(pid: u32) -> bool {
+        std::path::Path::new(&format!("/proc/{pid}")).exists()
+    }
+
+    /// Write an executable fake-Xvfb shell script into a unique temp dir and
+    /// return its path. `$0.ran` is the script's own scratch marker.
+    fn fixture(name: &str, body: &str) -> std::path::PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir().join(format!("glass-xvfb-fixture-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let p = dir.join(name);
+        std::fs::write(&p, format!("#!/bin/sh\n{body}")).unwrap();
+        std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).unwrap();
+        p
+    }
+
+    #[test]
+    fn a_refused_stderr_reader_is_not_reported_as_a_missing_binary() {
+        // The server started; what failed was the host giving glass a thread. `Spawn`'s remedy
+        // — install it, or point GLASS_XVFB somewhere else — would send the user after a
+        // binary that is already there and working.
+        let GlassError::Backend(msg) = super::into_glass_error(
+            "/usr/bin/Xvfb",
+            super::StartErr::NoReader("Resource temporarily unavailable".into()),
+            Duration::from_secs(10),
+        ) else {
+            panic!("a start failure is a Backend error")
+        };
+        assert!(
+            msg.contains("Resource temporarily unavailable"),
+            "the host's own reason is the diagnosis: {msg}"
+        );
+        assert!(
+            !msg.contains("install it"),
+            "nothing is missing, so nothing needs installing: {msg}"
         );
     }
 
@@ -475,7 +496,7 @@ mod tests {
 
     #[test]
     fn chatty_stderr_before_report_does_not_stall_startup() {
-        // The drain thread must keep reading past STDERR_CAP: a server writing
+        // The drain thread must keep reading past what it keeps: a server writing
         // more than the 64KiB pipe buffer before reporting its display would
         // otherwise block on write() forever and turn every start into a wedge.
         let script = fixture(
@@ -531,6 +552,17 @@ mod tests {
             err.contains("fixture stderr complaint"),
             "must include Xvfb stderr: {err}"
         );
+    }
+
+    #[test]
+    fn a_server_that_printed_only_whitespace_is_reported_as_silent() {
+        // The trim is what makes the silent branch true for a server whose last word was a
+        // newline; without it the error ends in an empty quote for the reader to interpret.
+        let script = fixture("blank-stderr.sh", "printf '  \\n \\n' >&2\nexit 1\n");
+        let err = start_fixture(&script, Duration::from_millis(500))
+            .expect_err("exit must fail")
+            .to_string();
+        assert!(err.contains("nothing arrived"), "msg: {err}");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #471.

The X11 and Wayland backends each carried a drainer for a child's stderr, and neither reader could end except at EOF. A child's stderr write end is inherited by everything it spawns, so a process that outlives the teardown holds the pipe open for its own lifetime and the reader parks in `read` holding an fd. `glass_doctor` takes `deep` from its caller, so a long-lived `glass-mcp serve --http` accumulated one parked thread and one fd per deep probe that left something behind.

## The reader

`glass_proc_linux::StderrTail` replaces both. An `AtomicBool` stops it, read before every read so neither a child that never stops writing nor a lost wakeup can keep the reader there. An eventfd polled alongside the pipe is only the wakeup, so a stop is heard at once and an idle reader costs one look every five seconds rather than a tick. The pipe is `O_NONBLOCK` — without it a read parks past every look at the flag, and `Xvfb` holds its tail for the life of a server that is normally silent, so that would be `drop` hanging.

`finish` waits out the caller's grace for a natural EOF, then stops the reader and joins it. The join is what makes the fd closed rather than assumed closed. A tail dropped instead of finished ends its reader too.

Both callers reap before they collect: `finish` closes the read end, and doing that under a live child takes its stderr away mid-sentence.

## Also here

- A host that refuses the reader is its own X11 start failure. `Spawn`'s remedy — install it, or point `GLASS_XVFB` elsewhere — would send the user after a binary that is already there and working.
- `glass-proc-linux` joins the mutation gate and the weekly sweep. The code moved out of a gated crate into an ungated one, which would have silently dropped ~100 lines of concurrency code from the gate. The shard check name is left as written: the ruleset matches on it, so renaming it would stop it being required.
- The deep sway check counts its own compositor by binary as well as by runtime-dir prefix. The prefix is shared by every probe, so a sibling test's fixture compositor was counted — latent before, and reliable once a new test held a fixture alive longer.

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, and `cargo test --workspace` clean. glass-x11, glass-wayland and glass-proc-linux clean with `--include-ignored`, the wayland suite three times in a row. `scripts/test-x11.sh` (49) and `scripts/test-wayland.sh` (25) pass; `software_render.rs`'s two failures are this box lacking `python3-gi` and predate the branch.

Every new assertion was watched fail against the code it pins: the reader parking in `read`, the reaped server leaving `pipe:[…]` open, a tail dropped without `finish`, the read end without `O_NONBLOCK`, the cap asserted against nothing but itself, `finish` burning its whole grace, the missing trim, the tail not held past a successful start, sway's dying words lost to a collect-before-reap, and a survivor holding sway's stderr.

One thing has no test: `drain`'s failure arm needs `RLIMIT_NOFILE` or `RLIMIT_NPROC` pressure, which is only reachable from a helper process. The message it renders is covered; the reap on that arm is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)