### PR TITLE
fix(a11y-linux): subscribe() spawns with a fallible thread, so a refusal degrades to polling (fixes #463)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ internal refactors, CI, or test-only changes.
 ## [Unreleased]
 
 ### Fixed
+- On Linux, the event subscription's pump thread now spawns fallibly: a host that refuses the thread (a low `pids` limit is the ordinary way an MCP server is confined) no longer panics the caller — the session degrades to polling the tree, the fallback the caller already has.
 - Linux: a deep `glass doctor` probe no longer leaves a stuck thread and an open pipe behind for
   the rest of the process's life. The X11 and Wayland probes each read their child's stderr on a
   helper thread, and that thread could only stop at end-of-file — which anything the probe left

--- a/crates/glass-a11y-linux/src/events.rs
+++ b/crates/glass-a11y-linux/src/events.rs
@@ -70,16 +70,23 @@ pub(crate) fn subscribe(ctx: &AxContext) -> Option<Box<dyn ChangeSignal>> {
     let (ready_tx, ready_rx) = std::sync::mpsc::channel();
     let running = Arc::new(AtomicBool::new(true));
     let pump_running = running.clone();
-    std::thread::spawn(move || {
-        let Ok(rt) = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-        else {
-            let _ = ready_tx.send(false);
-            return;
-        };
-        rt.block_on(pump(&ctx, tx, ready_tx, pump_running));
-    });
+    // Named and fallible, unlike a bare `spawn`: a host that refuses the thread (a low `pids`
+    // cgroup limit) used to panic the caller instead of returning the no-subscription that the
+    // caller already handles (glass#463, the #454 defect in this crate). No pump started, so
+    // there is nothing to stop — the `running` flag is simply never set.
+    std::thread::Builder::new()
+        .name("glass-a11y-atspi-subscribe".into())
+        .spawn(move || {
+            let Ok(rt) = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            else {
+                let _ = ready_tx.send(false);
+                return;
+            };
+            rt.block_on(pump(&ctx, tx, ready_tx, pump_running));
+        })
+        .ok()?;
     // Wait for the subscription to be established before returning: a caller reads the tree the
     // moment it gets a signal back, and a change landing before the match rule is in place would
     // be lost.


### PR DESCRIPTION
## What this does

subscribe() started its event pump with a bare std::thread::spawn on a product path (the reader's subscribe_changes seam). A host that refuses the thread — a low pids cgroup limit is the ordinary way an MCP server is confined — panicked the caller instead of returning the no-subscription result that the caller already handles.

Use std::thread::Builder::new().name(...).spawn(...) (the A11yThread::detached pattern in glass-core) and map a refusal to the existing None return: no pump started, so there is nothing to stop, and the caller falls back to polling exactly as it did before.

## What it deliberately does not do

The second half of #463 — the ready_rx match that reads three pump outcomes (no runtime / not-ready-within-timeout / thread-unwound) as one _ arm — is log-diagnostic only: the pump's own timeout is deliberate and documented, so distinguishing the outcomes would be churn without behaviour change. Left for a follow-up.

## Verification

cargo build --workspace --all-targets, cargo clippy, cargo fmt — clean.
cargo test -p glass-a11y-linux — 53 passed.

The new code path (thread refusal) is the same pattern as A11yThread::detached, which is exercised by its own tests.

---
*— Jcode agent (automated triage), on behalf of @fixed-width*