### PR TITLE
fix(wayland): the Mesa check reads the host's own multiarch triplet dirs

### DIFF
--- a/crates/glass-wayland/src/doctor.rs
+++ b/crates/glass-wayland/src/doctor.rs
@@ -21,7 +21,8 @@ use crate::swayipc::Ipc;
 /// a headless sway to prove it actually starts.
 pub fn checks(deep: bool) -> Vec<Check> {
     let sway = discover_sway();
-    let gl = gl_present_in(EGL_SONAMES, DRI_DIRS);
+    let (egl_sonames, dri_dirs) = mesa_candidates();
+    let gl = gl_present_in(&egl_sonames, &dri_dirs);
     let deep_spawn = match (deep, &sway) {
         (true, Ok((path, _))) => Some(probe_sway(path)),
         _ => None,
@@ -263,25 +264,50 @@ fn sway_check(path: &Path, answer: &VersionAnswer) -> Check {
     }
 }
 
-/// Where a distro puts libEGL.
-const EGL_SONAMES: &[&str] = &[
-    "/usr/lib/x86_64-linux-gnu/libEGL.so.1",
-    "/usr/lib/libEGL.so.1",
-    "/lib/x86_64-linux-gnu/libEGL.so.1",
-    "/usr/lib64/libEGL.so.1",
-];
-/// Where a distro puts the Mesa DRI drivers.
-const DRI_DIRS: &[&str] = &[
-    "/usr/lib/x86_64-linux-gnu/dri",
-    "/usr/lib/dri",
-    "/usr/lib64/dri",
-];
+/// Where a distro puts libEGL — the layouts that are not arch-specific. The Debian multiarch
+/// layout (one triplet subdirectory, `x86_64-linux-gnu`/`aarch64-linux-gnu`/…) is added at
+/// runtime from the host's own triplets, so the check works on every architecture rather than
+/// only x86_64 (glass#468).
+const EGL_SONAMES: &[&str] = &["/usr/lib/libEGL.so.1", "/usr/lib64/libEGL.so.1"];
+/// Where a distro puts the Mesa DRI drivers — likewise, with the multiarch `dri` dirs added
+/// at runtime from the host's own triplets.
+const DRI_DIRS: &[&str] = &["/usr/lib/dri", "/usr/lib64/dri"];
+/// The Debian-family multiarch roots, each holding one subdirectory per installed architecture.
+const MULTIARCH_ROOTS: &[&str] = &["/usr/lib", "/lib"];
+
+/// The Mesa paths the check should look in: the distro layouts above, plus the Debian multiarch
+/// layout for each architecture the host actually has. Built from the directories under the
+/// multiarch root instead of naming one triplet, so an `aarch64` host finds its own
+/// `/usr/lib/aarch64-linux-gnu/` rather than being sent to install a package it has (glass#468).
+fn mesa_candidates() -> (Vec<String>, Vec<String>) {
+    let mut egl = EGL_SONAMES
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<Vec<_>>();
+    let mut dri = DRI_DIRS.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+    for root in MULTIARCH_ROOTS {
+        let Ok(entries) = std::fs::read_dir(root) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let Some(name) = entry.file_name().into_string().ok() else {
+                continue;
+            };
+            if !name.ends_with("-linux-gnu") {
+                continue;
+            }
+            egl.push(format!("{root}/{name}/libEGL.so.1"));
+            dri.push(format!("{root}/{name}/dri"));
+        }
+    }
+    (egl, dri)
+}
 
 /// Heuristic check for the host Mesa software-GL stack the headless sway needs.
 ///
 /// Both halves must be present — a loader cannot render without a driver, or a driver be reached
 /// without the loader. Either swrast name counts: a host may carry only one.
-fn gl_present_in(egl_sonames: &[&str], dri_dirs: &[&str]) -> bool {
+fn gl_present_in(egl_sonames: &[String], dri_dirs: &[String]) -> bool {
     let egl = egl_sonames.iter().any(|p| Path::new(p).exists());
     let swrast = dri_dirs.iter().any(|d| {
         let d = Path::new(d);
@@ -595,9 +621,42 @@ mod tests {
 
     fn gl_present_for(egl: bool, dri: Option<&str>) -> bool {
         let (_root, egls, dris) = gl_tree(egl, dri);
-        let egls: Vec<&str> = egls.iter().map(String::as_str).collect();
-        let dris: Vec<&str> = dris.iter().map(String::as_str).collect();
         gl_present_in(&egls, &dris)
+    }
+
+    /// The multiarch half of glass#468: a `aarch64` (or any non-x86_64) host puts its Mesa under
+    /// `<root>/<triplet>/`, and the old check named only `x86_64-linux-gnu`. `mesa_candidates`
+    /// must add the triplet dir it finds under the multiarch roots, so the check is
+    /// architecture-neutral rather than x86_64-only.
+    #[test]
+    fn mesa_candidates_add_the_multiarch_triplet_dirs_the_host_has() {
+        let (egl, dri) = mesa_candidates();
+        // The architecture-independent layouts are always present.
+        assert!(egl.contains(&"/usr/lib/libEGL.so.1".to_string()));
+        assert!(dri.contains(&"/usr/lib/dri".to_string()));
+        // And for every `<root>/<arch>-linux-gnu` directory on this host, the arch-specific
+        // layout is included too — which is what the old constant list failed to do on aarch64.
+        for root in MULTIARCH_ROOTS {
+            let Ok(entries) = std::fs::read_dir(root) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let Some(name) = entry.file_name().into_string().ok() else {
+                    continue;
+                };
+                if !name.ends_with("-linux-gnu") {
+                    continue;
+                }
+                assert!(
+                    egl.contains(&format!("{root}/{name}/libEGL.so.1")),
+                    "missing the multiarch libEGL for {name}"
+                );
+                assert!(
+                    dri.contains(&format!("{root}/{name}/dri")),
+                    "missing the multiarch dri dir for {name}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/glass-wayland/src/doctor.rs
+++ b/crates/glass-wayland/src/doctor.rs
@@ -265,20 +265,19 @@ fn sway_check(path: &Path, answer: &VersionAnswer) -> Check {
 }
 
 /// Where a distro puts libEGL — the layouts that are not arch-specific. The Debian multiarch
-/// layout (one triplet subdirectory, `x86_64-linux-gnu`/`aarch64-linux-gnu`/…) is added at
-/// runtime from the host's own triplets, so the check works on every architecture rather than
-/// only x86_64 (glass#468).
+/// layout (one triplet subdirectory per installed arch) is added at runtime from the host's own
+/// triplets, so the check works on every architecture, not only x86_64 (glass#468).
 const EGL_SONAMES: &[&str] = &["/usr/lib/libEGL.so.1", "/usr/lib64/libEGL.so.1"];
-/// Where a distro puts the Mesa DRI drivers — likewise, with the multiarch `dri` dirs added
-/// at runtime from the host's own triplets.
+/// Where a distro puts the Mesa DRI drivers — likewise, with the multiarch `dri` dirs added at
+/// runtime from the host's own triplets.
 const DRI_DIRS: &[&str] = &["/usr/lib/dri", "/usr/lib64/dri"];
 /// The Debian-family multiarch roots, each holding one subdirectory per installed architecture.
 const MULTIARCH_ROOTS: &[&str] = &["/usr/lib", "/lib"];
 
 /// The Mesa paths the check should look in: the distro layouts above, plus the Debian multiarch
-/// layout for each architecture the host actually has. Built from the directories under the
-/// multiarch root instead of naming one triplet, so an `aarch64` host finds its own
-/// `/usr/lib/aarch64-linux-gnu/` rather than being sent to install a package it has (glass#468).
+/// layout for each architecture the host actually has — built from the directories under the
+/// multiarch root rather than naming one triplet, so an `aarch64` host finds its own
+/// `/usr/lib/aarch64-linux-gnu/` (glass#468).
 fn mesa_candidates() -> (Vec<String>, Vec<String>) {
     let mut egl = EGL_SONAMES
         .iter()
@@ -624,18 +623,16 @@ mod tests {
         gl_present_in(&egls, &dris)
     }
 
-    /// The multiarch half of glass#468: a `aarch64` (or any non-x86_64) host puts its Mesa under
-    /// `<root>/<triplet>/`, and the old check named only `x86_64-linux-gnu`. `mesa_candidates`
-    /// must add the triplet dir it finds under the multiarch roots, so the check is
-    /// architecture-neutral rather than x86_64-only.
+    /// The multiarch half of glass#468: a non-x86_64 host puts its Mesa under `<root>/<triplet>/`,
+    /// and the old check named only `x86_64-linux-gnu`. `mesa_candidates` must add the triplet
+    /// dir it finds under the multiarch roots.
     #[test]
     fn mesa_candidates_add_the_multiarch_triplet_dirs_the_host_has() {
         let (egl, dri) = mesa_candidates();
         // The architecture-independent layouts are always present.
         assert!(egl.contains(&"/usr/lib/libEGL.so.1".to_string()));
         assert!(dri.contains(&"/usr/lib/dri".to_string()));
-        // And for every `<root>/<arch>-linux-gnu` directory on this host, the arch-specific
-        // layout is included too — which is what the old constant list failed to do on aarch64.
+        // And so is the arch-specific layout for every `<root>/<arch>-linux-gnu` on this host.
         for root in MULTIARCH_ROOTS {
             let Ok(entries) = std::fs::read_dir(root) else {
                 continue;


### PR DESCRIPTION
## What this does

EGL_SONAMES and DRI_DIRS in the Wayland doctor named only the x86_64-linux-gnu multiarch layout (plus the arch-independent /usr/lib and /usr/lib64). On a Debian-family **aarch64** host, Mesa installs to /usr/lib/aarch64-linux-gnu/, which matched none of them, so the check reported the software-GL stack missing and sent the operator to install a package already present. Same shape as #391: a lookup that cannot see the file reported as the file not being there.

The fix builds the multiarch candidate list at runtime from the *-linux-gnu triplet subdirectories under the /usr/lib and /lib multiarch roots the host actually has — mirroring glass-dbus-linux's multiarch_candidates for the AT-SPI launcher — so the check is architecture-neutral. On x86_64 the result is the same set it had before, so nothing changes for the working case.

A new test pins that each <root>/<arch>-linux-gnu dir on the host is included. The resulting doctor output on an aarch64 host is inferred (no arm64 Linux host to run it on), as the issue notes.

Fixes #468.

--- *— Jcode agent (automated triage), on behalf of @fixed-width*