### PR TITLE
fix: a launch's log readers end at teardown, not at an EOF that never comes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,7 +270,7 @@ jobs:
 
   mutants:
     # The ruleset matches this check by name, so it stays as written even as the list below
-    # grows — glass-proc-linux is gated too, and deliberately unnamed here.
+    # grows — glass-proc-linux and glass-pipe-unix are gated too, and deliberately unnamed here.
     name: Mutation shard ${{ matrix.shard }} (glass-core, glass-android, glass-x11, glass-exec-unix, glass-dbus-linux)
     runs-on: ubuntu-latest
     # A push carries no base ref to diff against; this gate is a pull-request check.
@@ -309,7 +309,8 @@ jobs:
                ':(glob)crates/glass-x11/src/**/*.rs' \
                ':(glob)crates/glass-exec-unix/src/**/*.rs' \
                ':(glob)crates/glass-dbus-linux/src/**/*.rs' \
-               ':(glob)crates/glass-proc-linux/src/**/*.rs' > "$RUNNER_TEMP/pr.diff"
+               ':(glob)crates/glass-proc-linux/src/**/*.rs' \
+               ':(glob)crates/glass-pipe-unix/src/**/*.rs' > "$RUNNER_TEMP/pr.diff"
           wc -l "$RUNNER_TEMP/pr.diff"
           if [ -s "$RUNNER_TEMP/pr.diff" ]; then
             echo "touched=true" >> "$GITHUB_OUTPUT"
@@ -343,7 +344,7 @@ jobs:
             --test-tool nextest \
             --package glass-core --package glass-android --package glass-x11 \
             --package glass-exec-unix --package glass-dbus-linux \
-            --package glass-proc-linux \
+            --package glass-proc-linux --package glass-pipe-unix \
             --shard ${{ matrix.shard }}/8 --sharding round-robin \
             --in-diff "$RUNNER_TEMP/pr.diff"
 

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -15,7 +15,8 @@ env:
 
 jobs:
   sweep:
-    # Named crates plus glass-proc-linux; the name matches the PR gate's, which the ruleset
+    # Named crates plus glass-proc-linux and glass-pipe-unix; the name matches the PR gate's,
+    # which the ruleset
     # requires by name.
     name: Mutation sweep shard ${{ matrix.shard }} (glass-core, glass-android, glass-x11, glass-exec-unix, glass-dbus-linux)
     runs-on: ubuntu-latest
@@ -45,7 +46,7 @@ jobs:
             --test-tool nextest \
             --package glass-core --package glass-android --package glass-x11 \
             --package glass-exec-unix --package glass-dbus-linux \
-            --package glass-proc-linux \
+            --package glass-proc-linux --package glass-pipe-unix \
             --shard ${{ matrix.shard }}/8 --sharding round-robin
       - name: Upload the outcome
         if: always()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1361,6 +1361,7 @@ dependencies = [
  "glass-core",
  "glass-dbus-linux",
  "glass-exec-unix",
+ "glass-pipe-unix",
  "glass-proc-linux",
  "glass-sandbox-linux",
  "rustix",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,6 +1302,7 @@ dependencies = [
 name = "glass-proc-linux"
 version = "0.0.0"
 dependencies = [
+ "glass-pipe-unix",
  "rustix",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1239,6 +1239,7 @@ dependencies = [
  "block2",
  "glass-a11y-macos",
  "glass-core",
+ "glass-pipe-unix",
  "glass-sandbox-macos",
  "objc2",
  "objc2-app-kit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,6 +1292,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "glass-pipe-unix"
+version = "0.0.0"
+dependencies = [
+ "rustix",
+]
+
+[[package]]
 name = "glass-proc-linux"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1397,6 +1397,7 @@ dependencies = [
  "glass-core",
  "glass-dbus-linux",
  "glass-exec-unix",
+ "glass-pipe-unix",
  "glass-proc-linux",
  "glass-sandbox-linux",
  "rustix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/glass-core", "crates/glass-x11", "crates/glass-testapp", "crates/glass-mcp", "crates/glass-wayland", "crates/glass-a11y-linux", "crates/glass-windows", "crates/glass-a11y-windows", "crates/glass-exec-unix", "crates/glass-sandbox-unix", "crates/glass-sandbox-linux", "crates/glass-proc-linux", "crates/glass-clip-shim-windows", "crates/glass-dbus-linux", "crates/glass-android", "crates/glass-macos", "crates/glass-a11y-macos", "crates/glass-sandbox-macos", "crates/glass-clip-shim-macos", "crates/glass-ios"]
+members = ["crates/glass-core", "crates/glass-x11", "crates/glass-testapp", "crates/glass-mcp", "crates/glass-wayland", "crates/glass-a11y-linux", "crates/glass-windows", "crates/glass-a11y-windows", "crates/glass-exec-unix", "crates/glass-pipe-unix", "crates/glass-sandbox-unix", "crates/glass-sandbox-linux", "crates/glass-proc-linux", "crates/glass-clip-shim-windows", "crates/glass-dbus-linux", "crates/glass-android", "crates/glass-macos", "crates/glass-a11y-macos", "crates/glass-sandbox-macos", "crates/glass-clip-shim-macos", "crates/glass-ios"]
 # glass-fixture-egui is intentionally excluded: heavy egui deps, only exercised by #[ignore]d
 # on-box a11y tests CI can't run. Built on-demand on the box.
 exclude = ["crates/glass-fixture-egui"]
@@ -41,6 +41,7 @@ glass-android = { path = "crates/glass-android" }
 glass-ios = { path = "crates/glass-ios" }
 glass-core = { path = "crates/glass-core" }
 glass-exec-unix = { path = "crates/glass-exec-unix" }
+glass-pipe-unix = { path = "crates/glass-pipe-unix" }
 glass-sandbox-unix = { path = "crates/glass-sandbox-unix" }
 glass-sandbox-linux = { path = "crates/glass-sandbox-linux" }
 glass-sandbox-macos = { path = "crates/glass-sandbox-macos" }

--- a/crates/glass-macos/Cargo.toml
+++ b/crates/glass-macos/Cargo.toml
@@ -227,6 +227,9 @@ block2 = "0.6.2"
 # glass-proc-linux use it on Linux); its `kill_process`/`Pid`/`Signal` are plain POSIX
 # and available on macOS too.
 rustix.workspace = true
+# The launched app's stdout/stderr readers (`process.rs::spawn`), which end at teardown rather
+# than at an EOF a survivor holding the pipe never delivers. Shared with the Linux backends.
+glass-pipe-unix.workspace = true
 # Seatbelt process containment (`process.rs::spawn`'s `SandboxLevel::Default`/`Strict`
 # pre_exec): the pure SBPL generator (`build_profile`) plus the macOS-only `sandbox_init`
 # FFI (`apply_cstr`).

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -82,9 +82,9 @@ pub struct MacosPlatform {
     /// it. `None` until `start_app` and after `stop_app` (idempotent).
     child: Option<Child>,
     /// The launched app's stdout/stderr readers, cleared by `stop_app`/`Drop` once the child is
-    /// terminated. The app's write ends are inherited by everything it spawns, so a reader that
-    /// ended only at EOF would park on a survivor's pipe (glass#477). Empty until `start_app`,
-    /// and for a LaunchServices-adopted app, which glass never gave a pipe.
+    /// terminated. The app's write ends are inherited by everything it spawns, so an EOF-only
+    /// reader parks on a survivor's pipe (glass#477). Empty until `start_app`, and for a
+    /// LaunchServices-adopted app, which glass never gave a pipe.
     taps: Vec<glass_pipe_unix::LineTap>,
     /// The active window's `CGWindowID` — the implicit target of `capture_frame`/
     /// `send_pointer`/`send_key`, per the `Platform` contract. Set by `start_app` to the first
@@ -395,9 +395,8 @@ impl MacosPlatform {
                 // only for a contained launch that failed.
                 process::terminate(&mut child);
                 release_clip(clip.as_ref());
-                // Terminated first, so the final drain catches what the inner exec said on its
-                // way out — which on this path is the diagnosis. Explicit rather than left to
-                // the end of the scope: the handoff below runs in between.
+                // Terminated first, so the final drain catches what the inner exec said on its way
+                // out — the diagnosis, on this path. Explicit because the handoff runs in between.
                 drop(taps);
                 // Only an early inner-exec exit (`AppExited`) is the handoff signal; any other
                 // failure is propagated as-is.
@@ -471,8 +470,8 @@ impl MacosPlatform {
             }
         };
         self.child = None;
-        // With the child goes what read it. An adopted app was never given a pipe, so a tap left
-        // running here would file the *previous* launch's output into this session's logs.
+        // With the child goes what read it: an adopted app was never given a pipe, so a tap left
+        // running here files the *previous* launch's output into this session's logs.
         self.taps.clear();
         // AppKit's pids are `i32` but always non-negative for a real process, so the cast to
         // `app_pid`'s `u32` is exact.
@@ -717,8 +716,8 @@ impl Platform for MacosPlatform {
             process::terminate(&mut child);
         }
         // Terminated first, so each tap's final drain sees what the app wrote on the way out.
-        // Dropping them ends the reader threads and releases the pipes, which anything the launch
-        // left running would otherwise hold for the life of this process (glass#477).
+        // Dropping them releases the pipes anything the launch left running still holds
+        // (glass#477).
         self.taps.clear();
         // Named pasteboards persist system-wide until released, and a leftover `.ready`
         // sentinel could mask a failed injection in a later session. Only released when a shim
@@ -944,8 +943,7 @@ impl Drop for MacosPlatform {
         if let Some(mut child) = self.child.take() {
             process::terminate(&mut child);
         }
-        // Terminated first, so each tap's final drain sees what the app wrote on the way out.
-        // Explicit rather than left to field-drop order, so this path reads like `stop_app` and
+        // Terminated first, as in `stop_app`. Explicit rather than left to field-drop order, so
         // reordering two fields cannot silently change it.
         self.taps.clear();
         // Release this session's named pasteboards too if `stop_app` didn't run (panic-unwind

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -81,7 +81,7 @@ pub struct MacosPlatform {
     /// The launched child process, kept so `stop_app`/`Drop` can `process::terminate`
     /// it. `None` until `start_app` and after `stop_app` (idempotent).
     child: Option<Child>,
-    /// The launched app's stdout/stderr readers, dropped in `stop_app`/`Drop` once the child is
+    /// The launched app's stdout/stderr readers, cleared by `stop_app`/`Drop` once the child is
     /// terminated. The app's write ends are inherited by everything it spawns, so a reader that
     /// ended only at EOF would park on a survivor's pipe (glass#477). Empty until `start_app`,
     /// and for a LaunchServices-adopted app, which glass never gave a pipe.
@@ -471,6 +471,9 @@ impl MacosPlatform {
             }
         };
         self.child = None;
+        // With the child goes what read it. An adopted app was never given a pipe, so a tap left
+        // running here would file the *previous* launch's output into this session's logs.
+        self.taps.clear();
         // AppKit's pids are `i32` but always non-negative for a real process, so the cast to
         // `app_pid`'s `u32` is exact.
         self.app_pid = Some(pid as u32);
@@ -941,6 +944,10 @@ impl Drop for MacosPlatform {
         if let Some(mut child) = self.child.take() {
             process::terminate(&mut child);
         }
+        // Terminated first, so each tap's final drain sees what the app wrote on the way out.
+        // Explicit rather than left to field-drop order, so this path reads like `stop_app` and
+        // reordering two fields cannot silently change it.
+        self.taps.clear();
         // Release this session's named pasteboards too if `stop_app` didn't run (panic-unwind
         // or the process-exit backstop). `stop_app` sets `self.clip = None`, so this is a no-op
         // when it already ran; otherwise the boards would leak system-wide.

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -81,6 +81,11 @@ pub struct MacosPlatform {
     /// The launched child process, kept so `stop_app`/`Drop` can `process::terminate`
     /// it. `None` until `start_app` and after `stop_app` (idempotent).
     child: Option<Child>,
+    /// The launched app's stdout/stderr readers, dropped in `stop_app`/`Drop` once the child is
+    /// terminated. The app's write ends are inherited by everything it spawns, so a reader that
+    /// ended only at EOF would park on a survivor's pipe (glass#477). Empty until `start_app`,
+    /// and for a LaunchServices-adopted app, which glass never gave a pipe.
+    taps: Vec<glass_pipe_unix::LineTap>,
     /// The active window's `CGWindowID` — the implicit target of `capture_frame`/
     /// `send_pointer`/`send_key`, per the `Platform` contract. Set by `start_app` to the first
     /// window discovered, and by `select_window`; `None` before `start_app` and after
@@ -143,6 +148,7 @@ impl MacosPlatform {
             logs: Arc::new(Mutex::new(Vec::new())),
             app_pid: None,
             child: None,
+            taps: Vec::new(),
             active_window: None,
             clipboard_route: ClipboardRoute::default(),
             clip: None,
@@ -360,12 +366,17 @@ impl MacosPlatform {
         // `spec.run.first()` before delegating here.
         let mut direct = spec.clone();
         direct.run[0] = inner.to_string_lossy().into_owned();
-        let (mut child, clip) = process::spawn(&direct, self.logs.clone())?;
+        let process::Launch {
+            mut child,
+            clip,
+            taps,
+        } = process::spawn(&direct, self.logs.clone())?;
         let pid = child.id();
         match Self::discover_window(&mut child, pid, spec.timeout_ms) {
             Ok(m) => {
                 // Foreground app: adopt exactly as the plain-exec Ok arm does.
                 self.child = Some(child);
+                self.taps = taps;
                 self.app_pid = Some(pid);
                 self.active_window = Some(m.window_id);
                 // Defensive: a direct-spawn is never an adopted session — clear any stale
@@ -384,6 +395,10 @@ impl MacosPlatform {
                 // only for a contained launch that failed.
                 process::terminate(&mut child);
                 release_clip(clip.as_ref());
+                // Terminated first, so the final drain catches what the inner exec said on its
+                // way out — which on this path is the diagnosis. Explicit rather than left to
+                // the end of the scope: the handoff below runs in between.
+                drop(taps);
                 // Only an early inner-exec exit (`AppExited`) is the handoff signal; any other
                 // failure is propagated as-is.
                 //
@@ -636,11 +651,16 @@ impl Platform for MacosPlatform {
         let geometry = if crate::bundle::is_app_bundle(run0) {
             self.start_bundle(spec, Path::new(run0))?
         } else {
-            let (mut child, clip) = process::spawn(spec, self.logs.clone())?;
+            let process::Launch {
+                mut child,
+                clip,
+                taps,
+            } = process::spawn(spec, self.logs.clone())?;
             let pid = child.id();
             match Self::discover_window(&mut child, pid, spec.timeout_ms) {
                 Ok(m) => {
                     self.child = Some(child);
+                    self.taps = taps;
                     self.app_pid = Some(pid);
                     // Defensive: a plain exec is never an adopted session — clear any stale
                     // handoff record from a prior un-stopped session so it can't widen
@@ -693,6 +713,10 @@ impl Platform for MacosPlatform {
         if let Some(mut child) = self.child.take() {
             process::terminate(&mut child);
         }
+        // Terminated first, so each tap's final drain sees what the app wrote on the way out.
+        // Dropping them ends the reader threads and releases the pipes, which anything the launch
+        // left running would otherwise hold for the life of this process (glass#477).
+        self.taps.clear();
         // Named pasteboards persist system-wide until released, and a leftover `.ready`
         // sentinel could mask a failed injection in a later session. Only released when a shim
         // launch name is known — uncontained/hardened launches have none.
@@ -936,6 +960,7 @@ mod tests {
             logs: Arc::new(Mutex::new(vec![(Stream::Stdout, "hi".into())])),
             app_pid: Some(42),
             child: None,
+            taps: Vec::new(),
             active_window: None,
             clipboard_route: ClipboardRoute::default(),
             clip: None,
@@ -951,6 +976,7 @@ mod tests {
             logs: Arc::new(Mutex::new(Vec::new())),
             app_pid: Some(42),
             child: None,
+            taps: Vec::new(),
             active_window: None,
             clipboard_route: ClipboardRoute::default(),
             clip: None,
@@ -968,6 +994,7 @@ mod tests {
             logs: Arc::new(Mutex::new(Vec::new())),
             app_pid: None,
             child: None,
+            taps: Vec::new(),
             active_window: None,
             clipboard_route: ClipboardRoute::default(),
             clip: None,
@@ -987,6 +1014,7 @@ mod tests {
             logs: Arc::new(Mutex::new(Vec::new())),
             app_pid: Some(42),
             child: None,
+            taps: Vec::new(),
             active_window: Some(7),
             clipboard_route: ClipboardRoute::default(),
             clip: None,
@@ -1006,6 +1034,7 @@ mod tests {
             logs: Arc::new(Mutex::new(Vec::new())),
             app_pid: Some(42),
             child: None,
+            taps: Vec::new(),
             active_window: Some(7),
             clipboard_route: ClipboardRoute::Private("tech.fixedwidth.glass.clip.42.1.1".into()),
             clip: None,
@@ -1024,6 +1053,7 @@ mod tests {
             logs: Arc::new(Mutex::new(Vec::new())),
             app_pid: Some(42),
             child: None,
+            taps: Vec::new(),
             active_window: Some(7),
             clipboard_route: ClipboardRoute::Private("tech.fixedwidth.glass.clip.42.1.1".into()),
             clip: Some(ClipLaunch {
@@ -1045,6 +1075,7 @@ mod tests {
             logs: Arc::new(Mutex::new(Vec::new())),
             app_pid: Some(999_999),
             child: None,
+            taps: Vec::new(),
             active_window: Some(7),
             clipboard_route: ClipboardRoute::Private("tech.fixedwidth.glass.clip.9.1.1".into()),
             clip: None,
@@ -1068,6 +1099,7 @@ mod tests {
             logs: Arc::new(Mutex::new(Vec::new())),
             app_pid: Some(999_999),
             child: None,
+            taps: Vec::new(),
             active_window: Some(7),
             clipboard_route: ClipboardRoute::default(),
             clip: None,
@@ -1091,6 +1123,7 @@ mod tests {
             logs: Arc::new(Mutex::new(Vec::new())),
             app_pid: None,
             child: None,
+            taps: Vec::new(),
             active_window: None,
             clipboard_route: ClipboardRoute::default(),
             clip: None,
@@ -1139,6 +1172,7 @@ mod tests {
             logs: Arc::new(Mutex::new(Vec::new())),
             app_pid: None,
             child: None,
+            taps: Vec::new(),
             active_window: None,
             clipboard_route: ClipboardRoute::Unsupported,
             clip: None,
@@ -1161,6 +1195,7 @@ mod tests {
             logs: Arc::new(Mutex::new(Vec::new())),
             app_pid: None,
             child: None,
+            taps: Vec::new(),
             active_window: None,
             clipboard_route: ClipboardRoute::RealGeneral,
             clip: None,

--- a/crates/glass-macos/src/process.rs
+++ b/crates/glass-macos/src/process.rs
@@ -4,7 +4,7 @@
 //! `std::process::Command` built from [`AppSpec`], stdout/stderr piped into a shared,
 //! `Arc<Mutex<_>>`-guarded log buffer via one reader thread per stream, so
 //! `MacosPlatform::drain_logs` can read it without blocking the readers. The taps go back to the
-//! caller with the child, because ending them is part of teardown (glass#477). `terminate` asks
+//! caller with the child: ending them is part of teardown (glass#477). `terminate` asks
 //! the app to quit first — AppKit runs no shutdown path for a signal — and only then falls
 //! back to `glass-proc-linux::reap`'s SIGTERM -> brief wait -> SIGKILL -> reap sequence,
 //! reimplemented here (rather than depending on that crate) because it is `/proc`-based
@@ -369,10 +369,9 @@ pub(crate) fn spawn(spec: &AppSpec, logs: LogSink) -> Result<Launch> {
     ) {
         (Ok(out), Ok(err)) => vec![out, err],
         (out, err) => {
-            // The shim's boards outlive the process that was going to use them, and this is the
-            // first path that ends a `ClipLaunch` — `release_clip`'s doc requires every one of
-            // them to release, or they persist system-wide and a later session can read a stale
-            // `.ready` sentinel.
+            // The first path that ends a `ClipLaunch`, and `release_clip`'s doc requires every one
+            // of them to release: the boards persist system-wide, and a later session can read a
+            // stale `.ready` sentinel.
             release_named_boards(clip.as_ref());
             return Err(out.err().or(err.err()).expect("one of the two failed"));
         }
@@ -381,9 +380,8 @@ pub(crate) fn spawn(spec: &AppSpec, logs: LogSink) -> Result<Launch> {
     Ok(Launch { child, clip, taps })
 }
 
-/// Release the named pasteboards a shim launch created, for a launch that is being abandoned
-/// before the caller ever sees its [`ClipLaunch`]. `backend::release_clip` is the same call on the
-/// paths that do have one.
+/// Release the named pasteboards a shim launch created, for a launch abandoned before the caller
+/// ever sees its [`ClipLaunch`]. `backend::release_clip` is the same call where one exists.
 fn release_named_boards(clip: Option<&ClipLaunch>) {
     if let Some(c) = clip {
         crate::clipboard::release_named(&c.name);
@@ -398,16 +396,16 @@ pub(crate) struct Launch {
     /// The clip-shim launch facts — see [`spawn`], which decides them.
     pub(crate) clip: Option<ClipLaunch>,
     /// The app's stdout/stderr readers, held for the app's lifetime. The app's write ends are
-    /// inherited by everything it spawns, so a reader that ended only at EOF would park on a
-    /// survivor's pipe, holding a thread and an fd for the life of the process (glass#477).
+    /// inherited by everything it spawns, so an EOF-only reader parks on a survivor's pipe, holding
+    /// a thread and an fd for the life of the process (glass#477).
     pub(crate) taps: Vec<LineTap>,
 }
 
 /// Start a reader over one of the launch's streams, or terminate the launch and say why it could
 /// not.
 ///
-/// The failed start consumed the pipe, so its read end is already closed and the app's next write
-/// to that stream takes `SIGPIPE` — a death mid-run with nothing in the logs to say why.
+/// The failed start consumed the pipe, so the app's next write to that stream takes `SIGPIPE` — a
+/// death mid-run with nothing in the logs to say why.
 fn tap_or_reap<R: std::io::Read + AsFd + Send + 'static>(
     stream: R,
     tag: Stream,
@@ -714,19 +712,18 @@ mod tests {
     /// glass#477: the launch's readers are the caller's to end, and the last thing the app said
     /// survives that ending.
     ///
-    /// **What this covers and what it does not.** Not the fd release: that property is
-    /// `glass-pipe-unix`'s, and its assertion for it reads `/proc/self/fd`, so it is Linux-gated
-    /// and does not run here. Not the final drain either — `child.wait()` below returns long
-    /// after the reader has had the line through its ordinary loop, so ablating the drain leaves
-    /// this green; `glass-pipe-unix` drives that function directly instead. What is this crate's
-    /// own to get right, and what this pins, is the wiring: `spawn` hands the taps back rather
-    /// than detaching them, and stopping them joins rather than losing what the app already said.
+    /// **What this covers and what it does not.** Not the fd release: that assertion reads
+    /// `/proc/self/fd` and is Linux-gated. Not the final drain either — `child.wait()` below
+    /// returns long after the reader has had the line through its ordinary loop, so ablating the
+    /// drain leaves this green, and `glass-pipe-unix` drives that function directly instead. What
+    /// this pins is the wiring: `spawn` hands the taps back rather than detaching them, and
+    /// stopping them joins rather than losing what the app already said.
     #[test]
     #[cfg(target_os = "macos")]
     fn a_launch_hands_back_taps_that_catch_the_apps_last_line() {
         let logs = empty_sink();
         // The sleeper inherits both pipes and outlives the child, so EOF is not a deadline the
-        // readers can reach — `drop(taps)` has to be what ends them.
+        // readers can reach: `drop(taps)` has to be what ends them.
         let Launch {
             mut child, taps, ..
         } = spawn(
@@ -741,10 +738,9 @@ mod tests {
             "both streams must be tapped, and handed back"
         );
 
-        // Waited for, not slept past: the child exits as soon as it has backgrounded the sleeper,
-        // and that is what makes "everything it wrote is already in the pipe" true rather than a
-        // race the reader can lose. `terminate` is then the idempotent no-op it is in production
-        // on an app that left on its own, and keeps this in the order teardown uses.
+        // Waited for, not slept past: the child exits once it has backgrounded the sleeper, which
+        // is what makes "everything it wrote is already in the pipe" true rather than a race.
+        // `terminate` is then the no-op it is on an app that left on its own, in teardown's order.
         child.wait().expect("the child exits, the sleeper does not");
         terminate(&mut child);
         // Reaped first, so each tap's final drain sees what the app wrote on the way out.
@@ -766,8 +762,7 @@ mod tests {
     #[cfg(target_os = "macos")]
     fn spawn_pipes_stdout_and_stderr_lines() {
         let logs = empty_sink();
-        // `_taps` rather than `..`: the readers are the caller's to hold now, and dropping them
-        // here would stop them before the child had written anything.
+        // `_taps` rather than `..`: dropping them here stops the readers before the child writes.
         let Launch {
             mut child,
             taps: _taps,

--- a/crates/glass-macos/src/process.rs
+++ b/crates/glass-macos/src/process.rs
@@ -1,9 +1,10 @@
 //! App spawn, background log-piping, and terminate for the macOS backend.
 //!
-//! Mirrors `glass-x11`/`glass-wayland`'s `spawn`+`spawn_reader`+`LogSink` shape: a plain
+//! Mirrors `glass-x11`/`glass-wayland`'s `spawn`+`LineTap`+`LogSink` shape: a plain
 //! `std::process::Command` built from [`AppSpec`], stdout/stderr piped into a shared,
 //! `Arc<Mutex<_>>`-guarded log buffer via one reader thread per stream, so
-//! `MacosPlatform::drain_logs` can read it without blocking the readers. `terminate` asks
+//! `MacosPlatform::drain_logs` can read it without blocking the readers. The taps go back to the
+//! caller with the child, because ending them is part of teardown (glass#477). `terminate` asks
 //! the app to quit first — AppKit runs no shutdown path for a signal — and only then falls
 //! back to `glass-proc-linux::reap`'s SIGTERM -> brief wait -> SIGKILL -> reap sequence,
 //! reimplemented here (rather than depending on that crate) because it is `/proc`-based

--- a/crates/glass-macos/src/process.rs
+++ b/crates/glass-macos/src/process.rs
@@ -23,7 +23,6 @@
 //! and the clipboard route can be decided.
 
 use std::ffi::CString;
-use std::io::{BufRead, BufReader};
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
@@ -31,6 +30,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use glass_pipe_unix::LineTap;
 use rustix::process::{Pid, Signal, kill_process};
 
 use glass_core::platform::{AppSpec, SandboxLevel};
@@ -144,7 +144,7 @@ fn shim_dylib_path_with(env_override: Option<PathBuf>) -> Option<PathBuf> {
     crate::shim_path::resolve_shim(&exe_dir, env_override)
 }
 
-/// Log lines captured by the per-stream reader threads spawned in [`spawn`], drained by
+/// Log lines captured by the per-stream [`LineTap`]s started in [`spawn`], drained by
 /// `MacosPlatform::drain_logs`. `Arc<Mutex<_>>` (not a bare `Vec`) because the reader
 /// threads outlive `spawn`'s call and push into it concurrently with `drain_logs` reading
 /// it from the main thread — the same shape `glass-x11`/`glass-wayland` use.
@@ -187,12 +187,12 @@ const EXIT_POLL: Duration = Duration::from_millis(20);
 /// generated Seatbelt (`sandbox_init`) profile to the launched app via a fork-safe
 /// `pre_exec` (see below). [`SandboxLevel::Off`] spawns unchanged.
 ///
-/// The second return value is the clip-shim launch facts ([`ClipLaunch`]), `Some` only for
+/// The [`Launch`]'s `clip` is the clip-shim launch facts ([`ClipLaunch`]), `Some` only for
 /// a contained launch whose target is injectable (see [`target_is_injectable`]) and whose
 /// shim dylib resolved (see [`shim_dylib_path`]); `None` for `SandboxLevel::Off` or a
 /// non-injectable/unresolved target. The caller (`MacosPlatform::start_app`) holds it for a
 /// later clipboard-routing decision — this function only sets up the injection.
-pub(crate) fn spawn(spec: &AppSpec, logs: LogSink) -> Result<(Child, Option<ClipLaunch>)> {
+pub(crate) fn spawn(spec: &AppSpec, logs: LogSink) -> Result<Launch> {
     let mut cmd = Command::new(&spec.run[0]);
 
     // Apply the caller's env FIRST, so glass's own containment/injection vars are written LAST
@@ -346,24 +346,47 @@ pub(crate) fn spawn(spec: &AppSpec, logs: LogSink) -> Result<(Child, Option<Clip
     // `Stdio::piped()` guarantees these are `Some` immediately after a successful spawn.
     let stdout = child.stdout.take().expect("stdout was piped");
     let stderr = child.stderr.take().expect("stderr was piped");
-    spawn_reader(stdout, Stream::Stdout, logs.clone());
-    spawn_reader(stderr, Stream::Stderr, logs);
+    let taps = vec![
+        tap_or_reap(stdout, Stream::Stdout, &logs, &mut child, spec)?,
+        tap_or_reap(stderr, Stream::Stderr, &logs, &mut child, spec)?,
+    ];
 
-    Ok((child, clip))
+    Ok(Launch { child, clip, taps })
 }
 
-/// Pipe a child stream's lines into the shared log sink on a background thread. Exits
-/// quietly (no error surfaced — this is a best-effort log tap, not the app's lifecycle)
-/// once the stream hits EOF (the child closed it, typically by exiting) or a read fails.
-fn spawn_reader<R: std::io::Read + Send + 'static>(reader: R, stream: Stream, sink: LogSink) {
-    std::thread::spawn(move || {
-        for line in BufReader::new(reader).lines() {
-            match line {
-                Ok(text) => sink.lock().expect("log sink mutex").push((stream, text)),
-                Err(_) => break,
-            }
-        }
-    });
+/// What a direct spawn produced.
+#[derive(Debug)]
+pub(crate) struct Launch {
+    pub(crate) child: Child,
+    /// The clip-shim launch facts — see [`spawn`], which decides them.
+    pub(crate) clip: Option<ClipLaunch>,
+    /// The app's stdout/stderr readers, held for the app's lifetime. The app's write ends are
+    /// inherited by everything it spawns, so a reader that ended only at EOF would park on a
+    /// survivor's pipe, holding a thread and an fd for the life of the process (glass#477).
+    pub(crate) taps: Vec<LineTap>,
+}
+
+/// Start a reader over one of the launch's streams, or terminate the launch and say why it could
+/// not.
+///
+/// The failed start consumed the pipe, so its read end is already closed and the app's next write
+/// to that stream takes `SIGPIPE` — a death mid-run with nothing in the logs to say why.
+fn tap_or_reap<R: std::io::Read + std::os::fd::AsFd + Send + 'static>(
+    stream: R,
+    tag: Stream,
+    logs: &LogSink,
+    child: &mut Child,
+    spec: &AppSpec,
+) -> Result<LineTap> {
+    LineTap::start(stream, tag, logs.clone()).map_err(|e| {
+        terminate(child);
+        GlassError::AppNotStarted(format!(
+            "started {:?} but could not read its output ({e}); the app was stopped rather than \
+             left to write into a pipe nobody drains — free up threads and file descriptors on \
+             the host",
+            spec.run
+        ))
+    })
 }
 
 /// Idempotently terminate `child`: ask it to quit, wait up to [`QUIT_GRACE`], then SIGTERM,
@@ -543,7 +566,9 @@ mod tests {
             ("SECRET_PATH".to_string(), secret.to_string()),
         ];
         let logs = empty_sink();
-        let (mut child, clip) = spawn(&denied, logs.clone())
+        let Launch {
+            mut child, clip, ..
+        } = spawn(&denied, logs.clone())
             .unwrap_or_else(|e| panic!("sandboxed spawn should succeed: {e}"));
         // The probe is a plain, unsigned arm64 binary — always injectable — so a `None` here
         // means the shim never resolved (most likely `glass-clip-shim-macos` wasn't built; see
@@ -617,7 +642,9 @@ mod tests {
         launch.cwd = Some(std::env::temp_dir());
 
         let logs = empty_sink();
-        let (mut child, clip) = spawn(&launch, logs.clone()).unwrap_or_else(|e| {
+        let Launch {
+            mut child, clip, ..
+        } = spawn(&launch, logs.clone()).unwrap_or_else(|e| {
             panic!(
                 "sandboxed spawn of a launch target under $HOME (cwd outside $HOME) should \
                  succeed: {e}"
@@ -646,11 +673,68 @@ mod tests {
         );
     }
 
+    /// glass#477: the launch's readers are the caller's to end, and the last thing the app said
+    /// survives that ending.
+    ///
+    /// **What this covers and what it does not.** The fd-release property belongs to
+    /// `glass-pipe-unix` and is asserted by its own suite, which runs on this host too — macOS has
+    /// no cheap in-process equivalent of the `/proc/self/fd` check the Linux backends use, and
+    /// `spawn` is `pub(crate)`, so the assertion cannot move to its own test binary the way
+    /// theirs did. What is this crate's own to get right is the wiring: `spawn` hands the taps
+    /// back rather than detaching them, and the drain after the stop keeps what the app wrote on
+    /// its way out.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn a_launch_hands_back_taps_that_catch_the_apps_last_line() {
+        let logs = empty_sink();
+        // The sleeper inherits both pipes and outlives the child, so EOF is not a deadline the
+        // readers can reach — `drop(taps)` has to be what ends them.
+        let Launch {
+            mut child, taps, ..
+        } = spawn(
+            &spec(&["/bin/sh", "-c", "echo 'the last line'; sleep 30 &"]),
+            Arc::clone(&logs),
+        )
+        .expect("spawn /bin/sh");
+
+        assert_eq!(
+            taps.len(),
+            2,
+            "both streams must be tapped, and handed back"
+        );
+
+        // Waited for, not slept past: the child exits as soon as it has backgrounded the sleeper,
+        // and that is what makes "everything it wrote is already in the pipe" true rather than a
+        // race the reader can lose. `terminate` is then the idempotent no-op it is in production
+        // on an app that left on its own, and keeps this in the order teardown uses.
+        child.wait().expect("the child exits, the sleeper does not");
+        terminate(&mut child);
+        // Reaped first, so each tap's final drain sees what the app wrote on the way out.
+        drop(taps);
+
+        let said: Vec<String> = logs
+            .lock()
+            .expect("log sink mutex")
+            .iter()
+            .map(|(_, line)| line.clone())
+            .collect();
+        assert!(
+            said.iter().any(|line| line == "the last line"),
+            "the drain after the stop must keep the app's last line: {said:?}"
+        );
+    }
+
     #[test]
     #[cfg(target_os = "macos")]
     fn spawn_pipes_stdout_and_stderr_lines() {
         let logs = empty_sink();
-        let (mut child, _clip) = spawn(
+        // `_taps` rather than `..`: the readers are the caller's to hold now, and dropping them
+        // here would stop them before the child had written anything.
+        let Launch {
+            mut child,
+            taps: _taps,
+            ..
+        } = spawn(
             &spec(&["/bin/sh", "-c", "echo out; echo err 1>&2"]),
             logs.clone(),
         )
@@ -729,7 +813,7 @@ mod tests {
     #[test]
     #[cfg(target_os = "macos")]
     fn terminate_kills_a_long_running_child() {
-        let (mut child, _clip) =
+        let Launch { mut child, .. } =
             spawn(&spec(&["/bin/sleep", "100"]), empty_sink()).expect("spawn /bin/sleep");
         terminate(&mut child);
         let status = child.try_wait().expect("try_wait after terminate");
@@ -788,7 +872,7 @@ mod tests {
 
         let (fixture, build_dir) = build_quit_fixture("ask");
         let sink = empty_sink();
-        let (mut child, _clip) = spawn(
+        let Launch { mut child, .. } = spawn(
             &spec(&[fixture.to_string_lossy().as_ref()]),
             Arc::clone(&sink),
         )
@@ -824,7 +908,8 @@ mod tests {
         spec.env = vec![("GLASS_FIXTURE_VETO_QUIT".to_string(), "1".to_string())];
 
         let sink = empty_sink();
-        let (mut child, _clip) = spawn(&spec, Arc::clone(&sink)).expect("spawn the AppKit fixture");
+        let Launch { mut child, .. } =
+            spawn(&spec, Arc::clone(&sink)).expect("spawn the AppKit fixture");
         std::thread::sleep(FIXTURE_LAUNCH_SETTLE);
 
         let started = Instant::now();
@@ -861,7 +946,7 @@ mod tests {
         // `terminate_app` reports that. The quit grace must then be skipped entirely rather
         // than spent — otherwise asking first would add `QUIT_GRACE` to the teardown of every
         // app glass cannot ask, which is every console-shaped one.
-        let (mut child, _clip) =
+        let Launch { mut child, .. } =
             spawn(&spec(&["/bin/sleep", "100"]), empty_sink()).expect("spawn /bin/sleep");
         let started = Instant::now();
         terminate(&mut child);
@@ -883,7 +968,7 @@ mod tests {
     #[test]
     #[cfg(target_os = "macos")]
     fn terminate_is_idempotent_on_an_already_exited_child() {
-        let (mut child, _clip) =
+        let Launch { mut child, .. } =
             spawn(&spec(&["/bin/echo", "hi"]), empty_sink()).expect("spawn /bin/echo");
         child.wait().expect("wait for /bin/echo to exit");
         // Already reaped; terminate must not panic or hang.

--- a/crates/glass-macos/src/process.rs
+++ b/crates/glass-macos/src/process.rs
@@ -398,6 +398,9 @@ pub(crate) struct Launch {
     /// The app's stdout/stderr readers, held for the app's lifetime. The app's write ends are
     /// inherited by everything it spawns, so an EOF-only reader parks on a survivor's pipe, holding
     /// a thread and an fd for the life of the process (glass#477).
+    ///
+    /// Bind these, do not `..` them, in anything that later reads the sink: dropping a tap stops
+    /// its reader, and `..` does that at the destructuring — before the app has written a line.
     pub(crate) taps: Vec<LineTap>,
 }
 
@@ -603,7 +606,9 @@ mod tests {
         ];
         let logs = empty_sink();
         let Launch {
-            mut child, clip, ..
+            mut child,
+            clip,
+            taps: _taps,
         } = spawn(&denied, logs.clone())
             .unwrap_or_else(|e| panic!("sandboxed spawn should succeed: {e}"));
         // The probe is a plain, unsigned arm64 binary — always injectable — so a `None` here
@@ -679,7 +684,9 @@ mod tests {
 
         let logs = empty_sink();
         let Launch {
-            mut child, clip, ..
+            mut child,
+            clip,
+            taps: _taps,
         } = spawn(&launch, logs.clone()).unwrap_or_else(|e| {
             panic!(
                 "sandboxed spawn of a launch target under $HOME (cwd outside $HOME) should \
@@ -762,7 +769,6 @@ mod tests {
     #[cfg(target_os = "macos")]
     fn spawn_pipes_stdout_and_stderr_lines() {
         let logs = empty_sink();
-        // `_taps` rather than `..`: dropping them here stops the readers before the child writes.
         let Launch {
             mut child,
             taps: _taps,
@@ -905,7 +911,11 @@ mod tests {
 
         let (fixture, build_dir) = build_quit_fixture("ask");
         let sink = empty_sink();
-        let Launch { mut child, .. } = spawn(
+        let Launch {
+            mut child,
+            taps: _taps,
+            ..
+        } = spawn(
             &spec(&[fixture.to_string_lossy().as_ref()]),
             Arc::clone(&sink),
         )
@@ -941,8 +951,11 @@ mod tests {
         spec.env = vec![("GLASS_FIXTURE_VETO_QUIT".to_string(), "1".to_string())];
 
         let sink = empty_sink();
-        let Launch { mut child, .. } =
-            spawn(&spec, Arc::clone(&sink)).expect("spawn the AppKit fixture");
+        let Launch {
+            mut child,
+            taps: _taps,
+            ..
+        } = spawn(&spec, Arc::clone(&sink)).expect("spawn the AppKit fixture");
         std::thread::sleep(FIXTURE_LAUNCH_SETTLE);
 
         let started = Instant::now();

--- a/crates/glass-macos/src/process.rs
+++ b/crates/glass-macos/src/process.rs
@@ -32,6 +32,8 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use glass_pipe_unix::LineTap;
+use std::os::fd::AsFd;
+
 use rustix::process::{Pid, Signal, kill_process};
 
 use glass_core::platform::{AppSpec, SandboxLevel};
@@ -347,12 +349,46 @@ pub(crate) fn spawn(spec: &AppSpec, logs: LogSink) -> Result<Launch> {
     // `Stdio::piped()` guarantees these are `Some` immediately after a successful spawn.
     let stdout = child.stdout.take().expect("stdout was piped");
     let stderr = child.stderr.take().expect("stderr was piped");
-    let taps = vec![
-        tap_or_reap(stdout, Stream::Stdout, &logs, &mut child, spec)?,
-        tap_or_reap(stderr, Stream::Stderr, &logs, &mut child, spec)?,
-    ];
+    let taps = match (
+        tap_or_reap(
+            stdout,
+            Stream::Stdout,
+            "glass-app-stdout",
+            &logs,
+            &mut child,
+            spec,
+        ),
+        tap_or_reap(
+            stderr,
+            Stream::Stderr,
+            "glass-app-stderr",
+            &logs,
+            &mut child,
+            spec,
+        ),
+    ) {
+        (Ok(out), Ok(err)) => vec![out, err],
+        (out, err) => {
+            // The shim's boards outlive the process that was going to use them, and this is the
+            // first path that ends a `ClipLaunch` — `release_clip`'s doc requires every one of
+            // them to release, or they persist system-wide and a later session can read a stale
+            // `.ready` sentinel.
+            release_named_boards(clip.as_ref());
+            return Err(out.err().or(err.err()).expect("one of the two failed"));
+        }
+    };
 
     Ok(Launch { child, clip, taps })
+}
+
+/// Release the named pasteboards a shim launch created, for a launch that is being abandoned
+/// before the caller ever sees its [`ClipLaunch`]. `backend::release_clip` is the same call on the
+/// paths that do have one.
+fn release_named_boards(clip: Option<&ClipLaunch>) {
+    if let Some(c) = clip {
+        crate::clipboard::release_named(&c.name);
+        crate::clipboard::release_named(&format!("{}.ready", c.name));
+    }
 }
 
 /// What a direct spawn produced.
@@ -372,14 +408,15 @@ pub(crate) struct Launch {
 ///
 /// The failed start consumed the pipe, so its read end is already closed and the app's next write
 /// to that stream takes `SIGPIPE` — a death mid-run with nothing in the logs to say why.
-fn tap_or_reap<R: std::io::Read + std::os::fd::AsFd + Send + 'static>(
+fn tap_or_reap<R: std::io::Read + AsFd + Send + 'static>(
     stream: R,
     tag: Stream,
+    name: &str,
     logs: &LogSink,
     child: &mut Child,
     spec: &AppSpec,
 ) -> Result<LineTap> {
-    LineTap::start(stream, tag, logs.clone()).map_err(|e| {
+    LineTap::start(stream, tag, name, logs.clone()).map_err(|e| {
         terminate(child);
         GlassError::AppNotStarted(format!(
             "started {:?} but could not read its output ({e}); the app was stopped rather than \
@@ -677,13 +714,13 @@ mod tests {
     /// glass#477: the launch's readers are the caller's to end, and the last thing the app said
     /// survives that ending.
     ///
-    /// **What this covers and what it does not.** The fd-release property belongs to
-    /// `glass-pipe-unix` and is asserted by its own suite, which runs on this host too — macOS has
-    /// no cheap in-process equivalent of the `/proc/self/fd` check the Linux backends use, and
-    /// `spawn` is `pub(crate)`, so the assertion cannot move to its own test binary the way
-    /// theirs did. What is this crate's own to get right is the wiring: `spawn` hands the taps
-    /// back rather than detaching them, and the drain after the stop keeps what the app wrote on
-    /// its way out.
+    /// **What this covers and what it does not.** Not the fd release: that property is
+    /// `glass-pipe-unix`'s, and its assertion for it reads `/proc/self/fd`, so it is Linux-gated
+    /// and does not run here. Not the final drain either — `child.wait()` below returns long
+    /// after the reader has had the line through its ordinary loop, so ablating the drain leaves
+    /// this green; `glass-pipe-unix` drives that function directly instead. What is this crate's
+    /// own to get right, and what this pins, is the wiring: `spawn` hands the taps back rather
+    /// than detaching them, and stopping them joins rather than losing what the app already said.
     #[test]
     #[cfg(target_os = "macos")]
     fn a_launch_hands_back_taps_that_catch_the_apps_last_line() {
@@ -721,7 +758,7 @@ mod tests {
             .collect();
         assert!(
             said.iter().any(|line| line == "the last line"),
-            "the drain after the stop must keep the app's last line: {said:?}"
+            "stopping the taps must join, not lose what the app already wrote: {said:?}"
         );
     }
 

--- a/crates/glass-pipe-unix/Cargo.toml
+++ b/crates/glass-pipe-unix/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "glass-pipe-unix"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[dependencies]
+# Non-blocking mode, the self-pipe wakeup, and the poll that waits on both at once.
+rustix.workspace = true
+
+[lints]
+workspace = true

--- a/crates/glass-pipe-unix/Cargo.toml
+++ b/crates/glass-pipe-unix/Cargo.toml
@@ -7,7 +7,8 @@ repository.workspace = true
 publish.workspace = true
 
 [dependencies]
-# Non-blocking mode, the self-pipe wakeup, and the poll that waits on both at once.
+# Non-blocking mode, the write that rings the self-pipe wakeup, and the poll that waits on the
+# pipe and the wakeup at once. The wakeup pipe itself comes from std — see `tap.rs`.
 rustix.workspace = true
 
 [lints]

--- a/crates/glass-pipe-unix/src/lib.rs
+++ b/crates/glass-pipe-unix/src/lib.rs
@@ -1,0 +1,18 @@
+//! Reading a child's pipe on a background thread, with a way to stop.
+//!
+//! A reader that ends only at EOF cannot be ended at all when the child's write end outlives the
+//! child: everything the child spawned inherits it, so a process left running holds the pipe open
+//! and the reader parks in `read` forever, holding a thread and an fd. Under a long-lived
+//! `glass-mcp serve --http` that accumulates per launch.
+//!
+//! What a tap adds is an exit that does not depend on the far end: the read is non-blocking so no
+//! read parks past a look at the stop flag, a self-pipe polled alongside the data is the wakeup,
+//! and `Drop` joins. Unix rather than Linux because macOS needs the same thing and has no eventfd;
+//! Windows cannot share any of it (`glass-windows` carries its own over `PeekNamedPipe`).
+
+#![cfg(unix)]
+#![forbid(unsafe_code)]
+
+mod tap;
+
+pub use tap::{ChunkSink, PipeTap};

--- a/crates/glass-pipe-unix/src/lib.rs
+++ b/crates/glass-pipe-unix/src/lib.rs
@@ -15,6 +15,8 @@
 
 mod line;
 mod tap;
+#[cfg(test)]
+mod testsup;
 
 pub use line::LineTap;
 pub use tap::{ChunkSink, PipeTap};

--- a/crates/glass-pipe-unix/src/lib.rs
+++ b/crates/glass-pipe-unix/src/lib.rs
@@ -13,6 +13,8 @@
 #![cfg(unix)]
 #![forbid(unsafe_code)]
 
+mod line;
 mod tap;
 
+pub use line::LineTap;
 pub use tap::{ChunkSink, PipeTap};

--- a/crates/glass-pipe-unix/src/lib.rs
+++ b/crates/glass-pipe-unix/src/lib.rs
@@ -2,13 +2,13 @@
 //!
 //! A reader that ends only at EOF cannot be ended at all when the child's write end outlives the
 //! child: everything the child spawned inherits it, so a process left running holds the pipe open
-//! and the reader parks in `read` forever, holding a thread and an fd. Under a long-lived
-//! `glass-mcp serve --http` that accumulates per launch.
+//! and the reader parks in `read` forever, holding a thread and an fd — accumulating per launch
+//! under a long-lived `glass-mcp serve --http`.
 //!
-//! What a tap adds is an exit that does not depend on the far end: the read is non-blocking so no
-//! read parks past a look at the stop flag, a self-pipe polled alongside the data is the wakeup,
-//! and `Drop` joins. Unix rather than Linux because macOS needs the same thing and has no eventfd;
-//! Windows cannot share any of it (`glass-windows` carries its own over `PeekNamedPipe`).
+//! What a tap adds is an exit that does not depend on the far end: the read is non-blocking, a
+//! self-pipe polled alongside the data is the wakeup, and `Drop` joins. Unix rather than Linux
+//! because macOS needs the same thing and has no eventfd; Windows cannot share any of it
+//! (`glass-windows` carries its own over `PeekNamedPipe`).
 
 #![cfg(unix)]
 #![forbid(unsafe_code)]

--- a/crates/glass-pipe-unix/src/line.rs
+++ b/crates/glass-pipe-unix/src/line.rs
@@ -6,9 +6,9 @@ use crate::{ChunkSink, PipeTap};
 
 /// A child's stream read as tagged lines into a buffer the caller drains.
 ///
-/// Held by the backend for the app's lifetime and dropped at teardown: the app's stdout/stderr
-/// write ends are inherited by everything it spawns, so a reader that ended only at EOF would
-/// park on a survivor's pipe (glass#477).
+/// Held by the backend for the app's lifetime and dropped at teardown: the app's write ends are
+/// inherited by everything it spawns, so an EOF-only reader parks on a survivor's pipe
+/// (glass#477).
 #[derive(Debug)]
 pub struct LineTap(PipeTap);
 
@@ -41,8 +41,8 @@ impl LineTap {
 /// Splits what the pipe delivered into lines. Chunks arrive at pipe boundaries, so a line can
 /// span any number of them — `pending` is what has been seen of the line still open.
 ///
-/// `glass-windows/src/logtap.rs` carries a twin of this, because that crate cannot link a
-/// `cfg(unix)` one. A decision made here about newlines, `\r` or invalid bytes belongs in both.
+/// `glass-windows/src/logtap.rs` carries a twin, since that crate cannot link a `cfg(unix)` one:
+/// a decision here about newlines, `\r` or invalid bytes belongs in both.
 struct Lines<S> {
     tag: S,
     sink: Arc<Mutex<Vec<(S, String)>>>,
@@ -63,9 +63,8 @@ impl<S: Copy> Lines<S> {
     /// File `pending` as a line and start the next one.
     ///
     /// Lossy rather than a decode that can fail: `BufRead::lines` returns `Err` on a bad byte and
-    /// the readers this replaces stopped there, so one stray byte silenced an app for the rest of
-    /// its run. The trailing `\r` goes the way `BufRead::lines` drops it, so a CRLF-writing app
-    /// does not gain one at the end of every line.
+    /// the readers this replaces stopped there, silencing an app for the rest of its run over one
+    /// stray byte. The trailing `\r` goes the way `BufRead::lines` drops it.
     fn emit(&mut self) {
         let line = std::mem::take(&mut self.pending);
         let text = String::from_utf8_lossy(&line);
@@ -89,8 +88,8 @@ impl<S: Copy> ChunkSink for Lines<S> {
     }
 
     /// A last line that never got its newline is still what the app said — a crash mid-write, or a
-    /// process killed between the text and the terminator. An empty `pending` is the ordinary case
-    /// of a stream that ended on a newline, and must not become a blank line.
+    /// process killed between the text and the terminator. An empty `pending` is a stream that
+    /// ended on a newline, and must not become a blank line.
     fn end(&mut self) {
         if !self.pending.is_empty() {
             self.emit();

--- a/crates/glass-pipe-unix/src/line.rs
+++ b/crates/glass-pipe-unix/src/line.rs
@@ -13,20 +13,23 @@ use crate::{ChunkSink, PipeTap};
 pub struct LineTap(PipeTap);
 
 impl LineTap {
-    /// Start reading `source`, filing each line into `sink` under `tag`.
+    /// Start reading `source`, filing each line into `sink` under `tag`. `name` names the reader
+    /// thread — a launch starts one per stream, and the name is what tells them apart in a
+    /// backtrace or a thread listing.
     ///
     /// `Err` is the host refusing the thread or the fds — see [`PipeTap::start`], whose failures
     /// these are. `source` is consumed either way.
     pub fn start<S, R>(
         source: R,
         tag: S,
+        name: &str,
         sink: Arc<Mutex<Vec<(S, String)>>>,
     ) -> std::io::Result<LineTap>
     where
         S: Copy + Send + 'static,
         R: Read + AsFd + Send + 'static,
     {
-        PipeTap::start(source, "glass-log-tap", Lines::new(tag, sink)).map(LineTap)
+        PipeTap::start(source, name, Lines::new(tag, sink)).map(LineTap)
     }
 
     /// Stop the reader and wait for it to go, releasing the pipe. Idempotent; `drop` runs it too.
@@ -37,6 +40,9 @@ impl LineTap {
 
 /// Splits what the pipe delivered into lines. Chunks arrive at pipe boundaries, so a line can
 /// span any number of them — `pending` is what has been seen of the line still open.
+///
+/// `glass-windows/src/logtap.rs` carries a twin of this, because that crate cannot link a
+/// `cfg(unix)` one. A decision made here about newlines, `\r` or invalid bytes belongs in both.
 struct Lines<S> {
     tag: S,
     sink: Arc<Mutex<Vec<(S, String)>>>,
@@ -73,11 +79,11 @@ impl<S: Copy> Lines<S> {
 
 impl<S: Copy> ChunkSink for Lines<S> {
     fn chunk(&mut self, bytes: &[u8]) {
-        for byte in bytes {
-            if *byte == b'\n' {
+        for &byte in bytes {
+            if byte == b'\n' {
                 self.emit();
             } else {
-                self.pending.push(*byte);
+                self.pending.push(byte);
             }
         }
     }
@@ -95,11 +101,10 @@ impl<S: Copy> ChunkSink for Lines<S> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::{BufRead, BufReader};
-    use std::process::{ChildStderr, Command, Stdio};
+    use std::process::ChildStderr;
     use std::time::{Duration, Instant};
 
-    use rustix::process::{Pid, Signal, kill_process};
+    use crate::testsup::{Survivor, child_with_survivor};
 
     /// Stands in for `glass_core::logbuf::Stream`, which this crate does not depend on.
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -107,41 +112,18 @@ mod tests {
         Out,
     }
 
-    /// A process holding the pipe after the child that made it is gone; killed with the test.
-    struct Survivor(Option<u32>);
-
-    impl Drop for Survivor {
-        fn drop(&mut self) {
-            if let Some(pid) = self.0.and_then(|p| Pid::from_raw(p as i32)) {
-                let _ = kill_process(pid, Signal::KILL);
-            }
-        }
-    }
-
-    /// Run `script`, which must print the pid it backgrounded on stdout, and return its stderr
-    /// pipe plus a guard for the survivor.
+    /// `script`'s stderr pipe, plus a guard for the survivor holding it open.
     fn stderr_of(script: &str) -> (ChildStderr, Survivor) {
-        let mut c = Command::new("sh")
-            .arg("-c")
-            .arg(script)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .expect("sh is runnable");
-        let mut pid = String::new();
-        let read = BufReader::new(c.stdout.take().expect("piped stdout")).read_line(&mut pid);
-        let survivor = Survivor(pid.trim().parse().ok());
-        read.expect("sh reports the pid it backgrounded");
-        assert!(survivor.0.is_some(), "sh reported {pid:?}, not a pid");
-        c.wait().expect("the child exits, the survivor does not");
-        (c.stderr.take().expect("piped stderr"), survivor)
+        let (mut child, survivor) = child_with_survivor(script);
+        (child.stderr.take().expect("piped stderr"), survivor)
     }
 
     /// What the tap filed after being stopped with the survivor still holding the pipe.
     fn lines_after_stopping(script: &str) -> Vec<(Tag, String)> {
         let (stderr, _survivor) = stderr_of(script);
         let sink: Arc<Mutex<Vec<(Tag, String)>>> = Arc::default();
-        let mut tap = LineTap::start(stderr, Tag::Out, Arc::clone(&sink)).expect("a reader");
+        let mut tap =
+            LineTap::start(stderr, Tag::Out, "test-log-tap", Arc::clone(&sink)).expect("a reader");
         tap.stop();
         sink.lock().expect("sink").clone()
     }
@@ -231,7 +213,7 @@ mod tests {
     fn stop_is_bounded_when_a_survivor_holds_the_pipe() {
         let (stderr, _survivor) = stderr_of("printf 'one\\n' >&2; sleep 30 & echo $!");
         let sink: Arc<Mutex<Vec<(Tag, String)>>> = Arc::default();
-        let mut tap = LineTap::start(stderr, Tag::Out, sink).expect("a reader");
+        let mut tap = LineTap::start(stderr, Tag::Out, "test-log-tap", sink).expect("a reader");
 
         let t0 = Instant::now();
         tap.stop();

--- a/crates/glass-pipe-unix/src/line.rs
+++ b/crates/glass-pipe-unix/src/line.rs
@@ -1,0 +1,245 @@
+use std::io::Read;
+use std::os::fd::AsFd;
+use std::sync::{Arc, Mutex, PoisonError};
+
+use crate::{ChunkSink, PipeTap};
+
+/// A child's stream read as tagged lines into a buffer the caller drains.
+///
+/// Held by the backend for the app's lifetime and dropped at teardown: the app's stdout/stderr
+/// write ends are inherited by everything it spawns, so a reader that ended only at EOF would
+/// park on a survivor's pipe (glass#477).
+#[derive(Debug)]
+pub struct LineTap(PipeTap);
+
+impl LineTap {
+    /// Start reading `source`, filing each line into `sink` under `tag`.
+    ///
+    /// `Err` is the host refusing the thread or the fds — see [`PipeTap::start`], whose failures
+    /// these are. `source` is consumed either way.
+    pub fn start<S, R>(
+        source: R,
+        tag: S,
+        sink: Arc<Mutex<Vec<(S, String)>>>,
+    ) -> std::io::Result<LineTap>
+    where
+        S: Copy + Send + 'static,
+        R: Read + AsFd + Send + 'static,
+    {
+        PipeTap::start(source, "glass-log-tap", Lines::new(tag, sink)).map(LineTap)
+    }
+
+    /// Stop the reader and wait for it to go, releasing the pipe. Idempotent; `drop` runs it too.
+    pub fn stop(&mut self) {
+        self.0.stop();
+    }
+}
+
+/// Splits what the pipe delivered into lines. Chunks arrive at pipe boundaries, so a line can
+/// span any number of them — `pending` is what has been seen of the line still open.
+struct Lines<S> {
+    tag: S,
+    sink: Arc<Mutex<Vec<(S, String)>>>,
+    pending: Vec<u8>,
+}
+
+impl<S> Lines<S> {
+    fn new(tag: S, sink: Arc<Mutex<Vec<(S, String)>>>) -> Self {
+        Lines {
+            tag,
+            sink,
+            pending: Vec::new(),
+        }
+    }
+}
+
+impl<S: Copy> Lines<S> {
+    /// File `pending` as a line and start the next one.
+    ///
+    /// Lossy rather than a decode that can fail: `BufRead::lines` returns `Err` on a bad byte and
+    /// the readers this replaces stopped there, so one stray byte silenced an app for the rest of
+    /// its run. The trailing `\r` goes the way `BufRead::lines` drops it, so a CRLF-writing app
+    /// does not gain one at the end of every line.
+    fn emit(&mut self) {
+        let line = std::mem::take(&mut self.pending);
+        let text = String::from_utf8_lossy(&line);
+        let text = text.strip_suffix('\r').unwrap_or(&text).to_owned();
+        self.sink
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .push((self.tag, text));
+    }
+}
+
+impl<S: Copy> ChunkSink for Lines<S> {
+    fn chunk(&mut self, bytes: &[u8]) {
+        for byte in bytes {
+            if *byte == b'\n' {
+                self.emit();
+            } else {
+                self.pending.push(*byte);
+            }
+        }
+    }
+
+    /// A last line that never got its newline is still what the app said — a crash mid-write, or a
+    /// process killed between the text and the terminator. An empty `pending` is the ordinary case
+    /// of a stream that ended on a newline, and must not become a blank line.
+    fn end(&mut self) {
+        if !self.pending.is_empty() {
+            self.emit();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{BufRead, BufReader};
+    use std::process::{ChildStderr, Command, Stdio};
+    use std::time::{Duration, Instant};
+
+    use rustix::process::{Pid, Signal, kill_process};
+
+    /// Stands in for `glass_core::logbuf::Stream`, which this crate does not depend on.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum Tag {
+        Out,
+    }
+
+    /// A process holding the pipe after the child that made it is gone; killed with the test.
+    struct Survivor(Option<u32>);
+
+    impl Drop for Survivor {
+        fn drop(&mut self) {
+            if let Some(pid) = self.0.and_then(|p| Pid::from_raw(p as i32)) {
+                let _ = kill_process(pid, Signal::KILL);
+            }
+        }
+    }
+
+    /// Run `script`, which must print the pid it backgrounded on stdout, and return its stderr
+    /// pipe plus a guard for the survivor.
+    fn stderr_of(script: &str) -> (ChildStderr, Survivor) {
+        let mut c = Command::new("sh")
+            .arg("-c")
+            .arg(script)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("sh is runnable");
+        let mut pid = String::new();
+        let read = BufReader::new(c.stdout.take().expect("piped stdout")).read_line(&mut pid);
+        let survivor = Survivor(pid.trim().parse().ok());
+        read.expect("sh reports the pid it backgrounded");
+        assert!(survivor.0.is_some(), "sh reported {pid:?}, not a pid");
+        c.wait().expect("the child exits, the survivor does not");
+        (c.stderr.take().expect("piped stderr"), survivor)
+    }
+
+    /// What the tap filed after being stopped with the survivor still holding the pipe.
+    fn lines_after_stopping(script: &str) -> Vec<(Tag, String)> {
+        let (stderr, _survivor) = stderr_of(script);
+        let sink: Arc<Mutex<Vec<(Tag, String)>>> = Arc::default();
+        let mut tap = LineTap::start(stderr, Tag::Out, Arc::clone(&sink)).expect("a reader");
+        tap.stop();
+        sink.lock().expect("sink").clone()
+    }
+
+    #[test]
+    fn each_line_lands_tagged_and_without_its_newline() {
+        let lines = lines_after_stopping("printf 'one\\ntwo\\n' >&2; sleep 30 & echo $!");
+        assert_eq!(
+            lines,
+            vec![(Tag::Out, "one".to_string()), (Tag::Out, "two".to_string())]
+        );
+    }
+
+    #[test]
+    fn a_final_line_with_no_newline_is_still_emitted() {
+        // `BufRead::lines` yields it; a splitter that only emitted on '\n' would drop the last
+        // thing a crashing app said.
+        let lines = lines_after_stopping("printf 'one\\ntruncated' >&2; sleep 30 & echo $!");
+        assert_eq!(
+            lines,
+            vec![
+                (Tag::Out, "one".to_string()),
+                (Tag::Out, "truncated".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn a_trailing_carriage_return_is_not_part_of_the_line() {
+        // `BufRead::lines` strips it, so a CRLF-writing app must not gain a stray '\r' at the end
+        // of every captured line.
+        let lines = lines_after_stopping("printf 'one\\r\\n' >&2; sleep 30 & echo $!");
+        assert_eq!(lines, vec![(Tag::Out, "one".to_string())]);
+    }
+
+    #[test]
+    fn a_blank_line_between_two_others_is_kept() {
+        // Blank lines are content — an app's own paragraph breaks in a stack trace.
+        let lines = lines_after_stopping("printf 'one\\n\\ntwo\\n' >&2; sleep 30 & echo $!");
+        assert_eq!(
+            lines,
+            vec![
+                (Tag::Out, "one".to_string()),
+                (Tag::Out, String::new()),
+                (Tag::Out, "two".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn nothing_written_emits_nothing() {
+        // `end` must not invent a trailing empty line out of an empty pending buffer.
+        let lines = lines_after_stopping("sleep 30 & echo $!");
+        assert!(lines.is_empty(), "expected no lines, got {lines:?}");
+    }
+
+    #[test]
+    fn invalid_utf8_is_replaced_rather_than_ending_the_reader() {
+        // `BufRead::lines` returns `Err(InvalidData)` here and the reader this replaces stopped
+        // on it, losing every later line — an app that wrote one stray byte went quiet.
+        let lines =
+            lines_after_stopping("printf 'good\\n\\377\\nafter\\n' >&2; sleep 30 & echo $!");
+        assert_eq!(
+            lines.len(),
+            3,
+            "the reader must not stop at bad bytes: {lines:?}"
+        );
+        assert_eq!(lines[0].1, "good");
+        assert_eq!(lines[2].1, "after");
+    }
+
+    #[test]
+    fn a_line_split_across_reads_arrives_whole() {
+        // Chunks arrive at pipe boundaries, not line boundaries.
+        let lines = lines_after_stopping(
+            "head -c 9000 /dev/zero | tr '\\0' x >&2; printf '\\n' >&2; sleep 30 & echo $!",
+        );
+        assert_eq!(lines.len(), 1);
+        assert_eq!(
+            lines[0].1.len(),
+            9000,
+            "the line must not be cut at a chunk edge"
+        );
+    }
+
+    #[test]
+    fn stop_is_bounded_when_a_survivor_holds_the_pipe() {
+        let (stderr, _survivor) = stderr_of("printf 'one\\n' >&2; sleep 30 & echo $!");
+        let sink: Arc<Mutex<Vec<(Tag, String)>>> = Arc::default();
+        let mut tap = LineTap::start(stderr, Tag::Out, sink).expect("a reader");
+
+        let t0 = Instant::now();
+        tap.stop();
+
+        assert!(
+            t0.elapsed() < Duration::from_secs(2),
+            "stop must not wait for an EOF that is not coming: {:?}",
+            t0.elapsed()
+        );
+    }
+}

--- a/crates/glass-pipe-unix/src/tap.rs
+++ b/crates/glass-pipe-unix/src/tap.rs
@@ -256,13 +256,48 @@ mod tests {
         t0.elapsed()
     }
 
-    /// A `Read` that always fills the buffer and never ends, so only the cap can stop a drain.
-    struct Endless;
+    /// A `Read` that hands back at most `per_read` bytes and never ends, so only the cap can stop
+    /// a drain.
+    ///
+    /// `per_read` divides neither [`CHUNK`] nor [`FINAL_DRAIN`], so the last read is a short one
+    /// and the remaining-room arithmetic is what decides the total — chunk-aligned, any error in
+    /// it lands on a boundary and cancels out.
+    struct Endless {
+        per_read: usize,
+    }
 
     impl Read for Endless {
         fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-            buf.fill(b'x');
-            Ok(buf.len())
+            assert!(
+                !buf.is_empty(),
+                "the drain must not ask for zero bytes; it has room or it is finished"
+            );
+            let n = buf.len().min(self.per_read);
+            buf[..n].fill(b'x');
+            Ok(n)
+        }
+    }
+
+    /// A `Read` that reports `Interrupted` `left` times, then hands back `bytes` once, then says
+    /// the pipe is empty.
+    struct InterruptedThen {
+        left: u32,
+        bytes: usize,
+    }
+
+    impl Read for InterruptedThen {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            if self.left > 0 {
+                self.left -= 1;
+                return Err(std::io::Error::from(ErrorKind::Interrupted));
+            }
+            match std::mem::take(&mut self.bytes) {
+                0 => Err(std::io::Error::from(ErrorKind::WouldBlock)),
+                n => {
+                    buf[..n].fill(b'y');
+                    Ok(n)
+                }
+            }
         }
     }
 
@@ -297,7 +332,37 @@ mod tests {
     #[test]
     fn the_final_drain_stops_at_the_cap_rather_than_reading_on() {
         // The cap is the whole bound against a survivor that keeps writing.
-        assert_eq!(drained(Endless).len(), FINAL_DRAIN);
+        assert_eq!(drained(Endless { per_read: 3000 }).len(), FINAL_DRAIN);
+    }
+
+    #[test]
+    fn the_final_drain_absorbs_interrupts_and_still_takes_what_follows() {
+        // An interrupt takes no bytes. Ending the drain on one loses what the app already wrote,
+        // and not counting it lets a persistent signal spin here.
+        assert_eq!(
+            drained(InterruptedThen {
+                left: DRAIN_INTERRUPTS as u32 - 1,
+                bytes: 5,
+            }),
+            "yyyyy"
+        );
+    }
+
+    #[test]
+    fn the_final_drain_gives_up_on_a_pipe_that_only_ever_interrupts() {
+        // Off-thread: without a budget on the interrupts this never returns, and the suite should
+        // fail rather than hang.
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            tx.send(drained(InterruptedThen {
+                left: u32::MAX,
+                bytes: 5,
+            }))
+        });
+        let took = rx
+            .recv_timeout(NEVER_RETURNS)
+            .expect("the drain must give up on interrupts, not spin on them");
+        assert_eq!(took, "", "nothing was ever readable");
     }
 
     #[test]
@@ -322,6 +387,124 @@ mod tests {
             }),
             "yy"
         );
+    }
+
+    #[test]
+    fn a_tap_over_a_pipe_that_closes_ends_itself() {
+        // The EOF exit, which every other test here deliberately never reaches — its survivor
+        // holds the pipe open. Without it, `StderrTail::finish` has nothing to wait on.
+        let mut c = Command::new("sh")
+            .arg("-c")
+            .arg("printf 'all of it\n' >&2")
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("sh is runnable");
+        let collected = Collected::default();
+        let tap = PipeTap::start(
+            c.stderr.take().expect("piped stderr"),
+            "test-tap",
+            collected.clone(),
+        )
+        .expect("a reader");
+        c.wait().expect("the child exits");
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline && !tap.is_done() {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        assert!(
+            tap.is_done(),
+            "a closed pipe must end its reader on its own"
+        );
+        assert_eq!(collected.read(), ("all of it\n".to_string(), true));
+    }
+
+    #[test]
+    fn a_tap_whose_pipe_a_survivor_holds_open_is_not_done() {
+        // The other half: `is_done` must not report a reader still parked on a live pipe as gone,
+        // or a caller waiting for a child's last words stops waiting at once.
+        let (mut c, _survivor) = said_then_survived("the last line\n");
+        let tap = PipeTap::start(
+            c.stderr.take().expect("piped stderr"),
+            "test-tap",
+            Collected::default(),
+        )
+        .expect("a reader");
+
+        assert!(!tap.is_done(), "the survivor still holds the write end");
+    }
+
+    #[test]
+    fn debug_reports_whether_the_reader_left_and_never_the_capture() {
+        // Derived, this would render the sink — a whole log buffer — into whatever printed the
+        // struct holding it.
+        let (mut c, _survivor) = said_then_survived("the fatal line\n");
+        let tap = PipeTap::start(
+            c.stderr.take().expect("piped stderr"),
+            "test-tap",
+            Collected::default(),
+        )
+        .expect("a reader");
+
+        let rendered = format!("{tap:?}");
+        assert!(rendered.contains("done: false"), "{rendered}");
+        assert!(
+            !rendered.contains("fatal"),
+            "the capture must not be in it: {rendered}"
+        );
+    }
+
+    #[test]
+    fn a_reader_waits_out_a_quiet_pipe_rather_than_leaving_it() {
+        // A pipe with nothing in it yet reads `WouldBlock`. Send that to the same arm as a real
+        // error and the reader leaves at the app's first quiet moment, losing everything after.
+        let (mut c, _survivor) = child_with_survivor(
+            "(printf 'first\n' >&2; sleep 0.4; printf 'second\n' >&2; sleep 30) & echo $!",
+        );
+        let collected = Collected::default();
+        let _tap = PipeTap::start(
+            c.stderr.take().expect("piped stderr"),
+            "test-tap",
+            collected.clone(),
+        )
+        .expect("a reader");
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while Instant::now() < deadline && !collected.read().0.contains("second") {
+            std::thread::sleep(Duration::from_millis(20));
+        }
+
+        assert!(
+            collected.read().0.contains("second"),
+            "the reader must still be there after the pause: {:?}",
+            collected.read().0
+        );
+    }
+
+    #[test]
+    fn dropping_a_tap_instead_of_stopping_it_still_ends_the_reader() {
+        // `Drop` is how every backend ends a tap — none of them call `stop`. Without it a
+        // teardown that just lets the field go leaves the reader parked on the survivor's pipe.
+        let (mut c, _survivor) = said_then_survived("the last line\n");
+        let collected = Collected::default();
+        let tap = PipeTap::start(
+            c.stderr.take().expect("piped stderr"),
+            "test-tap",
+            collected.clone(),
+        )
+        .expect("a reader");
+
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            drop(tap);
+            tx.send(())
+        });
+        rx.recv_timeout(NEVER_RETURNS)
+            .expect("drop must end the reader; one parked in read() never returns");
+
+        assert!(collected.read().1, "the sink must have been ended");
     }
 
     #[test]

--- a/crates/glass-pipe-unix/src/tap.rs
+++ b/crates/glass-pipe-unix/src/tap.rs
@@ -8,30 +8,25 @@ use std::time::Duration;
 use rustix::event::{PollFd, PollFlags, Timespec, poll};
 use rustix::fs::{OFlags, fcntl_getfl, fcntl_setfl};
 
-/// How long an idle reader sleeps before looking at the stop flag again.
-///
-/// Not normally what a stop waits for: [`PipeTap::stop`] rings the wakeup first, and the write
-/// can only fail once the reader is already leaving. It is the backstop if that ever does not
-/// arrive.
+/// How long an idle reader sleeps before looking at the stop flag again — the backstop for a
+/// wakeup that never arrives, not what a stop normally waits for.
 const HEARD_BY: Timespec = Timespec {
     tv_sec: 5,
     tv_nsec: 0,
 };
 
-/// A cap on the drain after the stop flag, not a measure of what is there: it is at least one
-/// pipe buffer on either platform (Linux defaults to 64 KiB, macOS to 16), so an ordinary child's
-/// last words fit, and a survivor still writing cannot hold the stop open.
+/// A cap on the drain after the stop flag, so a survivor still writing cannot hold the stop open.
+/// At least one pipe buffer on either platform — Linux defaults to 64 KiB, macOS to 16.
 const FINAL_DRAIN: usize = 64 * 1024;
 
-/// How many `EINTR`s the final drain will absorb. It makes no progress on one, so without a
-/// budget a persistent signal would spin inside the function whose whole job is a bound.
+/// How many `EINTR`s the final drain will absorb. It takes no bytes on one, so without a budget a
+/// persistent signal spins there.
 const DRAIN_INTERRUPTS: u8 = 8;
 
 /// What a `poll` that errored falls back to, rather than spinning the loop on an `EAGAIN` read.
-/// Not a re-check cadence — the poll itself is the wait when it works.
 const POLL_ERROR_BACKOFF: Duration = Duration::from_millis(20);
 
-/// How much one read asks for. A pipe buffer's worth arrives in these.
+/// How much one read asks for.
 const CHUNK: usize = 4096;
 
 /// What to do with what a [`PipeTap`] read, and what to do once no more is coming.
@@ -39,7 +34,7 @@ pub trait ChunkSink {
     /// Bytes as they arrive, in order, at whatever boundaries the pipe delivered them.
     fn chunk(&mut self, bytes: &[u8]);
     /// The reader is leaving: EOF, an unreadable pipe, or a stop. Anything held back — a line
-    /// still waiting for its newline — has no later chance to be emitted.
+    /// still waiting for its newline — has no later chance.
     fn end(&mut self) {}
 }
 
@@ -48,22 +43,20 @@ pub trait ChunkSink {
 /// Not a read at the end: a child whose output nobody drains stalls on a full pipe, which the
 /// caller reads as a process that never came up.
 ///
-/// The write end is inherited by everything the child spawned, so a process outliving the
-/// teardown holds the pipe open, and a reader that could only stop at EOF would park there
-/// holding an fd — one per stream per launch, for the life of a `glass-mcp serve --http`
-/// (glass#477).
+/// The write end is inherited by everything the child spawned, so a process outliving the teardown
+/// holds the pipe open and a reader that could only stop at EOF parks there holding an fd — one
+/// per stream per launch, for the life of a `glass-mcp serve --http` (glass#477).
 pub struct PipeTap {
     /// What actually stops the reader. A flag rather than the wakeup below, so a wakeup that
     /// never arrives costs [`HEARD_BY`] rather than the life of the process.
     stopping: Arc<AtomicBool>,
     /// Wakes a reader asleep in `poll` so it reads the flag now instead of at [`HEARD_BY`]. The
-    /// write end of a self-pipe; nobody drains it, so one byte stays readable and the next poll
-    /// is certain to see it. Only ever written by [`PipeTap::stop`], whose flag the loop checks
-    /// immediately afterwards, so an always-readable byte cannot spin the reader.
+    /// write end of a self-pipe nobody drains, so one byte stays readable and the next poll is
+    /// certain to see it.
     ///
-    /// Closed only after the reader is joined — which `stop` guarantees, and `Drop` runs `stop`
-    /// before any field is dropped. Close it while the reader lives and its `poll` returns
-    /// `POLLHUP` forever, spinning the loop on a flag that is still false.
+    /// Do not close it while the reader lives: `poll` would return `POLLHUP` forever, spinning the
+    /// loop on a flag that is still false. `stop` joins first, and `Drop` runs `stop` before any
+    /// field is dropped.
     wake: PipeWriter,
     /// Taken by whichever of [`PipeTap::stop`] and `drop` runs first.
     reader: Option<JoinHandle<()>>,
@@ -73,22 +66,19 @@ impl PipeTap {
     /// Start reading `source` into `sink` on a thread called `name`.
     ///
     /// `Err` is the host refusing a resource the bounded read is built from: the thread —
-    /// `Builder`, where `thread::spawn` panics (glass#454) — the wakeup pipe, or the
-    /// non-blocking mode. `source` is consumed either way, so on `Err` the read end is already
-    /// closed and the child will take `EPIPE` rather than stall.
+    /// `Builder`, where `thread::spawn` panics (glass#454) — the wakeup pipe, or the non-blocking
+    /// mode. `source` is consumed either way, so on `Err` the child takes `EPIPE` rather than
+    /// stalling on a pipe nobody drains.
     pub fn start<R, S>(source: R, name: &str, mut sink: S) -> std::io::Result<PipeTap>
     where
         R: Read + AsFd + Send + 'static,
         S: ChunkSink + Send + 'static,
     {
-        // Blocking, a read with nothing to read parks past every look at the flag. Safe for the
-        // child: `pipe(2)` gives the two ends separate open file descriptions, so a status flag
-        // set here never reaches the write end it inherited.
+        // Blocking, a read with nothing to read parks past every look at the flag. `pipe(2)` gives
+        // the two ends separate open file descriptions, so this never reaches the child's.
         fcntl_setfl(&source, fcntl_getfl(&source)?.union(OFlags::NONBLOCK))?;
-        // `std::io::pipe` rather than rustix's: `pipe_with(CLOEXEC)` is `pipe2(2)`, which macOS
-        // does not have and rustix therefore gates out there. std closes the gap per platform,
-        // and sets close-on-exec either way — without it these land in every process the host
-        // spawns afterwards.
+        // `std::io::pipe` rather than rustix's `pipe_with(CLOEXEC)`: that is `pipe2(2)`, which
+        // macOS lacks and rustix gates out there. std sets close-on-exec on both platforms.
         let (woken, wake) = std::io::pipe()?;
         let stopping: Arc<AtomicBool> = Arc::default();
         let stop = Arc::clone(&stopping);
@@ -105,13 +95,11 @@ impl PipeTap {
         })
     }
 
-    /// Whether the reader has left and the sink has been told so — the pipe closed, or nothing
-    /// more can be read from it. A caller waiting on a child's last words watches this rather
-    /// than guessing a sleep.
+    /// Whether the reader has left and the sink has been told so. A caller waiting on a child's
+    /// last words watches this rather than guessing a sleep.
     ///
-    /// The thread's own state rather than a flag beside it, so it is still the truth when the
-    /// reader leaves by unwinding: a flag stored on the way out is never stored on that path, and
-    /// a caller polling it would wait out its whole grace for a thread that is already gone.
+    /// The thread's own state, not a flag stored on the way out: that is never stored when the
+    /// reader unwinds, and a caller would wait out its whole grace for a thread already gone.
     pub fn is_done(&self) -> bool {
         self.reader
             .as_ref()
@@ -127,8 +115,8 @@ impl PipeTap {
         // Set before the wake, or a reader the write pulls out of `poll` finds the flag still
         // false and goes back to sleep for another `HEARD_BY`.
         self.stopping.store(true, Ordering::Release);
-        // Retried, because a signal landing here would drop the byte and leave the reader asleep
-        // until `HEARD_BY` — inside a teardown budget measured in seconds.
+        // Retried: a signal landing here drops the byte and leaves the reader asleep until
+        // `HEARD_BY`, inside a teardown budget measured in seconds.
         let _ = rustix::io::retry_on_intr(|| rustix::io::write(&self.wake, &[1u8]));
         let _ = reader.join();
     }
@@ -159,8 +147,8 @@ fn read_until_stopped<R: Read + AsFd, S: ChunkSink>(
     sink: &mut S,
 ) {
     let mut chunk = [0u8; CHUNK];
-    // The flag is read before every read, not only when the pipe runs dry, so a child that never
-    // stops writing cannot keep the reader here either.
+    // Read before every read, not only when the pipe runs dry, so a child that never stops
+    // writing cannot keep the reader here either.
     while !stopping.load(Ordering::Acquire) {
         match source.read(&mut chunk) {
             Ok(0) => return,
@@ -173,17 +161,15 @@ fn read_until_stopped<R: Read + AsFd, S: ChunkSink>(
             },
         }
     }
-    // Only reached via the flag. The loop above leaves without reading, so a teardown that stops
-    // the tap right after reaping the child would lose the last thing it wrote — the lines a
-    // failed teardown is most likely to need.
+    // Only reached via the flag, which the loop leaves on without reading — so without this a
+    // teardown loses the last thing the app wrote, which is what a failed one is diagnosed from.
     final_drain(&mut source, &mut chunk, sink);
 }
 
 /// Read what is already in the pipe, at most [`FINAL_DRAIN`] bytes, without waiting for more.
 ///
 /// The read is non-blocking, so `WouldBlock` is the pipe being empty right now — the end of the
-/// drain, not a reason to wait. The cap is the other half: a survivor still writing would
-/// otherwise keep the drain fed for as long as it kept going.
+/// drain, not a reason to wait.
 fn final_drain<R: Read, S: ChunkSink>(source: &mut R, chunk: &mut [u8; CHUNK], sink: &mut S) {
     let mut taken = 0;
     let mut interrupts = 0;
@@ -195,8 +181,7 @@ fn final_drain<R: Read, S: ChunkSink>(source: &mut R, chunk: &mut [u8; CHUNK], s
                 taken += n;
                 sink.chunk(&chunk[..n]);
             }
-            // An interrupt takes nothing, so it cannot be what ends the loop — it needs its own
-            // budget or a persistent signal spins here.
+            // An interrupt takes no bytes, so `taken` cannot be what ends the loop on one.
             Err(e) if e.kind() == ErrorKind::Interrupted && interrupts < DRAIN_INTERRUPTS => {
                 interrupts += 1;
             }
@@ -208,8 +193,8 @@ fn final_drain<R: Read, S: ChunkSink>(source: &mut R, chunk: &mut [u8; CHUNK], s
 /// Sleep until the pipe has more to say, the wakeup is rung, or [`HEARD_BY`] elapses. The caller
 /// re-reads whichever it was, so none of the three needs telling apart.
 ///
-/// A poll that errors sleeps instead of returning at once: a persistent one — `EINVAL` under an
-/// `RLIMIT_NOFILE` below two — would otherwise spin this loop on an `EAGAIN` read and burn a core.
+/// A poll that errors sleeps rather than returning at once: a persistent one — `EINVAL` under an
+/// `RLIMIT_NOFILE` below two — would spin this loop on an `EAGAIN` read and burn a core.
 fn wait_for_more<R: AsFd>(source: &R, woken: &PipeReader) {
     let mut waiting = [
         PollFd::new(source, PollFlags::IN),
@@ -223,7 +208,7 @@ fn wait_for_more<R: AsFd>(source: &R, woken: &PipeReader) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    // Only the two `/proc`-based assertions below need it, and they are Linux-only.
+    // Only the `/proc`-based assertions below use it, and they are Linux-only.
     #[cfg(target_os = "linux")]
     use std::os::fd::AsRawFd;
     use std::process::{Command, Stdio};
@@ -299,11 +284,8 @@ mod tests {
         }
     }
 
-    /// Bytes `final_drain` handed the sink, driving it directly.
-    ///
-    /// Directly, because through a real pipe it cannot be told apart from the main loop: the
-    /// reader thread races the caller's `stop`, and whichever wins, the bytes arrive and every
-    /// assertion passes. Ablating `final_drain` would leave those tests green.
+    /// Bytes `final_drain` handed the sink, driving it directly — through a real pipe it cannot be
+    /// told apart from the main loop, which races it, so ablating it leaves those tests green.
     fn drained(mut source: impl Read) -> String {
         let collected = Collected::default();
         let mut sink = collected.clone();
@@ -314,15 +296,14 @@ mod tests {
 
     #[test]
     fn the_final_drain_stops_at_the_cap_rather_than_reading_on() {
-        // The cap is the whole bound: a survivor that keeps writing must not be able to keep the
-        // drain fed, and the drain must not stop short of what a child actually left behind.
+        // The cap is the whole bound against a survivor that keeps writing.
         assert_eq!(drained(Endless).len(), FINAL_DRAIN);
     }
 
     #[test]
     fn the_final_drain_ends_on_an_empty_pipe_rather_than_waiting() {
-        // The read is non-blocking, so `WouldBlock` is "nothing more right now" — the end of the
-        // drain. Treating it as a reason to wait would put teardown behind a survivor's silence.
+        // Non-blocking, so `WouldBlock` ends the drain; waiting on it would put teardown behind a
+        // survivor's silence.
         assert_eq!(
             drained(ThenErr {
                 first: Some(4),
@@ -345,8 +326,8 @@ mod tests {
 
     #[test]
     fn stop_returns_while_a_survivor_holds_the_pipe_open() {
-        // The write end is inherited by everything the child spawned, so EOF is not a deadline
-        // any reader can count on reaching (glass#477).
+        // The write end is inherited by everything the child spawned, so EOF is not a deadline any
+        // reader can count on reaching (glass#477).
         let (mut c, _survivor) = said_then_survived("the last line\\n");
         let tap = PipeTap::start(
             c.stderr.take().expect("piped stderr"),
@@ -363,9 +344,8 @@ mod tests {
         );
     }
 
-    // `/proc/self/fd`, so Linux only. The property is not: what it proves — the reader closes its
-    // end — holds on every unix, and `stop_returns_while_a_survivor_holds_the_pipe_open` above
-    // covers the half that can be asserted anywhere.
+    // `/proc/self/fd`, so Linux only; the property is not. `stop_returns_while_a_survivor_holds_
+    // the_pipe_open` above covers the half that can be asserted anywhere.
     #[test]
     #[cfg(target_os = "linux")]
     fn stop_releases_the_pipe_a_survivor_holds_open() {
@@ -378,8 +358,8 @@ mod tests {
 
         stop_within(tap);
 
-        // The survivor still holds the write end, so this pipe cannot be reopened by anything
-        // else: finding the same target again means the same fd, still ours.
+        // The survivor still holds the write end, so nothing else can be handed this pipe —
+        // finding the same target again means the same fd, still ours.
         assert!(
             std::fs::read_link(&link).ok().is_none_or(|now| now != held),
             "the reader must close its end, but {link} still points at {held:?}"
@@ -388,8 +368,8 @@ mod tests {
 
     #[test]
     fn what_the_child_wrote_before_exiting_survives_the_stop() {
-        // The loop leaves at the flag without reading, so without a final drain a teardown that
-        // stops the tap right after reaping loses the last thing the app said.
+        // The loop leaves at the flag without reading, so a stop straight after the reap would
+        // lose the last thing the app said.
         let (mut c, _survivor) = said_then_survived("the last line\\n");
         let collected = Collected::default();
         let mut tap = PipeTap::start(
@@ -410,8 +390,8 @@ mod tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn the_read_end_is_non_blocking() {
-        // Blocking, a read with nothing to read parks past every look at the stop flag, and the
-        // wakeup cannot reach a thread that is no longer in `poll`.
+        // Blocking, a read with nothing to read parks past every look at the stop flag, where the
+        // wakeup cannot reach it.
         let (mut c, _survivor) = said_then_survived("the last line\\n");
         let stderr = c.stderr.take().expect("piped stderr");
         let fd = stderr.as_raw_fd();
@@ -432,8 +412,8 @@ mod tests {
 
     #[test]
     fn a_child_that_floods_the_pipe_is_never_blocked_writing() {
-        // Stop draining and the child blocks in write() once the 64 KiB pipe buffer fills, which
-        // every caller reads as a hang.
+        // Stop draining and the child blocks in write() once the pipe buffer fills, which every
+        // caller reads as a hang.
         let mut c = Command::new("sh")
             .arg("-c")
             .arg("dd if=/dev/zero bs=1024 count=1024 2>/dev/null | tr '\\0' e >&2")
@@ -460,9 +440,8 @@ mod tests {
 
     #[test]
     fn the_final_drain_is_bounded_against_a_survivor_that_never_stops_writing() {
-        // The drain reads what is already there; a survivor still writing must not be able to
-        // keep handing it more and hold teardown open. `yes` self-limits once the pipe fills, so
-        // it costs nothing while the guard is waiting to kill it.
+        // A survivor still writing must not be able to keep the drain fed. `yes` self-limits once
+        // the pipe fills, so it costs nothing while the guard waits to kill it.
         let (mut c, _survivor) = child_with_survivor("yes noise >&2 & echo $!");
         let tap = PipeTap::start(
             c.stderr.take().expect("piped stderr"),

--- a/crates/glass-pipe-unix/src/tap.rs
+++ b/crates/glass-pipe-unix/src/tap.rs
@@ -1,5 +1,5 @@
-use std::io::{ErrorKind, Read};
-use std::os::fd::{AsFd, OwnedFd};
+use std::io::{ErrorKind, PipeReader, PipeWriter, Read};
+use std::os::fd::AsFd;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::JoinHandle;
@@ -7,7 +7,6 @@ use std::time::Duration;
 
 use rustix::event::{PollFd, PollFlags, Timespec, poll};
 use rustix::fs::{OFlags, fcntl_getfl, fcntl_setfl};
-use rustix::pipe::{PipeFlags, pipe_with};
 
 /// How long an idle reader sleeps before looking at the stop flag again.
 ///
@@ -57,7 +56,7 @@ pub struct PipeTap {
     /// write end of a self-pipe; nobody drains it, so one byte stays readable and the next poll
     /// is certain to see it. Only ever written by [`PipeTap::stop`], whose flag the loop checks
     /// immediately afterwards, so an always-readable byte cannot spin the reader.
-    wake: OwnedFd,
+    wake: PipeWriter,
     /// Taken by whichever of [`PipeTap::stop`] and `drop` runs first.
     reader: Option<JoinHandle<()>>,
 }
@@ -78,8 +77,11 @@ impl PipeTap {
         // child: `pipe(2)` gives the two ends separate open file descriptions, so a status flag
         // set here never reaches the write end it inherited.
         fcntl_setfl(&source, fcntl_getfl(&source)?.union(OFlags::NONBLOCK))?;
-        // CLOEXEC or these land in every process the host spawns afterwards.
-        let (woken, wake) = pipe_with(PipeFlags::CLOEXEC)?;
+        // `std::io::pipe` rather than rustix's: `pipe_with(CLOEXEC)` is `pipe2(2)`, which macOS
+        // does not have and rustix therefore gates out there. std closes the gap per platform,
+        // and sets close-on-exec either way — without it these land in every process the host
+        // spawns afterwards.
+        let (woken, wake) = std::io::pipe()?;
         let done: Arc<AtomicBool> = Arc::default();
         let stopping: Arc<AtomicBool> = Arc::default();
         let (ended, stop) = (Arc::clone(&done), Arc::clone(&stopping));
@@ -138,7 +140,7 @@ impl std::fmt::Debug for PipeTap {
 /// Read `source` into `sink` until it ends or `stopping` says to.
 fn read_until_stopped<R: Read + AsFd, S: ChunkSink>(
     mut source: R,
-    woken: &OwnedFd,
+    woken: &PipeReader,
     stopping: &AtomicBool,
     sink: &mut S,
 ) {
@@ -189,7 +191,7 @@ fn final_drain<R: Read, S: ChunkSink>(source: &mut R, chunk: &mut [u8; CHUNK], s
 ///
 /// A poll that errors sleeps instead of returning at once: a persistent one — `EINVAL` under an
 /// `RLIMIT_NOFILE` below two — would otherwise spin this loop on an `EAGAIN` read and burn a core.
-fn wait_for_more<R: AsFd>(source: &R, woken: &OwnedFd) {
+fn wait_for_more<R: AsFd>(source: &R, woken: &PipeReader) {
     let mut waiting = [
         PollFd::new(source, PollFlags::IN),
         PollFd::new(woken, PollFlags::IN),
@@ -311,7 +313,11 @@ mod tests {
         );
     }
 
+    // `/proc/self/fd`, so Linux only. The property is not: what it proves — the reader closes its
+    // end — holds on every unix, and `stop_returns_while_a_survivor_holds_the_pipe_open` above
+    // covers the half that can be asserted anywhere.
     #[test]
+    #[cfg(target_os = "linux")]
     fn stop_releases_the_pipe_a_survivor_holds_open() {
         // A tap that stops without ending its reader leaves the fd held for the process's life.
         let (mut c, _survivor) = said_then_survived("the last line\\n");
@@ -350,7 +356,9 @@ mod tests {
         assert!(ended, "the sink must be told no more is coming");
     }
 
+    // `/proc/self/fdinfo`, so Linux only — macOS exposes no per-fd status flags to read back.
     #[test]
+    #[cfg(target_os = "linux")]
     fn the_read_end_is_non_blocking() {
         // Blocking, a read with nothing to read parks past every look at the stop flag, and the
         // wakeup cannot reach a thread that is no longer in `poll`.

--- a/crates/glass-pipe-unix/src/tap.rs
+++ b/crates/glass-pipe-unix/src/tap.rs
@@ -1,0 +1,423 @@
+use std::io::{ErrorKind, Read};
+use std::os::fd::{AsFd, OwnedFd};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use rustix::event::{PollFd, PollFlags, Timespec, poll};
+use rustix::fs::{OFlags, fcntl_getfl, fcntl_setfl};
+use rustix::pipe::{PipeFlags, pipe_with};
+
+/// How long an idle reader sleeps before looking at the stop flag again.
+///
+/// Also the ceiling on [`PipeTap::stop`]'s join if the wakeup is lost — the flag is what stops
+/// the reader.
+const HEARD_BY: Timespec = Timespec {
+    tv_sec: 5,
+    tv_nsec: 0,
+};
+
+/// The most the drain after the stop flag will read: one pipe buffer, which is everything a
+/// child can have left behind, so a survivor still writing cannot hold the stop open.
+const FINAL_DRAIN: usize = 64 * 1024;
+
+/// What a `poll` that errored falls back to, rather than spinning the loop on an `EAGAIN` read.
+const POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+/// How much one read asks for. A pipe buffer's worth arrives in these.
+const CHUNK: usize = 4096;
+
+/// What to do with what a [`PipeTap`] read, and what to do once no more is coming.
+pub trait ChunkSink {
+    /// Bytes as they arrive, in order, at whatever boundaries the pipe delivered them.
+    fn chunk(&mut self, bytes: &[u8]);
+    /// The reader is leaving: EOF, an unreadable pipe, or a stop. Anything held back — a line
+    /// still waiting for its newline — has no later chance to be emitted.
+    fn end(&mut self) {}
+}
+
+/// A child's pipe, read on a helper thread until it closes or the tap ends it.
+///
+/// Not a read at the end: a child whose output nobody drains stalls on a full pipe, which the
+/// caller reads as a process that never came up.
+///
+/// The write end is inherited by everything the child spawned, so a process outliving the
+/// teardown holds the pipe open, and a reader that could only stop at EOF would park there
+/// holding an fd — one per stream per launch, for the life of a `glass-mcp serve --http`
+/// (glass#477).
+pub struct PipeTap {
+    /// Set by the reader on its way out, so a caller can tell a pipe that closed on its own from
+    /// one still held open.
+    done: Arc<AtomicBool>,
+    /// What actually stops the reader. A flag rather than the wakeup below, so a wakeup that
+    /// never arrives costs [`HEARD_BY`] rather than the life of the process.
+    stopping: Arc<AtomicBool>,
+    /// Wakes a reader asleep in `poll` so it reads the flag now instead of at [`HEARD_BY`]. The
+    /// write end of a self-pipe; nobody drains it, so one byte stays readable and the next poll
+    /// is certain to see it. Only ever written by [`PipeTap::stop`], whose flag the loop checks
+    /// immediately afterwards, so an always-readable byte cannot spin the reader.
+    wake: OwnedFd,
+    /// Taken by whichever of [`PipeTap::stop`] and `drop` runs first.
+    reader: Option<JoinHandle<()>>,
+}
+
+impl PipeTap {
+    /// Start reading `source` into `sink` on a thread called `name`.
+    ///
+    /// `Err` is the host refusing a resource the bounded read is built from: the thread —
+    /// `Builder`, where `thread::spawn` panics (glass#454) — the wakeup pipe, or the
+    /// non-blocking mode. `source` is consumed either way, so on `Err` the read end is already
+    /// closed and the child will take `EPIPE` rather than stall.
+    pub fn start<R, S>(source: R, name: &str, mut sink: S) -> std::io::Result<PipeTap>
+    where
+        R: Read + AsFd + Send + 'static,
+        S: ChunkSink + Send + 'static,
+    {
+        // Blocking, a read with nothing to read parks past every look at the flag. Safe for the
+        // child: `pipe(2)` gives the two ends separate open file descriptions, so a status flag
+        // set here never reaches the write end it inherited.
+        fcntl_setfl(&source, fcntl_getfl(&source)?.union(OFlags::NONBLOCK))?;
+        // CLOEXEC or these land in every process the host spawns afterwards.
+        let (woken, wake) = pipe_with(PipeFlags::CLOEXEC)?;
+        let done: Arc<AtomicBool> = Arc::default();
+        let stopping: Arc<AtomicBool> = Arc::default();
+        let (ended, stop) = (Arc::clone(&done), Arc::clone(&stopping));
+        let reader = std::thread::Builder::new()
+            .name(name.to_owned())
+            .spawn(move || {
+                read_until_stopped(source, &woken, &stop, &mut sink);
+                sink.end();
+                ended.store(true, Ordering::Release);
+            })?;
+        Ok(PipeTap {
+            done,
+            stopping,
+            wake,
+            reader: Some(reader),
+        })
+    }
+
+    /// Whether the reader has already left — the pipe closed, or nothing more can be read from
+    /// it. A caller waiting on a child's last words watches this rather than guessing a sleep.
+    pub fn is_done(&self) -> bool {
+        self.done.load(Ordering::Acquire)
+    }
+
+    /// Stop the reader and wait for it to go, which is what makes the pipe closed rather than
+    /// assumed closed. Idempotent, because `drop` runs it too.
+    pub fn stop(&mut self) {
+        let Some(reader) = self.reader.take() else {
+            return;
+        };
+        // Set before the wake, or a reader the write pulls out of `poll` finds the flag still
+        // false and goes back to sleep for another `HEARD_BY`.
+        self.stopping.store(true, Ordering::Release);
+        let _ = rustix::io::write(&self.wake, &[1u8]);
+        let _ = reader.join();
+    }
+}
+
+impl Drop for PipeTap {
+    /// A tap nobody stopped still ends its reader.
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+/// Hides whatever the sink is holding: a derived `Debug` would render a capture, or a log buffer,
+/// into whatever printed the struct holding this.
+impl std::fmt::Debug for PipeTap {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PipeTap")
+            .field("done", &self.is_done())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Read `source` into `sink` until it ends or `stopping` says to.
+fn read_until_stopped<R: Read + AsFd, S: ChunkSink>(
+    mut source: R,
+    woken: &OwnedFd,
+    stopping: &AtomicBool,
+    sink: &mut S,
+) {
+    let mut chunk = [0u8; CHUNK];
+    // The flag is read before every read, not only when the pipe runs dry, so a child that never
+    // stops writing cannot keep the reader here either.
+    while !stopping.load(Ordering::Acquire) {
+        match source.read(&mut chunk) {
+            Ok(0) => return,
+            Ok(n) => sink.chunk(&chunk[..n]),
+            Err(e) => match e.kind() {
+                // Nothing to read yet, or the read was interrupted: back to the wait.
+                ErrorKind::WouldBlock | ErrorKind::Interrupted => wait_for_more(&source, woken),
+                // Anything else will not read better next time.
+                _ => return,
+            },
+        }
+    }
+    // Only reached via the flag. The loop above leaves without reading, so a teardown that stops
+    // the tap right after reaping the child would lose the last thing it wrote — the lines a
+    // failed teardown is most likely to need.
+    final_drain(&mut source, &mut chunk, sink);
+}
+
+/// Read what is already in the pipe, at most [`FINAL_DRAIN`] bytes, without waiting for more.
+///
+/// The read is non-blocking, so `WouldBlock` is the pipe being empty right now — the end of the
+/// drain, not a reason to wait. The cap is the other half: a survivor still writing would
+/// otherwise keep the drain fed for as long as it kept going.
+fn final_drain<R: Read, S: ChunkSink>(source: &mut R, chunk: &mut [u8; CHUNK], sink: &mut S) {
+    let mut taken = 0;
+    while taken < FINAL_DRAIN {
+        let room = (FINAL_DRAIN - taken).min(CHUNK);
+        match source.read(&mut chunk[..room]) {
+            Ok(0) => return,
+            Ok(n) => {
+                taken += n;
+                sink.chunk(&chunk[..n]);
+            }
+            Err(e) if e.kind() == ErrorKind::Interrupted => continue,
+            Err(_) => return,
+        }
+    }
+}
+
+/// Sleep until the pipe has more to say, the wakeup is rung, or [`HEARD_BY`] elapses. The caller
+/// re-reads whichever it was, so none of the three needs telling apart.
+///
+/// A poll that errors sleeps instead of returning at once: a persistent one — `EINVAL` under an
+/// `RLIMIT_NOFILE` below two — would otherwise spin this loop on an `EAGAIN` read and burn a core.
+fn wait_for_more<R: AsFd>(source: &R, woken: &OwnedFd) {
+    let mut waiting = [
+        PollFd::new(source, PollFlags::IN),
+        PollFd::new(woken, PollFlags::IN),
+    ];
+    if poll(&mut waiting, Some(&HEARD_BY)).is_err() {
+        std::thread::sleep(POLL_INTERVAL);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{BufRead, BufReader};
+    use std::os::fd::AsRawFd;
+    use std::process::{Child, Command, Stdio};
+    use std::sync::mpsc;
+    use std::sync::{Arc, Mutex};
+    use std::time::{Duration, Instant};
+
+    use rustix::process::{Pid, Signal, kill_process};
+
+    /// How long a test waits for a `stop` that is supposed to be bounded — a third of the
+    /// survivor's life, which must not be what ends it.
+    const NEVER_RETURNS: Duration = Duration::from_secs(10);
+
+    /// A process holding a child's pipe after the child is gone, killed when the test ends,
+    /// panic included. It outlives [`NEVER_RETURNS`] three times over, so a reader that only
+    /// stops at EOF stays parked for the whole test, and self-limits if the guard cannot run.
+    ///
+    /// Load-bearing for the fd assertions, not only for cleanup: while it holds the write end
+    /// the pipe's inode cannot be freed, so no sibling test thread can be handed the same
+    /// `pipe:[n]` and read as a false failure.
+    struct Survivor(Option<u32>);
+
+    impl Drop for Survivor {
+        fn drop(&mut self) {
+            if let Some(pid) = self.0.and_then(|p| Pid::from_raw(p as i32)) {
+                let _ = kill_process(pid, Signal::KILL);
+            }
+        }
+    }
+
+    /// Run `script` — which must background something and print its pid on stdout — and hand back
+    /// the exited child plus a guard for the survivor.
+    fn child_with_survivor(script: &str) -> (Child, Survivor) {
+        let mut c = Command::new("sh")
+            .arg("-c")
+            .arg(script)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("sh is runnable");
+        let mut pid = String::new();
+        let read = BufReader::new(c.stdout.take().expect("piped stdout")).read_line(&mut pid);
+        // Guarded before anything that can panic: the sleeper exists from the moment `sh` runs.
+        let survivor = Survivor(pid.trim().parse().ok());
+        read.expect("sh reports the pid it backgrounded");
+        assert!(survivor.0.is_some(), "sh reported {pid:?}, not a pid");
+        c.wait().expect("the child exits, the survivor does not");
+        (c, survivor)
+    }
+
+    /// A child that says `said` on stderr, leaves a sleeper holding that pipe, and exits.
+    fn said_then_survived(said: &str) -> (Child, Survivor) {
+        child_with_survivor(&format!("printf '{said}' >&2; sleep 30 & echo $!"))
+    }
+
+    /// Collects every chunk handed to it, and records whether `end` ran.
+    #[derive(Clone, Default)]
+    struct Collected(Arc<Mutex<(Vec<u8>, bool)>>);
+
+    impl ChunkSink for Collected {
+        fn chunk(&mut self, bytes: &[u8]) {
+            self.0.lock().expect("collector").0.extend_from_slice(bytes);
+        }
+        fn end(&mut self) {
+            self.0.lock().expect("collector").1 = true;
+        }
+    }
+
+    impl Collected {
+        fn read(&self) -> (String, bool) {
+            let held = self.0.lock().expect("collector");
+            (String::from_utf8_lossy(&held.0).into_owned(), held.1)
+        }
+    }
+
+    /// Stop `tap` off-thread, so a reader with no exit fails the test rather than hanging the
+    /// suite. Returns how long the stop took.
+    fn stop_within(mut tap: PipeTap) -> Duration {
+        let (tx, rx) = mpsc::channel();
+        let t0 = Instant::now();
+        std::thread::spawn(move || {
+            tap.stop();
+            tx.send(())
+        });
+        rx.recv_timeout(NEVER_RETURNS)
+            .expect("stop must return; a reader parked in read() never does");
+        t0.elapsed()
+    }
+
+    #[test]
+    fn stop_returns_while_a_survivor_holds_the_pipe_open() {
+        // The write end is inherited by everything the child spawned, so EOF is not a deadline
+        // any reader can count on reaching (glass#477).
+        let (mut c, _survivor) = said_then_survived("the last line\\n");
+        let tap = PipeTap::start(
+            c.stderr.take().expect("piped stderr"),
+            "test-tap",
+            Collected::default(),
+        )
+        .expect("a reader");
+
+        let took = stop_within(tap);
+
+        assert!(
+            took < Duration::from_secs(2),
+            "stop must not wait for an EOF that is not coming: took {took:?}"
+        );
+    }
+
+    #[test]
+    fn stop_releases_the_pipe_a_survivor_holds_open() {
+        // A tap that stops without ending its reader leaves the fd held for the process's life.
+        let (mut c, _survivor) = said_then_survived("the last line\\n");
+        let stderr = c.stderr.take().expect("piped stderr");
+        let link = format!("/proc/self/fd/{}", stderr.as_raw_fd());
+        let held = std::fs::read_link(&link).expect("the read end is open");
+        let tap = PipeTap::start(stderr, "test-tap", Collected::default()).expect("a reader");
+
+        stop_within(tap);
+
+        // The survivor still holds the write end, so this pipe cannot be reopened by anything
+        // else: finding the same target again means the same fd, still ours.
+        assert!(
+            std::fs::read_link(&link).ok().is_none_or(|now| now != held),
+            "the reader must close its end, but {link} still points at {held:?}"
+        );
+    }
+
+    #[test]
+    fn what_the_child_wrote_before_exiting_survives_the_stop() {
+        // The loop leaves at the flag without reading, so without a final drain a teardown that
+        // stops the tap right after reaping loses the last thing the app said.
+        let (mut c, _survivor) = said_then_survived("the last line\\n");
+        let collected = Collected::default();
+        let mut tap = PipeTap::start(
+            c.stderr.take().expect("piped stderr"),
+            "test-tap",
+            collected.clone(),
+        )
+        .expect("a reader");
+
+        tap.stop();
+
+        let (said, ended) = collected.read();
+        assert_eq!(said, "the last line\n");
+        assert!(ended, "the sink must be told no more is coming");
+    }
+
+    #[test]
+    fn the_read_end_is_non_blocking() {
+        // Blocking, a read with nothing to read parks past every look at the stop flag, and the
+        // wakeup cannot reach a thread that is no longer in `poll`.
+        let (mut c, _survivor) = said_then_survived("the last line\\n");
+        let stderr = c.stderr.take().expect("piped stderr");
+        let fd = stderr.as_raw_fd();
+        // Held for the whole assertion, so this reads our own pipe and not a reused number.
+        let _tap = PipeTap::start(stderr, "test-tap", Collected::default()).expect("a reader");
+
+        let fdinfo = std::fs::read_to_string(format!("/proc/self/fdinfo/{fd}")).expect("fdinfo");
+        let flags = fdinfo
+            .lines()
+            .find_map(|l| l.strip_prefix("flags:"))
+            .expect("fdinfo reports the open file description's flags");
+        let bits = u32::from_str_radix(flags.trim(), 8).expect("octal");
+        assert!(
+            bits & 0o4000 != 0,
+            "the read end must carry O_NONBLOCK, but fdinfo says flags:{flags}"
+        );
+    }
+
+    #[test]
+    fn a_child_that_floods_the_pipe_is_never_blocked_writing() {
+        // Stop draining and the child blocks in write() once the 64 KiB pipe buffer fills, which
+        // every caller reads as a hang.
+        let mut c = Command::new("sh")
+            .arg("-c")
+            .arg("dd if=/dev/zero bs=1024 count=1024 2>/dev/null | tr '\\0' e >&2")
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("sh is runnable");
+        let _tap = PipeTap::start(
+            c.stderr.take().expect("piped stderr"),
+            "test-tap",
+            Collected::default(),
+        )
+        .expect("a reader");
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while Instant::now() < deadline && !matches!(c.try_wait(), Ok(Some(_))) {
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        assert!(
+            matches!(c.try_wait(), Ok(Some(_))),
+            "1 MiB of stderr must not block the child writing it"
+        );
+    }
+
+    #[test]
+    fn the_final_drain_is_bounded_against_a_survivor_that_never_stops_writing() {
+        // The drain reads what is already there; a survivor still writing must not be able to
+        // keep handing it more and hold teardown open. `yes` self-limits once the pipe fills, so
+        // it costs nothing while the guard is waiting to kill it.
+        let (mut c, _survivor) = child_with_survivor("yes noise >&2 & echo $!");
+        let tap = PipeTap::start(
+            c.stderr.take().expect("piped stderr"),
+            "test-tap",
+            Collected::default(),
+        )
+        .expect("a reader");
+
+        let took = stop_within(tap);
+
+        assert!(
+            took < Duration::from_secs(2),
+            "the final drain must be capped, not run as long as somebody keeps writing: {took:?}"
+        );
+    }
+}

--- a/crates/glass-pipe-unix/src/tap.rs
+++ b/crates/glass-pipe-unix/src/tap.rs
@@ -222,23 +222,46 @@ mod tests {
     /// survivor's life, which must not be what ends it.
     const NEVER_RETURNS: Duration = Duration::from_secs(10);
 
-    /// Collects every chunk handed to it, and records whether `end` ran.
+    /// The most a collector keeps. Past it only the count grows.
+    ///
+    /// Bounded on purpose: several fixtures here read from something that never ends, so a mutant
+    /// that breaks the cap or the stop flag turns them into an unbounded read. Storing every byte
+    /// then exhausts the host's memory and takes the whole CI job down — which reports as a runner
+    /// shutdown, not as the one missed mutant it is.
+    const COLLECTED_KEPT: usize = 128 * 1024;
+
+    /// Collects what it is handed, keeping at most [`COLLECTED_KEPT`] bytes, counting all of them,
+    /// and recording whether `end` ran.
     #[derive(Clone, Default)]
-    struct Collected(Arc<Mutex<(Vec<u8>, bool)>>);
+    struct Collected(Arc<Mutex<Held>>);
+
+    #[derive(Default)]
+    struct Held {
+        kept: Vec<u8>,
+        total: usize,
+        ended: bool,
+    }
 
     impl ChunkSink for Collected {
         fn chunk(&mut self, bytes: &[u8]) {
-            self.0.lock().expect("collector").0.extend_from_slice(bytes);
+            let mut held = self.0.lock().expect("collector");
+            held.total += bytes.len();
+            let room = COLLECTED_KEPT.saturating_sub(held.kept.len());
+            held.kept.extend_from_slice(&bytes[..bytes.len().min(room)]);
         }
         fn end(&mut self) {
-            self.0.lock().expect("collector").1 = true;
+            self.0.lock().expect("collector").ended = true;
         }
     }
 
     impl Collected {
         fn read(&self) -> (String, bool) {
             let held = self.0.lock().expect("collector");
-            (String::from_utf8_lossy(&held.0).into_owned(), held.1)
+            (String::from_utf8_lossy(&held.kept).into_owned(), held.ended)
+        }
+
+        fn total(&self) -> usize {
+            self.0.lock().expect("collector").total
         }
     }
 
@@ -256,23 +279,42 @@ mod tests {
         t0.elapsed()
     }
 
-    /// A `Read` that hands back at most `per_read` bytes and never ends, so only the cap can stop
-    /// a drain.
+    /// A `Read` with far more to give than the drain may take: `per_read` bytes at a time until
+    /// `left` runs out, then an empty pipe.
     ///
-    /// `per_read` divides neither [`CHUNK`] nor [`FINAL_DRAIN`], so the last read is a short one
-    /// and the remaining-room arithmetic is what decides the total — chunk-aligned, any error in
-    /// it lands on a boundary and cancels out.
-    struct Endless {
+    /// `per_read` divides neither [`CHUNK`] nor [`FINAL_DRAIN`], so the last read the cap allows is
+    /// a short one and the remaining-room arithmetic is what decides the total — chunk-aligned, an
+    /// error in it lands on a boundary and cancels out.
+    ///
+    /// `left` rather than truly endless so that a drain which reads past its cap gives a wrong
+    /// *finite* answer instead of an unbounded one. Endless, the same mutant exhausts the host's
+    /// memory and takes the CI job with it.
+    struct Flooding {
         per_read: usize,
+        left: usize,
     }
 
-    impl Read for Endless {
+    impl Flooding {
+        /// Twice what the drain may take, so reading past the cap is unmistakable and still ends.
+        fn twice_the_cap() -> Self {
+            Flooding {
+                per_read: 3000,
+                left: FINAL_DRAIN * 2,
+            }
+        }
+    }
+
+    impl Read for Flooding {
         fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
             assert!(
                 !buf.is_empty(),
                 "the drain must not ask for zero bytes; it has room or it is finished"
             );
-            let n = buf.len().min(self.per_read);
+            let n = buf.len().min(self.per_read).min(self.left);
+            if n == 0 {
+                return Err(std::io::Error::from(ErrorKind::WouldBlock));
+            }
+            self.left -= n;
             buf[..n].fill(b'x');
             Ok(n)
         }
@@ -321,18 +363,24 @@ mod tests {
 
     /// Bytes `final_drain` handed the sink, driving it directly — through a real pipe it cannot be
     /// told apart from the main loop, which races it, so ablating it leaves those tests green.
-    fn drained(mut source: impl Read) -> String {
+    fn drained(source: impl Read) -> String {
+        drain_all(source).0
+    }
+
+    /// What `final_drain` took from `source`: the bytes it kept, and how many it read in total.
+    fn drain_all(mut source: impl Read) -> (String, usize) {
         let collected = Collected::default();
         let mut sink = collected.clone();
         let mut chunk = [0u8; CHUNK];
         final_drain(&mut source, &mut chunk, &mut sink);
-        collected.read().0
+        (collected.read().0, collected.total())
     }
 
     #[test]
     fn the_final_drain_stops_at_the_cap_rather_than_reading_on() {
-        // The cap is the whole bound against a survivor that keeps writing.
-        assert_eq!(drained(Endless { per_read: 3000 }).len(), FINAL_DRAIN);
+        // The cap is the whole bound against a survivor that keeps writing. Counted, not kept: the
+        // collector holds far less than the cap on purpose.
+        assert_eq!(drain_all(Flooding::twice_the_cap()).1, FINAL_DRAIN);
     }
 
     #[test]
@@ -359,23 +407,6 @@ mod tests {
             }),
             ""
         );
-    }
-
-    #[test]
-    fn the_final_drain_gives_up_on_a_pipe_that_only_ever_interrupts() {
-        // Off-thread: without a budget on the interrupts this never returns, and the suite should
-        // fail rather than hang.
-        let (tx, rx) = mpsc::channel();
-        std::thread::spawn(move || {
-            tx.send(drained(InterruptedThen {
-                left: u32::MAX,
-                bytes: 5,
-            }))
-        });
-        let took = rx
-            .recv_timeout(NEVER_RETURNS)
-            .expect("the drain must give up on interrupts, not spin on them");
-        assert_eq!(took, "", "nothing was ever readable");
     }
 
     #[test]

--- a/crates/glass-pipe-unix/src/tap.rs
+++ b/crates/glass-pipe-unix/src/tap.rs
@@ -10,19 +10,26 @@ use rustix::fs::{OFlags, fcntl_getfl, fcntl_setfl};
 
 /// How long an idle reader sleeps before looking at the stop flag again.
 ///
-/// Also the ceiling on [`PipeTap::stop`]'s join if the wakeup is lost — the flag is what stops
-/// the reader.
+/// Not normally what a stop waits for: [`PipeTap::stop`] rings the wakeup first, and the write
+/// can only fail once the reader is already leaving. It is the backstop if that ever does not
+/// arrive.
 const HEARD_BY: Timespec = Timespec {
     tv_sec: 5,
     tv_nsec: 0,
 };
 
-/// The most the drain after the stop flag will read: one pipe buffer, which is everything a
-/// child can have left behind, so a survivor still writing cannot hold the stop open.
+/// A cap on the drain after the stop flag, not a measure of what is there: it is at least one
+/// pipe buffer on either platform (Linux defaults to 64 KiB, macOS to 16), so an ordinary child's
+/// last words fit, and a survivor still writing cannot hold the stop open.
 const FINAL_DRAIN: usize = 64 * 1024;
 
+/// How many `EINTR`s the final drain will absorb. It makes no progress on one, so without a
+/// budget a persistent signal would spin inside the function whose whole job is a bound.
+const DRAIN_INTERRUPTS: u8 = 8;
+
 /// What a `poll` that errored falls back to, rather than spinning the loop on an `EAGAIN` read.
-const POLL_INTERVAL: Duration = Duration::from_millis(20);
+/// Not a re-check cadence — the poll itself is the wait when it works.
+const POLL_ERROR_BACKOFF: Duration = Duration::from_millis(20);
 
 /// How much one read asks for. A pipe buffer's worth arrives in these.
 const CHUNK: usize = 4096;
@@ -46,9 +53,6 @@ pub trait ChunkSink {
 /// holding an fd — one per stream per launch, for the life of a `glass-mcp serve --http`
 /// (glass#477).
 pub struct PipeTap {
-    /// Set by the reader on its way out, so a caller can tell a pipe that closed on its own from
-    /// one still held open.
-    done: Arc<AtomicBool>,
     /// What actually stops the reader. A flag rather than the wakeup below, so a wakeup that
     /// never arrives costs [`HEARD_BY`] rather than the life of the process.
     stopping: Arc<AtomicBool>,
@@ -56,6 +60,10 @@ pub struct PipeTap {
     /// write end of a self-pipe; nobody drains it, so one byte stays readable and the next poll
     /// is certain to see it. Only ever written by [`PipeTap::stop`], whose flag the loop checks
     /// immediately afterwards, so an always-readable byte cannot spin the reader.
+    ///
+    /// Closed only after the reader is joined — which `stop` guarantees, and `Drop` runs `stop`
+    /// before any field is dropped. Close it while the reader lives and its `poll` returns
+    /// `POLLHUP` forever, spinning the loop on a flag that is still false.
     wake: PipeWriter,
     /// Taken by whichever of [`PipeTap::stop`] and `drop` runs first.
     reader: Option<JoinHandle<()>>,
@@ -82,28 +90,32 @@ impl PipeTap {
         // and sets close-on-exec either way — without it these land in every process the host
         // spawns afterwards.
         let (woken, wake) = std::io::pipe()?;
-        let done: Arc<AtomicBool> = Arc::default();
         let stopping: Arc<AtomicBool> = Arc::default();
-        let (ended, stop) = (Arc::clone(&done), Arc::clone(&stopping));
+        let stop = Arc::clone(&stopping);
         let reader = std::thread::Builder::new()
             .name(name.to_owned())
             .spawn(move || {
                 read_until_stopped(source, &woken, &stop, &mut sink);
                 sink.end();
-                ended.store(true, Ordering::Release);
             })?;
         Ok(PipeTap {
-            done,
             stopping,
             wake,
             reader: Some(reader),
         })
     }
 
-    /// Whether the reader has already left — the pipe closed, or nothing more can be read from
-    /// it. A caller waiting on a child's last words watches this rather than guessing a sleep.
+    /// Whether the reader has left and the sink has been told so — the pipe closed, or nothing
+    /// more can be read from it. A caller waiting on a child's last words watches this rather
+    /// than guessing a sleep.
+    ///
+    /// The thread's own state rather than a flag beside it, so it is still the truth when the
+    /// reader leaves by unwinding: a flag stored on the way out is never stored on that path, and
+    /// a caller polling it would wait out its whole grace for a thread that is already gone.
     pub fn is_done(&self) -> bool {
-        self.done.load(Ordering::Acquire)
+        self.reader
+            .as_ref()
+            .is_none_or(std::thread::JoinHandle::is_finished)
     }
 
     /// Stop the reader and wait for it to go, which is what makes the pipe closed rather than
@@ -115,7 +127,9 @@ impl PipeTap {
         // Set before the wake, or a reader the write pulls out of `poll` finds the flag still
         // false and goes back to sleep for another `HEARD_BY`.
         self.stopping.store(true, Ordering::Release);
-        let _ = rustix::io::write(&self.wake, &[1u8]);
+        // Retried, because a signal landing here would drop the byte and leave the reader asleep
+        // until `HEARD_BY` — inside a teardown budget measured in seconds.
+        let _ = rustix::io::retry_on_intr(|| rustix::io::write(&self.wake, &[1u8]));
         let _ = reader.join();
     }
 }
@@ -172,6 +186,7 @@ fn read_until_stopped<R: Read + AsFd, S: ChunkSink>(
 /// otherwise keep the drain fed for as long as it kept going.
 fn final_drain<R: Read, S: ChunkSink>(source: &mut R, chunk: &mut [u8; CHUNK], sink: &mut S) {
     let mut taken = 0;
+    let mut interrupts = 0;
     while taken < FINAL_DRAIN {
         let room = (FINAL_DRAIN - taken).min(CHUNK);
         match source.read(&mut chunk[..room]) {
@@ -180,7 +195,11 @@ fn final_drain<R: Read, S: ChunkSink>(source: &mut R, chunk: &mut [u8; CHUNK], s
                 taken += n;
                 sink.chunk(&chunk[..n]);
             }
-            Err(e) if e.kind() == ErrorKind::Interrupted => continue,
+            // An interrupt takes nothing, so it cannot be what ends the loop — it needs its own
+            // budget or a persistent signal spins here.
+            Err(e) if e.kind() == ErrorKind::Interrupted && interrupts < DRAIN_INTERRUPTS => {
+                interrupts += 1;
+            }
             Err(_) => return,
         }
     }
@@ -197,67 +216,26 @@ fn wait_for_more<R: AsFd>(source: &R, woken: &PipeReader) {
         PollFd::new(woken, PollFlags::IN),
     ];
     if poll(&mut waiting, Some(&HEARD_BY)).is_err() {
-        std::thread::sleep(POLL_INTERVAL);
+        std::thread::sleep(POLL_ERROR_BACKOFF);
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::{BufRead, BufReader};
+    // Only the two `/proc`-based assertions below need it, and they are Linux-only.
+    #[cfg(target_os = "linux")]
     use std::os::fd::AsRawFd;
-    use std::process::{Child, Command, Stdio};
+    use std::process::{Command, Stdio};
     use std::sync::mpsc;
     use std::sync::{Arc, Mutex};
     use std::time::{Duration, Instant};
 
-    use rustix::process::{Pid, Signal, kill_process};
+    use crate::testsup::{child_with_survivor, said_then_survived};
 
     /// How long a test waits for a `stop` that is supposed to be bounded — a third of the
     /// survivor's life, which must not be what ends it.
     const NEVER_RETURNS: Duration = Duration::from_secs(10);
-
-    /// A process holding a child's pipe after the child is gone, killed when the test ends,
-    /// panic included. It outlives [`NEVER_RETURNS`] three times over, so a reader that only
-    /// stops at EOF stays parked for the whole test, and self-limits if the guard cannot run.
-    ///
-    /// Load-bearing for the fd assertions, not only for cleanup: while it holds the write end
-    /// the pipe's inode cannot be freed, so no sibling test thread can be handed the same
-    /// `pipe:[n]` and read as a false failure.
-    struct Survivor(Option<u32>);
-
-    impl Drop for Survivor {
-        fn drop(&mut self) {
-            if let Some(pid) = self.0.and_then(|p| Pid::from_raw(p as i32)) {
-                let _ = kill_process(pid, Signal::KILL);
-            }
-        }
-    }
-
-    /// Run `script` — which must background something and print its pid on stdout — and hand back
-    /// the exited child plus a guard for the survivor.
-    fn child_with_survivor(script: &str) -> (Child, Survivor) {
-        let mut c = Command::new("sh")
-            .arg("-c")
-            .arg(script)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .expect("sh is runnable");
-        let mut pid = String::new();
-        let read = BufReader::new(c.stdout.take().expect("piped stdout")).read_line(&mut pid);
-        // Guarded before anything that can panic: the sleeper exists from the moment `sh` runs.
-        let survivor = Survivor(pid.trim().parse().ok());
-        read.expect("sh reports the pid it backgrounded");
-        assert!(survivor.0.is_some(), "sh reported {pid:?}, not a pid");
-        c.wait().expect("the child exits, the survivor does not");
-        (c, survivor)
-    }
-
-    /// A child that says `said` on stderr, leaves a sleeper holding that pipe, and exits.
-    fn said_then_survived(said: &str) -> (Child, Survivor) {
-        child_with_survivor(&format!("printf '{said}' >&2; sleep 30 & echo $!"))
-    }
 
     /// Collects every chunk handed to it, and records whether `end` ran.
     #[derive(Clone, Default)]
@@ -291,6 +269,78 @@ mod tests {
         rx.recv_timeout(NEVER_RETURNS)
             .expect("stop must return; a reader parked in read() never does");
         t0.elapsed()
+    }
+
+    /// A `Read` that always fills the buffer and never ends, so only the cap can stop a drain.
+    struct Endless;
+
+    impl Read for Endless {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            buf.fill(b'x');
+            Ok(buf.len())
+        }
+    }
+
+    /// A `Read` that yields `first` once and then reports what `then` says.
+    struct ThenErr {
+        first: Option<usize>,
+        then: ErrorKind,
+    }
+
+    impl Read for ThenErr {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            match self.first.take() {
+                Some(n) => {
+                    buf[..n].fill(b'y');
+                    Ok(n)
+                }
+                None => Err(std::io::Error::from(self.then)),
+            }
+        }
+    }
+
+    /// Bytes `final_drain` handed the sink, driving it directly.
+    ///
+    /// Directly, because through a real pipe it cannot be told apart from the main loop: the
+    /// reader thread races the caller's `stop`, and whichever wins, the bytes arrive and every
+    /// assertion passes. Ablating `final_drain` would leave those tests green.
+    fn drained(mut source: impl Read) -> String {
+        let collected = Collected::default();
+        let mut sink = collected.clone();
+        let mut chunk = [0u8; CHUNK];
+        final_drain(&mut source, &mut chunk, &mut sink);
+        collected.read().0
+    }
+
+    #[test]
+    fn the_final_drain_stops_at_the_cap_rather_than_reading_on() {
+        // The cap is the whole bound: a survivor that keeps writing must not be able to keep the
+        // drain fed, and the drain must not stop short of what a child actually left behind.
+        assert_eq!(drained(Endless).len(), FINAL_DRAIN);
+    }
+
+    #[test]
+    fn the_final_drain_ends_on_an_empty_pipe_rather_than_waiting() {
+        // The read is non-blocking, so `WouldBlock` is "nothing more right now" — the end of the
+        // drain. Treating it as a reason to wait would put teardown behind a survivor's silence.
+        assert_eq!(
+            drained(ThenErr {
+                first: Some(4),
+                then: ErrorKind::WouldBlock,
+            }),
+            "yyyy"
+        );
+    }
+
+    #[test]
+    fn the_final_drain_ends_at_eof() {
+        assert_eq!(
+            drained(ThenErr {
+                first: Some(2),
+                then: ErrorKind::UnexpectedEof,
+            }),
+            "yy"
+        );
     }
 
     #[test]

--- a/crates/glass-pipe-unix/src/tap.rs
+++ b/crates/glass-pipe-unix/src/tap.rs
@@ -336,15 +336,28 @@ mod tests {
     }
 
     #[test]
-    fn the_final_drain_absorbs_interrupts_and_still_takes_what_follows() {
-        // An interrupt takes no bytes. Ending the drain on one loses what the app already wrote,
-        // and not counting it lets a persistent signal spin here.
+    fn the_final_drain_absorbs_its_whole_interrupt_budget_and_still_takes_what_follows() {
+        // An interrupt takes no bytes, so ending the drain on one loses what the app already
+        // wrote. The budget is spent exactly here, and the read after it must still be taken.
         assert_eq!(
             drained(InterruptedThen {
-                left: DRAIN_INTERRUPTS as u32 - 1,
+                left: DRAIN_INTERRUPTS.into(),
                 bytes: 5,
             }),
             "yyyyy"
+        );
+    }
+
+    #[test]
+    fn the_final_drain_gives_up_one_interrupt_past_the_budget() {
+        // The other edge, and what makes the budget a bound rather than a number: one more
+        // interrupt than it allows ends the drain, whatever would have followed.
+        assert_eq!(
+            drained(InterruptedThen {
+                left: u32::from(DRAIN_INTERRUPTS) + 1,
+                bytes: 5,
+            }),
+            ""
         );
     }
 

--- a/crates/glass-pipe-unix/src/testsup.rs
+++ b/crates/glass-pipe-unix/src/testsup.rs
@@ -1,0 +1,49 @@
+//! Fixtures shared by the tap and line-splitter suites: a child that leaves a process holding its
+//! pipe, and a guard that kills it.
+
+use std::io::{BufRead, BufReader};
+use std::process::{Child, Command, Stdio};
+
+use rustix::process::{Pid, Signal, kill_process};
+
+/// A process holding a child's pipe after the child is gone, killed when the test ends, panic
+/// included. It outlives the suites' own deadlines several times over, so a reader that only
+/// stops at EOF stays parked for the whole test, and self-limits if the guard cannot run.
+///
+/// Load-bearing for the fd assertions, not only for cleanup: while it holds the write end the
+/// pipe's inode cannot be freed, so no sibling test thread can be handed the same `pipe:[n]` and
+/// read as a false failure.
+pub(crate) struct Survivor(pub(crate) Option<u32>);
+
+impl Drop for Survivor {
+    fn drop(&mut self) {
+        if let Some(pid) = self.0.and_then(|p| Pid::from_raw(p as i32)) {
+            let _ = kill_process(pid, Signal::KILL);
+        }
+    }
+}
+
+/// Run `script` — which must background something and print its pid on stdout — and hand back the
+/// exited child plus a guard for the survivor.
+pub(crate) fn child_with_survivor(script: &str) -> (Child, Survivor) {
+    let mut c = Command::new("sh")
+        .arg("-c")
+        .arg(script)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("sh is runnable");
+    let mut pid = String::new();
+    let read = BufReader::new(c.stdout.take().expect("piped stdout")).read_line(&mut pid);
+    // Guarded before anything that can panic: the sleeper exists from the moment `sh` runs.
+    let survivor = Survivor(pid.trim().parse().ok());
+    read.expect("sh reports the pid it backgrounded");
+    assert!(survivor.0.is_some(), "sh reported {pid:?}, not a pid");
+    c.wait().expect("the child exits, the survivor does not");
+    (c, survivor)
+}
+
+/// A child that says `said` on stderr, leaves a sleeper holding that pipe, and exits.
+pub(crate) fn said_then_survived(said: &str) -> (Child, Survivor) {
+    child_with_survivor(&format!("printf '{said}' >&2; sleep 30 & echo $!"))
+}

--- a/crates/glass-pipe-unix/src/testsup.rs
+++ b/crates/glass-pipe-unix/src/testsup.rs
@@ -7,12 +7,11 @@ use std::process::{Child, Command, Stdio};
 use rustix::process::{Pid, Signal, kill_process};
 
 /// A process holding a child's pipe after the child is gone, killed when the test ends, panic
-/// included. It outlives the suites' own deadlines several times over, so a reader that only
-/// stops at EOF stays parked for the whole test, and self-limits if the guard cannot run.
+/// included. It outlives the suites' deadlines several times over, and self-limits if the guard
+/// cannot run.
 ///
-/// Load-bearing for the fd assertions, not only for cleanup: while it holds the write end the
-/// pipe's inode cannot be freed, so no sibling test thread can be handed the same `pipe:[n]` and
-/// read as a false failure.
+/// Load-bearing beyond cleanup: while it holds the write end the pipe's inode cannot be freed, so
+/// no sibling test thread can be handed the same `pipe:[n]` and read as a false failure.
 pub(crate) struct Survivor(pub(crate) Option<u32>);
 
 impl Drop for Survivor {

--- a/crates/glass-pipe-unix/tests/idle_tap_does_not_spin.rs
+++ b/crates/glass-pipe-unix/tests/idle_tap_does_not_spin.rs
@@ -1,0 +1,67 @@
+//! The reader sleeps between reads.
+//!
+//! Nothing in the unit tests reaches this: a reader that turned every empty read straight into
+//! another empty read would pass all of them, while pinning a core per stream for the life of a
+//! launch — and a quiet app is the ordinary case.
+//!
+//! Its own test binary: the measurement is this process's CPU time, which a sibling test running
+//! in parallel would add to.
+
+#![cfg(target_os = "linux")]
+
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+/// How long the reader is watched. Long enough that a spinning one is unmistakable, short enough
+/// that the survivor below outlives it many times over.
+const WATCHED_FOR: Duration = Duration::from_millis(300);
+
+/// This process's CPU time in clock ticks: `utime` + `stime`, read after the last `)` because the
+/// comm field before it can itself contain spaces and parens.
+fn cpu_ticks() -> u64 {
+    let stat = std::fs::read_to_string("/proc/self/stat").expect("/proc/self/stat");
+    let after_comm = &stat[stat.rfind(')').expect("comm is parenthesised") + 1..];
+    let fields: Vec<&str> = after_comm.split_whitespace().collect();
+    // `state` is the first field left, which puts utime and stime at 11 and 12.
+    fields[11].parse::<u64>().expect("utime") + fields[12].parse::<u64>().expect("stime")
+}
+
+/// Discards what it is handed; this test measures CPU, not capture.
+struct Ignored;
+
+impl glass_pipe_unix::ChunkSink for Ignored {
+    fn chunk(&mut self, _bytes: &[u8]) {}
+}
+
+#[test]
+fn an_idle_reader_costs_no_cpu() {
+    // The survivor keeps the pipe open with nothing to say, which is the state a tap over a quiet
+    // app spends its life in. It outlives the watch and then goes on its own.
+    let mut child = Command::new("sh")
+        .arg("-c")
+        .arg("printf 'the only line\\n' >&2; sleep 5 &")
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("sh is runnable");
+    let _tap = glass_pipe_unix::PipeTap::start(
+        child.stderr.take().expect("piped stderr"),
+        "test-idle-tap",
+        Ignored,
+    )
+    .expect("a reader");
+    child
+        .wait()
+        .expect("the child exits, the survivor does not");
+
+    let before = cpu_ticks();
+    std::thread::sleep(WATCHED_FOR);
+    let spent = cpu_ticks() - before;
+
+    // Clock ticks are 100/s on Linux, so a reader spinning through the watch bills ~30 and one
+    // asleep in `poll` bills none. Ten is far above the noise and far below a spin.
+    assert!(
+        spent < 10,
+        "an idle reader must sleep, not spin: {spent} ticks of CPU in {WATCHED_FOR:?}"
+    );
+}

--- a/crates/glass-proc-linux/Cargo.toml
+++ b/crates/glass-proc-linux/Cargo.toml
@@ -8,6 +8,7 @@ publish.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rustix.workspace = true
+glass-pipe-unix.workspace = true
 
 [lints]
 workspace = true

--- a/crates/glass-proc-linux/src/lib.rs
+++ b/crates/glass-proc-linux/src/lib.rs
@@ -16,8 +16,7 @@
 //! the Windows backend for the same reason — the OS APIs can't share an impl.
 //!
 //! It also holds what both backends need *around* a spawned process: reaping it and its
-//! descendants, and reading what it wrote — its stderr under a cap and a stop
-//! ([`StderrTail`]), or its output line-by-line until EOF ([`spawn_reader`]).
+//! descendants, and reading its stderr under a cap and a stop ([`StderrTail`]).
 
 #![cfg(target_os = "linux")]
 
@@ -26,9 +25,7 @@ mod stderr;
 pub use stderr::{STDERR_KEPT, StderrTail};
 
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::io::{BufRead, BufReader, Read};
 use std::process::Child;
-use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use rustix::process::{Pid, Signal, kill_process, kill_process_group};
@@ -376,26 +373,6 @@ fn collect_descendants(root: u32, parent_of: &HashMap<u32, u32>) -> Vec<u32> {
         }
     }
     out
-}
-
-/// Drain a child's piped output line-by-line into a shared buffer on a background
-/// thread, tagging each line with `tag`. The X11 and Wayland backends both spawn an
-/// app and capture its stdout/stderr this way; sharing it here keeps them from
-/// re-implementing the reader. Generic over the tag so this crate needn't depend on
-/// glass-core's `Stream` enum.
-pub fn spawn_reader<S: Copy + Send + 'static, R: Read + Send + 'static>(
-    reader: R,
-    tag: S,
-    sink: Arc<Mutex<Vec<(S, String)>>>,
-) {
-    std::thread::spawn(move || {
-        for line in BufReader::new(reader).lines() {
-            match line {
-                Ok(text) => sink.lock().expect("log sink mutex").push((tag, text)),
-                Err(_) => break,
-            }
-        }
-    });
 }
 
 #[cfg(test)]

--- a/crates/glass-proc-linux/src/stderr.rs
+++ b/crates/glass-proc-linux/src/stderr.rs
@@ -1,30 +1,16 @@
 //! Bounded capture of a child's stderr, shared by the Linux backends.
 
-use std::io::{ErrorKind, Read};
-use std::os::fd::OwnedFd;
 use std::process::ChildStderr;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, PoisonError};
-use std::thread::JoinHandle;
 use std::time::Duration;
 
-use rustix::event::{EventfdFlags, PollFd, PollFlags, Timespec, eventfd, poll};
-use rustix::fs::{OFlags, fcntl_getfl, fcntl_setfl};
+use glass_pipe_unix::{ChunkSink, PipeTap};
 
 /// How much of a child's stderr is kept for diagnostics.
 ///
 /// An X server dumps its option table (~5 KiB) *after* the fatal line and sway's complaints come
 /// first, so the head is what is kept.
 pub const STDERR_KEPT: usize = 8 * 1024;
-
-/// How long an idle reader sleeps before looking at the stop flag again.
-///
-/// Also the ceiling on [`StderrTail::finish`]'s join if the wakeup is lost — the flag is what
-/// stops the reader.
-const HEARD_BY: Timespec = Timespec {
-    tv_sec: 5,
-    tv_nsec: 0,
-};
 
 /// A child's stderr, read on a helper thread until the pipe closes or the tail ends it.
 ///
@@ -36,55 +22,26 @@ const HEARD_BY: Timespec = Timespec {
 /// holding an fd — one per deep probe, for the life of a `glass-mcp serve --http` (glass#471).
 pub struct StderrTail {
     kept: Arc<Mutex<Vec<u8>>>,
-    /// Set by the reader on its way out, so [`StderrTail::finish`] can end its wait as soon as
-    /// the pipe closes on its own.
-    done: Arc<AtomicBool>,
-    /// What actually stops the reader. A flag rather than the wakeup below, so a wakeup that
-    /// never arrives costs [`HEARD_BY`] rather than the life of the process.
-    stopping: Arc<AtomicBool>,
-    /// Wakes a reader asleep in `poll` so it reads the flag now instead of at [`HEARD_BY`].
-    /// Nobody drains the counter, so one write stays readable and the next poll is certain to
-    /// see it.
-    wake: OwnedFd,
-    /// Taken by whichever of [`StderrTail::finish`] and `drop` runs first.
-    reader: Option<JoinHandle<()>>,
+    reader: PipeTap,
 }
 
 impl StderrTail {
     /// Start reading.
     ///
     /// `Err` is the host refusing a resource the bounded read is built from: the thread —
-    /// `Builder`, where `thread::spawn` panics (glass#454) — the wakeup fd or its dup, or the
+    /// `Builder`, where `thread::spawn` panics (glass#454) — the wakeup pipe, or the
     /// non-blocking mode. `stderr` is consumed either way, so on `Err` the read end is already
     /// closed and the child will take `EPIPE` rather than stall.
     pub fn drain(stderr: ChildStderr) -> std::io::Result<StderrTail> {
-        // Blocking, a read with nothing to read parks past every look at the flag. Safe for the
-        // child: `pipe(2)` gives the two ends separate open file descriptions, so a status flag
-        // set here never reaches the write end it inherited.
-        fcntl_setfl(&stderr, fcntl_getfl(&stderr)?.union(OFlags::NONBLOCK))?;
-        // CLOEXEC or this fd lands in every process the host spawns afterwards. No NONBLOCK:
-        // `end` writes to it once, and only a saturated counter would block that.
-        let wake = eventfd(0, EventfdFlags::CLOEXEC)?;
-        // A dup, not a second eventfd: both fds name one counter, so `end`'s write is what this
-        // reader's poll sees.
-        let woken = wake.try_clone()?;
         let kept: Arc<Mutex<Vec<u8>>> = Arc::default();
-        let done: Arc<AtomicBool> = Arc::default();
-        let stopping: Arc<AtomicBool> = Arc::default();
-        let (keeping, ended, stop) = (Arc::clone(&kept), Arc::clone(&done), Arc::clone(&stopping));
-        let reader = std::thread::Builder::new()
-            .name("glass-stderr-tail".into())
-            .spawn(move || {
-                read_until_stopped(stderr, &woken, &stop, &keeping);
-                ended.store(true, Ordering::Release);
-            })?;
-        Ok(StderrTail {
-            kept,
-            done,
-            stopping,
-            wake,
-            reader: Some(reader),
-        })
+        let reader = PipeTap::start(
+            stderr,
+            "glass-stderr-tail",
+            Head {
+                kept: Arc::clone(&kept),
+            },
+        )?;
+        Ok(StderrTail { kept, reader })
     }
 
     /// What it said, at most [`STDERR_KEPT`] bytes, after `grace` for the pipe to close — call
@@ -93,30 +50,10 @@ impl StderrTail {
     /// Collected whether or not the pipe closed: anything the child left running holds it open,
     /// and the reader is ended either way.
     pub fn finish(mut self, grace: Duration) -> String {
-        crate::await_condition(grace, || self.done.load(Ordering::Acquire));
-        self.end();
+        crate::await_condition(grace, || self.reader.is_done());
+        self.reader.stop();
         let kept = self.kept.lock().unwrap_or_else(PoisonError::into_inner);
         String::from_utf8_lossy(&kept).into_owned()
-    }
-
-    /// Stop the reader and wait for it to go, which is what makes the pipe closed rather than
-    /// assumed closed. Idempotent, because `finish` runs it and then drops.
-    fn end(&mut self) {
-        let Some(reader) = self.reader.take() else {
-            return;
-        };
-        // Set before the wake, or a reader the write pulls out of `poll` finds the flag still
-        // false and goes back to sleep for another `HEARD_BY`.
-        self.stopping.store(true, Ordering::Release);
-        let _ = rustix::io::write(&self.wake, &1u64.to_ne_bytes());
-        let _ = reader.join();
-    }
-}
-
-impl Drop for StderrTail {
-    /// A tail nobody reads still ends its reader.
-    fn drop(&mut self) {
-        self.end();
     }
 }
 
@@ -127,53 +64,22 @@ impl std::fmt::Debug for StderrTail {
         let kept = self.kept.lock().unwrap_or_else(PoisonError::into_inner);
         f.debug_struct("StderrTail")
             .field("kept", &format_args!("{} bytes", kept.len()))
-            .field("done", &self.done.load(Ordering::Acquire))
+            .field("done", &self.reader.is_done())
             .finish_non_exhaustive()
     }
 }
 
-/// Read `stderr` until it ends or `stopping` says to, keeping the first [`STDERR_KEPT`] bytes.
-fn read_until_stopped(
-    mut stderr: ChildStderr,
-    wake: &OwnedFd,
-    stopping: &AtomicBool,
-    keeping: &Mutex<Vec<u8>>,
-) {
-    let mut chunk = [0u8; 4096];
-    // The flag is read before every read, not only when the pipe runs dry, so a child that
-    // never stops writing cannot keep the reader here either.
-    while !stopping.load(Ordering::Acquire) {
-        match stderr.read(&mut chunk) {
-            Ok(0) => break,
-            Ok(n) => {
-                let mut kept = keeping.lock().unwrap_or_else(PoisonError::into_inner);
-                // Past the cap the pipe is still drained, so the child is never blocked writing
-                // to it.
-                let room = STDERR_KEPT.saturating_sub(kept.len());
-                kept.extend_from_slice(&chunk[..n.min(room)]);
-            }
-            Err(e) => match e.kind() {
-                // Nothing to read yet, or the read was interrupted: back to the wait.
-                ErrorKind::WouldBlock | ErrorKind::Interrupted => wait_for_more(&stderr, wake),
-                // Anything else will not read better next time.
-                _ => break,
-            },
-        }
-    }
+/// Keeps the first [`STDERR_KEPT`] bytes and drops the rest. Past the cap the pipe is still
+/// drained, so the child is never blocked writing to it.
+struct Head {
+    kept: Arc<Mutex<Vec<u8>>>,
 }
 
-/// Sleep until the pipe has more to say, the wakeup is rung, or [`HEARD_BY`] elapses. The caller
-/// re-reads whichever it was, so none of the three needs telling apart.
-///
-/// A poll that errors sleeps instead of returning at once: a persistent one — `EINVAL` under an
-/// `RLIMIT_NOFILE` below two — would otherwise spin this loop on an `EAGAIN` read and burn a core.
-fn wait_for_more(stderr: &ChildStderr, wake: &OwnedFd) {
-    let mut waiting = [
-        PollFd::new(stderr, PollFlags::IN),
-        PollFd::new(wake, PollFlags::IN),
-    ];
-    if poll(&mut waiting, Some(&HEARD_BY)).is_err() {
-        std::thread::sleep(crate::POLL_INTERVAL);
+impl ChunkSink for Head {
+    fn chunk(&mut self, bytes: &[u8]) {
+        let mut kept = self.kept.lock().unwrap_or_else(PoisonError::into_inner);
+        let room = STDERR_KEPT.saturating_sub(kept.len());
+        kept.extend_from_slice(&bytes[..bytes.len().min(room)]);
     }
 }
 

--- a/crates/glass-wayland/Cargo.toml
+++ b/crates/glass-wayland/Cargo.toml
@@ -23,6 +23,7 @@ glass-a11y-linux.workspace = true
 glass-dbus-linux = { path = "../glass-dbus-linux" }
 glass-sandbox-linux.workspace = true
 glass-proc-linux.workspace = true
+glass-pipe-unix.workspace = true
 wayland-client.workspace = true
 wayland-protocols-wlr.workspace = true
 wayland-protocols-misc.workspace = true

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -56,8 +56,8 @@ const _: () = assert!(
 struct ActiveSession {
     child: Child,
     /// sway's stdout/stderr readers, dropped when the session is torn down. Everything sway
-    /// spawns inherits its write ends, so a reader that ended only at EOF would park on a
-    /// survivor's pipe (glass#477).
+    /// spawns inherits its write ends, so an EOF-only reader parks on a survivor's pipe
+    /// (glass#477).
     taps: Vec<LineTap>,
     _runtime_dir: TempDir, // kept alive: the wayland socket lives here
     socket_path: PathBuf,  // path to the sway wayland socket (for clipboard threads)
@@ -1152,12 +1152,12 @@ fn open_session(
 
 /// Start a reader over one of sway's streams, or reap the session and say why it could not.
 ///
-/// The failed start consumed the pipe, so its read end is already closed and sway's next write to
-/// that stream takes `SIGPIPE`. The group rather than the leader, and matching every other
-/// error path in `bring_up_session`: sway forks Xwayland into its own group, and a leader-only
-/// reap would leave it holding the X display in the global namespace. It does *not* reach the
-/// apps sway `exec`s — those are `setsid`ed into their own sessions (see `kill_session`) — but at
-/// this point sway has not read its config, so there are none yet.
+/// The failed start consumed the pipe, so sway's next write to that stream takes `SIGPIPE`.
+///
+/// The group rather than the leader, matching every other error path here: sway forks Xwayland
+/// into its own group, and a leader-only reap leaves it holding the X display in the global
+/// namespace. It does not reach the apps sway `exec`s — those are `setsid`ed out (see
+/// `kill_session`) — but sway has not read its config yet, so there are none.
 fn tap_or_reap<R: std::io::Read + AsFd + Send + 'static>(
     stream: R,
     tag: Stream,
@@ -1210,9 +1210,9 @@ fn bring_up_session(
         .spawn()
         .map_err(|e| GlassError::AppNotStarted(format!("spawn sway: {e}")))?;
     // Declared before the discovery loop below, so each of its `return Err(...)` paths drops the
-    // taps *after* its own reap — the reap-then-stop order teardown uses, so the final drain sees
-    // what sway wrote on the way out. `Stdio::piped()` above guarantees both are `Some`; skipping
-    // a stream that is not would silently stop capturing it.
+    // taps *after* its own reap — the order teardown uses, so the final drain sees what sway wrote
+    // on the way out. `Stdio::piped()` guarantees both are `Some`; skipping one that is not would
+    // silently stop capturing it.
     let stdout = child.stdout.take().expect("stdout was piped");
     let stderr = child.stderr.take().expect("stderr was piped");
     let taps = vec![
@@ -1239,10 +1239,9 @@ fn bring_up_session(
         }
         if let Ok(Some(status)) = child.try_wait() {
             // sway exited — but on an *unclean* exit Xwayland, which sway forks into its own
-            // group, can outlive it. Reap the whole group, not just the leader, or a leaked
-            // Xwayland holds the X display in the global namespace and breaks the next session.
-            // (The app sway `exec`s is `setsid`ed out of that group — see `kill_session` — and is
-            // covered by the `reap_launch` tree walk there, not here.)
+            // group, can outlive it and hold the X display in the global namespace, breaking the
+            // next session. (The app sway `exec`s is `setsid`ed out of that group — see
+            // `kill_session` — and is covered by the `reap_launch` tree walk there.)
             glass_proc_linux::reap_group(&mut child, glass_proc_linux::REAP_GRACE);
             return Err(GlassError::app_exited_during_discovery(
                 status.code(),

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -11,6 +11,7 @@ use glass_core::{
     TEARDOWN_BUDGET, WindowGeometry, WindowId, WindowInfo, WindowOp,
 };
 use glass_exec_unix::{Resolved, is_executable_file, resolve_path};
+use glass_pipe_unix::LineTap;
 use glass_proc_linux::{APP_REAP_GRACE, Asked, CLOSE_GRACE};
 use smithay_client_toolkit::delegate_dispatch2;
 use smithay_client_toolkit::delegate_registry;
@@ -54,6 +55,10 @@ const _: () = assert!(
 
 struct ActiveSession {
     child: Child,
+    /// sway's stdout/stderr readers, dropped when the session is torn down. Everything sway
+    /// spawns inherits its write ends, so a reader that ended only at EOF would park on a
+    /// survivor's pipe (glass#477).
+    taps: Vec<LineTap>,
     _runtime_dir: TempDir, // kept alive: the wayland socket lives here
     socket_path: PathBuf,  // path to the sway wayland socket (for clipboard threads)
     conn: Connection,
@@ -134,6 +139,8 @@ impl WaylandPlatform {
                 &tree,
                 glass_proc_linux::APP_REAP_GRACE,
             );
+            // Reaped first, so each tap's final drain sees what sway wrote on its way out.
+            s.taps.clear();
             glass_proc_linux::disclose_teardown(&asked.outcome(closed_itself));
         }
         self.dbus = None;
@@ -1143,6 +1150,27 @@ fn open_session(
     ))
 }
 
+/// Start a reader over one of sway's streams, or reap the session and say why it could not.
+///
+/// The failed start consumed the pipe, so its read end is already closed and sway's next write to
+/// that stream takes `SIGPIPE`. The group rather than the leader: sway's `exec`ed children are
+/// already running by the time this can fail.
+fn tap_or_reap<R: std::io::Read + AsFd + Send + 'static>(
+    stream: R,
+    tag: Stream,
+    logs: &LogSink,
+    child: &mut Child,
+) -> Result<LineTap> {
+    LineTap::start(stream, tag, logs.clone()).map_err(|e| {
+        glass_proc_linux::reap_group(child, glass_proc_linux::REAP_GRACE);
+        GlassError::AppNotStarted(format!(
+            "started sway but could not read its output ({e}); the session was stopped rather \
+             than left to write into a pipe nobody drains — free up threads and file descriptors \
+             on the host"
+        ))
+    })
+}
+
 /// Spawn one per-session sway+Xwayland, connect, and discover the app's first
 /// window — the full compositor bring-up for `start_app`, factored out so it can
 /// be retried. On any failure the spawned compositor's process group is reaped, so
@@ -1177,11 +1205,15 @@ fn bring_up_session(
     let mut child = cmd
         .spawn()
         .map_err(|e| GlassError::AppNotStarted(format!("spawn sway: {e}")))?;
+    // Declared before the discovery loop below, so each of its `return Err(...)` paths drops the
+    // taps *after* its own reap — the reap-then-stop order teardown uses, so the final drain sees
+    // what sway wrote on the way out.
+    let mut taps = Vec::new();
     if let Some(out) = child.stdout.take() {
-        glass_proc_linux::spawn_reader(out, Stream::Stdout, logs.clone());
+        taps.push(tap_or_reap(out, Stream::Stdout, logs, &mut child)?);
     }
     if let Some(err) = child.stderr.take() {
-        glass_proc_linux::spawn_reader(err, Stream::Stderr, logs.clone());
+        taps.push(tap_or_reap(err, Stream::Stderr, logs, &mut child)?);
     }
 
     let deadline = Instant::now() + Duration::from_millis(spec.timeout_ms.max(1));
@@ -1302,6 +1334,7 @@ fn bring_up_session(
     let geometry = active_rect.clone();
     let session = ActiveSession {
         child,
+        taps,
         _runtime_dir: runtime_dir,
         socket_path,
         conn,

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -1153,15 +1153,19 @@ fn open_session(
 /// Start a reader over one of sway's streams, or reap the session and say why it could not.
 ///
 /// The failed start consumed the pipe, so its read end is already closed and sway's next write to
-/// that stream takes `SIGPIPE`. The group rather than the leader: sway's `exec`ed children are
-/// already running by the time this can fail.
+/// that stream takes `SIGPIPE`. The group rather than the leader, and matching every other
+/// error path in `bring_up_session`: sway forks Xwayland into its own group, and a leader-only
+/// reap would leave it holding the X display in the global namespace. It does *not* reach the
+/// apps sway `exec`s — those are `setsid`ed into their own sessions (see `kill_session`) — but at
+/// this point sway has not read its config, so there are none yet.
 fn tap_or_reap<R: std::io::Read + AsFd + Send + 'static>(
     stream: R,
     tag: Stream,
+    name: &str,
     logs: &LogSink,
     child: &mut Child,
 ) -> Result<LineTap> {
-    LineTap::start(stream, tag, logs.clone()).map_err(|e| {
+    LineTap::start(stream, tag, name, logs.clone()).map_err(|e| {
         glass_proc_linux::reap_group(child, glass_proc_linux::REAP_GRACE);
         GlassError::AppNotStarted(format!(
             "started sway but could not read its output ({e}); the session was stopped rather \
@@ -1207,14 +1211,26 @@ fn bring_up_session(
         .map_err(|e| GlassError::AppNotStarted(format!("spawn sway: {e}")))?;
     // Declared before the discovery loop below, so each of its `return Err(...)` paths drops the
     // taps *after* its own reap — the reap-then-stop order teardown uses, so the final drain sees
-    // what sway wrote on the way out.
-    let mut taps = Vec::new();
-    if let Some(out) = child.stdout.take() {
-        taps.push(tap_or_reap(out, Stream::Stdout, logs, &mut child)?);
-    }
-    if let Some(err) = child.stderr.take() {
-        taps.push(tap_or_reap(err, Stream::Stderr, logs, &mut child)?);
-    }
+    // what sway wrote on the way out. `Stdio::piped()` above guarantees both are `Some`; skipping
+    // a stream that is not would silently stop capturing it.
+    let stdout = child.stdout.take().expect("stdout was piped");
+    let stderr = child.stderr.take().expect("stderr was piped");
+    let taps = vec![
+        tap_or_reap(
+            stdout,
+            Stream::Stdout,
+            "glass-sway-stdout",
+            logs,
+            &mut child,
+        )?,
+        tap_or_reap(
+            stderr,
+            Stream::Stderr,
+            "glass-sway-stderr",
+            logs,
+            &mut child,
+        )?,
+    ];
 
     let deadline = Instant::now() + Duration::from_millis(spec.timeout_ms.max(1));
     let socket = loop {
@@ -1222,10 +1238,11 @@ fn bring_up_session(
             break s;
         }
         if let Ok(Some(status)) = child.try_wait() {
-            // sway exited — but on an *unclean* exit its group children
-            // (Xwayland + the exec'd app) can outlive it. Reap the whole
-            // group, not just the leader, or a leaked Xwayland holds the X
-            // display in the global namespace and breaks the next session.
+            // sway exited — but on an *unclean* exit Xwayland, which sway forks into its own
+            // group, can outlive it. Reap the whole group, not just the leader, or a leaked
+            // Xwayland holds the X display in the global namespace and breaks the next session.
+            // (The app sway `exec`s is `setsid`ed out of that group — see `kill_session` — and is
+            // covered by the `reap_launch` tree walk there, not here.)
             glass_proc_linux::reap_group(&mut child, glass_proc_linux::REAP_GRACE);
             return Err(GlassError::app_exited_during_discovery(
                 status.code(),

--- a/crates/glass-wayland/tests/session_releases_pipes.rs
+++ b/crates/glass-wayland/tests/session_releases_pipes.rs
@@ -11,6 +11,7 @@
 #![cfg(target_os = "linux")]
 
 use std::collections::HashSet;
+use std::path::Path;
 
 use glass_core::{AppSpec, Deadline, Platform, TEARDOWN_BUDGET};
 use rustix::process::{Pid, Signal, kill_process};
@@ -56,15 +57,17 @@ fn open_pipes() -> HashSet<String> {
 /// teardown — what glass#470 measures and reports as `leaked` — is a process that escaped both.
 /// `setsid` covers the group, the subshell covers the tree.
 ///
-/// It prints the pid it left, so the test can kill what glass deliberately could not; the sleep
-/// self-limits well inside a suite run if that kill never happens.
+/// It prints the pid it left, so the test can kill what glass deliberately could not. The sleep
+/// self-limits if that kill never happens, and is long enough to outlive a sway bring-up plus the
+/// whole teardown budget on a loaded runner — a survivor that died first would take the pipes to
+/// EOF and turn this gate into a vacuous pass.
 fn spec_leaving_a_survivor() -> AppSpec {
     AppSpec {
         build: None,
         run: [
             "sh",
             "-c",
-            "printf 'complaint\\n' >&2; ( setsid sleep 10 & echo \"survivor $!\" ); sleep 30",
+            "printf 'complaint\\n' >&2; ( setsid sleep 60 & echo \"survivor $!\" ); sleep 30",
         ]
         .map(String::from)
         .to_vec(),
@@ -99,11 +102,19 @@ fn stopping_a_session_releases_the_pipes_a_survivor_holds_open() {
     // Armed before the first assertion, so a failure still cleans up what glass could not.
     let _survivor = Survivor(survivor);
 
-    // Half the assertion, and what keeps the other half from passing vacuously: a session whose
-    // output nobody read would leak nothing *because* it tapped nothing.
+    // Two vacuity guards, because either alone can go green for the wrong reason. A launch
+    // whose output nobody read would leak nothing *because* it tapped nothing...
     assert!(
         survivor.is_some(),
         "the tap must deliver what the session printed, but the log holds {said:?}"
+    );
+    // ...and a fixture that stopped leaving a *live* survivor would let the pipes reach EOF on
+    // their own, which the EOF-only reader this replaces would also have released. Then the
+    // assertion below would pass without covering glass#477 at all, and nothing would say so.
+    assert!(
+        survivor.is_some_and(|pid| Path::new(&format!("/proc/{pid}")).exists()),
+        "the fixture must leave a live survivor holding the write ends, or this gate proves \
+         nothing an EOF-only reader would not also pass"
     );
     let leaked: Vec<_> = open_pipes().difference(&before).cloned().collect();
     assert!(

--- a/crates/glass-wayland/tests/session_releases_pipes.rs
+++ b/crates/glass-wayland/tests/session_releases_pipes.rs
@@ -1,0 +1,113 @@
+//! glass#477: the session's log readers end at teardown.
+//!
+//! Nothing in the unit tests reaches this. sway's stdout/stderr write ends are inherited by
+//! Xwayland and by every app sway `exec`s, so anything the teardown leaves behind holds them —
+//! and a reader that could only stop at EOF would park there holding an fd for the life of the
+//! process, one pair per session under `glass-mcp serve --http`.
+//!
+//! Its own test binary: the measurement is this process's open fds, and the crate's other tests
+//! run live sessions whose threads open and close pipes while they live.
+
+#![cfg(target_os = "linux")]
+
+use std::collections::HashSet;
+
+use glass_core::{AppSpec, Deadline, Platform, TEARDOWN_BUDGET};
+use rustix::process::{Pid, Signal, kill_process};
+
+/// The process the session leaves behind, killed when the test ends, panic included.
+///
+/// Load-bearing beyond cleanup: while it holds the write ends the pipes' inodes cannot be freed,
+/// so no other pipe in this process can be handed the same `pipe:[n]` and read as a false pass.
+/// Killed only after the assertions, for that reason.
+struct Survivor(Option<u32>);
+
+impl Drop for Survivor {
+    fn drop(&mut self) {
+        if let Some(pid) = self.0.and_then(|p| Pid::from_raw(p as i32)) {
+            let _ = kill_process(pid, Signal::KILL);
+        }
+    }
+}
+
+/// Every pipe this process holds, as `fd -> pipe:[inode]`. The inode is half the identity: an fd
+/// number the kernel released and handed straight back for a different pipe must not read as the
+/// same one still held.
+fn open_pipes() -> HashSet<String> {
+    std::fs::read_dir("/proc/self/fd")
+        .expect("/proc/self/fd")
+        .filter_map(|entry| {
+            let path = entry.ok()?.path();
+            let target = std::fs::read_link(&path).ok()?;
+            let target = target.to_string_lossy().into_owned();
+            let fd = path.file_name()?.to_string_lossy().into_owned();
+            target
+                .starts_with("pipe:")
+                .then(|| format!("{fd}->{target}"))
+        })
+        .collect()
+}
+
+/// An app sway `exec`s that leaves a process holding the session's inherited pipes, and blocks.
+///
+/// The survivor is backgrounded from a subshell that exits at once, so it is reparented to init:
+/// `reap_launch` signals the launch's process *group* and every pid in a `/proc` walk of sway's
+/// tree, and a process still in either is reaped rather than left behind. What outlives a
+/// teardown — what glass#470 measures and reports as `leaked` — is a process that escaped both.
+/// `setsid` covers the group, the subshell covers the tree.
+///
+/// It prints the pid it left, so the test can kill what glass deliberately could not; the sleep
+/// self-limits well inside a suite run if that kill never happens.
+fn spec_leaving_a_survivor() -> AppSpec {
+    AppSpec {
+        build: None,
+        run: [
+            "sh",
+            "-c",
+            "printf 'complaint\\n' >&2; ( setsid sleep 10 & echo \"survivor $!\" ); sleep 30",
+        ]
+        .map(String::from)
+        .to_vec(),
+        cwd: None,
+        env: vec![],
+        window_hint: None,
+        // The stand-in maps no window, so discovery times out. The session and its readers still
+        // came up, and that failure path tears the session down the same way `stop_app` does.
+        timeout_ms: 1500,
+        sandbox: glass_core::SandboxLevel::Off,
+        a11y: false,
+    }
+}
+
+#[test]
+#[ignore = "starts a real compositor; needs sway, Mesa, Xwayland or Xvfb"]
+fn stopping_a_session_releases_the_pipes_a_survivor_holds_open() {
+    let mut plat = glass_wayland::WaylandPlatform::new().expect("sway resolves");
+    // Snapshotted after the backend is up, so anything it opened for itself is baseline.
+    let before = open_pipes();
+
+    plat.start_app(&spec_leaving_a_survivor())
+        .expect_err("a command that maps no window cannot be launched");
+    plat.stop_app_by(Deadline::from_millis(TEARDOWN_BUDGET.as_millis() as u64))
+        .expect("stop");
+
+    let said = plat.drain_logs();
+    let survivor = said.iter().find_map(|(_, line)| {
+        line.strip_prefix("survivor ")
+            .and_then(|pid| pid.trim().parse().ok())
+    });
+    // Armed before the first assertion, so a failure still cleans up what glass could not.
+    let _survivor = Survivor(survivor);
+
+    // Half the assertion, and what keeps the other half from passing vacuously: a session whose
+    // output nobody read would leak nothing *because* it tapped nothing.
+    assert!(
+        survivor.is_some(),
+        "the tap must deliver what the session printed, but the log holds {said:?}"
+    );
+    let leaked: Vec<_> = open_pipes().difference(&before).cloned().collect();
+    assert!(
+        leaked.is_empty(),
+        "stopping the session must release its pipes, but these are still held: {leaked:?}"
+    );
+}

--- a/crates/glass-wayland/tests/session_releases_pipes.rs
+++ b/crates/glass-wayland/tests/session_releases_pipes.rs
@@ -19,8 +19,8 @@ use rustix::process::{Pid, Signal, kill_process};
 /// The process the session leaves behind, killed when the test ends, panic included.
 ///
 /// Load-bearing beyond cleanup: while it holds the write ends the pipes' inodes cannot be freed,
-/// so no other pipe in this process can be handed the same `pipe:[n]` and read as a false pass.
-/// Killed only after the assertions, for that reason.
+/// so no other pipe here can be handed the same `pipe:[n]` and read as a false pass — which is
+/// why it is killed only after the assertions.
 struct Survivor(Option<u32>);
 
 impl Drop for Survivor {
@@ -32,8 +32,7 @@ impl Drop for Survivor {
 }
 
 /// Every pipe this process holds, as `fd -> pipe:[inode]`. The inode is half the identity: an fd
-/// number the kernel released and handed straight back for a different pipe must not read as the
-/// same one still held.
+/// number released and handed straight back for a different pipe must not read as one still held.
 fn open_pipes() -> HashSet<String> {
     std::fs::read_dir("/proc/self/fd")
         .expect("/proc/self/fd")

--- a/crates/glass-windows/src/containment/mod.rs
+++ b/crates/glass-windows/src/containment/mod.rs
@@ -88,11 +88,9 @@ mod imp {
                 Containment::Unconfined => {
                     let mut cmd = crate::process::build_command(spec);
                     let mut app = crate::process::spawn_suspended_in_job(&mut cmd, spec.sandbox)?;
-                    // Wired before `resume`, so the app's first lines are not missed. A failure
-                    // here has already closed the pipe it was for, so the launch fails rather
-                    // than resuming an app whose output goes nowhere. `abandon` is what makes
-                    // that true: the app is still suspended, and nothing else would ever
-                    // terminate it or close its Job.
+                    // Wired before `resume`, so the app's first lines are not missed. `abandon`
+                    // rather than `?` alone: the app is still suspended, and nothing else would
+                    // ever terminate it or close its Job.
                     if let Err(e) = app.tap_logs(&logs) {
                         app.abandon();
                         return Err(GlassError::AppNotStarted(format!(

--- a/crates/glass-windows/src/containment/mod.rs
+++ b/crates/glass-windows/src/containment/mod.rs
@@ -36,14 +36,13 @@ pub(crate) fn config_shim_dll_path(exe_dir: Option<&str>) -> Option<String> {
 
 #[cfg(windows)]
 mod imp {
-
     use glass_core::{AppSpec, GlassError, Result};
-
-    use super::config::{Decision, ProviderChoice, decide};
 
     /// Log lines captured from the app, tagged by stream. One alias, defined with the readers
     /// that fill it, rather than a second structurally-equal one here.
     pub(crate) use crate::logtap::LogSink;
+
+    use super::config::{Decision, ProviderChoice, decide};
 
     /// Read the provider choice (env `GLASS_WIN_SANDBOX_PROVIDER`, default `auto`).
     fn provider_choice() -> Result<ProviderChoice> {
@@ -91,16 +90,18 @@ mod imp {
                     let mut app = crate::process::spawn_suspended_in_job(&mut cmd, spec.sandbox)?;
                     // Wired before `resume`, so the app's first lines are not missed. A failure
                     // here has already closed the pipe it was for, so the launch fails rather
-                    // than resuming an app whose output goes nowhere — the app is still
-                    // suspended, and dropping `app` closes the Job, which terminates it.
-                    app.tap_logs(&logs).map_err(|e| {
-                        GlassError::AppNotStarted(format!(
+                    // than resuming an app whose output goes nowhere. `abandon` is what makes
+                    // that true: the app is still suspended, and nothing else would ever
+                    // terminate it or close its Job.
+                    if let Err(e) = app.tap_logs(&logs) {
+                        app.abandon();
+                        return Err(GlassError::AppNotStarted(format!(
                             "started {:?} but could not read its output ({e}); the app was \
                              stopped rather than left to write into a pipe nobody drains — free \
                              up threads on the host",
                             spec.run
-                        ))
-                    })?;
+                        )));
+                    }
                     app.resume();
                     Ok(Launched::Unconfined(app))
                 }

--- a/crates/glass-windows/src/containment/mod.rs
+++ b/crates/glass-windows/src/containment/mod.rs
@@ -36,29 +36,14 @@ pub(crate) fn config_shim_dll_path(exe_dir: Option<&str>) -> Option<String> {
 
 #[cfg(windows)]
 mod imp {
-    use std::io::{BufRead, BufReader};
-    use std::sync::{Arc, Mutex};
 
-    use glass_core::logbuf::Stream;
     use glass_core::{AppSpec, GlassError, Result};
 
     use super::config::{Decision, ProviderChoice, decide};
 
-    /// Log lines captured from the app, tagged by stream. (Lifted from lib.rs.)
-    pub(crate) type LogSink = Arc<Mutex<Vec<(Stream, String)>>>;
-
-    /// Read `reader` line-by-line on a thread, tagging + pushing into `sink`.
-    fn spawn_reader<R: std::io::Read + Send + 'static>(reader: R, stream: Stream, sink: LogSink) {
-        std::thread::spawn(move || {
-            let buf = BufReader::new(reader);
-            for line in buf.lines() {
-                match line {
-                    Ok(text) => sink.lock().expect("log sink mutex").push((stream, text)),
-                    Err(_) => break,
-                }
-            }
-        });
-    }
+    /// Log lines captured from the app, tagged by stream. One alias, defined with the readers
+    /// that fill it, rather than a second structurally-equal one here.
+    pub(crate) use crate::logtap::LogSink;
 
     /// Read the provider choice (env `GLASS_WIN_SANDBOX_PROVIDER`, default `auto`).
     fn provider_choice() -> Result<ProviderChoice> {
@@ -104,13 +89,18 @@ mod imp {
                 Containment::Unconfined => {
                     let mut cmd = crate::process::build_command(spec);
                     let mut app = crate::process::spawn_suspended_in_job(&mut cmd, spec.sandbox)?;
-                    let (out, err) = app.take_pipes();
-                    if let Some(o) = out {
-                        spawn_reader(o, Stream::Stdout, logs.clone());
-                    }
-                    if let Some(e) = err {
-                        spawn_reader(e, Stream::Stderr, logs.clone());
-                    }
+                    // Wired before `resume`, so the app's first lines are not missed. A failure
+                    // here has already closed the pipe it was for, so the launch fails rather
+                    // than resuming an app whose output goes nowhere — the app is still
+                    // suspended, and dropping `app` closes the Job, which terminates it.
+                    app.tap_logs(&logs).map_err(|e| {
+                        GlassError::AppNotStarted(format!(
+                            "started {:?} but could not read its output ({e}); the app was \
+                             stopped rather than left to write into a pipe nobody drains — free \
+                             up threads on the host",
+                            spec.run
+                        ))
+                    })?;
                     app.resume();
                     Ok(Launched::Unconfined(app))
                 }

--- a/crates/glass-windows/src/lib.rs
+++ b/crates/glass-windows/src/lib.rs
@@ -20,6 +20,7 @@ pub mod doctor; // pure check-mapping cross-platform; Windows fact-gathering is 
 pub mod dpi; // pure coordinate math — cross-platform, unit-tested on any host
 pub mod jobcfg; // pure SandboxLevel -> job-limit descriptor — unit-tested on any host
 pub mod jobpids; // pure JOBOBJECT_BASIC_PROCESS_ID_LIST byte parser — Miri'd on the host
+pub mod logtap; // pure line splitting — cross-platform, host-tested; the reader is cfg(windows)
 #[doc(hidden)]
 pub mod onbox_support; // env-resolved paths shared by the on-box examples + tests; host-tested
 pub mod pixels; // pure BGRA->RGBA swizzle — cross-platform, unit-tested on any host

--- a/crates/glass-windows/src/logtap.rs
+++ b/crates/glass-windows/src/logtap.rs
@@ -1,0 +1,382 @@
+//! A launched app's stdout/stderr, read on a thread that can be stopped.
+//!
+//! The line splitting is pure and tested on any host; the reader around it is `cfg(windows)` and
+//! runs on the Windows job. A reader that ended only at EOF could not be ended at all when
+//! something the app spawned inherited the write end and outlived the teardown — it would park in
+//! `ReadFile` holding a thread and a handle for the life of the process (glass#477). The unix
+//! backends get the same bound from `glass-pipe-unix`, which this crate cannot link.
+
+use std::sync::{Arc, Mutex, PoisonError};
+
+use glass_core::logbuf::Stream;
+
+/// Log lines captured from the app, tagged by stream.
+pub type LogSink = Arc<Mutex<Vec<(Stream, String)>>>;
+
+/// Splits what the pipe delivered into lines. Reads land at pipe boundaries, so a line can span
+/// any number of them — `pending` is what has been seen of the line still open.
+pub struct Lines {
+    tag: Stream,
+    sink: LogSink,
+    pending: Vec<u8>,
+}
+
+impl Lines {
+    pub fn new(tag: Stream, sink: LogSink) -> Self {
+        Lines {
+            tag,
+            sink,
+            pending: Vec::new(),
+        }
+    }
+
+    /// Feed the next read's bytes in.
+    pub fn push(&mut self, bytes: &[u8]) {
+        for byte in bytes {
+            if *byte == b'\n' {
+                self.emit();
+            } else {
+                self.pending.push(*byte);
+            }
+        }
+    }
+
+    /// No more is coming. A last line that never got its newline is still what the app said — a
+    /// crash mid-write, or a process terminated between the text and the terminator. An empty
+    /// `pending` is the ordinary case of a stream that ended on a newline, and must not become a
+    /// blank line.
+    pub fn flush(&mut self) {
+        if !self.pending.is_empty() {
+            self.emit();
+        }
+    }
+
+    /// File `pending` as a line and start the next one.
+    ///
+    /// Lossy rather than a decode that can fail: the reader this replaces stopped at the first
+    /// bad byte, so one stray byte silenced an app for the rest of its run. The trailing `\r` is
+    /// dropped the way `BufRead::lines` drops it — Windows apps write CRLF.
+    fn emit(&mut self) {
+        let line = std::mem::take(&mut self.pending);
+        let text = String::from_utf8_lossy(&line);
+        let text = text.strip_suffix('\r').unwrap_or(&text).to_owned();
+        self.sink
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .push((self.tag, text));
+    }
+}
+
+#[cfg(windows)]
+pub(crate) use imp::LogTap;
+
+#[cfg(windows)]
+mod imp {
+    use std::io::Read;
+    use std::os::windows::io::AsRawHandle;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::thread::JoinHandle;
+    use std::time::Duration;
+
+    use windows::Win32::Foundation::HANDLE;
+    use windows::Win32::System::Pipes::PeekNamedPipe;
+
+    use super::{Lines, LogSink};
+    use glass_core::logbuf::Stream;
+
+    /// How long an idle reader sleeps before looking at the stop flag again. Also the ceiling on
+    /// [`LogTap::stop`]'s join.
+    const IDLE: Duration = Duration::from_millis(50);
+
+    /// The most the drain after the stop flag will read: one pipe buffer's worth, which is
+    /// everything the app can have left behind, so a survivor still writing cannot hold the stop
+    /// open.
+    const FINAL_DRAIN: usize = 64 * 1024;
+
+    /// How much one read asks for.
+    const CHUNK: usize = 4096;
+
+    /// A launched app's stream, read on a helper thread until the pipe breaks or the tap ends it.
+    pub(crate) struct LogTap {
+        /// What stops the reader. Read before every peek, so a survivor that never stops writing
+        /// cannot keep the reader here either.
+        stopping: Arc<AtomicBool>,
+        /// Taken by whichever of [`LogTap::stop`] and `drop` runs first.
+        reader: Option<JoinHandle<()>>,
+    }
+
+    impl LogTap {
+        /// Start reading `source`, filing each line into `logs` under `tag`.
+        ///
+        /// `Err` is the host refusing the thread — `Builder`, where `thread::spawn` panics.
+        /// `source` is consumed either way, so on `Err` the read end is already closed and the
+        /// app's next write to that stream is discarded rather than drained.
+        pub(crate) fn start<R>(source: R, tag: Stream, logs: LogSink) -> std::io::Result<LogTap>
+        where
+            R: Read + AsRawHandle + Send + 'static,
+        {
+            let stopping: Arc<AtomicBool> = Arc::default();
+            let stop = Arc::clone(&stopping);
+            let reader = std::thread::Builder::new()
+                .name("glass-log-tap".into())
+                .spawn(move || {
+                    let mut lines = Lines::new(tag, logs);
+                    read_until_stopped(source, &stop, &mut lines);
+                    lines.flush();
+                })?;
+            Ok(LogTap {
+                stopping,
+                reader: Some(reader),
+            })
+        }
+
+        /// Stop the reader and wait for it to go, which is what makes the pipe closed rather than
+        /// assumed closed. Idempotent, because `drop` runs it too.
+        pub(crate) fn stop(&mut self) {
+            let Some(reader) = self.reader.take() else {
+                return;
+            };
+            self.stopping.store(true, Ordering::Release);
+            let _ = reader.join();
+        }
+    }
+
+    impl Drop for LogTap {
+        /// A tap nobody stopped still ends its reader.
+        fn drop(&mut self) {
+            self.stop();
+        }
+    }
+
+    /// Hides the sink: a derived `Debug` would render the whole log buffer into whatever printed
+    /// the struct holding this.
+    impl std::fmt::Debug for LogTap {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("LogTap")
+                .field("running", &self.reader.is_some())
+                .finish_non_exhaustive()
+        }
+    }
+
+    /// How much is readable right now, or `None` once the pipe cannot be read at all — a broken
+    /// pipe (every writer gone) or a closed handle.
+    fn available<R: AsRawHandle>(source: &R) -> Option<usize> {
+        let mut avail: u32 = 0;
+        // SAFETY: the handle is `source`'s own, live for this borrow; `avail` is a local this
+        // call fills, and every other out-param is opted out of with `None`.
+        unsafe {
+            PeekNamedPipe(
+                HANDLE(source.as_raw_handle()),
+                None,
+                0,
+                None,
+                Some(&mut avail),
+                None,
+            )
+        }
+        .ok()?;
+        Some(avail as usize)
+    }
+
+    /// What one peek-and-read did.
+    enum Pumped {
+        Read(usize),
+        /// Nothing readable right now — the app is running and quiet.
+        Empty,
+        /// Nothing will be readable again.
+        Ended,
+    }
+
+    /// Peek, then read exactly what the peek reported, so the read itself never waits.
+    ///
+    /// A blocking `ReadFile` is what makes an EOF-only reader unstoppable: it parks past every
+    /// look at the stop flag, and an anonymous pipe offers nothing to interrupt it with.
+    fn pump<R: Read + AsRawHandle>(
+        source: &mut R,
+        chunk: &mut [u8; CHUNK],
+        cap: usize,
+        lines: &mut Lines,
+    ) -> Pumped {
+        let Some(avail) = available(source) else {
+            return Pumped::Ended;
+        };
+        if avail == 0 {
+            return Pumped::Empty;
+        }
+        let want = avail.min(cap).min(CHUNK);
+        match source.read(&mut chunk[..want]) {
+            Ok(0) => Pumped::Ended,
+            Ok(n) => {
+                lines.push(&chunk[..n]);
+                Pumped::Read(n)
+            }
+            Err(_) => Pumped::Ended,
+        }
+    }
+
+    /// Read `source` into `lines` until the pipe breaks or `stopping` says to.
+    fn read_until_stopped<R: Read + AsRawHandle>(
+        mut source: R,
+        stopping: &AtomicBool,
+        lines: &mut Lines,
+    ) {
+        let mut chunk = [0u8; CHUNK];
+        while !stopping.load(Ordering::Acquire) {
+            match pump(&mut source, &mut chunk, CHUNK, lines) {
+                Pumped::Read(_) => continue,
+                Pumped::Empty => std::thread::sleep(IDLE),
+                Pumped::Ended => return,
+            }
+        }
+        // Only reached via the flag. The loop above leaves without reading, so a teardown that
+        // stops the tap right after terminating the app would lose the last thing it wrote — the
+        // lines a failed teardown is most likely to need. Capped, so a survivor still writing
+        // cannot keep the drain fed for as long as it keeps going.
+        let mut taken = 0;
+        while taken < FINAL_DRAIN {
+            match pump(&mut source, &mut chunk, FINAL_DRAIN - taken, lines) {
+                Pumped::Read(n) => taken += n,
+                Pumped::Empty | Pumped::Ended => return,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// What the splitter filed, given reads that arrived at these boundaries.
+    fn split(chunks: &[&[u8]]) -> Vec<(Stream, String)> {
+        let sink: LogSink = Arc::default();
+        let mut lines = Lines::new(Stream::Stdout, Arc::clone(&sink));
+        for chunk in chunks {
+            lines.push(chunk);
+        }
+        lines.flush();
+        sink.lock().expect("sink").clone()
+    }
+
+    #[test]
+    fn each_line_lands_without_its_terminator() {
+        assert_eq!(
+            split(&[b"one\r\ntwo\n"]),
+            vec![
+                (Stream::Stdout, "one".to_string()),
+                (Stream::Stdout, "two".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn a_line_split_across_chunks_arrives_whole() {
+        // Reads land at pipe boundaries, not line boundaries.
+        assert_eq!(
+            split(&[b"one", b"-and-", b"the-same\n"]),
+            vec![(Stream::Stdout, "one-and-the-same".to_string())]
+        );
+    }
+
+    #[test]
+    fn a_final_line_with_no_terminator_is_still_emitted() {
+        // A crash mid-write, or a process terminated between the text and its newline.
+        assert_eq!(
+            split(&[b"truncated"]),
+            vec![(Stream::Stdout, "truncated".to_string())]
+        );
+    }
+
+    #[test]
+    fn nothing_written_emits_nothing() {
+        // `flush` must not invent a trailing empty line out of an empty pending buffer.
+        assert!(split(&[]).is_empty());
+    }
+
+    #[test]
+    fn a_blank_line_between_two_others_is_kept() {
+        // Blank lines are content — an app's own paragraph breaks in a stack trace.
+        assert_eq!(
+            split(&[b"one\n\ntwo\n"]),
+            vec![
+                (Stream::Stdout, "one".to_string()),
+                (Stream::Stdout, String::new()),
+                (Stream::Stdout, "two".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn invalid_utf8_is_replaced_rather_than_ending_the_split() {
+        // The reader this replaces stopped at the first bad byte, so one stray byte silenced an
+        // app for the rest of its run.
+        let out = split(&[b"good\n\xff\nafter\n"]);
+        assert_eq!(
+            out.len(),
+            3,
+            "a stray byte must not silence the rest: {out:?}"
+        );
+        assert_eq!(out[0].1, "good");
+        assert_eq!(out[2].1, "after");
+    }
+}
+
+/// The reader itself, which only exists on Windows. Runs on the Windows CI job, and under wine
+/// from a Linux host (`docs/how-to/verify-a-change.md`).
+#[cfg(all(test, windows))]
+mod reader_tests {
+    use super::*;
+    use std::io::{PipeReader, PipeWriter};
+    use std::process::{Child, Command, Stdio};
+    use std::time::{Duration, Instant};
+
+    use glass_core::logbuf::Stream;
+
+    /// A child writing into a pipe whose write end this test also holds, so the pipe stays open
+    /// after the child is gone.
+    ///
+    /// That is what a launch actually leaves behind — the app's write end is inherited by
+    /// everything it spawns, so a process outliving the teardown holds it — and holding a handle
+    /// here reproduces it without depending on `start /b` detaching a survivor, which wine does
+    /// not do. Ablating [`LogTap::stop`]'s flag must hang this test; a fixture where it still
+    /// passes is not testing the bound.
+    fn child_into_a_pipe_the_test_holds_open(said: &str) -> (Child, PipeReader, PipeWriter) {
+        let (reader, writer) = std::io::pipe().expect("a pipe");
+        let child = Command::new("cmd")
+            .args(["/c", &format!("echo {said}")])
+            .stdout(Stdio::from(writer.try_clone().expect("dup the write end")))
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("cmd is runnable");
+        (child, reader, writer)
+    }
+
+    #[test]
+    fn stopping_returns_and_keeps_what_the_app_said_while_the_pipe_is_still_held_open() {
+        let (mut child, reader, _held) = child_into_a_pipe_the_test_holds_open("the last line");
+        let sink: LogSink = Arc::default();
+        let mut tap = LogTap::start(reader, Stream::Stdout, Arc::clone(&sink)).expect("a reader");
+        // Waited for, not slept past: everything the child wrote is in the pipe once it is gone,
+        // so the drain below is not racing it. `_held` keeps the pipe from reaching EOF.
+        let _ = child.wait();
+
+        let t0 = Instant::now();
+        tap.stop();
+        let took = t0.elapsed();
+
+        assert!(
+            took < Duration::from_secs(5),
+            "stop must not wait for an EOF that is not coming: took {took:?}"
+        );
+        let said: Vec<String> = sink
+            .lock()
+            .expect("sink")
+            .iter()
+            .map(|(_, line)| line.trim().to_string())
+            .collect();
+        assert!(
+            said.iter().any(|line| line == "the last line"),
+            "the drain after the stop must keep what the app said: {said:?}"
+        );
+    }
+}

--- a/crates/glass-windows/src/logtap.rs
+++ b/crates/glass-windows/src/logtap.rs
@@ -32,11 +32,11 @@ impl Lines {
 
     /// Feed the next read's bytes in.
     pub fn push(&mut self, bytes: &[u8]) {
-        for byte in bytes {
-            if *byte == b'\n' {
+        for &byte in bytes {
+            if byte == b'\n' {
                 self.emit();
             } else {
-                self.pending.push(*byte);
+                self.pending.push(byte);
             }
         }
     }
@@ -111,7 +111,9 @@ mod imp {
         ///
         /// `Err` is the host refusing the thread — `Builder`, where `thread::spawn` panics.
         /// `source` is consumed either way, so on `Err` the read end is already closed and the
-        /// app's next write to that stream is discarded rather than drained.
+        /// app's next write to that stream fails with `ERROR_BROKEN_PIPE` — the analogue of the
+        /// `EPIPE` the unix siblings name, and an error path for some runtimes rather than a
+        /// silent drop.
         pub(crate) fn start<R>(source: R, tag: Stream, logs: LogSink) -> std::io::Result<LogTap>
         where
             R: Read + AsRawHandle + Send + 'static,
@@ -120,15 +122,19 @@ mod imp {
             let stop = Arc::clone(&stopping);
             let reader = std::thread::Builder::new()
                 .name("glass-log-tap".into())
-                .spawn(move || {
-                    let mut lines = Lines::new(tag, logs);
-                    read_until_stopped(source, &stop, &mut lines);
-                    lines.flush();
-                })?;
+                .spawn(move || read_until_stopped(source, &stop, Lines::new(tag, logs)))?;
             Ok(LogTap {
                 stopping,
                 reader: Some(reader),
             })
+        }
+
+        /// Whether the reader has left and the sink has been flushed — the pipe broke, or
+        /// nothing more can be read from it.
+        pub(crate) fn is_done(&self) -> bool {
+            self.reader
+                .as_ref()
+                .is_none_or(std::thread::JoinHandle::is_finished)
         }
 
         /// Stop the reader and wait for it to go, which is what makes the pipe closed rather than
@@ -154,7 +160,10 @@ mod imp {
     impl std::fmt::Debug for LogTap {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             f.debug_struct("LogTap")
-                .field("running", &self.reader.is_some())
+                // The thread's own state, not whether the handle is still held: `reader` is taken
+                // only by `stop`, so `is_some` would report a reader that died an hour ago as
+                // running. Named as the unix tap names it, so the two read the same.
+                .field("done", &self.is_done())
                 .finish_non_exhaustive()
         }
     }
@@ -211,31 +220,55 @@ mod imp {
                 lines.push(&chunk[..n]);
                 Pumped::Read(n)
             }
+            // Nothing was taken, but nothing is wrong either — the peek said the bytes are there.
+            // Ending capture here would silence the app for the rest of its run over one signal;
+            // the unix reader treats the same case as a retry.
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => Pumped::Empty,
             Err(_) => Pumped::Ended,
         }
     }
 
-    /// Read `source` into `lines` until the pipe breaks or `stopping` says to.
+    /// Read `source` into `lines` until the pipe breaks or `stopping` says to, then tell `lines`
+    /// no more is coming.
+    ///
+    /// `lines` is taken by value and flushed here rather than by the caller: a last line that
+    /// never got its newline is only emitted by that flush, and a hand-call beside the loop is
+    /// one a refactor can drop with every test still green.
     fn read_until_stopped<R: Read + AsRawHandle>(
         mut source: R,
         stopping: &AtomicBool,
-        lines: &mut Lines,
+        mut lines: Lines,
     ) {
         let mut chunk = [0u8; CHUNK];
         while !stopping.load(Ordering::Acquire) {
-            match pump(&mut source, &mut chunk, CHUNK, lines) {
+            match pump(&mut source, &mut chunk, CHUNK, &mut lines) {
                 Pumped::Read(_) => continue,
                 Pumped::Empty => std::thread::sleep(IDLE),
-                Pumped::Ended => return,
+                Pumped::Ended => {
+                    lines.flush();
+                    return;
+                }
             }
         }
-        // Only reached via the flag. The loop above leaves without reading, so a teardown that
-        // stops the tap right after terminating the app would lose the last thing it wrote — the
-        // lines a failed teardown is most likely to need. Capped, so a survivor still writing
-        // cannot keep the drain fed for as long as it keeps going.
+        final_drain(&mut source, &mut chunk, &mut lines);
+        lines.flush();
+    }
+
+    /// Read what the pipe already holds, at most [`FINAL_DRAIN`] bytes, without waiting for more.
+    ///
+    /// Only reached via the stop flag: the loop above leaves without reading, so a teardown that
+    /// stops the tap right after terminating the app would lose the last thing it wrote — the
+    /// lines a failed teardown is most likely to need. The peek reports what is there right now,
+    /// so `Empty` ends the drain rather than being a reason to wait, and the cap is the other
+    /// half: a survivor still writing would otherwise keep it fed for as long as it kept going.
+    fn final_drain<R: Read + AsRawHandle>(
+        source: &mut R,
+        chunk: &mut [u8; CHUNK],
+        lines: &mut Lines,
+    ) {
         let mut taken = 0;
         while taken < FINAL_DRAIN {
-            match pump(&mut source, &mut chunk, FINAL_DRAIN - taken, lines) {
+            match pump(source, chunk, FINAL_DRAIN - taken, lines) {
                 Pumped::Read(n) => taken += n,
                 Pumped::Empty | Pumped::Ended => return,
             }
@@ -349,6 +382,39 @@ mod reader_tests {
             .spawn()
             .expect("cmd is runnable");
         (child, reader, writer)
+    }
+
+    #[test]
+    fn the_final_drain_is_bounded_against_a_writer_that_never_stops() {
+        // The drain reads what is already there; something still writing must not be able to keep
+        // handing it more and hold teardown open. The unix tap has the same test against a real
+        // survivor; here the writer is a thread, so it needs nothing wine will not detach.
+        let (reader, writer) = std::io::pipe().expect("a pipe");
+        let stop_writing = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let writing = {
+            let stop_writing = Arc::clone(&stop_writing);
+            std::thread::spawn(move || {
+                let mut writer = writer;
+                while !stop_writing.load(std::sync::atomic::Ordering::Relaxed) {
+                    if std::io::Write::write_all(&mut writer, b"noise\n").is_err() {
+                        return;
+                    }
+                }
+            })
+        };
+        let sink: LogSink = Arc::default();
+        let mut tap = LogTap::start(reader, Stream::Stdout, sink).expect("a reader");
+
+        let t0 = Instant::now();
+        tap.stop();
+        let took = t0.elapsed();
+
+        stop_writing.store(true, std::sync::atomic::Ordering::Relaxed);
+        let _ = writing.join();
+        assert!(
+            took < Duration::from_secs(5),
+            "the final drain must be capped, not run as long as somebody keeps writing: {took:?}"
+        );
     }
 
     #[test]

--- a/crates/glass-windows/src/logtap.rs
+++ b/crates/glass-windows/src/logtap.rs
@@ -1,10 +1,10 @@
 //! A launched app's stdout/stderr, read on a thread that can be stopped.
 //!
-//! The line splitting is pure and tested on any host; the reader around it is `cfg(windows)` and
-//! runs on the Windows job. A reader that ended only at EOF could not be ended at all when
-//! something the app spawned inherited the write end and outlived the teardown — it would park in
-//! `ReadFile` holding a thread and a handle for the life of the process (glass#477). The unix
-//! backends get the same bound from `glass-pipe-unix`, which this crate cannot link.
+//! The line splitting is pure and tested on any host; the reader around it is `cfg(windows)`. A
+//! reader that ended only at EOF could not be ended at all once something the app spawned
+//! inherited the write end and outlived the teardown — it would park in `ReadFile` holding a
+//! thread and a handle for the life of the process (glass#477). The unix backends get the same
+//! bound from `glass-pipe-unix`, which this crate cannot link.
 
 use std::sync::{Arc, Mutex, PoisonError};
 
@@ -43,8 +43,7 @@ impl Lines {
 
     /// No more is coming. A last line that never got its newline is still what the app said — a
     /// crash mid-write, or a process terminated between the text and the terminator. An empty
-    /// `pending` is the ordinary case of a stream that ended on a newline, and must not become a
-    /// blank line.
+    /// `pending` is a stream that ended on a newline, and must not become a blank line.
     pub fn flush(&mut self) {
         if !self.pending.is_empty() {
             self.emit();
@@ -53,9 +52,9 @@ impl Lines {
 
     /// File `pending` as a line and start the next one.
     ///
-    /// Lossy rather than a decode that can fail: the reader this replaces stopped at the first
-    /// bad byte, so one stray byte silenced an app for the rest of its run. The trailing `\r` is
-    /// dropped the way `BufRead::lines` drops it — Windows apps write CRLF.
+    /// Lossy rather than a decode that can fail: the reader this replaces stopped at the first bad
+    /// byte, silencing an app for the rest of its run. The trailing `\r` is dropped the way
+    /// `BufRead::lines` drops it — Windows apps write CRLF.
     fn emit(&mut self) {
         let line = std::mem::take(&mut self.pending);
         let text = String::from_utf8_lossy(&line);
@@ -89,9 +88,7 @@ mod imp {
     /// [`LogTap::stop`]'s join.
     const IDLE: Duration = Duration::from_millis(50);
 
-    /// The most the drain after the stop flag will read: one pipe buffer's worth, which is
-    /// everything the app can have left behind, so a survivor still writing cannot hold the stop
-    /// open.
+    /// A cap on the drain after the stop flag, so a survivor still writing cannot hold it open.
     const FINAL_DRAIN: usize = 64 * 1024;
 
     /// How much one read asks for.
@@ -110,10 +107,8 @@ mod imp {
         /// Start reading `source`, filing each line into `logs` under `tag`.
         ///
         /// `Err` is the host refusing the thread — `Builder`, where `thread::spawn` panics.
-        /// `source` is consumed either way, so on `Err` the read end is already closed and the
-        /// app's next write to that stream fails with `ERROR_BROKEN_PIPE` — the analogue of the
-        /// `EPIPE` the unix siblings name, and an error path for some runtimes rather than a
-        /// silent drop.
+        /// `source` is consumed either way, so on `Err` the app's next write to that stream fails
+        /// with `ERROR_BROKEN_PIPE`, the analogue of the `EPIPE` the unix siblings name.
         pub(crate) fn start<R>(source: R, tag: Stream, logs: LogSink) -> std::io::Result<LogTap>
         where
             R: Read + AsRawHandle + Send + 'static,
@@ -160,9 +155,8 @@ mod imp {
     impl std::fmt::Debug for LogTap {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             f.debug_struct("LogTap")
-                // The thread's own state, not whether the handle is still held: `reader` is taken
-                // only by `stop`, so `is_some` would report a reader that died an hour ago as
-                // running. Named as the unix tap names it, so the two read the same.
+                // The thread's own state: `reader` is taken only by `stop`, so `is_some` would
+                // report a reader that died an hour ago as running.
                 .field("done", &self.is_done())
                 .finish_non_exhaustive()
         }
@@ -220,9 +214,8 @@ mod imp {
                 lines.push(&chunk[..n]);
                 Pumped::Read(n)
             }
-            // Nothing was taken, but nothing is wrong either — the peek said the bytes are there.
-            // Ending capture here would silence the app for the rest of its run over one signal;
-            // the unix reader treats the same case as a retry.
+            // The peek said the bytes are there, so ending capture over one signal would silence
+            // the app for the rest of its run; the unix reader retries the same case.
             Err(e) if e.kind() == std::io::ErrorKind::Interrupted => Pumped::Empty,
             Err(_) => Pumped::Ended,
         }
@@ -231,9 +224,9 @@ mod imp {
     /// Read `source` into `lines` until the pipe breaks or `stopping` says to, then tell `lines`
     /// no more is coming.
     ///
-    /// `lines` is taken by value and flushed here rather than by the caller: a last line that
-    /// never got its newline is only emitted by that flush, and a hand-call beside the loop is
-    /// one a refactor can drop with every test still green.
+    /// `lines` is taken by value and flushed here rather than by the caller: a hand-call beside the
+    /// loop is one a refactor can drop with every test still green, losing every last unterminated
+    /// line.
     fn read_until_stopped<R: Read + AsRawHandle>(
         mut source: R,
         stopping: &AtomicBool,
@@ -256,11 +249,9 @@ mod imp {
 
     /// Read what the pipe already holds, at most [`FINAL_DRAIN`] bytes, without waiting for more.
     ///
-    /// Only reached via the stop flag: the loop above leaves without reading, so a teardown that
-    /// stops the tap right after terminating the app would lose the last thing it wrote — the
-    /// lines a failed teardown is most likely to need. The peek reports what is there right now,
-    /// so `Empty` ends the drain rather than being a reason to wait, and the cap is the other
-    /// half: a survivor still writing would otherwise keep it fed for as long as it kept going.
+    /// Only reached via the stop flag, which the loop leaves on without reading — so without this
+    /// a teardown loses the last thing the app wrote, which is what a failed one is diagnosed
+    /// from. The peek reports what is there now, so `Empty` ends the drain rather than waiting.
     fn final_drain<R: Read + AsRawHandle>(
         source: &mut R,
         chunk: &mut [u8; CHUNK],
@@ -366,13 +357,12 @@ mod reader_tests {
     use glass_core::logbuf::Stream;
 
     /// A child writing into a pipe whose write end this test also holds, so the pipe stays open
-    /// after the child is gone.
+    /// after the child is gone — what a launch leaves behind when something it spawned outlives
+    /// the teardown.
     ///
-    /// That is what a launch actually leaves behind — the app's write end is inherited by
-    /// everything it spawns, so a process outliving the teardown holds it — and holding a handle
-    /// here reproduces it without depending on `start /b` detaching a survivor, which wine does
-    /// not do. Ablating [`LogTap::stop`]'s flag must hang this test; a fixture where it still
-    /// passes is not testing the bound.
+    /// Held here rather than by a detached process: `start /b` does not detach one under wine.
+    /// Ablating [`LogTap::stop`]'s flag must hang this test; a fixture where it still passes is
+    /// not testing the bound.
     fn child_into_a_pipe_the_test_holds_open(said: &str) -> (Child, PipeReader, PipeWriter) {
         let (reader, writer) = std::io::pipe().expect("a pipe");
         let child = Command::new("cmd")
@@ -386,9 +376,8 @@ mod reader_tests {
 
     #[test]
     fn the_final_drain_is_bounded_against_a_writer_that_never_stops() {
-        // The drain reads what is already there; something still writing must not be able to keep
-        // handing it more and hold teardown open. The unix tap has the same test against a real
-        // survivor; here the writer is a thread, so it needs nothing wine will not detach.
+        // Something still writing must not be able to keep the drain fed. A thread rather than a
+        // process, so it needs nothing wine will not detach.
         let (reader, writer) = std::io::pipe().expect("a pipe");
         let stop_writing = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let writing = {
@@ -422,8 +411,8 @@ mod reader_tests {
         let (mut child, reader, _held) = child_into_a_pipe_the_test_holds_open("the last line");
         let sink: LogSink = Arc::default();
         let mut tap = LogTap::start(reader, Stream::Stdout, Arc::clone(&sink)).expect("a reader");
-        // Waited for, not slept past: everything the child wrote is in the pipe once it is gone,
-        // so the drain below is not racing it. `_held` keeps the pipe from reaching EOF.
+        // Waited for, not slept past: everything the child wrote is in the pipe once it is gone.
+        // `_held` keeps the pipe from reaching EOF.
         let _ = child.wait();
 
         let t0 = Instant::now();

--- a/crates/glass-windows/src/process.rs
+++ b/crates/glass-windows/src/process.rs
@@ -149,6 +149,25 @@ impl LaunchedApp {
         Ok(())
     }
 
+    /// Terminate a launch that never started, closing the Job handle with it.
+    ///
+    /// `LaunchedApp` releases the Job only in [`LaunchedApp::kill`], and neither `SendHandle` nor
+    /// `Child` frees anything on drop — so a launch abandoned between `spawn_suspended_in_job`
+    /// and `resume` would sit `CREATE_SUSPENDED` and alive for the life of this process, with its
+    /// Job handle leaked and `KILL_ON_JOB_CLOSE` therefore never firing. The root is still
+    /// suspended and job-assigned but has never run, so it has no children of its own; this is
+    /// the same reasoning `spawn_suspended_in_job`'s own error arm uses.
+    ///
+    /// Any tap already started is ended by the drop that follows, after the kill.
+    pub(crate) fn abandon(mut self) {
+        // SAFETY: closing the last job handle terminates anything left in the tree.
+        unsafe {
+            let _ = CloseHandle(self.job.0);
+        }
+        let _ = self.child.kill();
+        let _ = self.child.wait(); // reap, so an abandoned launch leaves no zombie
+    }
+
     /// Resume the suspended root thread(s) — call AFTER log readers are wired.
     pub(crate) fn resume(&self) {
         resume_process(self.pid());

--- a/crates/glass-windows/src/process.rs
+++ b/crates/glass-windows/src/process.rs
@@ -114,8 +114,8 @@ pub(crate) struct LaunchedApp {
     job: SendHandle,
     child: Child,
     /// The app's stdout/stderr readers, ended by `kill`. The app's write ends are inherited by
-    /// everything it spawns, so a reader that ended only at EOF would park on a survivor's pipe,
-    /// holding a thread and a handle for the life of the process (glass#477).
+    /// everything it spawns, so an EOF-only reader parks on a survivor's pipe, holding a thread
+    /// and a handle for the life of the process (glass#477).
     taps: Vec<crate::logtap::LogTap>,
 }
 
@@ -127,10 +127,10 @@ impl LaunchedApp {
     /// Start the log readers over the piped stdout/stderr, filing into `logs`. Call once, before
     /// `resume`, so nothing the app writes at startup is missed.
     ///
-    /// The readers are kept here rather than handed back: they are made from this handle's own
-    /// pipes, and `kill` is what ends them. `Err` is the host refusing a thread, and the pipe it
-    /// was for is closed by then — the caller must fail the launch rather than resume an app
-    /// whose output goes nowhere.
+    /// The readers stay here rather than being handed back: they are made from this handle's own
+    /// pipes, and `kill` ends them. `Err` is the host refusing a thread, with that stream's pipe
+    /// closed by then — the caller must fail the launch rather than resume an app whose output
+    /// goes nowhere.
     pub(crate) fn tap_logs(&mut self, logs: &crate::logtap::LogSink) -> std::io::Result<()> {
         if let Some(out) = self.child.stdout.take() {
             self.taps.push(crate::logtap::LogTap::start(
@@ -152,13 +152,12 @@ impl LaunchedApp {
     /// Terminate a launch that never started, closing the Job handle with it.
     ///
     /// `LaunchedApp` releases the Job only in [`LaunchedApp::kill`], and neither `SendHandle` nor
-    /// `Child` frees anything on drop — so a launch abandoned between `spawn_suspended_in_job`
-    /// and `resume` would sit `CREATE_SUSPENDED` and alive for the life of this process, with its
-    /// Job handle leaked and `KILL_ON_JOB_CLOSE` therefore never firing. The root is still
-    /// suspended and job-assigned but has never run, so it has no children of its own; this is
-    /// the same reasoning `spawn_suspended_in_job`'s own error arm uses.
+    /// `Child` frees anything on drop — so a launch abandoned between `spawn_suspended_in_job` and
+    /// `resume` sits `CREATE_SUSPENDED` and alive for the life of this process, its Job handle
+    /// leaked and `KILL_ON_JOB_CLOSE` therefore never firing. The root has never run, so it has no
+    /// children; `spawn_suspended_in_job`'s own error arm reasons the same way.
     ///
-    /// Any tap already started is ended by the drop that follows, after the kill.
+    /// Any tap already started is ended by the drop that follows the kill.
     pub(crate) fn abandon(mut self) {
         // SAFETY: closing the last job handle terminates anything left in the tree.
         unsafe {
@@ -203,8 +202,8 @@ impl LaunchedApp {
         let _ = self.child.kill(); // belt-and-suspenders: ensure the root is terminated so wait() can't block
         let _ = self.child.wait(); // reap the now-terminated root; avoids a zombie
         // Terminated first, so each tap's final drain sees what the app wrote on the way out.
-        // Dropping them ends the reader threads and releases the pipe handles, which anything the
-        // launch left running would otherwise hold for the life of this process (glass#477).
+        // Dropping them releases the pipe handles anything the launch left running still holds
+        // (glass#477).
         self.taps.clear();
         asked.outcome(closed_itself)
     }

--- a/crates/glass-windows/src/process.rs
+++ b/crates/glass-windows/src/process.rs
@@ -19,6 +19,7 @@ use std::os::windows::process::CommandExt;
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
+use glass_core::Stream;
 use glass_core::{AppSpec, GlassError, Result, SandboxLevel, TEARDOWN_BUDGET};
 
 use crate::teardown::{CloseStep, close_wait_step};
@@ -112,6 +113,10 @@ unsafe impl Send for SendHandle {}
 pub(crate) struct LaunchedApp {
     job: SendHandle,
     child: Child,
+    /// The app's stdout/stderr readers, ended by `kill`. The app's write ends are inherited by
+    /// everything it spawns, so a reader that ended only at EOF would park on a survivor's pipe,
+    /// holding a thread and a handle for the life of the process (glass#477).
+    taps: Vec<crate::logtap::LogTap>,
 }
 
 impl LaunchedApp {
@@ -119,14 +124,29 @@ impl LaunchedApp {
         self.child.id()
     }
 
-    /// Take the piped stdout/stderr (call once, before resume, to wire log readers).
-    pub(crate) fn take_pipes(
-        &mut self,
-    ) -> (
-        Option<std::process::ChildStdout>,
-        Option<std::process::ChildStderr>,
-    ) {
-        (self.child.stdout.take(), self.child.stderr.take())
+    /// Start the log readers over the piped stdout/stderr, filing into `logs`. Call once, before
+    /// `resume`, so nothing the app writes at startup is missed.
+    ///
+    /// The readers are kept here rather than handed back: they are made from this handle's own
+    /// pipes, and `kill` is what ends them. `Err` is the host refusing a thread, and the pipe it
+    /// was for is closed by then — the caller must fail the launch rather than resume an app
+    /// whose output goes nowhere.
+    pub(crate) fn tap_logs(&mut self, logs: &crate::logtap::LogSink) -> std::io::Result<()> {
+        if let Some(out) = self.child.stdout.take() {
+            self.taps.push(crate::logtap::LogTap::start(
+                out,
+                Stream::Stdout,
+                logs.clone(),
+            )?);
+        }
+        if let Some(err) = self.child.stderr.take() {
+            self.taps.push(crate::logtap::LogTap::start(
+                err,
+                Stream::Stderr,
+                logs.clone(),
+            )?);
+        }
+        Ok(())
     }
 
     /// Resume the suspended root thread(s) — call AFTER log readers are wired.
@@ -163,6 +183,10 @@ impl LaunchedApp {
         }
         let _ = self.child.kill(); // belt-and-suspenders: ensure the root is terminated so wait() can't block
         let _ = self.child.wait(); // reap the now-terminated root; avoids a zombie
+        // Terminated first, so each tap's final drain sees what the app wrote on the way out.
+        // Dropping them ends the reader threads and releases the pipe handles, which anything the
+        // launch left running would otherwise hold for the life of this process (glass#477).
+        self.taps.clear();
         asked.outcome(closed_itself)
     }
 
@@ -314,6 +338,7 @@ pub(crate) fn spawn_suspended_in_job(
         Ok(job) => Ok(LaunchedApp {
             job: SendHandle(job),
             child,
+            taps: Vec::new(),
         }),
         Err(e) => {
             // The child is still SUSPENDED and not yet job-assigned, so it has no children:

--- a/crates/glass-x11/Cargo.toml
+++ b/crates/glass-x11/Cargo.toml
@@ -22,6 +22,7 @@ glass-exec-unix.workspace = true
 glass-a11y-linux.workspace = true
 glass-sandbox-linux.workspace = true
 glass-proc-linux.workspace = true
+glass-pipe-unix.workspace = true
 glass-dbus-linux.workspace = true
 x11rb.workspace = true
 

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -59,9 +59,9 @@ pub struct X11Platform {
     child: Option<Child>,
     window: Option<Window>,
     logs: LogSink,
-    /// The launched app's stdout/stderr readers, kept for the app's lifetime and dropped in
-    /// `kill_child`. The app's write ends are inherited by everything it spawns, so a reader
-    /// that ended only at EOF would park on a survivor's pipe (glass#477).
+    /// The launched app's stdout/stderr readers, dropped in `kill_child`. The app's write ends
+    /// are inherited by everything it spawns, so an EOF-only reader parks on a survivor's pipe
+    /// (glass#477).
     taps: Vec<LineTap>,
     // A private Xvfb we spawned (default path); kept alive so Drop tears it down.
     xvfb: Option<crate::xvfb::Xvfb>,
@@ -112,15 +112,13 @@ fn is_window_gone(err: &ReplyError) -> bool {
 
 /// Start a reader over one of the launch's streams, or reap the launch and say why it could not.
 ///
-/// The failed start consumed the pipe, so its read end is already closed and the app's next write
-/// to that stream takes `SIGPIPE` — a death mid-run with nothing in the logs to say why. Stopping
-/// it here is the honest failure.
+/// The failed start consumed the pipe, so the app's next write to that stream takes `SIGPIPE` — a
+/// death mid-run with nothing in the logs to say why.
 ///
-/// The group, not the leader: `command.rs` spawns the app with `process_group(0)` precisely so a
-/// teardown reaches the whole tree, and under a sandbox the leader is `bwrap` with the real app
-/// as its child. A leader-only reap would leave that child holding the write end of the very pipe
-/// this could not read. (`xvfb.rs` reaps the leader for the X server, which is *not* spawned into
-/// its own group — that is why it can.)
+/// The group, not the leader: `command.rs` spawns the app with `process_group(0)`, and under a
+/// sandbox the leader is `bwrap` with the real app as its child — a leader-only reap leaves that
+/// child holding the write end of the very pipe this could not read. (`xvfb.rs` can reap the
+/// leader because the X server is not spawned into its own group.)
 fn tap_or_reap<R: std::io::Read + AsFd + Send + 'static>(
     stream: R,
     tag: Stream,
@@ -335,9 +333,8 @@ impl X11Platform {
         let mut child = cmd
             .spawn()
             .map_err(|e| GlassError::AppNotStarted(format!("spawn {:?}: {e}", spec.run)))?;
-        // `Stdio::piped()` above guarantees both are `Some` after a successful spawn. Skipping a
-        // stream that is unexpectedly `None` would silently stop capturing it, which is the
-        // fallback this crate's contract forbids.
+        // `Stdio::piped()` above guarantees both are `Some`. Skipping one that is not would
+        // silently stop capturing it, the fallback this crate's contract forbids.
         let stdout = child.stdout.take().expect("stdout was piped");
         let stderr = child.stderr.take().expect("stderr was piped");
         self.taps = vec![
@@ -535,9 +532,9 @@ impl X11Platform {
             glass_proc_linux::disclose_teardown(&asked.outcome(closed_itself));
         }
         self.window = None;
-        // Reaped first, so each tap's final drain sees what the app wrote on its way out. Dropping
-        // them ends the reader threads and releases the pipes, which anything the launch left
-        // running would otherwise hold for the life of this process (glass#477).
+        // Reaped first, so each tap's final drain sees what the app wrote on its way out.
+        // Dropping them releases the pipes anything the launch left running still holds
+        // (glass#477).
         self.taps.clear();
         // Drop the private a11y bus, reaping its dbus-daemon / at-spi children. Also
         // covers `start_app`'s failure path (which calls `kill_child`), so a launch

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -6,7 +6,8 @@ use glass_core::{
     AppSpec, Frame, GlassError, KeyEvent, Platform, PointerEvent, Region, Result, Stream,
     TEARDOWN_BUDGET, WindowGeometry, WindowHint, WindowId, WindowInfo, WindowOp,
 };
-use glass_proc_linux::{APP_REAP_GRACE, Asked, CLOSE_GRACE, proc_tree_pids, spawn_reader};
+use glass_pipe_unix::LineTap;
+use glass_proc_linux::{APP_REAP_GRACE, Asked, CLOSE_GRACE, proc_tree_pids};
 use x11rb::CURRENT_TIME;
 use x11rb::connection::Connection;
 use x11rb::errors::ReplyError;
@@ -57,6 +58,10 @@ pub struct X11Platform {
     child: Option<Child>,
     window: Option<Window>,
     logs: LogSink,
+    /// The launched app's stdout/stderr readers, kept for the app's lifetime and dropped in
+    /// `kill_child`. The app's write ends are inherited by everything it spawns, so a reader
+    /// that ended only at EOF would park on a survivor's pipe (glass#477).
+    taps: Vec<LineTap>,
     // A private Xvfb we spawned (default path); kept alive so Drop tears it down.
     xvfb: Option<crate::xvfb::Xvfb>,
     // A private a11y-enabled D-Bus session bus we spawned for the launched app;
@@ -102,6 +107,30 @@ fn is_window_gone(err: &ReplyError) -> bool {
         err,
         ReplyError::X11Error(x) if matches!(x.error_kind, ErrorKind::Window | ErrorKind::Drawable)
     )
+}
+
+/// Start a reader over one of the launch's streams, or reap the launch and say why it could not.
+///
+/// The failed start consumed the pipe, so its read end is already closed and the app's next write
+/// to that stream takes `SIGPIPE` — a death mid-run with nothing in the logs to say why. Stopping
+/// it here is the honest failure, and the call `xvfb.rs` already makes for the X server's own
+/// stderr.
+fn tap_or_reap<R: std::io::Read + std::os::fd::AsFd + Send + 'static>(
+    stream: R,
+    tag: Stream,
+    logs: &LogSink,
+    child: &mut Child,
+    spec: &AppSpec,
+) -> Result<LineTap> {
+    LineTap::start(stream, tag, logs.clone()).map_err(|e| {
+        glass_proc_linux::reap_graceful(child, glass_proc_linux::REAP_GRACE);
+        GlassError::AppNotStarted(format!(
+            "started {:?} but could not read its output ({e}); the app was stopped rather than \
+             left to write into a pipe nobody drains — free up threads and file descriptors on \
+             the host",
+            spec.run
+        ))
+    })
 }
 
 impl X11Platform {
@@ -150,6 +179,7 @@ impl X11Platform {
             child: None,
             window: None,
             logs: Arc::new(Mutex::new(Vec::new())),
+            taps: Vec::new(),
             xvfb: None,
             dbus: None,
             clipboard_owner: None,
@@ -298,12 +328,26 @@ impl X11Platform {
         let mut child = cmd
             .spawn()
             .map_err(|e| GlassError::AppNotStarted(format!("spawn {:?}: {e}", spec.run)))?;
+        let mut taps = Vec::new();
         if let Some(out) = child.stdout.take() {
-            spawn_reader(out, Stream::Stdout, self.logs.clone());
+            taps.push(tap_or_reap(
+                out,
+                Stream::Stdout,
+                &self.logs,
+                &mut child,
+                spec,
+            )?);
         }
         if let Some(err) = child.stderr.take() {
-            spawn_reader(err, Stream::Stderr, self.logs.clone());
+            taps.push(tap_or_reap(
+                err,
+                Stream::Stderr,
+                &self.logs,
+                &mut child,
+                spec,
+            )?);
         }
+        self.taps = taps;
         self.child = Some(child);
         Ok(())
     }
@@ -481,6 +525,10 @@ impl X11Platform {
             glass_proc_linux::disclose_teardown(&asked.outcome(closed_itself));
         }
         self.window = None;
+        // Reaped first, so each tap's final drain sees what the app wrote on its way out. Dropping
+        // them ends the reader threads and releases the pipes, which anything the launch left
+        // running would otherwise hold for the life of this process (glass#477).
+        self.taps.clear();
         // Drop the private a11y bus, reaping its dbus-daemon / at-spi children. Also
         // covers `start_app`'s failure path (which calls `kill_child`), so a launch
         // that never finds a window doesn't leave the bus running until Drop.

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -1,3 +1,4 @@
+use std::os::fd::AsFd;
 use std::process::{Child, Stdio};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -113,17 +114,23 @@ fn is_window_gone(err: &ReplyError) -> bool {
 ///
 /// The failed start consumed the pipe, so its read end is already closed and the app's next write
 /// to that stream takes `SIGPIPE` — a death mid-run with nothing in the logs to say why. Stopping
-/// it here is the honest failure, and the call `xvfb.rs` already makes for the X server's own
-/// stderr.
-fn tap_or_reap<R: std::io::Read + std::os::fd::AsFd + Send + 'static>(
+/// it here is the honest failure.
+///
+/// The group, not the leader: `command.rs` spawns the app with `process_group(0)` precisely so a
+/// teardown reaches the whole tree, and under a sandbox the leader is `bwrap` with the real app
+/// as its child. A leader-only reap would leave that child holding the write end of the very pipe
+/// this could not read. (`xvfb.rs` reaps the leader for the X server, which is *not* spawned into
+/// its own group — that is why it can.)
+fn tap_or_reap<R: std::io::Read + AsFd + Send + 'static>(
     stream: R,
     tag: Stream,
+    name: &str,
     logs: &LogSink,
     child: &mut Child,
     spec: &AppSpec,
 ) -> Result<LineTap> {
-    LineTap::start(stream, tag, logs.clone()).map_err(|e| {
-        glass_proc_linux::reap_graceful(child, glass_proc_linux::REAP_GRACE);
+    LineTap::start(stream, tag, name, logs.clone()).map_err(|e| {
+        glass_proc_linux::reap_group(child, glass_proc_linux::REAP_GRACE);
         GlassError::AppNotStarted(format!(
             "started {:?} but could not read its output ({e}); the app was stopped rather than \
              left to write into a pipe nobody drains — free up threads and file descriptors on \
@@ -328,26 +335,29 @@ impl X11Platform {
         let mut child = cmd
             .spawn()
             .map_err(|e| GlassError::AppNotStarted(format!("spawn {:?}: {e}", spec.run)))?;
-        let mut taps = Vec::new();
-        if let Some(out) = child.stdout.take() {
-            taps.push(tap_or_reap(
-                out,
+        // `Stdio::piped()` above guarantees both are `Some` after a successful spawn. Skipping a
+        // stream that is unexpectedly `None` would silently stop capturing it, which is the
+        // fallback this crate's contract forbids.
+        let stdout = child.stdout.take().expect("stdout was piped");
+        let stderr = child.stderr.take().expect("stderr was piped");
+        self.taps = vec![
+            tap_or_reap(
+                stdout,
                 Stream::Stdout,
+                "glass-app-stdout",
                 &self.logs,
                 &mut child,
                 spec,
-            )?);
-        }
-        if let Some(err) = child.stderr.take() {
-            taps.push(tap_or_reap(
-                err,
+            )?,
+            tap_or_reap(
+                stderr,
                 Stream::Stderr,
+                "glass-app-stderr",
                 &self.logs,
                 &mut child,
                 spec,
-            )?);
-        }
-        self.taps = taps;
+            )?,
+        ];
         self.child = Some(child);
         Ok(())
     }

--- a/crates/glass-x11/tests/launch_releases_pipes.rs
+++ b/crates/glass-x11/tests/launch_releases_pipes.rs
@@ -11,6 +11,7 @@
 #![cfg(target_os = "linux")]
 
 use std::collections::HashSet;
+use std::path::Path;
 
 use glass_core::{AppSpec, Deadline, Platform, TEARDOWN_BUDGET};
 use rustix::process::{Pid, Signal, kill_process};
@@ -56,15 +57,17 @@ fn open_pipes() -> HashSet<String> {
 /// teardown — what glass#470 measures and reports as `leaked` — is a process that escaped both,
 /// which is what this builds. `setsid` covers the group, the subshell covers the tree.
 ///
-/// It prints the pid it left, so the test can kill what glass deliberately could not; the sleep
-/// self-limits well inside a suite run if that kill never happens.
+/// It prints the pid it left, so the test can kill what glass deliberately could not. The sleep
+/// self-limits if that kill never happens, and is long enough to outlive discovery plus the whole
+/// teardown budget on a loaded runner — a survivor that died first would take the pipes to EOF
+/// and turn this gate into a vacuous pass.
 fn spec_leaving_a_survivor() -> AppSpec {
     AppSpec {
         build: None,
         run: [
             "sh",
             "-c",
-            "printf 'complaint\\n' >&2; ( setsid sleep 10 & echo \"survivor $!\" ); sleep 30",
+            "printf 'complaint\\n' >&2; ( setsid sleep 60 & echo \"survivor $!\" ); sleep 30",
         ]
         .map(String::from)
         .to_vec(),
@@ -99,11 +102,19 @@ fn tearing_down_a_launch_releases_the_pipes_a_survivor_holds_open() {
     // Armed before the first assertion, so a failure still cleans up what glass could not.
     let _survivor = Survivor(survivor);
 
-    // Half the assertion, and what keeps the other half from passing vacuously: a launch whose
-    // output nobody read would leak nothing *because* it tapped nothing.
+    // Two vacuity guards, because either alone can go green for the wrong reason. A launch
+    // whose output nobody read would leak nothing *because* it tapped nothing...
     assert!(
         survivor.is_some(),
         "the tap must deliver what the app printed, but the log holds {said:?}"
+    );
+    // ...and a fixture that stopped leaving a *live* survivor would let the pipes reach EOF on
+    // their own, which the EOF-only reader this replaces would also have released. Then the
+    // assertion below would pass without covering glass#477 at all, and nothing would say so.
+    assert!(
+        survivor.is_some_and(|pid| Path::new(&format!("/proc/{pid}")).exists()),
+        "the fixture must leave a live survivor holding the write ends, or this gate proves \
+         nothing an EOF-only reader would not also pass"
     );
     let leaked: Vec<_> = open_pipes().difference(&before).cloned().collect();
     assert!(

--- a/crates/glass-x11/tests/launch_releases_pipes.rs
+++ b/crates/glass-x11/tests/launch_releases_pipes.rs
@@ -1,0 +1,113 @@
+//! glass#477: the launch's log readers end at teardown.
+//!
+//! Nothing in the unit tests reaches this. The app's stdout/stderr write ends are inherited by
+//! everything it spawns, so a survivor holds them after teardown — and a reader that could only
+//! stop at EOF would park there holding an fd for the life of the process, one pair per launch
+//! under `glass-mcp serve --http`.
+//!
+//! Its own test binary: the measurement is this process's open fds, which a sibling test opening
+//! or closing a pipe in parallel would land in.
+
+#![cfg(target_os = "linux")]
+
+use std::collections::HashSet;
+
+use glass_core::{AppSpec, Deadline, Platform, TEARDOWN_BUDGET};
+use rustix::process::{Pid, Signal, kill_process};
+
+/// The process the launch leaves behind, killed when the test ends, panic included.
+///
+/// Load-bearing beyond cleanup: while it holds the write ends the pipes' inodes cannot be freed,
+/// so no other pipe in this process can be handed the same `pipe:[n]` and read as a false pass.
+/// Killed only after the assertions, for that reason.
+struct Survivor(Option<u32>);
+
+impl Drop for Survivor {
+    fn drop(&mut self) {
+        if let Some(pid) = self.0.and_then(|p| Pid::from_raw(p as i32)) {
+            let _ = kill_process(pid, Signal::KILL);
+        }
+    }
+}
+
+/// Every pipe this process holds, as `fd -> pipe:[inode]`. The inode is half the identity: an fd
+/// number the kernel released and handed straight back for a different pipe must not read as the
+/// same one still held.
+fn open_pipes() -> HashSet<String> {
+    std::fs::read_dir("/proc/self/fd")
+        .expect("/proc/self/fd")
+        .filter_map(|entry| {
+            let path = entry.ok()?.path();
+            let target = std::fs::read_link(&path).ok()?;
+            let target = target.to_string_lossy().into_owned();
+            let fd = path.file_name()?.to_string_lossy().into_owned();
+            target
+                .starts_with("pipe:")
+                .then(|| format!("{fd}->{target}"))
+        })
+        .collect()
+}
+
+/// A launch that says something on both streams, leaves a process holding them, and then blocks.
+///
+/// The survivor is backgrounded from a subshell that exits at once, so it is reparented to init:
+/// `reap_launch` signals the launch's process *group* and every pid in a `/proc` walk of its
+/// tree, and a process still in either is reaped rather than left behind. What outlives a
+/// teardown — what glass#470 measures and reports as `leaked` — is a process that escaped both,
+/// which is what this builds. `setsid` covers the group, the subshell covers the tree.
+///
+/// It prints the pid it left, so the test can kill what glass deliberately could not; the sleep
+/// self-limits well inside a suite run if that kill never happens.
+fn spec_leaving_a_survivor() -> AppSpec {
+    AppSpec {
+        build: None,
+        run: [
+            "sh",
+            "-c",
+            "printf 'complaint\\n' >&2; ( setsid sleep 10 & echo \"survivor $!\" ); sleep 30",
+        ]
+        .map(String::from)
+        .to_vec(),
+        cwd: None,
+        env: vec![],
+        window_hint: None,
+        // The stand-in maps no window, so discovery times out. The launch and its readers still
+        // happened, and that failure path runs the same `kill_child` the success path does.
+        timeout_ms: 250,
+        sandbox: glass_core::SandboxLevel::Off,
+        a11y: false,
+    }
+}
+
+#[test]
+#[ignore = "starts a real X server; needs Xvfb"]
+fn tearing_down_a_launch_releases_the_pipes_a_survivor_holds_open() {
+    let mut plat = glass_x11::X11Platform::from_env().expect("a display");
+    // Snapshotted after the platform is up, so the private Xvfb's own stderr pipe is baseline.
+    let before = open_pipes();
+
+    plat.start_app(&spec_leaving_a_survivor())
+        .expect_err("a command that maps no window cannot be launched");
+    plat.stop_app_by(Deadline::from_millis(TEARDOWN_BUDGET.as_millis() as u64))
+        .expect("stop");
+
+    let said = plat.drain_logs();
+    let survivor = said.iter().find_map(|(_, line)| {
+        line.strip_prefix("survivor ")
+            .and_then(|pid| pid.trim().parse().ok())
+    });
+    // Armed before the first assertion, so a failure still cleans up what glass could not.
+    let _survivor = Survivor(survivor);
+
+    // Half the assertion, and what keeps the other half from passing vacuously: a launch whose
+    // output nobody read would leak nothing *because* it tapped nothing.
+    assert!(
+        survivor.is_some(),
+        "the tap must deliver what the app printed, but the log holds {said:?}"
+    );
+    let leaked: Vec<_> = open_pipes().difference(&before).cloned().collect();
+    assert!(
+        leaked.is_empty(),
+        "teardown must release the launch's pipes, but these are still held: {leaked:?}"
+    );
+}

--- a/crates/glass-x11/tests/launch_releases_pipes.rs
+++ b/crates/glass-x11/tests/launch_releases_pipes.rs
@@ -19,8 +19,8 @@ use rustix::process::{Pid, Signal, kill_process};
 /// The process the launch leaves behind, killed when the test ends, panic included.
 ///
 /// Load-bearing beyond cleanup: while it holds the write ends the pipes' inodes cannot be freed,
-/// so no other pipe in this process can be handed the same `pipe:[n]` and read as a false pass.
-/// Killed only after the assertions, for that reason.
+/// so no other pipe here can be handed the same `pipe:[n]` and read as a false pass — which is
+/// why it is killed only after the assertions.
 struct Survivor(Option<u32>);
 
 impl Drop for Survivor {
@@ -32,8 +32,7 @@ impl Drop for Survivor {
 }
 
 /// Every pipe this process holds, as `fd -> pipe:[inode]`. The inode is half the identity: an fd
-/// number the kernel released and handed straight back for a different pipe must not read as the
-/// same one still held.
+/// number released and handed straight back for a different pipe must not read as one still held.
 fn open_pipes() -> HashSet<String> {
     std::fs::read_dir("/proc/self/fd")
         .expect("/proc/self/fd")


### PR DESCRIPTION
Closes #477.

`spawn_reader` read a launched app's stdout/stderr with `BufReader::lines()` on a detached thread.
`lines()` ends only at EOF, and the app's write ends are inherited by everything it spawns — so a
launch whose teardown leaves a survivor (the case `reap_launch` already measures and reports as
`leaked`, #470) parked two threads and held two fds for the life of the process. Under
`glass-mcp serve --http` that accumulates per launch.

Every backend carried a copy of that reader. All four now hold a tap for the app's lifetime and
end it at teardown, reap-then-stop, so the final drain still catches what the app wrote on the way
out.

## The mechanism

New `glass-pipe-unix` crate — the shape #471 put in `StderrTail`, generalised:

- the read end is `O_NONBLOCK`, so no read parks past a look at the stop flag
- a self-pipe is polled alongside the data as the wakeup
- the flag is read before every read, so a child that never stops writing cannot hold the reader
- `Drop` joins, which is what makes the pipe closed rather than assumed closed

One thing `StderrTail` did not have, and this needs: **a bounded final drain**. The loop leaves at
the flag without reading, so stopping a tap right after reaping would lose the last thing the app
wrote — the lines a failed teardown is diagnosed from. The drain is capped so a survivor still
writing cannot hold teardown open. `StderrTail` inherits it, rebuilt on `PipeTap` with its public
API and its whole test module unchanged — that module is the regression gate for the refactor.

`glass-windows` cannot link a unix crate, so `src/logtap.rs` carries the same shape over
`PeekNamedPipe`: peek, then read exactly what the peek reported, so the read itself never waits.
The line splitter is duplicated there rather than shared through `glass-core` — sharing 25 lines
would put `glass-core` and its dependencies into both lean unix crates' build graphs.

## Failure to start

A tap can fail to start (thread or fd exhaustion, #454) after it has already consumed the pipe, so
the app's next write to that stream takes `SIGPIPE`. The launch fails, naming the reader, rather
than running an app that dies mid-run with nothing in the logs to say why — the call `xvfb.rs`
already makes for the X server's own stderr. Each backend reaps the way it must: x11 the process
group (`command.rs` spawns the app as its leader, and under a sandbox the leader is `bwrap`),
wayland the group (Xwayland is sway's own fork), macOS `terminate` plus a release of the shim's
named pasteboards, Windows a Job close and kill on a root that is still `CREATE_SUSPENDED`.

## Coverage

The two Linux gates were each shown red before the fix and green after, in their own test binary —
the measurement is the process's open fds, which a sibling test opening a pipe would land in:

| | before | after |
|---|---|---|
| `glass-x11` `launch_releases_pipes` | 2 pipe fds still held after teardown | clean |
| `glass-wayland` `session_releases_pipes` | 4 (the session retry brings sway up twice) | clean |

Both assert the survivor is still alive when the fds are counted. Without that, a fixture that
stopped leaving one would let the pipes reach EOF on their own — which the reader this replaces
would also have released, so the gate would pass for the reason the bug would.

`final_drain` is driven directly rather than through a pipe: the reader thread races the caller's
stop, and whichever wins the bytes arrive, so a test through the pipe passes whether the drain
exists or not. The Windows reader test holds the write end itself, since `start /b` does not
detach a handle-holding survivor under wine; ablating the stop flag hangs it.

`glass-pipe-unix` is added to the mutation gate in both workflows — the loop and its constants
moved out of `glass-proc-linux`, which was gated. The check name is unchanged.

## Verified

- Linux: `cargo test --workspace` (90 test binaries), plus `glass-x11` and `glass-wayland` with
  `--include-ignored`; `cargo clippy --workspace --all-targets -- -D warnings`; `cargo fmt --check`
- macOS: on an M4 mini — `glass-pipe-unix` 15/15, `glass-macos` 134 passing. The two
  `default_sandbox_*` failures there are pre-existing and environmental (they need
  `scripts/test-macos.sh`'s fixture setup) and fail identically at the baseline commit
- Windows: `glass-windows` under wine, 86 passing
- Cross-target clippy for `x86_64-apple-darwin` and `x86_64-pc-windows-gnu`

That cross-target run is what caught the one real portability defect: `rustix`'s
`pipe_with(CLOEXEC)` is `pipe2(2)`, which macOS does not have and rustix gates out. The wake is
`std::io::pipe`, which uses `pipe2` on Linux and `pipe` plus `set_cloexec` on macOS.

## Not done here

`Lines::pending` stays unbounded, as `BufRead::lines` was before it. It is the one place this
changeset bounds fds and threads but not memory; capping it is a behavior change #477 does not ask
for.
