### PR TITLE
fix(android): a failed adb devices listing is Fail, not an empty host

### DIFF
--- a/crates/glass-android/src/doctor.rs
+++ b/crates/glass-android/src/doctor.rs
@@ -939,6 +939,48 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
+    fn a_failed_devices_listing_is_detected_by_the_probe_itself() {
+        use crate::adb::{Answer, FakeAdb};
+
+        // The rendering test above drives a hand-built `Probe`; this one drives the real
+        // `probe_with`, so the `adb devices` Err -> `devices_listing_failed` mapping itself is
+        // what is pinned (glass#460).
+        let fake = FakeAdb::new(&[
+            (
+                "version",
+                Answer::says("Android Debug Bridge version 1.0.41\nInstalled as /x/adb\n"),
+            ),
+            (
+                "devices",
+                Answer::fails("adb: cannot run server; libusb_init() failed"),
+            ),
+            ("*", Answer::Silent),
+        ]);
+        let p = probe_with(false, fake.adb(), &|_| None, &|_| false);
+        assert!(
+            p.devices_listing_failed.is_some(),
+            "an `adb devices` that failed must be recorded, not read as an empty host: {:?}",
+            p.devices_listing_failed
+        );
+        assert!(p.online.is_empty());
+        let d = build_checks(&p);
+        let d = find(&d, "device");
+        assert_eq!(d.status, CheckStatus::Fail);
+        assert!(
+            d.detail.contains("could not read the device list"),
+            "{}",
+            d.detail
+        );
+        assert!(
+            d.detail.contains("libusb_init"),
+            "the failure reason carries through: {}",
+            d.detail
+        );
+        assert!(d.remedy.as_deref().unwrap().contains("adb kill-server"));
+    }
+
+    #[test]
     fn device_boot_but_no_emulator_binary_is_fail() {
         let mut p = base_probe();
         p.online = vec![];

--- a/crates/glass-android/src/doctor.rs
+++ b/crates/glass-android/src/doctor.rs
@@ -39,7 +39,7 @@ struct Probe {
     /// Serials with `adb devices` state `"device"` (online), for display.
     online: Vec<String>,
     /// The reason `adb devices` failed to read, when it did — `Some` when the listing errored
-    /// (a spawn failure, a non-zero exit, or a timeout) rather than the empty list that an
+    /// (a spawn failure, a non-zero exit, or a timeout) rather than the empty list an
     /// "no devices attached" host produces. When set, `online` is empty for a reason the
     /// operator cannot follow, so the device check says so instead of prescribing a boot
     /// (glass#460).
@@ -115,8 +115,7 @@ fn probe_with(
         if adb_version.is_some() {
             match adb.run(["devices"]) {
                 // `Err` covers a spawn failure, a non-zero exit, and a timeout — none of which
-                // means "no devices attached" (the empty-list case), so it must not be read as
-                // an empty host (glass#460).
+                // means "no devices attached" (glass#460).
                 Ok(out) => (
                     parse_devices(&out)
                         .into_iter()
@@ -409,9 +408,7 @@ fn device_check(p: &Probe) -> Check {
     if p.adb_version.is_none() {
         return Check::new("device", CheckStatus::Skip, "skipped — adb unavailable");
     }
-    // The `adb devices` listing itself failed — a wedged adb server, a spawn failure, a non-zero
-    // exit, or a timeout. None of these means "no devices attached", so it must not read as an
-    // empty host with a boot remedy (glass#460).
+    // The listing failed, so this is a "could not read" finding, not an empty host (glass#460).
     if let Some(why) = &p.devices_listing_failed {
         return Check::new(
             "device",

--- a/crates/glass-android/src/doctor.rs
+++ b/crates/glass-android/src/doctor.rs
@@ -38,6 +38,12 @@ struct Probe {
     avds: Option<Vec<String>>,
     /// Serials with `adb devices` state `"device"` (online), for display.
     online: Vec<String>,
+    /// The reason `adb devices` failed to read, when it did — `Some` when the listing errored
+    /// (a spawn failure, a non-zero exit, or a timeout) rather than the empty list that an
+    /// "no devices attached" host produces. When set, `online` is empty for a reason the
+    /// operator cannot follow, so the device check says so instead of prescribing a boot
+    /// (glass#460).
+    devices_listing_failed: Option<String>,
     /// What `glass_start` would do with these devices — the runtime's own
     /// `decide(online, GLASS_ANDROID_SERIAL, GLASS_ANDROID_LIFECYCLE)` verdict, so the
     /// doctor matches the real backend (attach a serial / boot / refuse) by construction.
@@ -105,14 +111,24 @@ fn probe_with(
     let emulator_bin = resolve_emulator_bin(get, exists);
     let avds = list_avds(&emulator_bin);
 
-    let online_devices: Vec<Device> = if adb_version.is_some() {
-        parse_devices(&adb.run(["devices"]).unwrap_or_default())
-            .into_iter()
-            .filter(|d| d.state == "device")
-            .collect()
-    } else {
-        Vec::new()
-    };
+    let (online_devices, devices_listing_failed): (Vec<Device>, Option<String>) =
+        if adb_version.is_some() {
+            match adb.run(["devices"]) {
+                // `Err` covers a spawn failure, a non-zero exit, and a timeout — none of which
+                // means "no devices attached" (the empty-list case), so it must not be read as
+                // an empty host (glass#460).
+                Ok(out) => (
+                    parse_devices(&out)
+                        .into_iter()
+                        .filter(|d| d.state == "device")
+                        .collect(),
+                    None,
+                ),
+                Err(e) => (Vec::new(), Some(e.to_string())),
+            }
+        } else {
+            (Vec::new(), None)
+        };
     let online: Vec<String> = online_devices.iter().map(|d| d.serial.clone()).collect();
     // Reuse the runtime's own selection policy so the doctor's verdict matches what
     // `glass_start` will actually do (attach a specific serial / boot / refuse).
@@ -184,6 +200,7 @@ fn probe_with(
         emulator_bin,
         avds,
         online,
+        devices_listing_failed,
         selection,
         deep_requested,
         deep,
@@ -392,6 +409,20 @@ fn device_check(p: &Probe) -> Check {
     if p.adb_version.is_none() {
         return Check::new("device", CheckStatus::Skip, "skipped — adb unavailable");
     }
+    // The `adb devices` listing itself failed — a wedged adb server, a spawn failure, a non-zero
+    // exit, or a timeout. None of these means "no devices attached", so it must not read as an
+    // empty host with a boot remedy (glass#460).
+    if let Some(why) = &p.devices_listing_failed {
+        return Check::new(
+            "device",
+            CheckStatus::Fail,
+            format!("could not read the device list: {why}"),
+        )
+        .with_remedy(
+            "check that `adb devices` runs on this host (the adb server may be wedged — try \
+             `adb kill-server`), or point GLASS_ADB at a working adb",
+        );
+    }
     // Mirror the runtime's `decide`: Ok when glass would attach to a specific device,
     // Warn when it will boot one, Fail (carrying the runtime's own message) when it would
     // refuse — so a green `device` check guarantees `glass_start` won't reject the host.
@@ -483,6 +514,7 @@ mod tests {
             emulator_bin: "/sdk/emulator/emulator".into(),
             avds: Some(vec!["glass".into()]),
             online: vec!["emulator-5554".into()],
+            devices_listing_failed: None,
             selection: Action::Attach("emulator-5554".into()),
             deep_requested: false,
             deep: None,
@@ -884,6 +916,26 @@ mod tests {
         let d = find(&d, "device");
         assert_eq!(d.status, CheckStatus::Fail);
         assert!(d.remedy.as_deref().unwrap().contains("emulator -avd"));
+    }
+
+    /// The defect in glass#460: `adb devices` that fails must not read as an empty host. The
+    /// "no devices attached" host produces an empty *list*; a spawn failure / non-zero exit /
+    /// timeout is a different answer, and the boot remedy fits only the former.
+    #[test]
+    fn a_failed_devices_listing_is_fail_not_an_empty_host() {
+        let mut p = base_probe();
+        p.online = vec![];
+        p.selection = decide(&[], None, Lifecycle::Auto); // would otherwise say "boot one"
+        p.avds = Some(vec!["glass".into()]); // so it is not the "no AVD" Fail either
+        p.devices_listing_failed = Some("timeout: adb devices did not answer within 10s".into());
+        let d = build_checks(&p);
+        let d = find(&d, "device");
+        assert_eq!(d.status, CheckStatus::Fail);
+        assert!(d.detail.contains("could not read the device list"));
+        assert!(d.detail.contains("did not answer"));
+        // The remedy names the adb server, not a boot of an emulator the host may already have.
+        assert!(d.remedy.as_deref().unwrap().contains("adb kill-server"));
+        assert!(!d.remedy.as_deref().unwrap().contains("emulator -avd"));
     }
 
     #[test]


### PR DESCRIPTION
## What this does

`glass doctor`'s Android section read the device list with the error thrown away:

```rust
parse_devices(&adb.run(["devices"]).unwrap_or_default())
```

`Adb::run`'s `Err` covers a spawn failure, a non-zero exit **and** a timeout. `unwrap_or_default()` turned all three into "", which `parse_devices` reads as an empty list — the same value a host with no devices attached produces. The verdict that followed was `Action::Boot`: either "⚠ none online; glass will boot an AVD on start" or "✗ no online device and no AVD to boot", whose remedy tells the operator to start an emulator. On a host whose adb server is wedged, an emulator may already be running — and the message that would have said so was discarded. (The neighbouring probe on the same file reports the error via `inspect_err`; the silence here was inconsistent within the check.)

The fix keeps the `Err`'s reason in a new `Probe` field (`devices_listing_failed`), and `device_check` renders a `Fail` naming it ("could not read the device list: …") with a remedy that points at the adb server (`adb kill-server` / `GLASS_ADB`) rather than at a boot. The empty-list case ("no devices attached") is unchanged: an `Ok` listing => `None` => the existing `decide`-based verdicts.

A new test pins that a failed listing is a `Fail` naming the adb server, not the boot remedy.

Fixes #460.

--- *— Jcode agent (automated triage), on behalf of @fixed-width*