### PR TITLE
fix(exec-unix): a path glass cannot stat is Unreadable, not Absent

### DIFF
--- a/crates/glass-a11y-linux/src/doctor.rs
+++ b/crates/glass-a11y-linux/src/doctor.rs
@@ -335,6 +335,19 @@ fn a11y_checks(launcher: &Resolved, override_set: bool, facts: &HostA11yFacts) -
         .with_remedy(
             "restore its execute bit (`chmod +x`), or point GLASS_ATSPI_LAUNCHER at a runnable copy",
         ),
+        // A launcher glass could not even stat — a permission, not a missing package (glass#474).
+        Resolved::Unreadable(p, e) => Check::new(
+            "a11y",
+            CheckStatus::Warn,
+            format!(
+                "at-spi-bus-launcher at {} could not be looked at ({e}); it may be installed in \
+                 a location glass cannot read",
+                p.display()
+            ),
+        )
+        .with_remedy(
+            "check that path's permissions, or point GLASS_ATSPI_LAUNCHER at a readable copy",
+        ),
         // An override skips discovery outright, so the well-known paths were never consulted:
         // whatever this host has installed, the variable is what left glass with nothing.
         Resolved::Absent if override_set => Check::new(

--- a/crates/glass-a11y-linux/src/doctor.rs
+++ b/crates/glass-a11y-linux/src/doctor.rs
@@ -335,7 +335,7 @@ fn a11y_checks(launcher: &Resolved, override_set: bool, facts: &HostA11yFacts) -
         .with_remedy(
             "restore its execute bit (`chmod +x`), or point GLASS_ATSPI_LAUNCHER at a runnable copy",
         ),
-        // A launcher glass could not even stat — a permission, not a missing package (glass#474).
+        // A launcher glass could not stat: a permission, not a missing package (glass#474).
         Resolved::Unreadable(p, e) => Check::new(
             "a11y",
             CheckStatus::Warn,

--- a/crates/glass-dbus-linux/src/lib.rs
+++ b/crates/glass-dbus-linux/src/lib.rs
@@ -278,6 +278,7 @@ fn find_launcher_with(
         return resolve_path(Path::new(&p));
     }
     let mut first_non_executable = None;
+    let mut first_unreadable = None;
     // `once_with`, not a plain call: as a `chain` argument the scan would run on every lookup,
     // reading all of /usr/lib even when the first fixed candidate hits.
     let scanned = std::iter::once_with(scan_multiarch).flatten();
@@ -287,12 +288,23 @@ fn find_launcher_with(
             Resolved::NotExecutable(p) => {
                 first_non_executable.get_or_insert(p);
             }
+            // A prefix we could not stat (glass#474): keep walking, but remember it so an
+            // exhausted search names the permission rather than a missing launcher.
+            Resolved::Unreadable(p, e) => {
+                first_unreadable.get_or_insert((p, e));
+            }
             // A candidate is one path, judged on its own: `resolve_path` has no search list to
             // lack, so `NoSearchPath` cannot come from it. Both mean "nothing here" to the walk.
             Resolved::Absent | Resolved::NoSearchPath => {}
         }
     }
-    first_non_executable.map_or(Resolved::Absent, Resolved::NotExecutable)
+    // A runnable or present-but-unrunnable candidate outranks an unreadable prefix.
+    if let Some(p) = first_non_executable {
+        return Resolved::NotExecutable(p);
+    }
+    first_unreadable
+        .map(|(p, e)| Resolved::Unreadable(p, e))
+        .unwrap_or(Resolved::Absent)
 }
 
 /// `<multiarch_root>/<triplet>/at-spi2-core/at-spi-bus-launcher` for every entry under the root.
@@ -373,6 +385,14 @@ fn launcher_or_reason(resolved: Resolved) -> std::result::Result<PathBuf, String
             "at-spi-bus-launcher at {} is not executable",
             p.display()
         )),
+        // The launcher may well be installed — it just could not be stat'd. The remedy names the
+        // permission rather than an install (glass#474).
+        Resolved::Unreadable(p, e) => Err(format!(
+            "at-spi-bus-launcher at {} could not be looked at ({e}); it may be installed in a \
+             location glass cannot read — check that path's permissions, or set \
+             GLASS_ATSPI_LAUNCHER to a readable copy",
+            p.display()
+        )),
         Resolved::Absent => Err(
             "at-spi-bus-launcher not found (install at-spi2-core), or set GLASS_ATSPI_LAUNCHER"
                 .into(),
@@ -416,6 +436,14 @@ fn available_with(
         Resolved::NotExecutable(p) => {
             Err(format!("dbus-daemon at {} is not executable", p.display()))
         }
+        // The binary may be installed in a prefix glass cannot stat — name the permission, not
+        // an install (glass#474).
+        Resolved::Unreadable(p, e) => Err(format!(
+            "dbus-daemon at {} could not be looked at ({e}); it may be installed in a location \
+             glass cannot read — check that path's permissions, or set GLASS_DBUS_DAEMON to a \
+             readable copy",
+            p.display()
+        )),
         Resolved::Absent => Err(format!(
             "dbus-daemon ({dbus}) not found (install dbus, or set GLASS_DBUS_DAEMON to its path)"
         )),

--- a/crates/glass-dbus-linux/src/lib.rs
+++ b/crates/glass-dbus-linux/src/lib.rs
@@ -289,7 +289,7 @@ fn find_launcher_with(
                 first_non_executable.get_or_insert(p);
             }
             // A prefix we could not stat (glass#474): keep walking, but remember it so an
-            // exhausted search names the permission rather than a missing launcher.
+            // exhausted search names the permission.
             Resolved::Unreadable(p, e) => {
                 first_unreadable.get_or_insert((p, e));
             }
@@ -385,8 +385,7 @@ fn launcher_or_reason(resolved: Resolved) -> std::result::Result<PathBuf, String
             "at-spi-bus-launcher at {} is not executable",
             p.display()
         )),
-        // The launcher may well be installed — it just could not be stat'd. The remedy names the
-        // permission rather than an install (glass#474).
+        // The launcher may well be installed — it just could not be stat'd (glass#474).
         Resolved::Unreadable(p, e) => Err(format!(
             "at-spi-bus-launcher at {} could not be looked at ({e}); it may be installed in a \
              location glass cannot read — check that path's permissions, or set \
@@ -436,8 +435,7 @@ fn available_with(
         Resolved::NotExecutable(p) => {
             Err(format!("dbus-daemon at {} is not executable", p.display()))
         }
-        // The binary may be installed in a prefix glass cannot stat — name the permission, not
-        // an install (glass#474).
+        // The binary may be installed in a prefix glass cannot stat (glass#474).
         Resolved::Unreadable(p, e) => Err(format!(
             "dbus-daemon at {} could not be looked at ({e}); it may be installed in a location \
              glass cannot read — check that path's permissions, or set GLASS_DBUS_DAEMON to a \

--- a/crates/glass-exec-unix/src/lib.rs
+++ b/crates/glass-exec-unix/src/lib.rs
@@ -60,7 +60,10 @@ pub fn is_executable_file(p: &Path) -> bool {
 ///
 /// The `NotExecutable` case is the reason this is not an `Option<PathBuf>`: a caller that only
 /// learns "no" cannot tell a missing binary from an installed one whose execute bit is off, and
-/// sends the user to reinstall a package that is already there.
+/// sends the user to reinstall a package that is already there. The `Unreadable` case is the same
+/// harm from a third cause — the path could not be stat'd (e.g. a prefix this process cannot
+/// traverse, a macOS path outside its sandbox) — which the code must name as a permission rather
+/// than an install (glass#474).
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[must_use]
 pub enum Resolved {
@@ -68,6 +71,10 @@ pub enum Resolved {
     Found(PathBuf),
     /// A regular file is there, and this process may not execute it.
     NotExecutable(PathBuf),
+    /// The path could not be looked at at all: `metadata` failed, so neither its presence nor its
+    /// execute bit is knowable. Carries the OS error's message so the remedy can name the
+    /// permission rather than an install.
+    Unreadable(PathBuf, String),
     /// Nothing to point the user at: no such path, a directory, or a path that cannot be stat'd.
     Absent,
     /// A bare name and no `$PATH` to look it up in. Distinct from [`Resolved::Absent`] because the
@@ -91,24 +98,51 @@ pub fn resolve_bin(bin: &str, path: Option<&OsStr>) -> Resolved {
         return Resolved::NoSearchPath;
     };
     let mut first_non_executable = None;
+    let mut first_unreadable = None;
     for cand in std::env::split_paths(path).map(|dir| dir.join(bin)) {
         match resolve_path(&cand) {
             Resolved::Found(p) => return Resolved::Found(p),
             Resolved::NotExecutable(p) => {
                 first_non_executable.get_or_insert(p);
             }
+            // A prefix we could not traverse: keep walking (the binary may be in a later entry),
+            // but remember it so an exhausted search reports the permission, not a missing tool
+            // (glass#474).
+            Resolved::Unreadable(p, e) => {
+                first_unreadable.get_or_insert((p, e));
+            }
             // `resolve_path` judges one path and never wants a search list, so `NoSearchPath`
             // cannot come from it; both mean "nothing here" to the walk.
             Resolved::Absent | Resolved::NoSearchPath => {}
         }
     }
-    first_non_executable.map_or(Resolved::Absent, Resolved::NotExecutable)
+    // A runnable or present-but-unrunnable match outranks an unreadable prefix; only when neither
+    // was seen does the unreadable one become the report.
+    if let Some(p) = first_non_executable {
+        return Resolved::NotExecutable(p);
+    }
+    first_unreadable
+        .map(|(p, e)| Resolved::Unreadable(p, e))
+        .unwrap_or(Resolved::Absent)
 }
 
 /// The verdict on one path, with no `$PATH` search — for a caller holding a single candidate
 /// rather than a name to look up. A directory is [`Resolved::Absent`]: it is not a launch target
 /// however its mode bits read.
+///
+/// A path that cannot even be stat'd is [`Resolved::Unreadable`], not [`Resolved::Absent`]: a
+/// prefix this process cannot traverse (a `0700` directory owned by another user, a macOS path
+/// outside the sandbox, a volume that went away) holds no verdict glass can act on, and naming it
+/// as an install would send the user to fix what is not broken (glass#474).
 pub fn resolve_path(p: &Path) -> Resolved {
+    if let Err(e) = std::fs::metadata(p) {
+        // A clean "nothing is here" is still `Absent`; anything else — a permission error on a
+        // prefix traversal, an IO error on a path that may exist — is `Unreadable`.
+        if e.kind() != std::io::ErrorKind::NotFound {
+            return Resolved::Unreadable(p.to_path_buf(), e.to_string());
+        }
+        return Resolved::Absent;
+    }
     if is_executable_file(p) {
         Resolved::Found(p.to_path_buf())
     } else if p.is_file() {
@@ -381,5 +415,64 @@ mod tests {
             Resolved::Absent,
             "a directory answers X_OK but is not a launch target"
         );
+    }
+
+    /// The defect in glass#474: a prefix this process cannot traverse makes `metadata` fail with
+    /// `EACCES`, which used to fold into `Absent` — "not installed" — and send the user to
+    /// install what is already there. It must come out as `Unreadable`, naming the permission.
+    ///
+    /// Root can traverse a `0o000` directory, so this needs a non-root host (same guard as the
+    /// `a_file_whose_own_class_denies_exec_is_not_executable` test).
+    #[test]
+    fn a_path_glass_cannot_stat_is_unreadable_not_absent() {
+        if rustix::process::geteuid().is_root() {
+            eprintln!("skipped: root can traverse a 0o000 directory, so the EACCES never fires");
+            return;
+        }
+        let dir = tempfile::tempdir().expect("tempdir");
+        // A binary that is actually there, behind a prefix the process may not walk.
+        let bin = dir.path().join("idb_companion");
+        std::fs::write(&bin, b"").expect("write");
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        // Confirm it is reachable while the prefix is open, so the test is not a vacuous pass.
+        assert_eq!(
+            resolve_path(&bin),
+            Resolved::Found(dir.path().join("idb_companion")),
+            "the binary must be runnable before the prefix is locked"
+        );
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o000))
+            .expect("chmod prefix 0o000");
+        let resolved = resolve_path(&bin);
+        assert!(
+            matches!(resolved, Resolved::Unreadable(ref p, _) if p == &bin),
+            "an unreadable prefix must be Unreadable, not Absent: {resolved:?}"
+        );
+        // Restore so the tempdir can be cleaned up.
+        let _ = std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755));
+    }
+
+    /// The `$PATH` walk keeps going past an unreadable prefix and remembers it, so a search that
+    /// finds nothing runnable anywhere reports the permission rather than a missing tool.
+    #[test]
+    fn a_search_past_an_unreadable_prefix_reports_it_rather_than_absent() {
+        if rustix::process::geteuid().is_root() {
+            eprintln!("skipped: root can traverse a 0o000 directory, so the EACCES never fires");
+            return;
+        }
+        let locked = tempfile::tempdir().expect("locked tempdir");
+        // A real binary sits behind the locked prefix, but the prefix will be 0o000.
+        let bin = locked.path().join("Xvfb");
+        std::fs::write(&bin, b"").expect("write");
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        let empty = tempfile::tempdir().expect("empty tempdir");
+        let path = std::env::join_paths([locked.path(), empty.path()]).expect("join paths");
+        std::fs::set_permissions(locked.path(), std::fs::Permissions::from_mode(0o000))
+            .expect("chmod prefix 0o000");
+        let resolved = resolve_bin("Xvfb", Some(&path));
+        assert!(
+            matches!(resolved, Resolved::Unreadable(ref p, _) if p == &locked.path().join("Xvfb")),
+            "an unreadable prefix with no other match must be Unreadable, not Absent: {resolved:?}"
+        );
+        let _ = std::fs::set_permissions(locked.path(), std::fs::Permissions::from_mode(0o755));
     }
 }

--- a/crates/glass-exec-unix/src/lib.rs
+++ b/crates/glass-exec-unix/src/lib.rs
@@ -75,7 +75,8 @@ pub enum Resolved {
     /// execute bit is knowable. Carries the OS error's message so the remedy can name the
     /// permission rather than an install.
     Unreadable(PathBuf, String),
-    /// Nothing to point the user at: no such path, a directory, or a path that cannot be stat'd.
+    /// Nothing to point the user at: no such path, or a directory. A path that cannot be stat'd
+    /// is [`Resolved::Unreadable`], not this — the two send a reader to different remedies.
     Absent,
     /// A bare name and no `$PATH` to look it up in. Distinct from [`Resolved::Absent`] because the
     /// tool may well be installed: what is missing is the environment glass was spawned with.

--- a/crates/glass-exec-unix/src/lib.rs
+++ b/crates/glass-exec-unix/src/lib.rs
@@ -60,10 +60,9 @@ pub fn is_executable_file(p: &Path) -> bool {
 ///
 /// The `NotExecutable` case is the reason this is not an `Option<PathBuf>`: a caller that only
 /// learns "no" cannot tell a missing binary from an installed one whose execute bit is off, and
-/// sends the user to reinstall a package that is already there. The `Unreadable` case is the same
-/// harm from a third cause — the path could not be stat'd (e.g. a prefix this process cannot
-/// traverse, a macOS path outside its sandbox) — which the code must name as a permission rather
-/// than an install (glass#474).
+/// sends the user to reinstall a package that is already there. `Unreadable` is the same harm
+/// from a third cause — the path could not be stat'd — and must be named as a permission, not an
+/// install (glass#474).
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[must_use]
 pub enum Resolved {
@@ -72,11 +71,10 @@ pub enum Resolved {
     /// A regular file is there, and this process may not execute it.
     NotExecutable(PathBuf),
     /// The path could not be looked at at all: `metadata` failed, so neither its presence nor its
-    /// execute bit is knowable. Carries the OS error's message so the remedy can name the
-    /// permission rather than an install.
+    /// execute bit is knowable. Carries the OS error's message for the remedy.
     Unreadable(PathBuf, String),
     /// Nothing to point the user at: no such path, or a directory. A path that cannot be stat'd
-    /// is [`Resolved::Unreadable`], not this — the two send a reader to different remedies.
+    /// is [`Resolved::Unreadable`], not this.
     Absent,
     /// A bare name and no `$PATH` to look it up in. Distinct from [`Resolved::Absent`] because the
     /// tool may well be installed: what is missing is the environment glass was spawned with.
@@ -107,8 +105,7 @@ pub fn resolve_bin(bin: &str, path: Option<&OsStr>) -> Resolved {
                 first_non_executable.get_or_insert(p);
             }
             // A prefix we could not traverse: keep walking (the binary may be in a later entry),
-            // but remember it so an exhausted search reports the permission, not a missing tool
-            // (glass#474).
+            // but remember it for an exhausted search (glass#474).
             Resolved::Unreadable(p, e) => {
                 first_unreadable.get_or_insert((p, e));
             }
@@ -117,8 +114,8 @@ pub fn resolve_bin(bin: &str, path: Option<&OsStr>) -> Resolved {
             Resolved::Absent | Resolved::NoSearchPath => {}
         }
     }
-    // A runnable or present-but-unrunnable match outranks an unreadable prefix; only when neither
-    // was seen does the unreadable one become the report.
+    // A runnable or present-but-unrunnable match outranks an unreadable prefix; the unreadable one
+    // is the report only when neither was seen.
     if let Some(p) = first_non_executable {
         return Resolved::NotExecutable(p);
     }
@@ -131,14 +128,11 @@ pub fn resolve_bin(bin: &str, path: Option<&OsStr>) -> Resolved {
 /// rather than a name to look up. A directory is [`Resolved::Absent`]: it is not a launch target
 /// however its mode bits read.
 ///
-/// A path that cannot even be stat'd is [`Resolved::Unreadable`], not [`Resolved::Absent`]: a
-/// prefix this process cannot traverse (a `0700` directory owned by another user, a macOS path
-/// outside the sandbox, a volume that went away) holds no verdict glass can act on, and naming it
-/// as an install would send the user to fix what is not broken (glass#474).
+/// A path that cannot even be stat'd is [`Resolved::Unreadable`], not [`Resolved::Absent`]: it
+/// holds no verdict glass can act on (glass#474).
 pub fn resolve_path(p: &Path) -> Resolved {
     if let Err(e) = std::fs::metadata(p) {
-        // A clean "nothing is here" is still `Absent`; anything else — a permission error on a
-        // prefix traversal, an IO error on a path that may exist — is `Unreadable`.
+        // A clean "nothing is here" is still `Absent`; any other `metadata` error is `Unreadable`.
         if e.kind() != std::io::ErrorKind::NotFound {
             return Resolved::Unreadable(p.to_path_buf(), e.to_string());
         }
@@ -452,8 +446,8 @@ mod tests {
         let _ = std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755));
     }
 
-    /// The `$PATH` walk keeps going past an unreadable prefix and remembers it, so a search that
-    /// finds nothing runnable anywhere reports the permission rather than a missing tool.
+    /// The `$PATH` walk keeps going past an unreadable prefix and remembers it, so an exhausted
+    /// search reports it rather than [`Resolved::Absent`].
     #[test]
     fn a_search_past_an_unreadable_prefix_reports_it_rather_than_absent() {
         if rustix::process::geteuid().is_root() {

--- a/crates/glass-ios/src/idb/companion.rs
+++ b/crates/glass-ios/src/idb/companion.rs
@@ -57,6 +57,21 @@ impl NoCompanion {
         }
     }
 
+    /// The companion is installed, but glass could not even stat the path (a prefix it cannot
+    /// traverse). A permission to fix, not a package to install (glass#474).
+    fn unreadable(p: &Path, e: &str) -> NoCompanion {
+        NoCompanion {
+            cause: format!(
+                "idb_companion at {} could not be looked at ({e}) — it may be installed where \
+                 glass cannot read it",
+                p.display()
+            ),
+            remedy: "check that path's permissions, or point GLASS_IDB_COMPANION at a readable \
+                     copy"
+                .into(),
+        }
+    }
+
     /// Another install would not be looked at while the override stands.
     fn override_names_nothing() -> NoCompanion {
         NoCompanion {
@@ -135,6 +150,9 @@ impl CompanionFacts {
         match &self.resolved {
             Resolved::Found(p) => Ok(p),
             Resolved::NotExecutable(p) => Err(NoCompanion::not_executable(p)),
+            // The companion may be installed where glass cannot even stat it — a permission, not
+            // an install (glass#474).
+            Resolved::Unreadable(p, e) => Err(NoCompanion::unreadable(p, e)),
             Resolved::Absent if self.override_set => Err(NoCompanion::override_names_nothing()),
             Resolved::Absent => Err(NoCompanion::absent()),
             Resolved::NoSearchPath if self.override_set => {
@@ -161,6 +179,7 @@ fn resolve_companion_with(
         return resolve_bin(&bin, path.as_deref());
     }
     let mut first_unrunnable = None;
+    let mut first_unreadable = None;
     let mut nothing_to_search = false;
     for resolved in std::iter::once(resolve_bin(COMPANION_BIN, path.as_deref()))
         .chain(fallbacks.iter().map(|c| resolve_path(Path::new(c))))
@@ -170,19 +189,27 @@ fn resolve_companion_with(
             Resolved::NotExecutable(p) => {
                 first_unrunnable.get_or_insert(p);
             }
+            // A prefix glass could not stat (glass#474): remember it, but a runnable or
+            // present-but-unrunnable copy in a later entry still outranks it.
+            Resolved::Unreadable(p, e) => {
+                first_unreadable.get_or_insert((p, e));
+            }
             // Only the `$PATH` walk can lack a search list; a fallback is one fixed path.
             Resolved::NoSearchPath => nothing_to_search = true,
             Resolved::Absent => {}
         }
     }
-    match (first_unrunnable, nothing_to_search) {
-        // A file the user can act on outranks the missing search list, and the remedy's second
-        // clause covers a copy that a `$PATH` would have found.
-        (Some(p), _) => Resolved::NotExecutable(p),
+    match (first_unrunnable, first_unreadable, nothing_to_search) {
+        // A file the user can act on outranks an unreadable prefix and the missing search list;
+        // the remedy's second clause covers a copy that a `$PATH` would have found.
+        (Some(p), _, _) => Resolved::NotExecutable(p),
+        // No runnable/unrunnable file, but a prefix glass could not stat: name the permission
+        // rather than the install (glass#474).
+        (None, Some((p, e)), _) => Resolved::Unreadable(p, e),
         // No `$PATH` to walk and nothing in the standard prefixes: the companion may well be
         // installed somewhere glass was never told to look (glass#373).
-        (None, true) => Resolved::NoSearchPath,
-        (None, false) => Resolved::Absent,
+        (None, None, true) => Resolved::NoSearchPath,
+        (None, None, false) => Resolved::Absent,
     }
 }
 

--- a/crates/glass-ios/src/idb/companion.rs
+++ b/crates/glass-ios/src/idb/companion.rs
@@ -57,8 +57,8 @@ impl NoCompanion {
         }
     }
 
-    /// The companion is installed, but glass could not even stat the path (a prefix it cannot
-    /// traverse). A permission to fix, not a package to install (glass#474).
+    /// The companion is installed, but glass could not stat the path (a prefix it cannot
+    /// traverse): a permission to fix, not a package to install (glass#474).
     fn unreadable(p: &Path, e: &str) -> NoCompanion {
         NoCompanion {
             cause: format!(
@@ -150,8 +150,8 @@ impl CompanionFacts {
         match &self.resolved {
             Resolved::Found(p) => Ok(p),
             Resolved::NotExecutable(p) => Err(NoCompanion::not_executable(p)),
-            // The companion may be installed where glass cannot even stat it — a permission, not
-            // an install (glass#474).
+            // The companion may be installed where glass cannot stat it: a permission, not an
+            // install (glass#474).
             Resolved::Unreadable(p, e) => Err(NoCompanion::unreadable(p, e)),
             Resolved::Absent if self.override_set => Err(NoCompanion::override_names_nothing()),
             Resolved::Absent => Err(NoCompanion::absent()),
@@ -189,8 +189,8 @@ fn resolve_companion_with(
             Resolved::NotExecutable(p) => {
                 first_unrunnable.get_or_insert(p);
             }
-            // A prefix glass could not stat (glass#474): remember it, but a runnable or
-            // present-but-unrunnable copy in a later entry still outranks it.
+            // A prefix glass could not stat (glass#474): a later runnable or
+            // present-but-unrunnable copy still outranks it.
             Resolved::Unreadable(p, e) => {
                 first_unreadable.get_or_insert((p, e));
             }
@@ -201,10 +201,10 @@ fn resolve_companion_with(
     }
     match (first_unrunnable, first_unreadable, nothing_to_search) {
         // A file the user can act on outranks an unreadable prefix and the missing search list;
-        // the remedy's second clause covers a copy that a `$PATH` would have found.
+        // the remedy's second clause covers a copy a `$PATH` would have found.
         (Some(p), _, _) => Resolved::NotExecutable(p),
-        // No runnable/unrunnable file, but a prefix glass could not stat: name the permission
-        // rather than the install (glass#474).
+        // No runnable or unrunnable file, but a prefix glass could not stat: name the permission
+        // (glass#474).
         (None, Some((p, e)), _) => Resolved::Unreadable(p, e),
         // No `$PATH` to walk and nothing in the standard prefixes: the companion may well be
         // installed somewhere glass was never told to look (glass#373).

--- a/crates/glass-sandbox-linux/src/lib.rs
+++ b/crates/glass-sandbox-linux/src/lib.rs
@@ -354,6 +354,9 @@ enum NoSandbox {
     Missing(String),
     /// A bare `bwrap` and no `$PATH` to look it up in, so nothing says whether it is installed.
     NotLookedUp(String),
+    /// The configured `bwrap` path could not even be stat'd (a prefix this process cannot
+    /// traverse): a permission, not a missing package (glass#474).
+    Unreadable(String),
     /// bwrap ran and exited non-zero, including without saying why.
     Refused(String),
     /// bwrap had not exited when its budget ran out, so it was sent SIGKILL — which one wedged in
@@ -369,6 +372,9 @@ const INSTALL_BWRAP: &str = "install `bubblewrap`, or point GLASS_BWRAP at a cop
      execute; or run with sandbox:\"off\" (GLASS_SANDBOX=off) to launch unconfined";
 const NAME_BWRAP: &str = "point GLASS_BWRAP at bubblewrap's absolute path, or start glass with a \
      PATH to search; or run with sandbox:\"off\" (GLASS_SANDBOX=off) to launch unconfined";
+const READ_BWRAP: &str = "bubblewrap is there but glass could not read that path — check its \
+     permissions, or point GLASS_BWRAP at a readable copy; or run with sandbox:\"off\" \
+     (GLASS_SANDBOX=off) to launch unconfined";
 const CHECK_THE_MOUNTS: &str = "the probe read-only-binds the whole root, so a mount that has \
      stopped responding (an unreachable network filesystem) can hold it there; check for one, or \
      run with sandbox:\"off\" (GLASS_SANDBOX=off) to launch unconfined";
@@ -380,6 +386,7 @@ impl NoSandbox {
         match self {
             NoSandbox::Missing(why)
             | NoSandbox::NotLookedUp(why)
+            | NoSandbox::Unreadable(why)
             | NoSandbox::Refused(why)
             | NoSandbox::TimedOut(why)
             | NoSandbox::Unfinished(why) => why,
@@ -392,6 +399,7 @@ impl NoSandbox {
         match self {
             NoSandbox::Missing(_) => INSTALL_BWRAP,
             NoSandbox::NotLookedUp(_) => NAME_BWRAP,
+            NoSandbox::Unreadable(_) => READ_BWRAP,
             NoSandbox::Refused(_) => refusal_remedy(apparmor_restricted),
             NoSandbox::TimedOut(_) => CHECK_THE_MOUNTS,
             NoSandbox::Unfinished(_) => NOTHING_LEARNED,
@@ -422,6 +430,12 @@ fn resolved_bwrap(bin: &str, bwrap: Resolved) -> std::result::Result<PathBuf, No
         Resolved::Found(p) => Ok(p),
         Resolved::NotExecutable(p) => Err(NoSandbox::Missing(format!(
             "bubblewrap ({}) is not executable",
+            p.display()
+        ))),
+        // The binary may be installed in a prefix glass cannot stat — a permission, not an install
+        // (glass#474).
+        Resolved::Unreadable(p, e) => Err(NoSandbox::Unreadable(format!(
+            "bubblewrap at {} could not be looked at ({e})",
             p.display()
         ))),
         Resolved::Absent => Err(NoSandbox::Missing(format!("bubblewrap ({bin}) not found"))),

--- a/crates/glass-sandbox-linux/src/lib.rs
+++ b/crates/glass-sandbox-linux/src/lib.rs
@@ -354,8 +354,8 @@ enum NoSandbox {
     Missing(String),
     /// A bare `bwrap` and no `$PATH` to look it up in, so nothing says whether it is installed.
     NotLookedUp(String),
-    /// The configured `bwrap` path could not even be stat'd (a prefix this process cannot
-    /// traverse): a permission, not a missing package (glass#474).
+    /// The configured `bwrap` path could not be stat'd (a prefix this process cannot traverse):
+    /// a permission, not a missing package (glass#474).
     Unreadable(String),
     /// bwrap ran and exited non-zero, including without saying why.
     Refused(String),
@@ -432,8 +432,7 @@ fn resolved_bwrap(bin: &str, bwrap: Resolved) -> std::result::Result<PathBuf, No
             "bubblewrap ({}) is not executable",
             p.display()
         ))),
-        // The binary may be installed in a prefix glass cannot stat — a permission, not an install
-        // (glass#474).
+        // The binary may be installed in a prefix glass cannot stat (glass#474).
         Resolved::Unreadable(p, e) => Err(NoSandbox::Unreadable(format!(
             "bubblewrap at {} could not be looked at ({e})",
             p.display()

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -348,8 +348,7 @@ fn sway_verdict(
             "{} is not executable",
             p.display()
         ))),
-        // A bundled sway glass could not even stat — a permission, not a missing build
-        // (glass#474).
+        // A bundled sway glass could not even stat: a permission, not a missing build (glass#474).
         Resolved::Unreadable(p, e) => Err(NoSway {
             cause: format!(
                 "the bundled sway at {} could not be looked at ({e}) — it may be installed where \
@@ -366,8 +365,7 @@ fn sway_verdict(
             Some(PathWalk {
                 silent: Some(no), ..
             }) => no,
-            // A prefix the walk could not even look into outranks "no sway found": the binary may
-            // well be there, and the fix is a permission, not a build (glass#474).
+            // A prefix the walk could not even look into outranks "no sway found" (glass#474).
             Some(PathWalk {
                 unreadable: Some((p, e)),
                 ..
@@ -404,8 +402,8 @@ fn sway_bundle_in(data: Option<PathBuf>, exe_dir: Option<PathBuf>) -> Resolved {
             Resolved::NotExecutable(p) => {
                 first_non_executable.get_or_insert(p);
             }
-            // A bundle root glass could not stat (glass#474): remember it, but a runnable or
-            // present-but-unrunnable copy in a later root still outranks it.
+            // A bundle root glass could not stat (glass#474): a later runnable or
+            // present-but-unrunnable copy still outranks it.
             Resolved::Unreadable(p, e) => {
                 first_unreadable.get_or_insert((p, e));
             }
@@ -431,8 +429,8 @@ fn sway_override(
     value: Option<std::ffi::OsString>,
 ) -> Option<std::result::Result<PathBuf, NoSway>> {
     let p = PathBuf::from(value.filter(|s| !s.is_empty())?);
-    // `resolve_path`, not `is_executable_file`, so a path glass cannot even stat (a prefix outside
-    // the sandbox) is named as a permission rather than as "not executable" (glass#474).
+    // `resolve_path`, not `is_executable_file`, so a path glass cannot even stat is named as a
+    // permission, not "not executable" (glass#474).
     Some(match resolve_path(&p) {
         Resolved::Found(p) => Ok(p),
         Resolved::NotExecutable(p) => Err(NoSway::not_runnable(format!(
@@ -447,9 +445,8 @@ fn sway_override(
             ),
             remedy: MAKE_IT_RUNNABLE,
         }),
-        // `NoSearchPath` cannot come from `resolve_path`, which judges one path and never wants
-        // a search list; it is named for uniformity. A path that is a directory answers `Absent`,
-        // so keep the old "not an executable file" verdict for both.
+        // `NoSearchPath` cannot come from `resolve_path`, which judges one path; a directory
+        // answers `Absent`, so both keep the old "not an executable file" verdict.
         Resolved::Absent | Resolved::NoSearchPath => Err(NoSway::not_runnable(format!(
             "GLASS_SWAY={} is not an executable file",
             p.display()
@@ -500,12 +497,9 @@ pub(crate) fn ask_sway_version(sway: &Path, budget: Duration) -> VersionAnswer {
     }
 }
 
-/// The outcome of walking `PATH`: the sway to use, the first candidate that was there and
-/// gave no answer, and the first entry the walk could not even look into.
-///
-/// `silent` is kept so a walk that ends empty can name that candidate rather than report no
-/// sway. `unreadable` is the same from a permission: a `sway` the walk could not stat is not
-/// "no sway found" (glass#474), so it is remembered and reported when nothing qualified.
+/// The outcome of walking `PATH`: the sway to use, the first candidate that was there and gave no
+/// answer, and the first entry the walk could not look into — `unreadable`, the same from a
+/// permission, remembered so an empty walk can report it (glass#474).
 #[derive(Debug, Default, PartialEq, Eq)]
 struct PathWalk {
     found: Option<PathBuf>,
@@ -526,15 +520,14 @@ fn sway_in_dirs(dirs: impl Iterator<Item = PathBuf>, budget: Duration) -> PathWa
     let mut walk = PathWalk::default();
     for dir in dirs {
         let cand = dir.join("sway");
-        // `resolve_path`, not `is_executable_file`, so a candidate glass cannot even stat
-        // (a prefix outside the sandbox) is reported as a permission, not skipped as if it
-        // were not there (glass#474).
+        // `resolve_path`, not `is_executable_file`, so a candidate glass cannot stat is reported
+        // as a permission, not skipped as if it were not there (glass#474).
         match resolve_path(&cand) {
             Resolved::Found(_) => {}
             Resolved::NotExecutable(_) => continue,
             Resolved::Unreadable(p, e) => {
-                // A later entry may still hold a sway; the permission is reported only if the
-                // whole walk comes back empty.
+                // A later entry may still hold a sway; report the permission only if the walk
+                // comes back empty.
                 walk.unreadable.get_or_insert((p, e));
                 continue;
             }
@@ -3099,8 +3092,8 @@ mod pure_tests {
     }
 
     /// The verdict for a walk that could not stat any `$PATH` entry: the permission is named
-    /// rather than "no sway found" — the fix is the permission, not a build (glass#474). A
-    /// candidate that actually ran (silent) still outranks the permission.
+    /// rather than "no sway found" (glass#474); a candidate that actually ran (silent) still
+    /// outranks it.
     #[test]
     fn an_unreadable_path_walk_outranks_nothing_qualifies() {
         let unreadable = Some((
@@ -3147,9 +3140,10 @@ mod pure_tests {
         assert_eq!(no.remedy, CHECK_THAT_SWAY);
     }
 
-    /// A `$PATH` entry glass cannot even stat must not silently drop the sway it holds: the walk
-    /// records the permission and the verdict reports it. Root can traverse a `0o000` directory,
-    /// so the EACCES needs a non-root host (same guard as the `resolve_bin` permission test).
+    /// A `$PATH` entry glass cannot stat must not silently drop the sway it holds: the walk
+    /// records the permission and the verdict reports it (glass#474). Root can traverse a
+    /// `0o000` directory, so this needs a non-root host (same guard as the `resolve_bin`
+    /// permission test).
     #[test]
     fn a_path_prefix_the_walk_cannot_stat_is_named_not_skipped() {
         if rustix::process::geteuid().is_root() {

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -10,7 +10,7 @@ use glass_core::{
     AppSpec, Frame, GlassError, KeyEvent, Platform, PointerEvent, Region, Result, Stream,
     TEARDOWN_BUDGET, WindowGeometry, WindowId, WindowInfo, WindowOp,
 };
-use glass_exec_unix::{Resolved, is_executable_file, resolve_path};
+use glass_exec_unix::{Resolved, resolve_path};
 use glass_pipe_unix::LineTap;
 use glass_proc_linux::{APP_REAP_GRACE, Asked, CLOSE_GRACE};
 use smithay_client_toolkit::delegate_dispatch2;
@@ -363,7 +363,23 @@ fn sway_verdict(
         Resolved::Absent | Resolved::NoSearchPath => Err(match walk {
             // A silent candidate on PATH outranks "nothing qualifies" — telling the user to build
             // one sends them past the sway they have.
-            Some(walked) => walked.silent.unwrap_or_else(NoSway::nothing_qualifies),
+            Some(PathWalk {
+                silent: Some(no), ..
+            }) => no,
+            // A prefix the walk could not even look into outranks "no sway found": the binary may
+            // well be there, and the fix is a permission, not a build (glass#474).
+            Some(PathWalk {
+                unreadable: Some((p, e)),
+                ..
+            }) => NoSway {
+                cause: format!(
+                    "the sway at {} could not be looked at ({e}) — it may be installed where \
+                     glass cannot read it",
+                    p.display()
+                ),
+                remedy: MAKE_IT_RUNNABLE,
+            },
+            Some(_) => NoSway::nothing_qualifies(),
             None => NoSway::no_search_path(),
         }),
     }
@@ -431,8 +447,9 @@ fn sway_override(
             ),
             remedy: MAKE_IT_RUNNABLE,
         }),
-        // `Absent` and `NoSearchPath` cannot come from a path that contains `/`, but an override
-        // that is a directory answers `Absent` — keep the old "not an executable file" verdict.
+        // `NoSearchPath` cannot come from `resolve_path`, which judges one path and never wants
+        // a search list; it is named for uniformity. A path that is a directory answers `Absent`,
+        // so keep the old "not an executable file" verdict for both.
         Resolved::Absent | Resolved::NoSearchPath => Err(NoSway::not_runnable(format!(
             "GLASS_SWAY={} is not an executable file",
             p.display()
@@ -483,14 +500,17 @@ pub(crate) fn ask_sway_version(sway: &Path, budget: Duration) -> VersionAnswer {
     }
 }
 
-/// The outcome of walking `PATH`: the sway to use, and the first candidate that was there and
-/// gave no answer.
+/// The outcome of walking `PATH`: the sway to use, the first candidate that was there and
+/// gave no answer, and the first entry the walk could not even look into.
 ///
-/// The second field is kept so a walk that ends empty can name it rather than report no sway.
+/// `silent` is kept so a walk that ends empty can name that candidate rather than report no
+/// sway. `unreadable` is the same from a permission: a `sway` the walk could not stat is not
+/// "no sway found" (glass#474), so it is remembered and reported when nothing qualified.
 #[derive(Debug, Default, PartialEq, Eq)]
 struct PathWalk {
     found: Option<PathBuf>,
     silent: Option<NoSway>,
+    unreadable: Option<(PathBuf, String)>,
 }
 
 /// The first `sway` in `dirs` whose `--version` reports >= 1.12.
@@ -506,8 +526,19 @@ fn sway_in_dirs(dirs: impl Iterator<Item = PathBuf>, budget: Duration) -> PathWa
     let mut walk = PathWalk::default();
     for dir in dirs {
         let cand = dir.join("sway");
-        if !is_executable_file(&cand) {
-            continue;
+        // `resolve_path`, not `is_executable_file`, so a candidate glass cannot even stat
+        // (a prefix outside the sandbox) is reported as a permission, not skipped as if it
+        // were not there (glass#474).
+        match resolve_path(&cand) {
+            Resolved::Found(_) => {}
+            Resolved::NotExecutable(_) => continue,
+            Resolved::Unreadable(p, e) => {
+                // A later entry may still hold a sway; the permission is reported only if the
+                // whole walk comes back empty.
+                walk.unreadable.get_or_insert((p, e));
+                continue;
+            }
+            Resolved::Absent | Resolved::NoSearchPath => continue,
         }
         let why = match ask_sway_version(&cand, budget) {
             VersionAnswer::Answered(ver) => {
@@ -2232,6 +2263,7 @@ mod pure_tests {
 
     use super::*;
     use crate::testw::on_a_thread;
+    use glass_exec_unix::is_executable_file;
 
     /// The budget the pure waits below are given. `on_a_thread` allows a multiple of it, so a lost
     /// bound fails the test rather than hanging the suite.
@@ -3058,11 +3090,84 @@ mod pure_tests {
         let walk = PathWalk {
             found: Some(PathBuf::from("/usr/bin/sway")),
             silent: None,
+            unreadable: None,
         };
         let found = sway_verdict(Some(walk), || {
             panic!("the bundle must not be looked for once PATH has answered")
         });
         assert_eq!(found, Ok(PathBuf::from("/usr/bin/sway")));
+    }
+
+    /// The verdict for a walk that could not stat any `$PATH` entry: the permission is named
+    /// rather than "no sway found" — the fix is the permission, not a build (glass#474). A
+    /// candidate that actually ran (silent) still outranks the permission.
+    #[test]
+    fn an_unreadable_path_walk_outranks_nothing_qualifies() {
+        let unreadable = Some((
+            PathBuf::from("/usr/sway/bin/sway"),
+            "Permission denied (os error 13)".to_string(),
+        ));
+        let no = sway_verdict(
+            Some(PathWalk {
+                found: None,
+                silent: None,
+                unreadable,
+            }),
+            || Resolved::Absent,
+        )
+        .expect_err("nothing runnable");
+        assert!(no.cause.contains("/usr/sway/bin/sway"), "{}", no.message());
+        assert!(
+            no.cause.contains("could not be looked at"),
+            "{}",
+            no.message()
+        );
+        assert_eq!(no.remedy, MAKE_IT_RUNNABLE);
+
+        let no = sway_verdict(
+            Some(PathWalk {
+                found: None,
+                silent: Some(NoSway::silent(
+                    Path::new("/usr/bin/sway"),
+                    "it ran and said nothing",
+                )),
+                unreadable: Some((
+                    PathBuf::from("/usr/sway/bin/sway"),
+                    "Permission denied (os error 13)".to_string(),
+                )),
+            }),
+            || Resolved::Absent,
+        )
+        .expect_err("nothing runnable");
+        assert!(
+            no.cause.contains("/usr/bin/sway"),
+            "the running sway outranks the permission: {}",
+            no.message()
+        );
+        assert_eq!(no.remedy, CHECK_THAT_SWAY);
+    }
+
+    /// A `$PATH` entry glass cannot even stat must not silently drop the sway it holds: the walk
+    /// records the permission and the verdict reports it. Root can traverse a `0o000` directory,
+    /// so the EACCES needs a non-root host (same guard as the `resolve_bin` permission test).
+    #[test]
+    fn a_path_prefix_the_walk_cannot_stat_is_named_not_skipped() {
+        if rustix::process::geteuid().is_root() {
+            eprintln!("skipped: root can traverse a 0o000 directory, so the EACCES never fires");
+            return;
+        }
+        let _guard = one_spawner_at_a_time();
+        let dir = fake_sway("sway version 1.12-abc (Jun 3 2026)");
+        let prefix = dir.path().to_path_buf();
+        std::fs::set_permissions(&prefix, std::fs::Permissions::from_mode(0o000)).expect("chmod");
+        let walk = sway_in(&[dir.path()]);
+        std::fs::set_permissions(&prefix, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        let Some((p, e)) = walk.unreadable else {
+            panic!("the walk cannot stat {prefix:?}, so it must record the permission");
+        };
+        assert_eq!(p, prefix.join("sway"));
+        assert!(e.contains("Permission denied"), "{e}");
+        assert!(walk.found.is_none());
     }
 
     /// The launch path gets one string where doctor gets two columns, so it must carry both.

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -348,6 +348,16 @@ fn sway_verdict(
             "{} is not executable",
             p.display()
         ))),
+        // A bundled sway glass could not even stat — a permission, not a missing build
+        // (glass#474).
+        Resolved::Unreadable(p, e) => Err(NoSway {
+            cause: format!(
+                "the bundled sway at {} could not be looked at ({e}) — it may be installed where \
+                 glass cannot read it",
+                p.display()
+            ),
+            remedy: MAKE_IT_RUNNABLE,
+        }),
         // `NoSearchPath` cannot come from the bundle lookup, which walks fixed paths; both mean
         // there is no bundle to fall back to.
         Resolved::Absent | Resolved::NoSearchPath => Err(match walk {
@@ -371,18 +381,29 @@ fn sway_bundle_in(data: Option<PathBuf>, exe_dir: Option<PathBuf>) -> Resolved {
         exe_dir.map(|d| d.join("sway/bin/sway")),
     ];
     let mut first_non_executable = None;
+    let mut first_unreadable = None;
     for cand in candidates.into_iter().flatten() {
         match resolve_path(&cand) {
             Resolved::Found(p) => return Resolved::Found(p),
             Resolved::NotExecutable(p) => {
                 first_non_executable.get_or_insert(p);
             }
+            // A bundle root glass could not stat (glass#474): remember it, but a runnable or
+            // present-but-unrunnable copy in a later root still outranks it.
+            Resolved::Unreadable(p, e) => {
+                first_unreadable.get_or_insert((p, e));
+            }
             // Each candidate is one path, judged on its own: `resolve_path` has no search list
             // to lack, so `NoSearchPath` cannot come from it. Both mean "nothing here".
             Resolved::Absent | Resolved::NoSearchPath => {}
         }
     }
-    first_non_executable.map_or(Resolved::Absent, Resolved::NotExecutable)
+    if let Some(p) = first_non_executable {
+        return Resolved::NotExecutable(p);
+    }
+    first_unreadable
+        .map(|(p, e)| Resolved::Unreadable(p, e))
+        .unwrap_or(Resolved::Absent)
 }
 
 /// What `GLASS_SWAY` decides, or `None` when it is unset or empty and discovery should run.
@@ -394,13 +415,28 @@ fn sway_override(
     value: Option<std::ffi::OsString>,
 ) -> Option<std::result::Result<PathBuf, NoSway>> {
     let p = PathBuf::from(value.filter(|s| !s.is_empty())?);
-    Some(if is_executable_file(&p) {
-        Ok(p)
-    } else {
-        Err(NoSway::not_runnable(format!(
+    // `resolve_path`, not `is_executable_file`, so a path glass cannot even stat (a prefix outside
+    // the sandbox) is named as a permission rather than as "not executable" (glass#474).
+    Some(match resolve_path(&p) {
+        Resolved::Found(p) => Ok(p),
+        Resolved::NotExecutable(p) => Err(NoSway::not_runnable(format!(
             "GLASS_SWAY={} is not an executable file",
             p.display()
-        )))
+        ))),
+        Resolved::Unreadable(p, e) => Err(NoSway {
+            cause: format!(
+                "GLASS_SWAY={} could not be looked at ({e}) — it may point at a location glass \
+                 cannot read",
+                p.display()
+            ),
+            remedy: MAKE_IT_RUNNABLE,
+        }),
+        // `Absent` and `NoSearchPath` cannot come from a path that contains `/`, but an override
+        // that is a directory answers `Absent` — keep the old "not an executable file" verdict.
+        Resolved::Absent | Resolved::NoSearchPath => Err(NoSway::not_runnable(format!(
+            "GLASS_SWAY={} is not an executable file",
+            p.display()
+        ))),
     })
 }
 

--- a/crates/glass-x11/src/doctor.rs
+++ b/crates/glass-x11/src/doctor.rs
@@ -101,7 +101,7 @@ fn xvfb_check(xvfb: &Resolved) -> Check {
             "chmod +x {}, or point GLASS_XVFB at a runnable binary",
             p.display()
         )),
-        // Xvfb is there but glass could not even stat it — a permission, not an install
+        // Xvfb may be present, but glass could not stat it: a permission, not an install
         // (glass#474).
         Resolved::Unreadable(p, e) => Check::new(
             "Xvfb",

--- a/crates/glass-x11/src/doctor.rs
+++ b/crates/glass-x11/src/doctor.rs
@@ -101,6 +101,17 @@ fn xvfb_check(xvfb: &Resolved) -> Check {
             "chmod +x {}, or point GLASS_XVFB at a runnable binary",
             p.display()
         )),
+        // Xvfb is there but glass could not even stat it — a permission, not an install
+        // (glass#474).
+        Resolved::Unreadable(p, e) => Check::new(
+            "Xvfb",
+            CheckStatus::Fail,
+            format!(
+                "{} — could not be looked at ({e}); it may be installed where glass cannot read it",
+                p.display()
+            ),
+        )
+        .with_remedy("check that path's permissions, or point GLASS_XVFB at a readable copy"),
         Resolved::Absent => Check::new("Xvfb", CheckStatus::Fail, "not found").with_remedy(
             "install it (e.g. `apt install xvfb`), set GLASS_XVFB to its path, or set \
              GLASS_DISPLAY=:N to attach to an existing display",


### PR DESCRIPTION
## What this does

`resolve_path` folded every `metadata()` failure into `Resolved::Absent`, so a prefix the process cannot traverse (a `0700` dir owned by another user, a macOS path outside the sandbox, a volume that went away) read as "not installed" and every consumer prescribed an install — the same harm as #393 and #374, from a third cause the crate's own doc did not yet model.

The fix adds a `Resolved::Unreadable(PathBuf, String)` variant carrying the OS error, so the remedy can name the permission rather than an install. Every consumer's match is exhaustive with no wildcard arm, so adding one is a compile error at each site rather than a silent fold — the same property that made the `NoSearchPath` addition in #373 safe.

- **exec-unix**: `resolve_path` returns `Unreadable` on a metadata error that is not a clean NotFound; `resolve_bin` tracks it so a runnable or present-but-unrunnable match still outranks an unreadable prefix.
- **Consumers** name the permission instead of the install: dbus-linux launcher/dbus, a11y-linux doctor, sandbox-linux bwrap (own `NoSandbox::Unreadable` + remedy), wayland sway (bundle + override), x11 Xvfb, ios idb_companion.
- New exec-unix tests pin an EACCES-on-traversal prefix as `Unreadable` for a single path and for a $PATH walk.

Verified: `cargo build --workspace --all-targets`, `cargo clippy --workspace --all-targets`, and the affected crates' unit tests all pass on Linux (the macOS/Windows paths compile but their failure modes need a host to observe, as the issue notes).

Fixes #474.

--- *— Jcode agent (automated triage), on behalf of @fixed-width*