### PR TITLE
fix(update): a prerelease above the latest release is 'up to date', not 'the latest release'

### DIFF
--- a/crates/glass-mcp/src/update/mod.rs
+++ b/crates/glass-mcp/src/update/mod.rs
@@ -645,6 +645,26 @@ mod tests {
         assert_eq!(std::fs::read(&exe).unwrap(), b"old");
     }
 
+    /// The apply path's `latest <= current` decision (glass#447) in its non-equal shape: a
+    /// running build that is a prerelease *newer* than the latest release. The render test pins
+    /// the string; this pins the classification itself — the binary must be reported up to date
+    /// and left untouched, not downloaded (the `1.3.0` server below would 404 no asset for
+    /// `1.4.0-rc1`, so a misclassified "update" would fail the run, not just the assert).
+    #[tokio::test]
+    async fn a_prerelease_running_above_the_latest_release_is_up_to_date() {
+        if !apply_path_exists() {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let exe = install(dir.path(), b"old");
+        let asset = release::asset_name("v1.3.0").expect("supported target");
+        let server = FakeRelease::start("v1.3.0", &asset, BODY, &sidecar(&asset));
+        let src = ReleaseSource::with_base(server.base());
+        let out = run(opts(), &src, "1.4.0-rc1", &exe).await.unwrap().outcome;
+        assert!(matches!(out, Outcome::UpToDate), "{out:?}");
+        assert_eq!(std::fs::read(&exe).unwrap(), b"old");
+    }
+
     /// The whole flow, end to end, against the real code path.
     #[tokio::test]
     async fn a_newer_release_replaces_the_binary() {

--- a/crates/glass-mcp/src/update/mod.rs
+++ b/crates/glass-mcp/src/update/mod.rs
@@ -420,8 +420,11 @@ fn render(report: &Report, opts: &Options) -> String {
             "glass-mcp {} is a from-source build; the latest release is {}.\n",
             report.current, latest
         ),
+        // This arm covers `latest <= current`, which is only true when they are equal unless the
+        // running build is a prerelease newer than the latest release — "is the latest release"
+        // would be a claim the code never established in that case, so say "up to date" instead.
         Outcome::Checked | Outcome::UpToDate => {
-            format!("glass-mcp {} is the latest release.\n", report.current)
+            format!("glass-mcp {} is up to date.\n", report.current)
         }
         Outcome::Updated => format!(
             "{} glass-mcp {} → {}\n{}{}",
@@ -1095,6 +1098,42 @@ mod tests {
         assert!(
             !wrong.contains("not a `sha256sum` line"),
             "a sidecar that parsed must not be reported as unreadable: {wrong}"
+        );
+    }
+
+    /// The arm that renders "up to date" covers `latest <= current` — true for an equal build,
+    /// and true for a prerelease running above the latest release. "is the latest release" would
+    /// be false in the latter case, so neither path may make that claim. One render test per path
+    /// pins it (glass#447).
+    #[test]
+    fn up_to_date_does_not_claim_to_be_the_latest_release() {
+        // current == latest: the ordinary up-to-date case.
+        let mut r = report_fixture();
+        r.outcome = Outcome::UpToDate;
+        r.current = "1.4.0".into();
+        r.latest = Some("1.4.0".into());
+        r.update_available = false;
+        let human = render(&r, &plain(false));
+        assert!(human.contains("is up to date"), "the equal case: {human}");
+        assert!(
+            !human.contains("is the latest release"),
+            "must not claim to be the latest release: {human}"
+        );
+
+        // current newer than latest (a prerelease build, the shape glass#447 observed).
+        let mut r = report_fixture();
+        r.outcome = Outcome::Checked;
+        r.current = "1.4.0-rc1".into();
+        r.latest = Some("1.3.0".into());
+        r.update_available = false;
+        let human = render(&r, &plain(false));
+        assert!(
+            human.contains("is up to date"),
+            "the current-newer case: {human}"
+        );
+        assert!(
+            !human.contains("is the latest release"),
+            "a prerelease above the latest release is not the latest release: {human}"
         );
     }
 

--- a/crates/glass-mcp/src/update/mod.rs
+++ b/crates/glass-mcp/src/update/mod.rs
@@ -1121,10 +1121,9 @@ mod tests {
         );
     }
 
-    /// The arm that renders "up to date" covers `latest <= current` — true for an equal build,
-    /// and true for a prerelease running above the latest release. "is the latest release" would
-    /// be false in the latter case, so neither path may make that claim. One render test per path
-    /// pins it (glass#447).
+    /// The glass#447 render pin, one case per shape of `latest <= current`: an equal build and a
+    /// prerelease running above the latest release. Both must render "up to date" and neither may
+    /// claim "is the latest release" (that claim is false in the second case).
     #[test]
     fn up_to_date_does_not_claim_to_be_the_latest_release() {
         // current == latest: the ordinary up-to-date case.


### PR DESCRIPTION
## What this does

The Checked/UpToDate render arm in `glass-mcp update` covers `latest <= current`, which is only true when they are equal unless the running build is a prerelease newer than the latest release (e.g. `1.4.0-rc1` with latest `1.3.0`). That arm printed "glass-mcp {current} **is the latest release**" — a claim the code never established in that case.

The fix subtracts rather than adds a branch: "is **up to date**" is true in both cases and drops no information the JSON does not already carry (`action: checked`, `update_available: false` are true either way). A second arm saying "is newer than the latest release" would be a new claim to keep correct.

A render test pins both paths — current equal to latest, and current above it.

Fixes #447.

--- *— Jcode agent (automated triage), on behalf of @fixed-width*