### PR TITLE
test(a11y-android): pin the i64 far-edge promotion in encloses (fixes #322)

### DIFF
--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -1535,6 +1535,27 @@ mod tests {
         assert!(!encloses(None, rect(10, 10, 10, 10)));
     }
 
+    /// The far-edge arithmetic promotes to `i64` (glass#322): an outer at (0, 0) with a u32::MAX
+    /// width makes `x + width` = 2^32 - 1, which overflows an `i32`, so a node that genuinely
+    /// encloses its descendant would read as not enclosing it. Pin the result so a simplification
+    /// back to i32 arithmetic fails here instead of silently mis-actuating a control.
+    #[test]
+    fn encloses_does_not_overflow_on_max_edges() {
+        let rect = |x, y, width, height| {
+            Some(AxRect {
+                x,
+                y,
+                width,
+                height,
+            })
+        };
+        let outer = rect(0, 0, u32::MAX, u32::MAX);
+        let inner = rect(0, 0, 100, 100);
+        // outer.x + outer.width = 2^32 - 1 (overflowing as i32) >= the inner's right edge 100,
+        // and every start/far edge is within i32 range, so this genuinely encloses.
+        assert!(encloses(outer, inner));
+    }
+
     /// `GLASS_ANDROID_A11Y_APK` is caller-supplied and lands in the argv the error names, so a
     /// path quoting the phrase used to make every install failure take the uninstall branch.
     #[test]


### PR DESCRIPTION
## What this does

encloses widens x + width to i64 so a rect the mapper deliberately admits (json_to_node clamps out-of-range values instead of rejecting the node) cannot overflow the comparison. Nothing pinned the widening: a rewrite back to i32 survives the whole test suite, yet on o.x + o.width = 2^32 - 1 it wraps to a negative and encloses answers backwards, sending actuable_node's climb to the wrong ancestor.

This adds the test the issue asks for — an outer at (0, 0) with a u32::MAX width, a small inner inside it, asserting enclosure holds. Under i32 arithmetic the same inputs give far edge -1 and the assertion fails, so the test now fails if the i64::from calls are dropped.

## Also checked, as the issue suggests

The sibling axmap.rs reader: its edge math is (r - l).max(0) as u32, where r >= l is guaranteed by the [l,t][r,b] bounds string it parses, so it does not take the same shape. No change there.

## Verification

cargo test -p glass-android --lib — 428 passed (427 + this one).
cargo clippy / fmt clean.
Arithmetic verified independently: the old i32 path returns encloses = false on these inputs; the current i64 path returns true.

Closes #322.

---
*— Jcode agent (automated triage), on behalf of @fixed-width*