### PR TITLE
glass-ios: actuate a two-finger pinch through idb HIDPinch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ internal refactors, CI, or test-only changes.
 
 ## [Unreleased]
 
+### Added
+- On iOS, `glass_gesture` actuates a two-finger pinch: two pointers whose separation changes become a real pinch on the Simulator, recognised as one by the app under test. It needs an `idb_companion` that implements idb's `HIDPinch` event — a companion that does not is named in the error, along with the `--version` it reported. Other multi-touch gestures (rotation, two-finger pan, three or more fingers) are refused by name rather than actuated as something else.
+
 ### Fixed
 - `glass doctor` no longer waits forever on an X server that accepts connections and goes silent: the attach probe is bounded, and a server that answers then stops is reported as wedged with its own remedy, distinct from a refusal, a missing display, or a missing screen.
 - `glass doctor` on Android and iOS no longer reports a probe that timed out as a missing tool: a hung `emulator -list-avds` and a hung booted-simulator probe now say the probe timed out (carrying its cause), and the install remedy is reserved for a tool that is actually absent.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,8 @@ tree — served over MCP (stdio, or `serve --http`). Backends behind a `Platform
 and Wayland (headless sway) on Linux, Windows (WGC/SendInput), Android (native apps in an AVD
 emulator over `adb`, host-OS-agnostic; clipboard + high-fidelity input via an optional
 on-device companion agent), iOS (native apps in the Simulator over `xcrun simctl`; capture,
-logs, clipboard, plus input and the accessibility tree via `idb_companion`, multi-touch
-gestures excepted), macOS (ScreenCaptureKit
+logs, clipboard, plus input and the accessibility tree via `idb_companion`, including a
+two-finger pinch; other multi-touch gestures excepted), macOS (ScreenCaptureKit
 capture, CGEvent input, AXUIElement
 windows/logs, accessibility tree, clipboard (isolated + working under containment for
 apps not built with hardened runtime, via a `DYLD_INSERT_LIBRARIES` swizzle shim;

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ independently instead of asking the user "does this look right?".
 glass drives apps as an external black box, so it works with any native GUI app regardless of toolkit
 or language. It has two Linux backends (**X11** and **Wayland**), a **Windows** backend, an
 **Android** backend (an AVD emulator, driven over `adb` from any host), an **iOS** backend (native
-apps in the Simulator over `xcrun simctl`, with input and the accessibility tree via `idb_companion`;
-multi-touch gestures excepted), and a **macOS** backend, behind a platform-agnostic core.
+apps in the Simulator over `xcrun simctl`, with input and the accessibility tree via `idb_companion`,
+including a two-finger pinch), and a **macOS** backend, behind a platform-agnostic core.
 
 ## See it
 

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -34,7 +34,7 @@ pub mod drag;
 pub use drag::{DragGesture, DragSink, run_drag};
 
 pub mod pinch;
-pub use pinch::{NotAPinch, PAN_MIN_PX, Pinch, SCALE_EPSILON};
+pub use pinch::{NotAPinch, Pinch};
 
 pub mod chord;
 pub use chord::{CHORD_DWELL, ChordSink, run_chord};

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -33,6 +33,9 @@ pub use pixels::{SourceOrder, to_opaque_rgba, to_opaque_rgba_in_place};
 pub mod drag;
 pub use drag::{DragGesture, DragSink, run_drag};
 
+pub mod pinch;
+pub use pinch::{NotAPinch, PAN_MIN_PX, Pinch, SCALE_EPSILON};
+
 pub mod chord;
 pub use chord::{CHORD_DWELL, ChordSink, run_chord};
 

--- a/crates/glass-core/src/pinch.rs
+++ b/crates/glass-core/src/pinch.rs
@@ -13,6 +13,16 @@ use crate::platform::Segment;
 /// smaller than that delivery error cannot be told apart from it.
 pub const SCALE_EPSILON: f64 = 0.05;
 
+/// The band around 1 that [`SCALE_EPSILON`] describes, written out rather than computed.
+///
+/// Do not go back to comparing `(scale - 1.0).abs()` against the epsilon: `1.05 - 1.0` is not
+/// `0.05` in `f64`, so that boundary is one no input can land on. `scale` itself reaches exactly
+/// `1.05` and `0.95` — 200px separating to 210 or 190. `scale_bounds_match_the_epsilon` keeps
+/// them in step.
+pub const SCALE_MAX: f64 = 1.05;
+/// The lower end of the band; see [`SCALE_MAX`].
+pub const SCALE_MIN: f64 = 0.95;
+
 /// A two-finger pinch: where it is centred, how far apart the fingers start, and the factor
 /// their separation changes by.
 ///
@@ -100,7 +110,7 @@ impl Pinch {
         let start = separation((a.from_x, a.from_y), (b.from_x, b.from_y));
         let end = separation((a.to_x, a.to_y), (b.to_x, b.to_y));
         let scale = end / start;
-        if (scale - 1.0).abs() < SCALE_EPSILON {
+        if scale > SCALE_MIN && scale < SCALE_MAX {
             return Err(separation_held(a, b, scale));
         }
         Ok(Pinch {
@@ -146,10 +156,10 @@ fn axis_turned(a: &Segment, b: &Segment) -> bool {
     };
     let start = angle((a.from_x, a.from_y), (b.from_x, b.from_y));
     let end = angle((a.to_x, a.to_y), (b.to_x, b.to_y));
-    let mut turn = (end - start).abs();
-    if turn > std::f64::consts::PI {
-        turn = std::f64::consts::TAU - turn; // the short way round
-    }
+    let raw = (end - start).abs();
+    // The short way round, as a min rather than a `> PI` branch: at exactly PI the arms agree
+    // (`TAU - PI == PI`), so that comparison is undecidable by any test.
+    let turn = raw.min(std::f64::consts::TAU - raw);
     turn > (1.0 / separation((a.from_x, a.from_y), (b.from_x, b.from_y))).atan()
 }
 
@@ -329,6 +339,47 @@ mod tests {
             f64::from(u32::MAX),
             "the full i32 span, not a wrapped one"
         );
+    }
+
+    #[test]
+    fn scale_bounds_match_the_epsilon() {
+        // The bounds are literals so the comparison has a reachable boundary; this keeps them
+        // honest about the epsilon they claim to be.
+        assert!((SCALE_MAX - 1.0 - SCALE_EPSILON).abs() < 1e-12);
+        assert!((1.0 - SCALE_MIN - SCALE_EPSILON).abs() < 1e-12);
+    }
+
+    #[test]
+    fn a_shrink_to_exactly_the_lower_bound_is_a_pinch() {
+        // 200 -> 190 is exactly 0.95 in f64, the boundary the band excludes.
+        let p = Pinch::classify(&[seg((100, 400), (105, 400)), seg((300, 400), (295, 400))])
+            .expect("exactly the lower bound is a scale change");
+        assert_eq!(p.scale, SCALE_MIN);
+    }
+
+    #[test]
+    fn a_pan_along_a_vertical_axis_is_a_pan() {
+        // The axis is pi/2 rather than 0, so a sum in place of the difference no longer reads
+        // as no turn at all.
+        let g = [seg((100, 400), (150, 400)), seg((100, 600), (150, 600))];
+        assert_eq!(Pinch::classify(&g), Err(NotAPinch::Pan));
+    }
+
+    #[test]
+    fn a_small_rotation_is_still_a_rotation() {
+        // A 0.1 rad swing at separation 200: far above the one-pixel tolerance, far below the
+        // one a mistaken `1.0 % sep` or `1.0 * sep` would produce.
+        let g = [seg((100, 400), (100, 400)), seg((300, 400), (299, 420))];
+        assert_eq!(Pinch::classify(&g), Err(NotAPinch::Rotation));
+    }
+
+    #[test]
+    fn an_axis_crossing_the_half_turn_mark_turns_the_short_way() {
+        // The axis points left, so one pixel of perpendicular travel flips atan2 from +pi to
+        // -pi — a raw difference of nearly a full turn. Taken the long way round it reads as a
+        // rotation instead of a pan.
+        let g = [seg((100, 400), (100, 400)), seg((60, 400), (60, 399))];
+        assert_eq!(Pinch::classify(&g), Err(NotAPinch::Pan));
     }
 
     #[test]

--- a/crates/glass-core/src/pinch.rs
+++ b/crates/glass-core/src/pinch.rs
@@ -1,45 +1,58 @@
 //! Classify a two-pointer gesture as a pinch, or say why it is not one.
 //!
-//! Backend-agnostic geometry over [`Segment`], mirroring [`crate::drag`]: the plan is derived
-//! here and actuated by whichever backend has a pinch primitive.
+//! Backend-agnostic geometry over [`Segment`]. Unlike [`crate::drag`], which drives a backend
+//! through a sink, this module only derives the plan; the backend actuates it.
 
 use crate::platform::Segment;
 
 /// Below this fractional change in finger separation, a gesture is not a scale change.
+/// Compared against `|scale - 1.0|` — an absolute deviation from 1, not a percentage.
 ///
-/// Measured against idb companion 1.5.0b3 on iOS 26.5: a requested scale of 2.0 delivered 1.905
-/// and 0.5 delivered 0.513, because `UIPinchGestureRecognizer` takes its reference distance at
-/// its own `began`, already one interpolation step in. A request smaller than that error cannot
+/// Measured against idb companion 1.5.0b3 on iOS 26.5, pinching about the middle of an
+/// iPhone 17: a requested 2.0 arrived as 1.905 and a requested 0.5 as 0.513, both within about
+/// 5% of the request at a start radius of 80pt. That error grows sharply as the radius shrinks
+/// — the same requested 2.0 arrives as 1.333 at an 8pt radius — so 5% is the floor at a
+/// comfortable radius rather than a guarantee. A request smaller than the delivery error cannot
 /// be told apart from it.
 pub const SCALE_EPSILON: f64 = 0.05;
 
-/// Midpoint travel (px) separating a two-finger pan from a rotation. Consulted only when the
-/// separation held, so it discriminates those two and nothing else.
-pub const PAN_MIN_PX: f64 = 4.0;
-
 /// A two-finger pinch: where it is centred, how far apart the fingers start, and the factor
 /// their separation changes by.
+///
+/// `#[non_exhaustive]` so [`Pinch::classify`] stays the only way to build one, in the house
+/// style of `GlassError::Bounded`. The fields are read freely; what is prevented is a literal
+/// that skips the classification, which is where every invariant below comes from.
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[non_exhaustive]
 pub struct Pinch {
     /// Midpoint of the two **start** points, window-relative px.
     pub center: (i32, i32),
-    /// Half the starting separation, px.
+    /// Half the starting separation, px. Always finite and greater than zero — `classify`
+    /// rejects coincident start points, and distinct `i32` points are at least 1px apart.
     pub start_radius: f64,
     /// End separation divided by start separation. Above 1 the fingers spread.
+    ///
+    /// Always finite and non-negative, and at least [`SCALE_EPSILON`] away from 1. Exactly 0
+    /// when both fingers converge on one point, which is a real gesture rather than an error:
+    /// idb actuates it as a pinch all the way in.
     pub scale: f64,
 }
 
-/// Why a gesture is not a pinch. Each variant is a distinct gesture the caller asked for, so a
-/// backend can name the one it refused rather than answering "unsupported".
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// Why a gesture is not a pinch, named specifically enough that a backend's `Unsupported`
+/// error can say what it refused instead of only that it refused.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[non_exhaustive]
 pub enum NotAPinch {
     /// Not exactly two pointers; carries how many there were.
     PointerCount(usize),
     /// Both fingers start at the same point, leaving no separation to scale.
     Coincident,
-    /// Separation held while the midpoint travelled: a two-finger pan.
+    /// The separation changed by less than [`SCALE_EPSILON`]; carries the requested factor.
+    /// A pinch, but a smaller one than can be delivered faithfully.
+    ScaleTooSmall(f64),
+    /// Separation held while the pair travelled: a two-finger pan.
     Pan,
-    /// Separation and midpoint both held while the finger axis turned.
+    /// Separation held while the axis through the fingers turned.
     Rotation,
     /// Neither finger moved.
     Stationary,
@@ -50,12 +63,18 @@ impl NotAPinch {
     pub fn describe(self) -> String {
         match self {
             NotAPinch::PointerCount(n) => {
-                format!("a {n}-pointer gesture; only a 2-finger pinch can be actuated")
+                format!("a {n}-pointer gesture; only a two-finger pinch can be actuated")
             }
             NotAPinch::Coincident => {
                 "both fingers start at the same point, so there is no separation to scale"
                     .to_string()
             }
+            NotAPinch::ScaleTooSmall(scale) => format!(
+                "a separation change of {:.1}%, under the {:.0}% that can be delivered \
+                 faithfully — ask for a larger change",
+                (scale - 1.0).abs() * 100.0,
+                SCALE_EPSILON * 100.0
+            ),
             NotAPinch::Pan => {
                 "a two-finger pan, which is a different gesture from a pinch".to_string()
             }
@@ -70,15 +89,15 @@ impl NotAPinch {
 impl Pinch {
     /// Classify `pointers` as a pinch, or return the reason it is not one.
     ///
-    /// A change in separation is what makes a pinch; the axis it happens on does not, because a
-    /// pinch recognizer reports scale alone. An asymmetric pair — one finger held, the other
-    /// travelling — is therefore still a pinch.
+    /// A change in separation is what makes a pinch; the axis it happens on does not, because
+    /// what a pinch delivers is a scale factor about a centre. An asymmetric pair — one finger
+    /// held, the other travelling — is therefore still a pinch.
     pub fn classify(pointers: &[Segment]) -> Result<Pinch, NotAPinch> {
         let [a, b] = pointers else {
             return Err(NotAPinch::PointerCount(pointers.len()));
         };
-        // Compared as integers: a zero separation would make `scale` a division by zero, and the
-        // coordinates are exact, so this needs no float tolerance.
+        // Compared as integers: a zero separation would make `scale` a division by zero, and
+        // the coordinates are exact, so this needs no float tolerance.
         if a.from_x == b.from_x && a.from_y == b.from_y {
             return Err(NotAPinch::Coincident);
         }
@@ -86,7 +105,7 @@ impl Pinch {
         let end = separation((a.to_x, a.to_y), (b.to_x, b.to_y));
         let scale = end / start;
         if (scale - 1.0).abs() < SCALE_EPSILON {
-            return Err(separation_held(a, b));
+            return Err(separation_held(a, b, scale));
         }
         Ok(Pinch {
             center: midpoint((a.from_x, a.from_y), (b.from_x, b.from_y)),
@@ -96,24 +115,56 @@ impl Pinch {
     }
 }
 
-/// Which non-pinch a constant-separation pair is: nothing moved, the pair travelled, or it turned.
-fn separation_held(a: &Segment, b: &Segment) -> NotAPinch {
+/// What a pair whose separation held actually is: nothing moved, the axis turned, the pair
+/// travelled, or a pinch too small to deliver.
+///
+/// Rotation is told from pan by the **axis** through the fingers, not by midpoint travel: a
+/// rotation about one held finger moves the midpoint exactly as a pan does, and reporting that
+/// as a pan would name a gesture the caller did not ask for.
+fn separation_held(a: &Segment, b: &Segment, scale: f64) -> NotAPinch {
     let still = |s: &Segment| s.from_x == s.to_x && s.from_y == s.to_y;
     if still(a) && still(b) {
         return NotAPinch::Stationary;
     }
-    let from = midpoint((a.from_x, a.from_y), (b.from_x, b.from_y));
-    let to = midpoint((a.to_x, a.to_y), (b.to_x, b.to_y));
-    if separation(from, to) > PAN_MIN_PX {
-        NotAPinch::Pan
-    } else {
-        NotAPinch::Rotation
+    if axis_turned(a, b) {
+        return NotAPinch::Rotation;
     }
+    // Separation and axis both held, so the pair is rigid; if it also went nowhere it was the
+    // `Stationary` case above, and a rigid pair that moved has travelled.
+    if midpoint((a.from_x, a.from_y), (b.from_x, b.from_y))
+        != midpoint((a.to_x, a.to_y), (b.to_x, b.to_y))
+    {
+        return NotAPinch::Pan;
+    }
+    NotAPinch::ScaleTooSmall(scale)
 }
 
-/// Distance between two window-relative points, px.
+/// Whether the axis through the two fingers turned by more than one pixel of perpendicular
+/// travel at this separation.
+///
+/// The tolerance scales with the separation rather than being a constant: one pixel is the
+/// finest distinction integer coordinates can express, so a turn below `atan(1 / separation)`
+/// is rounding rather than a gesture. Widely separated fingers resolve a finer rotation than
+/// close ones, which is the physical truth of it.
+fn axis_turned(a: &Segment, b: &Segment) -> bool {
+    let angle = |from: (i32, i32), to: (i32, i32)| {
+        let d = |p: i32, q: i32| (i64::from(p) - i64::from(q)) as f64;
+        d(to.1, from.1).atan2(d(to.0, from.0))
+    };
+    let start = angle((a.from_x, a.from_y), (b.from_x, b.from_y));
+    let end = angle((a.to_x, a.to_y), (b.to_x, b.to_y));
+    let mut turn = (end - start).abs();
+    if turn > std::f64::consts::PI {
+        turn = std::f64::consts::TAU - turn; // the short way round
+    }
+    turn > (1.0 / separation((a.from_x, a.from_y), (b.from_x, b.from_y))).atan()
+}
+
+/// Distance between two window-relative points, px. Widened to `i64` before subtracting so
+/// extreme coordinates cannot overflow the intermediate, matching [`midpoint`].
 fn separation(a: (i32, i32), b: (i32, i32)) -> f64 {
-    f64::from(a.0 - b.0).hypot(f64::from(a.1 - b.1))
+    let d = |p: i32, q: i32| (i64::from(p) - i64::from(q)) as f64;
+    d(a.0, b.0).hypot(d(a.1, b.1))
 }
 
 /// Midpoint of two window-relative points. Summed as `i64` so extreme coordinates cannot
@@ -138,7 +189,6 @@ mod tests {
 
     #[test]
     fn symmetric_spread_is_a_pinch_centred_on_the_start_midpoint() {
-        // Fingers at x=100 and x=300 (y=400) move out to x=50 and x=350.
         let p = Pinch::classify(&[seg((100, 400), (50, 400)), seg((300, 400), (350, 400))])
             .expect("a symmetric spread is a pinch");
         assert_eq!(p.center, (200, 400));
@@ -168,6 +218,16 @@ mod tests {
             .expect("axis does not decide pinch-ness");
         assert_eq!(p.center, (400, 200));
         assert_eq!(p.scale, 1.5);
+    }
+
+    #[test]
+    fn fingers_converging_on_one_point_scale_to_zero() {
+        // The natural "pinch fully closed". The starts are distinct, so this is not
+        // `Coincident`; idb actuates it as a pinch all the way in.
+        let p = Pinch::classify(&[seg((100, 400), (200, 400)), seg((300, 400), (200, 400))])
+            .expect("converging on one point is a pinch, not an error");
+        assert_eq!(p.scale, 0.0);
+        assert_eq!(p.start_radius, 100.0);
     }
 
     #[test]
@@ -203,9 +263,32 @@ mod tests {
 
     #[test]
     fn a_turned_axis_at_constant_separation_is_a_rotation() {
-        // The pair swaps ends about a fixed midpoint: separation held, axis turned.
+        // The pair swaps ends: separation held, axis turned through pi.
         let g = [seg((100, 400), (300, 400)), seg((300, 400), (100, 400))];
         assert_eq!(Pinch::classify(&g), Err(NotAPinch::Rotation));
+    }
+
+    #[test]
+    fn a_rotation_about_one_held_finger_is_a_rotation_not_a_pan() {
+        // `a` is pinned and `b` swings a quarter turn around it, so the midpoint travels just
+        // as far as a pan's would. Only the axis tells these two apart.
+        let g = [seg((100, 400), (100, 400)), seg((300, 400), (100, 600))];
+        assert_eq!(Pinch::classify(&g), Err(NotAPinch::Rotation));
+    }
+
+    #[test]
+    fn exactly_one_pixel_of_perpendicular_travel_is_not_a_rotation() {
+        // The tolerance boundary, and it is exactly constructible: `b` moves one pixel
+        // perpendicular at a separation of 200, so the turn is `atan2(1, 200)`, bit-identical
+        // to the `atan(1 / 200)` tolerance. The axis must turn by *more* than one pixel, so
+        // this falls through as a separation change too small to deliver rather than being
+        // reported as a rotation.
+        let g = [seg((100, 400), (100, 400)), seg((300, 400), (300, 401))];
+        assert!(
+            matches!(Pinch::classify(&g), Err(NotAPinch::ScaleTooSmall(_))),
+            "got {:?}",
+            Pinch::classify(&g)
+        );
     }
 
     #[test]
@@ -215,11 +298,50 @@ mod tests {
     }
 
     #[test]
-    fn a_separation_change_under_the_epsilon_is_not_a_scale_change() {
-        // 200 -> 204 is 2%, inside SCALE_EPSILON, and the midpoint holds: a rotation-shaped
-        // no-op rather than a pinch glass would be unable to deliver faithfully.
+    fn a_spread_under_the_epsilon_is_named_as_a_too_small_pinch() {
+        // 200 -> 204 is 2%: a pinch, but a smaller one than can be delivered. It must not be
+        // reported as some other gesture the caller never asked for.
         let g = [seg((100, 400), (98, 400)), seg((300, 400), (302, 400))];
-        assert_eq!(Pinch::classify(&g), Err(NotAPinch::Rotation));
+        let Err(NotAPinch::ScaleTooSmall(scale)) = Pinch::classify(&g) else {
+            panic!("expected ScaleTooSmall, got {:?}", Pinch::classify(&g));
+        };
+        assert_eq!(scale, 1.02);
+    }
+
+    #[test]
+    fn a_shrink_under_the_epsilon_is_also_a_too_small_pinch() {
+        // The converging side of the band: 200 -> 196 is -2%.
+        let g = [seg((100, 400), (102, 400)), seg((300, 400), (298, 400))];
+        let Err(NotAPinch::ScaleTooSmall(scale)) = Pinch::classify(&g) else {
+            panic!("expected ScaleTooSmall");
+        };
+        assert_eq!(scale, 0.98);
+    }
+
+    #[test]
+    fn a_spread_just_outside_the_epsilon_is_a_pinch() {
+        // 200 -> 210 is exactly 1.05, and `1.05 - 1.0` in f64 is 0.050000000000000044, not
+        // below the epsilon. The smallest spread this accepts, pinning the constant from the
+        // side no other test covers.
+        let p = Pinch::classify(&[seg((100, 400), (95, 400)), seg((300, 400), (305, 400))])
+            .expect("just outside the epsilon is a scale change");
+        assert_eq!(p.scale, 1.05);
+    }
+
+    #[test]
+    fn separation_does_not_overflow_on_extreme_coordinates() {
+        // `classify` is public API with no stated precondition on coordinate range. Subtracting
+        // in i32 panics in debug and wraps to a confidently wrong answer in release.
+        let g = [
+            seg((i32::MAX, 0), (i32::MAX, 0)),
+            seg((i32::MIN, 0), (i32::MIN, 0)),
+        ];
+        assert_eq!(Pinch::classify(&g), Err(NotAPinch::Stationary));
+        assert_eq!(
+            separation((i32::MAX, 0), (i32::MIN, 0)),
+            f64::from(u32::MAX),
+            "the full i32 span, not a wrapped one"
+        );
     }
 
     #[test]
@@ -229,5 +351,11 @@ mod tests {
         assert!(NotAPinch::Rotation.describe().contains("rotation"));
         assert!(NotAPinch::Coincident.describe().contains("same point"));
         assert!(NotAPinch::Stationary.describe().contains("did not move"));
+        let too_small = NotAPinch::ScaleTooSmall(1.02).describe();
+        assert!(too_small.contains("2.0%"), "{too_small}");
+        assert!(
+            too_small.contains("larger"),
+            "it must say what to do instead: {too_small}"
+        );
     }
 }

--- a/crates/glass-core/src/pinch.rs
+++ b/crates/glass-core/src/pinch.rs
@@ -8,20 +8,16 @@ use crate::platform::Segment;
 /// Below this fractional change in finger separation, a gesture is not a scale change.
 /// Compared against `|scale - 1.0|` — an absolute deviation from 1, not a percentage.
 ///
-/// Measured against idb companion 1.5.0b3 on iOS 26.5, pinching about the middle of an
-/// iPhone 17: a requested 2.0 arrived as 1.905 and a requested 0.5 as 0.513, both within about
-/// 5% of the request at a start radius of 80pt. That error grows sharply as the radius shrinks
-/// — the same requested 2.0 arrives as 1.333 at an 8pt radius — so 5% is the floor at a
-/// comfortable radius rather than a guarantee. A request smaller than the delivery error cannot
-/// be told apart from it.
+/// Measured against idb companion 1.5.0b3 on iOS 26.5: a requested 2.0 arrived as 1.905 and a
+/// requested 0.5 as 0.513 at an 80pt start radius, and the same 2.0 as 1.333 at 8pt. A request
+/// smaller than that delivery error cannot be told apart from it.
 pub const SCALE_EPSILON: f64 = 0.05;
 
 /// A two-finger pinch: where it is centred, how far apart the fingers start, and the factor
 /// their separation changes by.
 ///
-/// `#[non_exhaustive]` so [`Pinch::classify`] stays the only way to build one, in the house
-/// style of `GlassError::Bounded`. The fields are read freely; what is prevented is a literal
-/// that skips the classification, which is where every invariant below comes from.
+/// `#[non_exhaustive]` so [`Pinch::classify`] stays the only way to build one — the field
+/// invariants below all come from it.
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[non_exhaustive]
 pub struct Pinch {
@@ -118,9 +114,8 @@ impl Pinch {
 /// What a pair whose separation held actually is: nothing moved, the axis turned, the pair
 /// travelled, or a pinch too small to deliver.
 ///
-/// Rotation is told from pan by the **axis** through the fingers, not by midpoint travel: a
-/// rotation about one held finger moves the midpoint exactly as a pan does, and reporting that
-/// as a pan would name a gesture the caller did not ask for.
+/// Do not go back to telling rotation from pan by midpoint travel: a rotation about one held
+/// finger moves the midpoint exactly as a pan does.
 fn separation_held(a: &Segment, b: &Segment, scale: f64) -> NotAPinch {
     let still = |s: &Segment| s.from_x == s.to_x && s.from_y == s.to_y;
     if still(a) && still(b) {
@@ -129,8 +124,8 @@ fn separation_held(a: &Segment, b: &Segment, scale: f64) -> NotAPinch {
     if axis_turned(a, b) {
         return NotAPinch::Rotation;
     }
-    // Separation and axis both held, so the pair is rigid; if it also went nowhere it was the
-    // `Stationary` case above, and a rigid pair that moved has travelled.
+    // Separation and axis both held, so the pair is rigid; one that also went nowhere was
+    // `Stationary` above.
     if midpoint((a.from_x, a.from_y), (b.from_x, b.from_y))
         != midpoint((a.to_x, a.to_y), (b.to_x, b.to_y))
     {
@@ -142,10 +137,8 @@ fn separation_held(a: &Segment, b: &Segment, scale: f64) -> NotAPinch {
 /// Whether the axis through the two fingers turned by more than one pixel of perpendicular
 /// travel at this separation.
 ///
-/// The tolerance scales with the separation rather than being a constant: one pixel is the
-/// finest distinction integer coordinates can express, so a turn below `atan(1 / separation)`
-/// is rounding rather than a gesture. Widely separated fingers resolve a finer rotation than
-/// close ones, which is the physical truth of it.
+/// One pixel is the finest distinction integer coordinates can express, so a turn below
+/// `atan(1 / separation)` is rounding rather than a gesture.
 fn axis_turned(a: &Segment, b: &Segment) -> bool {
     let angle = |from: (i32, i32), to: (i32, i32)| {
         let d = |p: i32, q: i32| (i64::from(p) - i64::from(q)) as f64;
@@ -222,8 +215,7 @@ mod tests {
 
     #[test]
     fn fingers_converging_on_one_point_scale_to_zero() {
-        // The natural "pinch fully closed". The starts are distinct, so this is not
-        // `Coincident`; idb actuates it as a pinch all the way in.
+        // The starts are distinct, so this is not `Coincident`; idb actuates it fully closed.
         let p = Pinch::classify(&[seg((100, 400), (200, 400)), seg((300, 400), (200, 400))])
             .expect("converging on one point is a pinch, not an error");
         assert_eq!(p.scale, 0.0);
@@ -270,19 +262,17 @@ mod tests {
 
     #[test]
     fn a_rotation_about_one_held_finger_is_a_rotation_not_a_pan() {
-        // `a` is pinned and `b` swings a quarter turn around it, so the midpoint travels just
-        // as far as a pan's would. Only the axis tells these two apart.
+        // `b` swings a quarter turn about the pinned `a`, so the midpoint travels as a pan's
+        // would — only the axis tells them apart.
         let g = [seg((100, 400), (100, 400)), seg((300, 400), (100, 600))];
         assert_eq!(Pinch::classify(&g), Err(NotAPinch::Rotation));
     }
 
     #[test]
     fn exactly_one_pixel_of_perpendicular_travel_is_not_a_rotation() {
-        // The tolerance boundary, and it is exactly constructible: `b` moves one pixel
-        // perpendicular at a separation of 200, so the turn is `atan2(1, 200)`, bit-identical
-        // to the `atan(1 / 200)` tolerance. The axis must turn by *more* than one pixel, so
-        // this falls through as a separation change too small to deliver rather than being
-        // reported as a rotation.
+        // `b` moves one pixel perpendicular at a separation of 200, so the turn is
+        // `atan2(1, 200)` — bit-identical to the `atan(1 / 200)` tolerance, and the boundary is
+        // therefore exactly constructible.
         let g = [seg((100, 400), (100, 400)), seg((300, 400), (300, 401))];
         assert!(
             matches!(Pinch::classify(&g), Err(NotAPinch::ScaleTooSmall(_))),
@@ -299,8 +289,7 @@ mod tests {
 
     #[test]
     fn a_spread_under_the_epsilon_is_named_as_a_too_small_pinch() {
-        // 200 -> 204 is 2%: a pinch, but a smaller one than can be delivered. It must not be
-        // reported as some other gesture the caller never asked for.
+        // 200 -> 204 is 2%: a pinch, but smaller than can be delivered.
         let g = [seg((100, 400), (98, 400)), seg((300, 400), (302, 400))];
         let Err(NotAPinch::ScaleTooSmall(scale)) = Pinch::classify(&g) else {
             panic!("expected ScaleTooSmall, got {:?}", Pinch::classify(&g));
@@ -320,9 +309,8 @@ mod tests {
 
     #[test]
     fn a_spread_just_outside_the_epsilon_is_a_pinch() {
-        // 200 -> 210 is exactly 1.05, and `1.05 - 1.0` in f64 is 0.050000000000000044, not
-        // below the epsilon. The smallest spread this accepts, pinning the constant from the
-        // side no other test covers.
+        // `1.05 - 1.0` in f64 is 0.050000000000000044, not below the epsilon — the smallest
+        // spread this accepts.
         let p = Pinch::classify(&[seg((100, 400), (95, 400)), seg((300, 400), (305, 400))])
             .expect("just outside the epsilon is a scale change");
         assert_eq!(p.scale, 1.05);
@@ -330,8 +318,7 @@ mod tests {
 
     #[test]
     fn separation_does_not_overflow_on_extreme_coordinates() {
-        // `classify` is public API with no stated precondition on coordinate range. Subtracting
-        // in i32 panics in debug and wraps to a confidently wrong answer in release.
+        // Subtracting in i32 panics in debug and wraps to a wrong answer in release.
         let g = [
             seg((i32::MAX, 0), (i32::MAX, 0)),
             seg((i32::MIN, 0), (i32::MIN, 0)),

--- a/crates/glass-core/src/pinch.rs
+++ b/crates/glass-core/src/pinch.rs
@@ -1,0 +1,233 @@
+//! Classify a two-pointer gesture as a pinch, or say why it is not one.
+//!
+//! Backend-agnostic geometry over [`Segment`], mirroring [`crate::drag`]: the plan is derived
+//! here and actuated by whichever backend has a pinch primitive.
+
+use crate::platform::Segment;
+
+/// Below this fractional change in finger separation, a gesture is not a scale change.
+///
+/// Measured against idb companion 1.5.0b3 on iOS 26.5: a requested scale of 2.0 delivered 1.905
+/// and 0.5 delivered 0.513, because `UIPinchGestureRecognizer` takes its reference distance at
+/// its own `began`, already one interpolation step in. A request smaller than that error cannot
+/// be told apart from it.
+pub const SCALE_EPSILON: f64 = 0.05;
+
+/// Midpoint travel (px) separating a two-finger pan from a rotation. Consulted only when the
+/// separation held, so it discriminates those two and nothing else.
+pub const PAN_MIN_PX: f64 = 4.0;
+
+/// A two-finger pinch: where it is centred, how far apart the fingers start, and the factor
+/// their separation changes by.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Pinch {
+    /// Midpoint of the two **start** points, window-relative px.
+    pub center: (i32, i32),
+    /// Half the starting separation, px.
+    pub start_radius: f64,
+    /// End separation divided by start separation. Above 1 the fingers spread.
+    pub scale: f64,
+}
+
+/// Why a gesture is not a pinch. Each variant is a distinct gesture the caller asked for, so a
+/// backend can name the one it refused rather than answering "unsupported".
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NotAPinch {
+    /// Not exactly two pointers; carries how many there were.
+    PointerCount(usize),
+    /// Both fingers start at the same point, leaving no separation to scale.
+    Coincident,
+    /// Separation held while the midpoint travelled: a two-finger pan.
+    Pan,
+    /// Separation and midpoint both held while the finger axis turned.
+    Rotation,
+    /// Neither finger moved.
+    Stationary,
+}
+
+impl NotAPinch {
+    /// A phrase naming what the caller asked for, for an error a user reads.
+    pub fn describe(self) -> String {
+        match self {
+            NotAPinch::PointerCount(n) => {
+                format!("a {n}-pointer gesture; only a 2-finger pinch can be actuated")
+            }
+            NotAPinch::Coincident => {
+                "both fingers start at the same point, so there is no separation to scale"
+                    .to_string()
+            }
+            NotAPinch::Pan => {
+                "a two-finger pan, which is a different gesture from a pinch".to_string()
+            }
+            NotAPinch::Rotation => {
+                "a rotation, which is a different gesture from a pinch".to_string()
+            }
+            NotAPinch::Stationary => "a gesture whose fingers did not move".to_string(),
+        }
+    }
+}
+
+impl Pinch {
+    /// Classify `pointers` as a pinch, or return the reason it is not one.
+    ///
+    /// A change in separation is what makes a pinch; the axis it happens on does not, because a
+    /// pinch recognizer reports scale alone. An asymmetric pair — one finger held, the other
+    /// travelling — is therefore still a pinch.
+    pub fn classify(pointers: &[Segment]) -> Result<Pinch, NotAPinch> {
+        let [a, b] = pointers else {
+            return Err(NotAPinch::PointerCount(pointers.len()));
+        };
+        // Compared as integers: a zero separation would make `scale` a division by zero, and the
+        // coordinates are exact, so this needs no float tolerance.
+        if a.from_x == b.from_x && a.from_y == b.from_y {
+            return Err(NotAPinch::Coincident);
+        }
+        let start = separation((a.from_x, a.from_y), (b.from_x, b.from_y));
+        let end = separation((a.to_x, a.to_y), (b.to_x, b.to_y));
+        let scale = end / start;
+        if (scale - 1.0).abs() < SCALE_EPSILON {
+            return Err(separation_held(a, b));
+        }
+        Ok(Pinch {
+            center: midpoint((a.from_x, a.from_y), (b.from_x, b.from_y)),
+            start_radius: start / 2.0,
+            scale,
+        })
+    }
+}
+
+/// Which non-pinch a constant-separation pair is: nothing moved, the pair travelled, or it turned.
+fn separation_held(a: &Segment, b: &Segment) -> NotAPinch {
+    let still = |s: &Segment| s.from_x == s.to_x && s.from_y == s.to_y;
+    if still(a) && still(b) {
+        return NotAPinch::Stationary;
+    }
+    let from = midpoint((a.from_x, a.from_y), (b.from_x, b.from_y));
+    let to = midpoint((a.to_x, a.to_y), (b.to_x, b.to_y));
+    if separation(from, to) > PAN_MIN_PX {
+        NotAPinch::Pan
+    } else {
+        NotAPinch::Rotation
+    }
+}
+
+/// Distance between two window-relative points, px.
+fn separation(a: (i32, i32), b: (i32, i32)) -> f64 {
+    f64::from(a.0 - b.0).hypot(f64::from(a.1 - b.1))
+}
+
+/// Midpoint of two window-relative points. Summed as `i64` so extreme coordinates cannot
+/// overflow the intermediate.
+fn midpoint(a: (i32, i32), b: (i32, i32)) -> (i32, i32) {
+    let mid = |p: i32, q: i32| ((i64::from(p) + i64::from(q)) / 2) as i32;
+    (mid(a.0, b.0), mid(a.1, b.1))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn seg(from: (i32, i32), to: (i32, i32)) -> Segment {
+        Segment {
+            from_x: from.0,
+            from_y: from.1,
+            to_x: to.0,
+            to_y: to.1,
+        }
+    }
+
+    #[test]
+    fn symmetric_spread_is_a_pinch_centred_on_the_start_midpoint() {
+        // Fingers at x=100 and x=300 (y=400) move out to x=50 and x=350.
+        let p = Pinch::classify(&[seg((100, 400), (50, 400)), seg((300, 400), (350, 400))])
+            .expect("a symmetric spread is a pinch");
+        assert_eq!(p.center, (200, 400));
+        assert_eq!(p.start_radius, 100.0);
+        assert_eq!(p.scale, 1.5);
+    }
+
+    #[test]
+    fn converging_fingers_scale_below_one() {
+        let p = Pinch::classify(&[seg((100, 400), (150, 400)), seg((300, 400), (250, 400))])
+            .expect("a converging pair is a pinch");
+        assert_eq!(p.scale, 0.5);
+    }
+
+    #[test]
+    fn one_finger_held_still_is_a_pinch_not_a_pan() {
+        // Asymmetric: only the right finger travels. Separation 200 -> 300.
+        let p = Pinch::classify(&[seg((100, 400), (100, 400)), seg((300, 400), (400, 400))])
+            .expect("an asymmetric spread is still a scale change");
+        assert_eq!(p.center, (200, 400));
+        assert_eq!(p.scale, 1.5);
+    }
+
+    #[test]
+    fn a_vertical_pinch_classifies_the_same_as_a_horizontal_one() {
+        let p = Pinch::classify(&[seg((400, 100), (400, 50)), seg((400, 300), (400, 350))])
+            .expect("axis does not decide pinch-ness");
+        assert_eq!(p.center, (400, 200));
+        assert_eq!(p.scale, 1.5);
+    }
+
+    #[test]
+    fn three_pointers_report_their_count() {
+        let g = [
+            seg((0, 0), (1, 1)),
+            seg((2, 2), (3, 3)),
+            seg((4, 4), (5, 5)),
+        ];
+        assert_eq!(Pinch::classify(&g), Err(NotAPinch::PointerCount(3)));
+    }
+
+    #[test]
+    fn one_pointer_reports_its_count() {
+        assert_eq!(
+            Pinch::classify(&[seg((0, 0), (1, 1))]),
+            Err(NotAPinch::PointerCount(1))
+        );
+    }
+
+    #[test]
+    fn fingers_starting_at_one_point_are_coincident() {
+        // Scale would be a division by zero, so this must be caught before the ratio.
+        let g = [seg((200, 400), (100, 400)), seg((200, 400), (300, 400))];
+        assert_eq!(Pinch::classify(&g), Err(NotAPinch::Coincident));
+    }
+
+    #[test]
+    fn parallel_travel_at_constant_separation_is_a_pan() {
+        let g = [seg((100, 400), (100, 200)), seg((300, 400), (300, 200))];
+        assert_eq!(Pinch::classify(&g), Err(NotAPinch::Pan));
+    }
+
+    #[test]
+    fn a_turned_axis_at_constant_separation_is_a_rotation() {
+        // The pair swaps ends about a fixed midpoint: separation held, axis turned.
+        let g = [seg((100, 400), (300, 400)), seg((300, 400), (100, 400))];
+        assert_eq!(Pinch::classify(&g), Err(NotAPinch::Rotation));
+    }
+
+    #[test]
+    fn two_fingers_that_never_move_are_stationary() {
+        let g = [seg((100, 400), (100, 400)), seg((300, 400), (300, 400))];
+        assert_eq!(Pinch::classify(&g), Err(NotAPinch::Stationary));
+    }
+
+    #[test]
+    fn a_separation_change_under_the_epsilon_is_not_a_scale_change() {
+        // 200 -> 204 is 2%, inside SCALE_EPSILON, and the midpoint holds: a rotation-shaped
+        // no-op rather than a pinch glass would be unable to deliver faithfully.
+        let g = [seg((100, 400), (98, 400)), seg((300, 400), (302, 400))];
+        assert_eq!(Pinch::classify(&g), Err(NotAPinch::Rotation));
+    }
+
+    #[test]
+    fn describe_names_what_the_caller_asked_for() {
+        assert!(NotAPinch::PointerCount(3).describe().contains('3'));
+        assert!(NotAPinch::Pan.describe().contains("pan"));
+        assert!(NotAPinch::Rotation.describe().contains("rotation"));
+        assert!(NotAPinch::Coincident.describe().contains("same point"));
+        assert!(NotAPinch::Stationary.describe().contains("did not move"));
+    }
+}

--- a/crates/glass-ios/src/idb/client.rs
+++ b/crates/glass-ios/src/idb/client.rs
@@ -39,6 +39,8 @@ const RPC_TIMEOUT: Duration = Duration::from_secs(30);
 pub struct IdbClient {
     rt: Runtime,
     client: CompanionServiceClient<Channel>,
+    /// The companion binary serving this channel, so an error can name what refused a call.
+    bin: PathBuf,
 }
 
 /// Budget for one `hid` stream. A `HidSwipe`/`HidDelay`/`HidPinch` plays out over
@@ -86,9 +88,44 @@ fn map_timed<T, E: std::fmt::Display>(
     }
 }
 
+/// Whether `status` is idb refusing an event its build does not implement. The companion answers
+/// `InvalidArgument` for both an unimplemented event and a malformed one, so the marker text is
+/// what separates them.
+fn unimplemented_event(status: &tonic::Status) -> bool {
+    status.code() == tonic::Code::InvalidArgument
+        && status.message().contains("Unrecognized request.event")
+}
+
+/// The error for an event this companion does not implement, with its build info injected.
+///
+/// It reports what was observed — the binary that refused, and idb's own words — and claims
+/// nothing about which builds carry the event, because that is not a fact this process can
+/// check and a claim that cannot be checked cannot be kept true.
+fn unimplemented_event_error_with(
+    bin: &Path,
+    status: &tonic::Status,
+    info: Option<String>,
+) -> GlassError {
+    let build = match info {
+        Some(text) => format!(" Its --version reports: {text}."),
+        None => String::new(),
+    };
+    GlassError::Backend(format!(
+        "the idb_companion at {} does not implement this event: it answered {:?}.{build} \
+         A newer idb_companion is required.",
+        bin.display(),
+        status.message()
+    ))
+}
+
+/// [`unimplemented_event_error_with`] for a companion whose build info has not been read.
+fn unimplemented_event_error(bin: &Path, status: &tonic::Status) -> GlassError {
+    unimplemented_event_error_with(bin, status, None)
+}
+
 impl IdbClient {
     /// Connect to `idb_companion`'s gRPC over the Unix socket at `sock`.
-    pub fn connect(sock: &Path) -> Result<IdbClient> {
+    pub fn connect(sock: &Path, bin: &Path) -> Result<IdbClient> {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -117,6 +154,7 @@ impl IdbClient {
         Ok(IdbClient {
             rt,
             client: CompanionServiceClient::new(channel),
+            bin: bin.to_path_buf(),
         })
     }
 
@@ -138,6 +176,7 @@ impl IdbClient {
         IdbClient {
             rt,
             client: CompanionServiceClient::new(channel),
+            bin: PathBuf::from("/nonexistent/idb_companion"),
         }
     }
 
@@ -191,8 +230,14 @@ impl IdbClient {
             let stream = tokio_stream::iter(events);
             tokio::time::timeout(timeout, client.hid(stream)).await
         });
-        map_timed("idb hid", timeout, outcome)?;
-        Ok(())
+        match outcome {
+            // An event this build does not implement is reported as that, rather than as the
+            // generic backend string every other status folds into.
+            Ok(Err(status)) if unimplemented_event(&status) => {
+                Err(unimplemented_event_error(&self.bin, &status))
+            }
+            other => map_timed("idb hid", timeout, other).map(|_| ()),
+        }
     }
 
     /// Guard the `block_on` threading invariant (see the type doc): calling an RPC from a
@@ -229,8 +274,8 @@ mod tests {
         let udid = std::env::var("GLASS_IOS_UDID").expect("set GLASS_IOS_UDID to a booted sim");
         let companion =
             crate::idb::companion::IdbCompanion::spawn(&udid).expect("idb_companion must start");
-        let client =
-            IdbClient::connect(companion.socket()).expect("companion must accept a client");
+        let client = IdbClient::connect(companion.socket(), companion.bin())
+            .expect("companion must accept a client");
 
         let d = client
             .describe()
@@ -266,6 +311,42 @@ mod tests {
         assert!(
             matches!(err, GlassError::Backend(ref msg) if msg.contains("timed out after 30s")),
             "{err:?}"
+        );
+    }
+
+    #[test]
+    fn an_unrecognized_event_is_recognised_as_an_unimplemented_one() {
+        let status = tonic::Status::invalid_argument("Unrecognized request.event");
+        assert!(unimplemented_event(&status));
+    }
+
+    #[test]
+    fn another_invalid_argument_is_not_mistaken_for_an_unimplemented_event() {
+        // A genuine argument error must keep its own message rather than being reported as
+        // an out-of-date companion.
+        let status = tonic::Status::invalid_argument("Unrecognized press.direction");
+        assert!(!unimplemented_event(&status));
+    }
+
+    #[test]
+    fn a_different_code_carrying_the_same_text_is_not_an_unimplemented_event() {
+        let status = tonic::Status::internal("Unrecognized request.event");
+        assert!(!unimplemented_event(&status));
+    }
+
+    #[test]
+    fn the_unimplemented_event_error_names_the_binary_that_refused_it() {
+        let err = unimplemented_event_error_with(
+            std::path::Path::new("/somewhere/idb_companion"),
+            &tonic::Status::invalid_argument("Unrecognized request.event"),
+            None,
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("/somewhere/idb_companion"), "{msg}");
+        assert!(msg.contains("does not implement"), "{msg}");
+        assert!(
+            msg.contains("Unrecognized request.event"),
+            "the cause is quoted: {msg}"
         );
     }
 
@@ -368,7 +449,11 @@ mod tests {
     #[test]
     fn connect_to_missing_socket_errors_cleanly() {
         // A UDS path that does not exist -> a structured Backend error, no panic. Runs on Linux.
-        let err = IdbClient::connect(std::path::Path::new("/nonexistent/idb.sock")).unwrap_err();
+        let err = IdbClient::connect(
+            std::path::Path::new("/nonexistent/idb.sock"),
+            std::path::Path::new("/nonexistent/idb_companion"),
+        )
+        .unwrap_err();
         assert!(matches!(err, glass_core::GlassError::Backend(_)), "{err:?}");
     }
 
@@ -387,7 +472,7 @@ mod tests {
         {
             let _listener = std::os::unix::net::UnixListener::bind(&sock).expect("bind");
         }
-        match IdbClient::connect(&sock) {
+        match IdbClient::connect(&sock, std::path::Path::new("/nonexistent/idb_companion")) {
             // Refused at the transport layer — the common case.
             Err(GlassError::Backend(_)) => {}
             // `connect` optimistically succeeded; the first RPC must then fail cleanly.

--- a/crates/glass-ios/src/idb/client.rs
+++ b/crates/glass-ios/src/idb/client.rs
@@ -41,6 +41,12 @@ pub struct IdbClient {
     client: CompanionServiceClient<Channel>,
     /// The companion binary serving this channel, so an error can name what refused a call.
     bin: PathBuf,
+    /// That binary's `--version` output as read **when the companion was spawned**, so the
+    /// error describes the process actually serving this channel. Re-reading it at error time
+    /// would report whatever is on disk by then — which, right after a user follows the
+    /// error's own advice and replaces the binary, is a fresh build quoted as evidence that
+    /// an old one is in the way.
+    build_info: Option<String>,
 }
 
 /// Budget for one `hid` stream. A `HidSwipe`/`HidDelay`/`HidPinch` plays out over
@@ -88,9 +94,37 @@ fn map_timed<T, E: std::fmt::Display>(
     }
 }
 
-/// Whether `status` is idb refusing an event its build does not implement. The companion answers
-/// `InvalidArgument` for both an unimplemented event and a malformed one, so the marker text is
-/// what separates them.
+/// Fold one `hid` outcome into a `Result`. An event this build does not implement is reported
+/// as that; everything else keeps the generic folding every other RPC gets.
+///
+/// Split out of [`IdbClient::hid`] so the routing itself is assertable without a live
+/// companion — the predicate and the message were each tested while the choice between them
+/// was not, which is the shape that passes while the feature is gone.
+fn map_hid_outcome<T>(
+    bin: &Path,
+    build_info: Option<&str>,
+    timeout: Duration,
+    outcome: std::result::Result<
+        std::result::Result<T, tonic::Status>,
+        tokio::time::error::Elapsed,
+    >,
+) -> Result<()> {
+    match outcome {
+        Ok(Err(status)) if unimplemented_event(&status) => Err(unimplemented_event_error_with(
+            bin,
+            &status,
+            build_info.map(str::to_owned),
+        )),
+        other => map_timed("idb hid", timeout, other).map(|_| ()),
+    }
+}
+
+/// Whether `status` is idb refusing an event its build does not implement.
+///
+/// Observed against companion 1.1.8: an unimplemented event and a malformed one both come back
+/// as `InvalidArgument`, so only the marker text separates them. If that wording ever drifts
+/// this answers `false` and the caller gets the generic folding, which still carries idb's own
+/// message — a worse-framed cause, never a swallowed one.
 fn unimplemented_event(status: &tonic::Status) -> bool {
     status.code() == tonic::Code::InvalidArgument
         && status.message().contains("Unrecognized request.event")
@@ -98,9 +132,9 @@ fn unimplemented_event(status: &tonic::Status) -> bool {
 
 /// The error for an event this companion does not implement, with its build info injected.
 ///
-/// It reports what was observed — the binary that refused, and idb's own words — and claims
-/// nothing about which builds carry the event, because that is not a fact this process can
-/// check and a claim that cannot be checked cannot be kept true.
+/// Reports what was observed: the binary that refused, and idb's own words. It does not say
+/// which builds carry the event — this process cannot check that, and an unverifiable claim
+/// cannot be kept true — so it points at the setup guide for where to get one instead.
 fn unimplemented_event_error_with(
     bin: &Path,
     status: &tonic::Status,
@@ -112,43 +146,15 @@ fn unimplemented_event_error_with(
     };
     GlassError::Backend(format!(
         "the idb_companion at {} does not implement this event: it answered {:?}.{build} \
-         A newer idb_companion is required.",
+         See docs/how-to/setup-ios.md for companion requirements.",
         bin.display(),
         status.message()
     ))
 }
 
-/// How long the companion's `--version` may take while an error is already being reported.
-/// `--version` needs no simulator and returns near-instantly, so this only bounds a wedged binary.
-const BUILD_INFO_TIMEOUT: Duration = Duration::from_secs(5);
-
-/// The companion's own `--version` output, or `None` if it could not be read.
-///
-/// Echoed raw and never parsed: idb prints a build date and no version number, and that format
-/// is not glass's to depend on. This runs while another error is already being reported, so every
-/// failure — unrunnable binary, non-zero exit, blown deadline, empty output — answers `None`
-/// rather than replacing the error it was called to explain.
-fn build_info(bin: &Path) -> Option<String> {
-    let mut cmd = std::process::Command::new(bin);
-    cmd.arg("--version");
-    let out =
-        glass_core::run_bounded(&mut cmd, BUILD_INFO_TIMEOUT, "idb_companion --version").ok()?;
-    if !out.status.success() {
-        return None;
-    }
-    let text = String::from_utf8_lossy(&out.stdout).trim().to_string();
-    (!text.is_empty()).then_some(text)
-}
-
-/// [`unimplemented_event_error_with`], reading the companion's build info first.
-fn unimplemented_event_error(bin: &Path, status: &tonic::Status) -> GlassError {
-    let info = build_info(bin);
-    unimplemented_event_error_with(bin, status, info)
-}
-
 impl IdbClient {
     /// Connect to `idb_companion`'s gRPC over the Unix socket at `sock`.
-    pub fn connect(sock: &Path, bin: &Path) -> Result<IdbClient> {
+    pub fn connect(sock: &Path, bin: &Path, build_info: Option<&str>) -> Result<IdbClient> {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -178,6 +184,7 @@ impl IdbClient {
             rt,
             client: CompanionServiceClient::new(channel),
             bin: bin.to_path_buf(),
+            build_info: build_info.map(str::to_owned),
         })
     }
 
@@ -200,6 +207,7 @@ impl IdbClient {
             rt,
             client: CompanionServiceClient::new(channel),
             bin: PathBuf::from("/nonexistent/idb_companion"),
+            build_info: None,
         }
     }
 
@@ -253,14 +261,14 @@ impl IdbClient {
             let stream = tokio_stream::iter(events);
             tokio::time::timeout(timeout, client.hid(stream)).await
         });
-        match outcome {
-            // An event this build does not implement is reported as that, rather than as the
-            // generic backend string every other status folds into.
-            Ok(Err(status)) if unimplemented_event(&status) => {
-                Err(unimplemented_event_error(&self.bin, &status))
-            }
-            other => map_timed("idb hid", timeout, other).map(|_| ()),
-        }
+        // The fold lives in `map_hid_outcome` so the routing is assertable off-device. This
+        // one delegating line is the residue that is not: swapping it for a bare `map_timed`
+        // compiles and keeps every off-device test green. Only the on-box leg catches it —
+        // `a_pinch_is_accepted_by_a_companion_that_implements_it` run against a companion that
+        // predates the event, where the named error is the observable difference. There is no
+        // in-process gRPC fake in this crate to close it with, and inventing one for a single
+        // delegation would buy less than it costs.
+        map_hid_outcome(&self.bin, self.build_info.as_deref(), timeout, outcome)
     }
 
     /// Guard the `block_on` threading invariant (see the type doc): calling an RPC from a
@@ -283,17 +291,9 @@ mod tests {
 
     use super::*;
 
-    /// The scale glass drives every tap at comes from this RPC (`platform::discover_scale`),
-    /// so a target that stops reporting a usable density silently breaks input placement.
-    /// That the value is *correct* is proved end-to-end by `tests/drive_integration.rs`,
-    /// which taps elements by their accessibility bounds and asserts the app responded.
-    ///
-    /// ```sh
-    /// GLASS_IOS_UDID=<udid> cargo test -p glass-ios --lib describe_reports -- --ignored --nocapture
-    /// ```
     /// The acceptance leg for glass#117: a pinch built by the injector is accepted and executed
-    /// by a real companion. CI cannot run this — as of 2026-08 the companion Homebrew ships
-    /// rejects `HIDPinch`, and that rejection is the thing under test.
+    /// by a real companion. CI cannot run this — it needs a booted Simulator and a companion
+    /// that implements the event.
     ///
     /// Point `GLASS_IDB_COMPANION` at a companion that implements the event. To confirm the
     /// pinch also *lands* as two contacts, run it with a foreground app whose touch handler
@@ -312,8 +312,9 @@ mod tests {
         let udid = std::env::var("GLASS_IOS_UDID").expect("set GLASS_IOS_UDID to a booted sim");
         let companion =
             crate::idb::companion::IdbCompanion::spawn(&udid).expect("idb_companion must start");
-        let client = IdbClient::connect(companion.socket(), companion.bin())
-            .expect("companion must accept a client");
+        let client =
+            IdbClient::connect(companion.socket(), companion.bin(), companion.build_info())
+                .expect("companion must accept a client");
 
         // A spread about the middle of an iPhone 17 in device px (1206x2622, scale 3): fingers
         // 240px either side of centre move out to 480px, a scale of 2.0.
@@ -343,14 +344,23 @@ mod tests {
         );
     }
 
+    /// The scale glass drives every tap at comes from this RPC (`platform::discover_scale`),
+    /// so a target that stops reporting a usable density silently breaks input placement.
+    /// That the value is *correct* is proved end-to-end by `tests/drive_integration.rs`,
+    /// which taps elements by their accessibility bounds and asserts the app responded.
+    ///
+    /// ```sh
+    /// GLASS_IOS_UDID=<udid> cargo test -p glass-ios --lib describe_reports -- --ignored --nocapture
+    /// ```
     #[test]
     #[ignore = "on-box only: needs a macOS host with a booted iOS Simulator and idb_companion"]
     fn describe_reports_a_usable_density_with_no_app_running() {
         let udid = std::env::var("GLASS_IOS_UDID").expect("set GLASS_IOS_UDID to a booted sim");
         let companion =
             crate::idb::companion::IdbCompanion::spawn(&udid).expect("idb_companion must start");
-        let client = IdbClient::connect(companion.socket(), companion.bin())
-            .expect("companion must accept a client");
+        let client =
+            IdbClient::connect(companion.socket(), companion.bin(), companion.build_info())
+                .expect("companion must accept a client");
 
         let d = client
             .describe()
@@ -389,6 +399,74 @@ mod tests {
         );
     }
 
+    fn elapsed() -> tokio::time::error::Elapsed {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build a current-thread runtime");
+        rt.block_on(async {
+            tokio::time::timeout(Duration::from_millis(1), std::future::pending::<()>())
+                .await
+                .expect_err("a pending future must time out")
+        })
+    }
+
+    #[test]
+    fn an_unimplemented_event_is_routed_to_the_named_error() {
+        // The routing itself, not the predicate or the formatter: without this, deleting the
+        // arm that chooses between them leaves every other test in this file passing.
+        let outcome: std::result::Result<std::result::Result<(), _>, _> = Ok(Err(
+            tonic::Status::invalid_argument("Unrecognized request.event"),
+        ));
+        let err = map_hid_outcome(
+            std::path::Path::new("/somewhere/idb_companion"),
+            Some("build 2022"),
+            Duration::from_secs(30),
+            outcome,
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("does not implement"), "{msg}");
+        assert!(
+            msg.contains("build 2022"),
+            "the spawn-time build info: {msg}"
+        );
+    }
+
+    #[test]
+    fn any_other_status_keeps_the_generic_folding() {
+        // The guard must not annex genuine argument errors — they keep idb's own message.
+        let outcome: std::result::Result<std::result::Result<(), _>, _> = Ok(Err(
+            tonic::Status::invalid_argument("Unrecognized press.direction"),
+        ));
+        let err = map_hid_outcome(
+            std::path::Path::new("/somewhere/idb_companion"),
+            None,
+            Duration::from_secs(30),
+            outcome,
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("idb hid:"),
+            "the generic folding's own prefix: {msg}"
+        );
+        assert!(msg.contains("press.direction"), "{msg}");
+        assert!(!msg.contains("does not implement"), "{msg}");
+    }
+
+    #[test]
+    fn a_blown_deadline_still_reports_as_a_timeout() {
+        let err = map_hid_outcome(
+            std::path::Path::new("/somewhere/idb_companion"),
+            None,
+            Duration::from_secs(30),
+            Err::<std::result::Result<(), tonic::Status>, _>(elapsed()),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("timed out after 30s"), "{err}");
+    }
+
     #[test]
     fn an_unrecognized_event_is_recognised_as_an_unimplemented_one() {
         let status = tonic::Status::invalid_argument("Unrecognized request.event");
@@ -407,87 +485,6 @@ mod tests {
     fn a_different_code_carrying_the_same_text_is_not_an_unimplemented_event() {
         let status = tonic::Status::internal("Unrecognized request.event");
         assert!(!unimplemented_event(&status));
-    }
-
-    /// `ETXTBSY`. Spelled as its raw errno rather than pulling in `libc` for one constant, or
-    /// `ErrorKind::ExecutableFileBusy`, which is not yet stable to match on.
-    const ETXTBSY: i32 = 26;
-
-    /// Write `script` as an executable at `dir/name` and return once it can actually be exec'd.
-    ///
-    /// Writing a file and immediately exec'ing it races `cargo test`'s parallel threads: a
-    /// sibling's `Command::spawn` forks while this fixture's write fd is still open, the child
-    /// inherits it, and the exec fails `ETXTBSY` until that fork exec's and CLOEXEC closes it.
-    /// Measured on this box at ~16% of attempts with forking siblings.
-    ///
-    /// The wait belongs here and nowhere else: a test that expects `build_info` to answer `None`
-    /// would otherwise pass for the wrong reason, on a binary that never ran. `build_info` must
-    /// **not** retry — a real installed companion is never being written, so `ETXTBSY` there
-    /// would be a genuine fault to report rather than a race to paper over.
-    fn write_executable(dir: &std::path::Path, name: &str, script: &str) -> std::path::PathBuf {
-        use std::os::unix::fs::PermissionsExt;
-        let bin = dir.join(name);
-        std::fs::write(&bin, script).expect("write the stub");
-        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755))
-            .expect("make the stub executable");
-        let deadline = std::time::Instant::now() + Duration::from_secs(5);
-        loop {
-            match std::process::Command::new(&bin).arg("--version").output() {
-                Ok(_) => return bin,
-                Err(e) if e.raw_os_error() == Some(ETXTBSY) => {
-                    assert!(
-                        std::time::Instant::now() < deadline,
-                        "{} stayed ETXTBSY past the deadline",
-                        bin.display()
-                    );
-                    std::thread::sleep(Duration::from_millis(20));
-                }
-                Err(e) => panic!("exec {}: {e}", bin.display()),
-            }
-        }
-    }
-
-    /// A stub companion whose `--version` prints a build line and which **rejects any other
-    /// argv**, so a test using it also pins that `--version` is the flag actually passed. A
-    /// system binary cannot stand in here: GNU `/bin/echo` interprets `--version` and prints
-    /// its own banner where macOS `/bin/echo` echoes the string.
-    fn stub_companion(dir: &std::path::Path) -> std::path::PathBuf {
-        write_executable(
-            dir,
-            "stub_companion",
-            "#!/bin/sh\n[ \"$1\" = \"--version\" ] || exit 64\n\
-             echo '{\"build_date\":\"Aug 12 2022\",\"build_time\":\"08:41:50\"}'\n",
-        )
-    }
-
-    #[test]
-    fn build_info_reports_what_the_binary_printed() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let info = build_info(&stub_companion(dir.path())).expect("the stub exits 0");
-        assert_eq!(
-            info, r#"{"build_date":"Aug 12 2022","build_time":"08:41:50"}"#,
-            "the raw output is carried through, unparsed"
-        );
-    }
-
-    #[test]
-    fn build_info_gives_up_when_the_binary_prints_but_fails() {
-        // A companion that writes to stdout and then exits non-zero has not reported a build;
-        // its output must not be quoted back as though it had.
-        let dir = tempfile::tempdir().expect("tempdir");
-        let bin = write_executable(
-            dir.path(),
-            "failing_companion",
-            "#!/bin/sh\necho 'not a build line'\nexit 3\n",
-        );
-        assert_eq!(build_info(&bin), None);
-    }
-
-    #[test]
-    fn build_info_gives_up_rather_than_failing_when_the_binary_cannot_run() {
-        // The give-up path is live: this runs while another error is already being reported,
-        // so a binary that cannot be executed must yield None, not an error and not a hang.
-        assert!(build_info(std::path::Path::new("/nonexistent/idb_companion")).is_none());
     }
 
     #[test]
@@ -633,6 +630,7 @@ mod tests {
         let err = IdbClient::connect(
             std::path::Path::new("/nonexistent/idb.sock"),
             std::path::Path::new("/nonexistent/idb_companion"),
+            None,
         )
         .unwrap_err();
         assert!(matches!(err, glass_core::GlassError::Backend(_)), "{err:?}");
@@ -653,7 +651,11 @@ mod tests {
         {
             let _listener = std::os::unix::net::UnixListener::bind(&sock).expect("bind");
         }
-        match IdbClient::connect(&sock, std::path::Path::new("/nonexistent/idb_companion")) {
+        match IdbClient::connect(
+            &sock,
+            std::path::Path::new("/nonexistent/idb_companion"),
+            None,
+        ) {
             // Refused at the transport layer — the common case.
             Err(GlassError::Backend(_)) => {}
             // `connect` optimistically succeeded; the first RPC must then fail cleanly.

--- a/crates/glass-ios/src/idb/client.rs
+++ b/crates/glass-ios/src/idb/client.rs
@@ -118,9 +118,32 @@ fn unimplemented_event_error_with(
     ))
 }
 
-/// [`unimplemented_event_error_with`] for a companion whose build info has not been read.
+/// How long the companion's `--version` may take while an error is already being reported.
+/// `--version` needs no simulator and returns near-instantly, so this only bounds a wedged binary.
+const BUILD_INFO_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// The companion's own `--version` output, or `None` if it could not be read.
+///
+/// Echoed raw and never parsed: idb prints a build date and no version number, and that format
+/// is not glass's to depend on. This runs while another error is already being reported, so every
+/// failure — unrunnable binary, non-zero exit, blown deadline, empty output — answers `None`
+/// rather than replacing the error it was called to explain.
+fn build_info(bin: &Path) -> Option<String> {
+    let mut cmd = std::process::Command::new(bin);
+    cmd.arg("--version");
+    let out =
+        glass_core::run_bounded(&mut cmd, BUILD_INFO_TIMEOUT, "idb_companion --version").ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!text.is_empty()).then_some(text)
+}
+
+/// [`unimplemented_event_error_with`], reading the companion's build info first.
 fn unimplemented_event_error(bin: &Path, status: &tonic::Status) -> GlassError {
-    unimplemented_event_error_with(bin, status, None)
+    let info = build_info(bin);
+    unimplemented_event_error_with(bin, status, info)
 }
 
 impl IdbClient {
@@ -332,6 +355,78 @@ mod tests {
     fn a_different_code_carrying_the_same_text_is_not_an_unimplemented_event() {
         let status = tonic::Status::internal("Unrecognized request.event");
         assert!(!unimplemented_event(&status));
+    }
+
+    /// A stub companion whose `--version` prints a build line and which **rejects any other
+    /// argv**, so a test using it also pins that `--version` is the flag actually passed. A
+    /// system binary cannot stand in here: GNU `/bin/echo` interprets `--version` and prints
+    /// its own banner where macOS `/bin/echo` echoes the string.
+    fn stub_companion(dir: &std::path::Path) -> std::path::PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let bin = dir.join("stub_companion");
+        std::fs::write(
+            &bin,
+            "#!/bin/sh\n[ \"$1\" = \"--version\" ] || exit 64\n\
+             echo '{\"build_date\":\"Aug 12 2022\",\"build_time\":\"08:41:50\"}'\n",
+        )
+        .expect("write the stub companion");
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755))
+            .expect("make the stub executable");
+        bin
+    }
+
+    #[test]
+    fn build_info_reports_what_the_binary_printed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let info = build_info(&stub_companion(dir.path())).expect("the stub exits 0");
+        assert_eq!(
+            info, r#"{"build_date":"Aug 12 2022","build_time":"08:41:50"}"#,
+            "the raw output is carried through, unparsed"
+        );
+    }
+
+    #[test]
+    fn build_info_gives_up_when_the_binary_prints_but_fails() {
+        // A companion that writes to stdout and then exits non-zero has not reported a build;
+        // its output must not be quoted back as though it had.
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bin = dir.path().join("failing_companion");
+        std::fs::write(&bin, "#!/bin/sh\necho 'not a build line'\nexit 3\n").expect("write");
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        assert_eq!(build_info(&bin), None);
+    }
+
+    #[test]
+    fn build_info_gives_up_rather_than_failing_when_the_binary_cannot_run() {
+        // The give-up path is live: this runs while another error is already being reported,
+        // so a binary that cannot be executed must yield None, not an error and not a hang.
+        assert!(build_info(std::path::Path::new("/nonexistent/idb_companion")).is_none());
+    }
+
+    #[test]
+    fn the_error_carries_the_build_info_when_it_is_available() {
+        let err = unimplemented_event_error_with(
+            std::path::Path::new("/somewhere/idb_companion"),
+            &tonic::Status::invalid_argument("Unrecognized request.event"),
+            Some("{\"build_date\":\"Aug 12 2022\"}".to_string()),
+        );
+        assert!(err.to_string().contains("Aug 12 2022"), "{err}");
+    }
+
+    #[test]
+    fn the_error_stands_alone_when_the_build_info_is_unavailable() {
+        let err = unimplemented_event_error_with(
+            std::path::Path::new("/somewhere/idb_companion"),
+            &tonic::Status::invalid_argument("Unrecognized request.event"),
+            None,
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("does not implement"), "{msg}");
+        assert!(
+            !msg.contains("--version"),
+            "no dangling half-sentence: {msg}"
+        );
     }
 
     #[test]

--- a/crates/glass-ios/src/idb/client.rs
+++ b/crates/glass-ios/src/idb/client.rs
@@ -41,11 +41,9 @@ pub struct IdbClient {
     client: CompanionServiceClient<Channel>,
     /// The companion binary serving this channel, so an error can name what refused a call.
     bin: PathBuf,
-    /// That binary's `--version` output as read **when the companion was spawned**, so the
-    /// error describes the process actually serving this channel. Re-reading it at error time
-    /// would report whatever is on disk by then — which, right after a user follows the
-    /// error's own advice and replaces the binary, is a fresh build quoted as evidence that
-    /// an old one is in the way.
+    /// Read **when the companion was spawned**. Do not re-read it at error time: right after a
+    /// user replaces the binary as the error advises, that reports a fresh build as evidence
+    /// the old one is in the way.
     build_info: Option<String>,
 }
 
@@ -97,9 +95,9 @@ fn map_timed<T, E: std::fmt::Display>(
 /// Fold one `hid` outcome into a `Result`. An event this build does not implement is reported
 /// as that; everything else keeps the generic folding every other RPC gets.
 ///
-/// Split out of [`IdbClient::hid`] so the routing itself is assertable without a live
-/// companion — the predicate and the message were each tested while the choice between them
-/// was not, which is the shape that passes while the feature is gone.
+/// Do not inline this back into [`IdbClient::hid`]: the predicate and the message were each
+/// tested there while the choice between them was not, so the suite passed with the feature
+/// gone.
 fn map_hid_outcome<T>(
     bin: &Path,
     build_info: Option<&str>,
@@ -261,13 +259,9 @@ impl IdbClient {
             let stream = tokio_stream::iter(events);
             tokio::time::timeout(timeout, client.hid(stream)).await
         });
-        // The fold lives in `map_hid_outcome` so the routing is assertable off-device. This
-        // one delegating line is the residue that is not: swapping it for a bare `map_timed`
-        // compiles and keeps every off-device test green. Only the on-box leg catches it —
-        // `a_pinch_is_accepted_by_a_companion_that_implements_it` run against a companion that
-        // predates the event, where the named error is the observable difference. There is no
-        // in-process gRPC fake in this crate to close it with, and inventing one for a single
-        // delegation would buy less than it costs.
+        // Swapping this line for a bare `map_timed` compiles and keeps every off-device test
+        // green; only `a_pinch_is_accepted_by_a_companion_that_implements_it`, run on-box
+        // against a companion that predates the event, catches it.
         map_hid_outcome(&self.bin, self.build_info.as_deref(), timeout, outcome)
     }
 
@@ -413,8 +407,8 @@ mod tests {
 
     #[test]
     fn an_unimplemented_event_is_routed_to_the_named_error() {
-        // The routing itself, not the predicate or the formatter: without this, deleting the
-        // arm that chooses between them leaves every other test in this file passing.
+        // The routing itself: without this, deleting the arm that chooses leaves every other
+        // test in this file passing.
         let outcome: std::result::Result<std::result::Result<(), _>, _> = Ok(Err(
             tonic::Status::invalid_argument("Unrecognized request.event"),
         ));

--- a/crates/glass-ios/src/idb/client.rs
+++ b/crates/glass-ios/src/idb/client.rs
@@ -291,6 +291,58 @@ mod tests {
     /// ```sh
     /// GLASS_IOS_UDID=<udid> cargo test -p glass-ios --lib describe_reports -- --ignored --nocapture
     /// ```
+    /// The acceptance leg for glass#117: a pinch built by the injector is accepted and executed
+    /// by a real companion. CI cannot run this — as of 2026-08 the companion Homebrew ships
+    /// rejects `HIDPinch`, and that rejection is the thing under test.
+    ///
+    /// Point `GLASS_IDB_COMPANION` at a companion that implements the event. To confirm the
+    /// pinch also *lands* as two contacts, run it with a foreground app whose touch handler
+    /// logs `event.allTouches.count` and watch for two.
+    ///
+    /// ```sh
+    /// GLASS_IOS_UDID=<udid> GLASS_IDB_COMPANION=<path> \
+    ///   cargo test -p glass-ios --lib a_pinch_is_accepted -- --ignored --nocapture
+    /// ```
+    #[test]
+    #[ignore = "on-box only: needs a booted iOS Simulator and a companion that implements HIDPinch"]
+    fn a_pinch_is_accepted_by_a_companion_that_implements_it() {
+        use crate::injector::IdbInjector;
+        use glass_core::{PointerEvent, Segment};
+
+        let udid = std::env::var("GLASS_IOS_UDID").expect("set GLASS_IOS_UDID to a booted sim");
+        let companion =
+            crate::idb::companion::IdbCompanion::spawn(&udid).expect("idb_companion must start");
+        let client = IdbClient::connect(companion.socket(), companion.bin())
+            .expect("companion must accept a client");
+
+        // A spread about the middle of an iPhone 17 in device px (1206x2622, scale 3): fingers
+        // 240px either side of centre move out to 480px, a scale of 2.0.
+        let events = IdbInjector::new(3.0)
+            .pointer_events(&PointerEvent::Gesture {
+                pointers: vec![
+                    Segment {
+                        from_x: 363,
+                        from_y: 1311,
+                        to_x: 123,
+                        to_y: 1311,
+                    },
+                    Segment {
+                        from_x: 843,
+                        from_y: 1311,
+                        to_x: 1083,
+                        to_y: 1311,
+                    },
+                ],
+                duration_ms: 1000,
+            })
+            .expect("a symmetric spread classifies as a pinch");
+
+        client.hid(events).expect(
+            "the companion must accept HIDPinch; a build that does not implement it is named \
+             in this error along with its --version output",
+        );
+    }
+
     #[test]
     #[ignore = "on-box only: needs a macOS host with a booted iOS Simulator and idb_companion"]
     fn describe_reports_a_usable_density_with_no_app_running() {
@@ -357,22 +409,55 @@ mod tests {
         assert!(!unimplemented_event(&status));
     }
 
+    /// `ETXTBSY`. Spelled as its raw errno rather than pulling in `libc` for one constant, or
+    /// `ErrorKind::ExecutableFileBusy`, which is not yet stable to match on.
+    const ETXTBSY: i32 = 26;
+
+    /// Write `script` as an executable at `dir/name` and return once it can actually be exec'd.
+    ///
+    /// Writing a file and immediately exec'ing it races `cargo test`'s parallel threads: a
+    /// sibling's `Command::spawn` forks while this fixture's write fd is still open, the child
+    /// inherits it, and the exec fails `ETXTBSY` until that fork exec's and CLOEXEC closes it.
+    /// Measured on this box at ~16% of attempts with forking siblings.
+    ///
+    /// The wait belongs here and nowhere else: a test that expects `build_info` to answer `None`
+    /// would otherwise pass for the wrong reason, on a binary that never ran. `build_info` must
+    /// **not** retry — a real installed companion is never being written, so `ETXTBSY` there
+    /// would be a genuine fault to report rather than a race to paper over.
+    fn write_executable(dir: &std::path::Path, name: &str, script: &str) -> std::path::PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let bin = dir.join(name);
+        std::fs::write(&bin, script).expect("write the stub");
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755))
+            .expect("make the stub executable");
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            match std::process::Command::new(&bin).arg("--version").output() {
+                Ok(_) => return bin,
+                Err(e) if e.raw_os_error() == Some(ETXTBSY) => {
+                    assert!(
+                        std::time::Instant::now() < deadline,
+                        "{} stayed ETXTBSY past the deadline",
+                        bin.display()
+                    );
+                    std::thread::sleep(Duration::from_millis(20));
+                }
+                Err(e) => panic!("exec {}: {e}", bin.display()),
+            }
+        }
+    }
+
     /// A stub companion whose `--version` prints a build line and which **rejects any other
     /// argv**, so a test using it also pins that `--version` is the flag actually passed. A
     /// system binary cannot stand in here: GNU `/bin/echo` interprets `--version` and prints
     /// its own banner where macOS `/bin/echo` echoes the string.
     fn stub_companion(dir: &std::path::Path) -> std::path::PathBuf {
-        use std::os::unix::fs::PermissionsExt;
-        let bin = dir.join("stub_companion");
-        std::fs::write(
-            &bin,
+        write_executable(
+            dir,
+            "stub_companion",
             "#!/bin/sh\n[ \"$1\" = \"--version\" ] || exit 64\n\
              echo '{\"build_date\":\"Aug 12 2022\",\"build_time\":\"08:41:50\"}'\n",
         )
-        .expect("write the stub companion");
-        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755))
-            .expect("make the stub executable");
-        bin
     }
 
     #[test]
@@ -389,11 +474,12 @@ mod tests {
     fn build_info_gives_up_when_the_binary_prints_but_fails() {
         // A companion that writes to stdout and then exits non-zero has not reported a build;
         // its output must not be quoted back as though it had.
-        use std::os::unix::fs::PermissionsExt;
         let dir = tempfile::tempdir().expect("tempdir");
-        let bin = dir.path().join("failing_companion");
-        std::fs::write(&bin, "#!/bin/sh\necho 'not a build line'\nexit 3\n").expect("write");
-        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        let bin = write_executable(
+            dir.path(),
+            "failing_companion",
+            "#!/bin/sh\necho 'not a build line'\nexit 3\n",
+        );
         assert_eq!(build_info(&bin), None);
     }
 

--- a/crates/glass-ios/src/idb/companion.rs
+++ b/crates/glass-ios/src/idb/companion.rs
@@ -240,6 +240,9 @@ fn stderr_log_path(dir: &Path, udid: &str, pid: u32) -> PathBuf {
 pub struct IdbCompanion {
     child: Child,
     sock: PathBuf,
+    /// The binary this companion was spawned from, carried rather than re-resolved so an
+    /// error can name the binary that actually ran even if the environment has since changed.
+    bin: PathBuf,
     /// File the companion's stderr is redirected to, read back on a startup failure so the
     /// error names the real cause; removed on `Drop`.
     stderr_log: PathBuf,
@@ -316,6 +319,7 @@ impl IdbCompanion {
         let mut this = IdbCompanion {
             child,
             sock,
+            bin: bin.to_path_buf(),
             stderr_log,
         };
         // From here any failure must kill+reap the child, so a failed spawn never leaks it.
@@ -330,6 +334,11 @@ impl IdbCompanion {
     /// The Unix socket `idb_companion` serves gRPC on.
     pub fn socket(&self) -> &Path {
         &self.sock
+    }
+
+    /// The companion binary this instance was spawned from.
+    pub fn bin(&self) -> &Path {
+        &self.bin
     }
 
     /// Block until the companion's gRPC socket accepts a connection, or `deadline`. Each
@@ -391,6 +400,7 @@ impl IdbCompanion {
         IdbCompanion {
             child,
             sock: PathBuf::from("/nonexistent/glass-idb-test.sock"),
+            bin: PathBuf::from("/nonexistent/idb_companion"),
             stderr_log: PathBuf::from("/nonexistent/glass-idb-test.stderr.log"),
         }
     }

--- a/crates/glass-ios/src/idb/companion.rs
+++ b/crates/glass-ios/src/idb/companion.rs
@@ -439,7 +439,7 @@ const BUILD_INFO_TIMEOUT: Duration = Duration::from_secs(5);
 ///
 /// Echoed raw and never parsed: the format is idb's, not glass's to depend on. Every failure —
 /// unrunnable binary, non-zero exit, blown deadline, empty output — answers `None`, because this
-/// only ever decorates an error raised for another reason and must not become one itself.
+/// only decorates an error raised for another reason.
 fn build_info(bin: &Path) -> Option<String> {
     let mut cmd = std::process::Command::new(bin);
     cmd.arg("--version");
@@ -466,11 +466,9 @@ mod tests {
     /// inherits it, and the exec fails `ETXTBSY` until that fork exec's and CLOEXEC closes it.
     /// Frequent enough under `cargo test`'s parallel threads to fail runs reliably.
     ///
-    /// The wait belongs here and nowhere else: a test that expects `build_info` to answer `None`
-    /// would otherwise pass for the wrong reason, on a binary that never ran. `build_info` must
-    /// **not** retry: a real installed companion is never mid-write, so `ETXTBSY` there is a
-    /// genuine fault, and swallowing it as `None` is the deliberate trade for a path that only
-    /// decorates someone else's error.
+    /// Do not move this wait into `build_info`: a real installed companion is never mid-write,
+    /// so `ETXTBSY` there is a genuine fault. Without it here, a test expecting `None` passes on
+    /// a binary that never ran.
     fn write_executable(dir: &std::path::Path, name: &str, script: &str) -> std::path::PathBuf {
         use std::os::unix::fs::PermissionsExt;
         let bin = dir.join(name);
@@ -519,9 +517,8 @@ mod tests {
 
     #[test]
     fn build_info_gives_up_when_the_binary_prints_nothing() {
-        // A companion that exits 0 in silence has reported no build. Without this the message
-        // would read "Its --version reports: ." — the dangling half-sentence the stands-alone
-        // test exists to prevent, arriving by a route that test cannot see.
+        // Without this the message reads "Its --version reports: ." — the dangling
+        // half-sentence, by a route the stands-alone test cannot see.
         let dir = tempfile::tempdir().expect("tempdir");
         let bin = write_executable(dir.path(), "silent_companion", "#!/bin/sh\nexit 0\n");
         assert_eq!(build_info(&bin), None);
@@ -529,8 +526,7 @@ mod tests {
 
     #[test]
     fn build_info_gives_up_when_the_binary_prints_but_fails() {
-        // A companion that writes to stdout and then exits non-zero has not reported a build;
-        // its output must not be quoted back as though it had.
+        // Output from a run that then failed must not be quoted back as a build.
         let dir = tempfile::tempdir().expect("tempdir");
         let bin = write_executable(
             dir.path(),

--- a/crates/glass-ios/src/idb/companion.rs
+++ b/crates/glass-ios/src/idb/companion.rs
@@ -243,6 +243,9 @@ pub struct IdbCompanion {
     /// The binary this companion was spawned from, carried rather than re-resolved so an
     /// error can name the binary that actually ran even if the environment has since changed.
     bin: PathBuf,
+    /// That binary's `--version` output, read at spawn. Read here rather than at error time
+    /// because only here is the file on disk still the image this process is running.
+    build_info: Option<String>,
     /// File the companion's stderr is redirected to, read back on a startup failure so the
     /// error names the real cause; removed on `Drop`.
     stderr_log: PathBuf,
@@ -320,6 +323,7 @@ impl IdbCompanion {
             child,
             sock,
             bin: bin.to_path_buf(),
+            build_info: build_info(bin),
             stderr_log,
         };
         // From here any failure must kill+reap the child, so a failed spawn never leaks it.
@@ -339,6 +343,11 @@ impl IdbCompanion {
     /// The companion binary this instance was spawned from.
     pub fn bin(&self) -> &Path {
         &self.bin
+    }
+
+    /// What that binary's `--version` printed at spawn, if it could be read.
+    pub fn build_info(&self) -> Option<&str> {
+        self.build_info.as_deref()
     }
 
     /// Block until the companion's gRPC socket accepts a connection, or `deadline`. Each
@@ -401,6 +410,7 @@ impl IdbCompanion {
             child,
             sock: PathBuf::from("/nonexistent/glass-idb-test.sock"),
             bin: PathBuf::from("/nonexistent/idb_companion"),
+            build_info: None,
             stderr_log: PathBuf::from("/nonexistent/glass-idb-test.stderr.log"),
         }
     }
@@ -421,12 +431,122 @@ impl Drop for IdbCompanion {
 /// immediately if the socket file exists but nothing is listening yet — so polling it
 /// keeps [`IdbCompanion::await_socket`]'s deadline responsive; the first real RPC carries
 /// its own timeout as a backstop.
+/// How long the companion's `--version` may take. Generous: it only has to bound a binary that
+/// never answers, on a path whose result is a decoration rather than a diagnosis.
+const BUILD_INFO_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// The companion's own `--version` output, or `None` if it could not be read.
+///
+/// Echoed raw and never parsed: the format is idb's, not glass's to depend on. Every failure —
+/// unrunnable binary, non-zero exit, blown deadline, empty output — answers `None`, because this
+/// only ever decorates an error raised for another reason and must not become one itself.
+fn build_info(bin: &Path) -> Option<String> {
+    let mut cmd = std::process::Command::new(bin);
+    cmd.arg("--version");
+    let out =
+        glass_core::run_bounded(&mut cmd, BUILD_INFO_TIMEOUT, "idb_companion --version").ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!text.is_empty()).then_some(text)
+}
+
 fn socket_ready(sock: &Path) -> bool {
     UnixStream::connect(sock).is_ok()
 }
 
 #[cfg(test)]
 mod tests {
+
+    /// Write `script` as an executable at `dir/name` and return once it can actually be exec'd.
+    ///
+    /// Writing a file and immediately exec'ing it races `cargo test`'s parallel threads: a
+    /// sibling's `Command::spawn` forks while this fixture's write fd is still open, the child
+    /// inherits it, and the exec fails `ETXTBSY` until that fork exec's and CLOEXEC closes it.
+    /// Frequent enough under `cargo test`'s parallel threads to fail runs reliably.
+    ///
+    /// The wait belongs here and nowhere else: a test that expects `build_info` to answer `None`
+    /// would otherwise pass for the wrong reason, on a binary that never ran. `build_info` must
+    /// **not** retry: a real installed companion is never mid-write, so `ETXTBSY` there is a
+    /// genuine fault, and swallowing it as `None` is the deliberate trade for a path that only
+    /// decorates someone else's error.
+    fn write_executable(dir: &std::path::Path, name: &str, script: &str) -> std::path::PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let bin = dir.join(name);
+        std::fs::write(&bin, script).expect("write the stub");
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755))
+            .expect("make the stub executable");
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            match std::process::Command::new(&bin).arg("--version").output() {
+                Ok(_) => return bin,
+                Err(e) if e.kind() == std::io::ErrorKind::ExecutableFileBusy => {
+                    assert!(
+                        std::time::Instant::now() < deadline,
+                        "{} stayed ETXTBSY past the deadline",
+                        bin.display()
+                    );
+                    std::thread::sleep(Duration::from_millis(20));
+                }
+                Err(e) => panic!("exec {}: {e}", bin.display()),
+            }
+        }
+    }
+
+    /// A stub companion whose `--version` prints a build line and which **rejects any other
+    /// argv**, so a test using it also pins that `--version` is the flag actually passed. A
+    /// system binary cannot stand in here: GNU `/bin/echo` interprets `--version` and prints
+    /// its own banner where macOS `/bin/echo` echoes the string.
+    fn stub_companion(dir: &std::path::Path) -> std::path::PathBuf {
+        write_executable(
+            dir,
+            "stub_companion",
+            "#!/bin/sh\n[ \"$1\" = \"--version\" ] || exit 64\n\
+             echo '{\"build_date\":\"Aug 12 2022\",\"build_time\":\"08:41:50\"}'\n",
+        )
+    }
+
+    #[test]
+    fn build_info_reports_what_the_binary_printed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let info = build_info(&stub_companion(dir.path())).expect("the stub exits 0");
+        assert_eq!(
+            info, r#"{"build_date":"Aug 12 2022","build_time":"08:41:50"}"#,
+            "the raw output is carried through, unparsed"
+        );
+    }
+
+    #[test]
+    fn build_info_gives_up_when_the_binary_prints_nothing() {
+        // A companion that exits 0 in silence has reported no build. Without this the message
+        // would read "Its --version reports: ." — the dangling half-sentence the stands-alone
+        // test exists to prevent, arriving by a route that test cannot see.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bin = write_executable(dir.path(), "silent_companion", "#!/bin/sh\nexit 0\n");
+        assert_eq!(build_info(&bin), None);
+    }
+
+    #[test]
+    fn build_info_gives_up_when_the_binary_prints_but_fails() {
+        // A companion that writes to stdout and then exits non-zero has not reported a build;
+        // its output must not be quoted back as though it had.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bin = write_executable(
+            dir.path(),
+            "failing_companion",
+            "#!/bin/sh\necho 'not a build line'\nexit 3\n",
+        );
+        assert_eq!(build_info(&bin), None);
+    }
+
+    #[test]
+    fn build_info_gives_up_rather_than_failing_when_the_binary_cannot_run() {
+        // The give-up path is live: this runs while another error is already being reported,
+        // so a binary that cannot be executed must yield None, not an error and not a hang.
+        assert!(build_info(std::path::Path::new("/nonexistent/idb_companion")).is_none());
+    }
+
     use super::*;
     use std::ffi::OsStr;
     use std::os::unix::fs::PermissionsExt;

--- a/crates/glass-ios/src/injector/mod.rs
+++ b/crates/glass-ios/src/injector/mod.rs
@@ -48,6 +48,23 @@ fn touch(pt: proto::Point, down: bool) -> proto::HidEvent {
     press(Action::Touch(HidTouch { point: Some(pt) }), down)
 }
 
+/// Smallest pinch radius idb can actuate as two contacts, in points. Below this the fingers
+/// fall inside a single fingertip and the pair is not resolvable as two. Bounded in points, not
+/// pixels, because the pixel equivalent moves with the device's scale.
+const MIN_RADIUS_PT: f64 = 8.0;
+
+fn pinch(center: proto::Point, scale: f64, radius_pt: f64, secs: f64) -> proto::HidEvent {
+    use proto::hid_event::{Event, HidPinch};
+    proto::HidEvent {
+        event: Some(Event::Pinch(HidPinch {
+            center: Some(center),
+            scale,
+            duration: secs,
+            radius: radius_pt,
+        })),
+    }
+}
+
 fn swipe(from: proto::Point, to: proto::Point, secs: f64) -> proto::HidEvent {
     use proto::hid_event::{Event, HidSwipe};
     proto::HidEvent {
@@ -126,12 +143,41 @@ impl IdbInjector {
                 let ey = y - dy * SCROLL_STEP_PX;
                 vec![swipe(point(x, y, s), point(ex, ey, s), SWIPE_SECS)]
             }
-            PointerEvent::Gesture { .. } => {
-                return Err(GlassError::unsupported(
-                    "multi_touch",
-                    crate::BACKEND,
-                    crate::capabilities().multi_touch.note,
-                ));
+            // idb's only multi-contact primitive is a canned pinch: centre, scale and radius,
+            // with the fingers on one axis. A gesture whose separation changes maps onto it; a
+            // pan or a rotation is a different gesture, refused by name rather than actuated as
+            // something the caller did not ask for.
+            PointerEvent::Gesture {
+                ref pointers,
+                duration_ms,
+            } => {
+                let plan = glass_core::Pinch::classify(pointers).map_err(|why| {
+                    let reason = why.describe();
+                    GlassError::unsupported("multi_touch", crate::BACKEND, Some(&reason))
+                })?;
+                let radius_pt = plan.start_radius / s;
+                if radius_pt < MIN_RADIUS_PT {
+                    let reason = format!(
+                        "the fingers start {radius_pt:.1}pt from centre, too close to actuate \
+                         as two contacts (minimum {MIN_RADIUS_PT}pt)"
+                    );
+                    return Err(GlassError::unsupported(
+                        "multi_touch",
+                        crate::BACKEND,
+                        Some(&reason),
+                    ));
+                }
+                let secs = if duration_ms == 0 {
+                    SWIPE_SECS
+                } else {
+                    duration_ms as f64 / 1000.0
+                };
+                vec![pinch(
+                    point(plan.center.0, plan.center.1, s),
+                    plan.scale,
+                    radius_pt,
+                    secs,
+                )]
             }
         })
     }
@@ -299,25 +345,127 @@ mod pointer_tests {
         );
     }
 
+    fn seg(from: (i32, i32), to: (i32, i32)) -> glass_core::Segment {
+        glass_core::Segment {
+            from_x: from.0,
+            from_y: from.1,
+            to_x: to.0,
+            to_y: to.1,
+        }
+    }
+
+    fn gesture(pointers: Vec<glass_core::Segment>, duration_ms: u64) -> PointerEvent {
+        PointerEvent::Gesture {
+            pointers,
+            duration_ms,
+        }
+    }
+
     #[test]
-    fn move_is_empty_and_gesture_unsupported() {
+    fn move_is_empty() {
         let inj = IdbInjector::new(3.0);
         assert!(
             inj.pointer_events(&PointerEvent::Move { x: 1, y: 2 })
                 .unwrap()
                 .is_empty()
         );
-        let g = PointerEvent::Gesture {
-            pointers: vec![],
-            duration_ms: 100,
+    }
+
+    #[test]
+    fn a_pinch_becomes_one_hid_pinch_in_points_not_pixels() {
+        use proto::hid_event::Event;
+        // scale 3.0: centre (600,1200)px = (200,400)pt, start separation 600px = 200pt,
+        // so radius 100pt; separation 600 -> 900px is scale 1.5.
+        let inj = IdbInjector::new(3.0);
+        let events = inj
+            .pointer_events(&gesture(
+                vec![
+                    seg((300, 1200), (150, 1200)),
+                    seg((900, 1200), (1050, 1200)),
+                ],
+                400,
+            ))
+            .expect("a symmetric spread actuates");
+        assert_eq!(events.len(), 1, "one pinch, not a stream of touches");
+        let Some(Event::Pinch(p)) = &events[0].event else {
+            panic!("expected a pinch event, got {:?}", events[0].event);
         };
-        let err = inj.pointer_events(&g).unwrap_err();
-        assert!(matches!(err, glass_core::GlassError::Unsupported(_)));
+        let center = p.center.as_ref().expect("a pinch carries its centre");
+        assert_eq!((center.x, center.y), (200.0, 400.0));
+        assert_eq!(p.radius, 100.0);
+        assert_eq!(p.scale, 1.5);
+        assert_eq!(p.duration, 0.4, "duration_ms is carried through as seconds");
+    }
+
+    #[test]
+    fn a_zero_duration_pinch_falls_back_to_the_default_swipe_duration() {
+        use proto::hid_event::Event;
+        let inj = IdbInjector::new(1.0);
+        let events = inj
+            .pointer_events(&gesture(
+                vec![seg((100, 400), (50, 400)), seg((300, 400), (350, 400))],
+                0,
+            ))
+            .expect("actuates");
+        let Some(Event::Pinch(p)) = &events[0].event else {
+            panic!("expected a pinch event")
+        };
+        assert_eq!(p.duration, SWIPE_SECS);
+    }
+
+    #[test]
+    fn a_rejected_gesture_names_the_gesture_it_refused() {
+        let inj = IdbInjector::new(1.0);
+        // A two-finger pan: separation held, midpoint travelled.
+        let err = inj
+            .pointer_events(&gesture(
+                vec![seg((100, 400), (100, 200)), seg((300, 400), (300, 200))],
+                250,
+            ))
+            .unwrap_err();
         let msg = err.to_string();
+        assert!(
+            matches!(err, glass_core::GlassError::Unsupported(_)),
+            "{err:?}"
+        );
+        assert!(
+            msg.contains("pan"),
+            "the reason must name the gesture: {msg}"
+        );
         assert!(msg.contains("ios backend"), "{msg}");
-        assert!(msg.contains("multi_touch"), "{msg}");
-        assert!(msg.contains("glass_capabilities"), "{msg}");
-        assert!(msg.contains("single-contact"), "{msg}");
+    }
+
+    #[test]
+    fn three_pointers_are_still_unsupported() {
+        let inj = IdbInjector::new(1.0);
+        let err = inj
+            .pointer_events(&gesture(
+                vec![
+                    seg((0, 0), (1, 1)),
+                    seg((2, 2), (3, 3)),
+                    seg((4, 4), (5, 5)),
+                ],
+                250,
+            ))
+            .unwrap_err();
+        assert!(err.to_string().contains('3'), "{err}");
+    }
+
+    #[test]
+    fn fingers_closer_than_one_fingertip_are_refused_in_points() {
+        // 18px apart at scale 3.0 is a 3pt radius — under MIN_RADIUS_PT. The same pixel
+        // separation at scale 1.0 is a legitimate pinch, so the bound must be applied in
+        // points, the unit idb actuates in.
+        let close = vec![seg((291, 400), (285, 400)), seg((309, 400), (330, 400))];
+        let err = IdbInjector::new(3.0)
+            .pointer_events(&gesture(close.clone(), 250))
+            .unwrap_err();
+        assert!(err.to_string().contains("too close"), "{err}");
+        assert!(
+            IdbInjector::new(1.0)
+                .pointer_events(&gesture(close, 250))
+                .is_ok()
+        );
     }
 
     #[test]

--- a/crates/glass-ios/src/injector/mod.rs
+++ b/crates/glass-ios/src/injector/mod.rs
@@ -48,17 +48,25 @@ fn touch(pt: proto::Point, down: bool) -> proto::HidEvent {
     press(Action::Touch(HidTouch { point: Some(pt) }), down)
 }
 
-/// Smallest pinch radius idb can actuate as two contacts, in points. Below this the fingers
-/// fall inside a single fingertip and the pair is not resolvable as two. Bounded in points, not
-/// pixels, because the pixel equivalent moves with the device's scale.
+/// Smallest pinch radius glass will actuate, in points.
+///
+/// Measured against idb companion 1.5.0b3 on iOS 26.5: two contacts arrive at any radius, even
+/// 1pt, but below roughly 5pt no pinch is recognised from them at all, and near the floor the
+/// delivered factor is far from the request — a requested 2.0 arrives as 1.333 at an 8pt
+/// radius against 1.905 at 80pt. 8pt keeps a margin over the smallest radius measured to be
+/// recognised; below it glass would actuate a gesture that silently does nothing.
+///
+/// Bounded in points, not pixels, because the pixel equivalent moves with the device's scale.
 const MIN_RADIUS_PT: f64 = 8.0;
 
-fn pinch(center: proto::Point, scale: f64, radius_pt: f64, secs: f64) -> proto::HidEvent {
+/// `factor` is the pinch's scale factor; the density that converts pixels to points is the
+/// injector's own `scale`, and the two are deliberately not spelled alike here.
+fn pinch(center: proto::Point, factor: f64, radius_pt: f64, secs: f64) -> proto::HidEvent {
     use proto::hid_event::{Event, HidPinch};
     proto::HidEvent {
         event: Some(Event::Pinch(HidPinch {
             center: Some(center),
-            scale,
+            scale: factor,
             duration: secs,
             radius: radius_pt,
         })),
@@ -104,10 +112,11 @@ impl IdbInjector {
     /// Maps one glass `PointerEvent` to the idb HID events that reproduce it as a
     /// touch: a `Click` is a touch DOWN then UP at the same point (repeated `count`
     /// times); a `Drag`/`Scroll` is a single swipe; a `Move` is empty — touch has no
-    /// hover state to emit. `Gesture` (multi-touch) returns `Unsupported` rather than
-    /// silently dropping the pointers: idb's raw-touch primitive is single-contact
-    /// (a second concurrent DOWN relocates the same finger), so there is no general
-    /// N-finger primitive to map it to.
+    /// hover state to emit. A `Gesture` whose two fingers change separation becomes one
+    /// pinch; any other multi-touch gesture returns `Unsupported` naming what it was,
+    /// rather than silently actuating something else — the raw-touch primitive is
+    /// single-contact (a second concurrent DOWN relocates the same finger), so a pinch is
+    /// the only multi-contact gesture there is anything to map onto.
     pub fn pointer_events(&self, e: &PointerEvent) -> Result<Vec<proto::HidEvent>> {
         let s = self.scale;
         Ok(match *e {
@@ -143,8 +152,8 @@ impl IdbInjector {
                 let ey = y - dy * SCROLL_STEP_PX;
                 vec![swipe(point(x, y, s), point(ex, ey, s), SWIPE_SECS)]
             }
-            // idb's only multi-contact primitive is a canned pinch: centre, scale and radius,
-            // with the fingers on one axis. A gesture whose separation changes maps onto it; a
+            // The vendored proto's `HIDEvent` oneof carries one multi-contact event: a canned
+            // pinch of centre, scale and radius. A separation change maps onto it; a
             // pan or a rotation is a different gesture, refused by name rather than actuated as
             // something the caller did not ask for.
             PointerEvent::Gesture {
@@ -448,7 +457,61 @@ mod pointer_tests {
                 250,
             ))
             .unwrap_err();
-        assert!(err.to_string().contains('3'), "{err}");
+        assert!(err.to_string().contains("only a two-finger pinch"), "{err}");
+    }
+
+    #[test]
+    fn a_radius_of_exactly_the_minimum_is_accepted() {
+        // 16px apart at scale 1.0 is a radius of exactly MIN_RADIUS_PT. The bound is a floor,
+        // not an exclusive one, and nothing else in the suite sits on it.
+        let g = vec![seg((292, 400), (286, 400)), seg((308, 400), (330, 400))];
+        let events = IdbInjector::new(1.0)
+            .pointer_events(&gesture(g, 250))
+            .expect("exactly the minimum radius is actuated");
+        let Some(proto::hid_event::Event::Pinch(p)) = &events[0].event else {
+            panic!("expected a pinch event")
+        };
+        assert_eq!(p.radius, MIN_RADIUS_PT);
+    }
+
+    #[test]
+    fn an_asymmetric_pinch_is_actuated_symmetrically_about_the_start_midpoint() {
+        // The fidelity deviation documented in docs/reference/tools.md: the caller holds the
+        // left finger still, and idb moves both. What survives is the scale factor. Pinned
+        // here because that promise is agent-facing and nothing else asserts it.
+        use proto::hid_event::Event;
+        let events = IdbInjector::new(1.0)
+            .pointer_events(&gesture(
+                vec![seg((100, 400), (100, 400)), seg((300, 400), (400, 400))],
+                250,
+            ))
+            .expect("an asymmetric spread actuates");
+        let Some(Event::Pinch(p)) = &events[0].event else {
+            panic!("expected a pinch event")
+        };
+        let center = p.center.as_ref().expect("a pinch carries its centre");
+        assert_eq!(
+            (center.x, center.y),
+            (200.0, 400.0),
+            "centred between the two START points, not on the held finger"
+        );
+        assert_eq!(p.radius, 100.0);
+        assert_eq!(p.scale, 1.5, "the requested factor is what survives");
+    }
+
+    #[test]
+    fn a_pinch_too_small_to_deliver_says_so_and_says_what_to_do() {
+        // The reason has to survive the trip from core through the injector's error, or the
+        // agent is told only that multi_touch is unsupported.
+        let err = IdbInjector::new(1.0)
+            .pointer_events(&gesture(
+                vec![seg((100, 400), (98, 400)), seg((300, 400), (302, 400))],
+                250,
+            ))
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("2.0%"), "it names how small: {msg}");
+        assert!(msg.contains("larger"), "and what to do instead: {msg}");
     }
 
     #[test]
@@ -461,11 +524,14 @@ mod pointer_tests {
             .pointer_events(&gesture(close.clone(), 250))
             .unwrap_err();
         assert!(err.to_string().contains("too close"), "{err}");
-        assert!(
-            IdbInjector::new(1.0)
-                .pointer_events(&gesture(close, 250))
-                .is_ok()
-        );
+        use proto::hid_event::Event;
+        let events = IdbInjector::new(1.0)
+            .pointer_events(&gesture(close, 250))
+            .expect("the same pixels at scale 1.0 are a 9pt radius, over the floor");
+        let Some(Event::Pinch(p)) = &events[0].event else {
+            panic!("expected a pinch event")
+        };
+        assert_eq!(p.radius, 9.0, "and the radius is the one that cleared it");
     }
 
     #[test]

--- a/crates/glass-ios/src/injector/mod.rs
+++ b/crates/glass-ios/src/injector/mod.rs
@@ -50,17 +50,15 @@ fn touch(pt: proto::Point, down: bool) -> proto::HidEvent {
 
 /// Smallest pinch radius glass will actuate, in points.
 ///
-/// Measured against idb companion 1.5.0b3 on iOS 26.5: two contacts arrive at any radius, even
-/// 1pt, but below roughly 5pt no pinch is recognised from them at all, and near the floor the
-/// delivered factor is far from the request — a requested 2.0 arrives as 1.333 at an 8pt
-/// radius against 1.905 at 80pt. 8pt keeps a margin over the smallest radius measured to be
-/// recognised; below it glass would actuate a gesture that silently does nothing.
+/// Measured against idb companion 1.5.0b3 on iOS 26.5: two contacts arrive at any radius down
+/// to 1pt, but below roughly 5pt no pinch is recognised from them at all. 8pt keeps a margin
+/// over that, so glass does not actuate a gesture that silently does nothing.
 ///
 /// Bounded in points, not pixels, because the pixel equivalent moves with the device's scale.
 const MIN_RADIUS_PT: f64 = 8.0;
 
-/// `factor` is the pinch's scale factor; the density that converts pixels to points is the
-/// injector's own `scale`, and the two are deliberately not spelled alike here.
+/// `factor` is the pinch's scale factor, not the injector's px-per-point `scale` — kept
+/// spelled apart on purpose.
 fn pinch(center: proto::Point, factor: f64, radius_pt: f64, secs: f64) -> proto::HidEvent {
     use proto::hid_event::{Event, HidPinch};
     proto::HidEvent {
@@ -153,9 +151,8 @@ impl IdbInjector {
                 vec![swipe(point(x, y, s), point(ex, ey, s), SWIPE_SECS)]
             }
             // The vendored proto's `HIDEvent` oneof carries one multi-contact event: a canned
-            // pinch of centre, scale and radius. A separation change maps onto it; a
-            // pan or a rotation is a different gesture, refused by name rather than actuated as
-            // something the caller did not ask for.
+            // pinch of centre, scale and radius. A pan or a rotation is refused by name
+            // rather than actuated as something the caller did not ask for.
             PointerEvent::Gesture {
                 ref pointers,
                 duration_ms,
@@ -462,8 +459,8 @@ mod pointer_tests {
 
     #[test]
     fn a_radius_of_exactly_the_minimum_is_accepted() {
-        // 16px apart at scale 1.0 is a radius of exactly MIN_RADIUS_PT. The bound is a floor,
-        // not an exclusive one, and nothing else in the suite sits on it.
+        // 16px apart at scale 1.0 is exactly MIN_RADIUS_PT — the bound is a floor, not an
+        // exclusive one.
         let g = vec![seg((292, 400), (286, 400)), seg((308, 400), (330, 400))];
         let events = IdbInjector::new(1.0)
             .pointer_events(&gesture(g, 250))
@@ -476,9 +473,8 @@ mod pointer_tests {
 
     #[test]
     fn an_asymmetric_pinch_is_actuated_symmetrically_about_the_start_midpoint() {
-        // The fidelity deviation documented in docs/reference/tools.md: the caller holds the
-        // left finger still, and idb moves both. What survives is the scale factor. Pinned
-        // here because that promise is agent-facing and nothing else asserts it.
+        // The agent-facing promise in docs/reference/tools.md: the caller holds the left
+        // finger still, idb moves both, and the scale factor survives.
         use proto::hid_event::Event;
         let events = IdbInjector::new(1.0)
             .pointer_events(&gesture(
@@ -501,8 +497,8 @@ mod pointer_tests {
 
     #[test]
     fn a_pinch_too_small_to_deliver_says_so_and_says_what_to_do() {
-        // The reason has to survive the trip from core through the injector's error, or the
-        // agent is told only that multi_touch is unsupported.
+        // The reason must survive from core into the error, or the agent is told only that
+        // multi_touch is unsupported.
         let err = IdbInjector::new(1.0)
             .pointer_events(&gesture(
                 vec![seg((100, 400), (98, 400)), seg((300, 400), (302, 400))],
@@ -516,9 +512,8 @@ mod pointer_tests {
 
     #[test]
     fn fingers_closer_than_one_fingertip_are_refused_in_points() {
-        // 18px apart at scale 3.0 is a 3pt radius — under MIN_RADIUS_PT. The same pixel
-        // separation at scale 1.0 is a legitimate pinch, so the bound must be applied in
-        // points, the unit idb actuates in.
+        // The same 18px separation is a 3pt radius at scale 3.0 and a 9pt one at scale 1.0,
+        // so the bound has to be applied in points.
         let close = vec![seg((291, 400), (285, 400)), seg((309, 400), (330, 400))];
         let err = IdbInjector::new(3.0)
             .pointer_events(&gesture(close.clone(), 250))

--- a/crates/glass-ios/src/lib.rs
+++ b/crates/glass-ios/src/lib.rs
@@ -7,10 +7,11 @@
 //! logic still compiles and unit-tests on the free Linux runner.
 //! The Simulator is the isolation boundary, so there is no sandbox machinery
 //! here. The backend drives input (tap, type, swipe, scroll) and reads the
-//! accessibility tree via `idb_companion`, including a two-finger pinch.
-//! Other multi-touch gestures are unsupported: idb's only multi-contact
-//! primitive is a canned pinch, and its raw-touch primitive is
-//! single-contact, so there is nothing to drive an N-finger gesture with.
+//! accessibility tree via `idb_companion` — and, on a companion that
+//! implements the event, a two-finger pinch. Other multi-touch gestures are
+//! unsupported: the vendored proto carries one multi-contact event, a canned
+//! pinch, and the raw-touch primitive is single-contact, so there is nothing
+//! to drive an N-finger gesture with.
 #![cfg(unix)]
 #![forbid(unsafe_code)]
 
@@ -52,11 +53,18 @@ fn capabilities_with(companion: bool) -> CapabilityMap {
         },
         multi_touch: if companion {
             CapabilityStatus::degraded(
-                "two-finger pinch only, and only with an idb_companion that implements it; \
-                 rotation, two-finger pan and 3-or-more fingers are unsupported",
+                "two-finger pinch only, and only with an idb_companion that implements it. \
+                 The pinch is delivered symmetrically about the midpoint of the two start \
+                 points, on idb's own axis: the scale factor is preserved, the individual \
+                 finger paths and the gesture's axis are not. Rotation, two-finger pan, \
+                 3-or-more fingers, fingers starting at one point, and fingers starting \
+                 closer than 8pt from centre are all refused by name",
             )
         } else {
-            CapabilityStatus::unsupported(Some("needs idb_companion (observe-only without it)"))
+            // RequiresSetup, not Unsupported: installing a companion moves this cell to
+            // Degraded, so the backend can do it in principle and only a setup step is
+            // missing — the same condition `input` and `accessibility` report that way.
+            CapabilityStatus::requires_setup("needs idb_companion (observe-only without it)")
         },
         clipboard: CapabilityStatus::new(
             Support::Supported,
@@ -103,7 +111,7 @@ mod capability_tests {
     }
 
     #[test]
-    fn multi_touch_is_degraded_with_a_companion_and_unsupported_without() {
+    fn multi_touch_is_degraded_with_a_companion_and_needs_setup_without() {
         let with = capabilities_with(true);
         assert_eq!(with.multi_touch.status, Support::Degraded);
         let note = with
@@ -112,12 +120,17 @@ mod capability_tests {
             .expect("a degraded cell explains itself");
         assert!(note.contains("pinch"), "{note}");
         assert!(
-            note.contains("rotation"),
+            note.contains("Rotation") && note.contains("two-finger pan"),
             "the refused gestures are named: {note}"
+        );
+        assert!(
+            note.contains("finger paths"),
+            "what is accepted is approximated, and the note must say so: {note}"
         );
         assert_eq!(
             capabilities_with(false).multi_touch.status,
-            Support::Unsupported
+            Support::RequiresSetup,
+            "a missing companion is a setup step, not a permanent incapacity"
         );
     }
 

--- a/crates/glass-ios/src/lib.rs
+++ b/crates/glass-ios/src/lib.rs
@@ -7,9 +7,10 @@
 //! logic still compiles and unit-tests on the free Linux runner.
 //! The Simulator is the isolation boundary, so there is no sandbox machinery
 //! here. The backend drives input (tap, type, swipe, scroll) and reads the
-//! accessibility tree via `idb_companion`; multi-touch gestures are
-//! unsupported — `idb`'s raw-touch primitive is single-contact, with no
-//! general N-finger primitive to drive them.
+//! accessibility tree via `idb_companion`, including a two-finger pinch.
+//! Other multi-touch gestures are unsupported: idb's only multi-contact
+//! primitive is a canned pinch, and its raw-touch primitive is
+//! single-contact, so there is nothing to drive an N-finger gesture with.
 #![cfg(unix)]
 #![forbid(unsafe_code)]
 
@@ -49,7 +50,14 @@ fn capabilities_with(companion: bool) -> CapabilityMap {
         } else {
             CapabilityStatus::requires_setup("needs idb_companion (observe-only without it)")
         },
-        multi_touch: CapabilityStatus::unsupported(Some("idb provides single-contact touch only")),
+        multi_touch: if companion {
+            CapabilityStatus::degraded(
+                "two-finger pinch only, and only with an idb_companion that implements it; \
+                 rotation, two-finger pan and 3-or-more fingers are unsupported",
+            )
+        } else {
+            CapabilityStatus::unsupported(Some("needs idb_companion (observe-only without it)"))
+        },
         clipboard: CapabilityStatus::new(
             Support::Supported,
             Some("paste needs on-screen consent (Allow Paste)"),
@@ -95,13 +103,27 @@ mod capability_tests {
     }
 
     #[test]
+    fn multi_touch_is_degraded_with_a_companion_and_unsupported_without() {
+        let with = capabilities_with(true);
+        assert_eq!(with.multi_touch.status, Support::Degraded);
+        let note = with
+            .multi_touch
+            .note
+            .expect("a degraded cell explains itself");
+        assert!(note.contains("pinch"), "{note}");
+        assert!(
+            note.contains("rotation"),
+            "the refused gestures are named: {note}"
+        );
+        assert_eq!(
+            capabilities_with(false).multi_touch.status,
+            Support::Unsupported
+        );
+    }
+
+    #[test]
     fn constant_cells_are_fixed() {
         let c = capabilities_with(true);
-        assert_eq!(c.multi_touch.status, Support::Unsupported);
-        assert_eq!(
-            c.multi_touch.note,
-            Some("idb provides single-contact touch only")
-        );
         assert_eq!(c.clipboard.status, Support::Supported);
         assert_eq!(
             c.clipboard.note,
@@ -114,15 +136,17 @@ mod capability_tests {
 #[cfg(test)]
 mod unsupported_message_tests {
     #[test]
-    fn multi_touch_unsupported_message_names_the_ios_backend_with_note() {
+    fn multi_touch_unsupported_message_names_the_ios_backend_with_its_reason() {
+        // The injector supplies the refused gesture as the note rather than a blanket
+        // capability string, so this pins the shape that reaches the caller.
         let msg = glass_core::GlassError::unsupported(
             "multi_touch",
             crate::BACKEND,
-            crate::capabilities().multi_touch.note,
+            Some("a rotation, which is a different gesture from a pinch"),
         )
         .to_string();
         assert!(msg.contains("ios backend"), "{msg}");
-        assert!(msg.contains("single-contact"), "{msg}");
+        assert!(msg.contains("rotation"), "{msg}");
         assert!(msg.contains("glass_capabilities"), "{msg}");
     }
 

--- a/crates/glass-ios/src/platform.rs
+++ b/crates/glass-ios/src/platform.rs
@@ -49,7 +49,7 @@ impl IdbDriver {
     /// Spawn the companion for `udid` and connect an input client to its socket.
     fn start(udid: &str) -> Result<IdbDriver> {
         let companion = IdbCompanion::spawn(udid)?;
-        let client = IdbClient::connect(companion.socket())?;
+        let client = IdbClient::connect(companion.socket(), companion.bin())?;
         Ok(IdbDriver { companion, client })
     }
 
@@ -377,7 +377,7 @@ impl IosPlatform {
         let Some(driver) = self.driver.as_ref() else {
             return Ok(None);
         };
-        let client = IdbClient::connect(driver.companion.socket())?;
+        let client = IdbClient::connect(driver.companion.socket(), driver.companion.bin())?;
         Ok(Some(crate::a11y::IosA11y::new(client)))
     }
 }

--- a/crates/glass-ios/src/platform.rs
+++ b/crates/glass-ios/src/platform.rs
@@ -49,7 +49,8 @@ impl IdbDriver {
     /// Spawn the companion for `udid` and connect an input client to its socket.
     fn start(udid: &str) -> Result<IdbDriver> {
         let companion = IdbCompanion::spawn(udid)?;
-        let client = IdbClient::connect(companion.socket(), companion.bin())?;
+        let client =
+            IdbClient::connect(companion.socket(), companion.bin(), companion.build_info())?;
         Ok(IdbDriver { companion, client })
     }
 
@@ -377,7 +378,11 @@ impl IosPlatform {
         let Some(driver) = self.driver.as_ref() else {
             return Ok(None);
         };
-        let client = IdbClient::connect(driver.companion.socket(), driver.companion.bin())?;
+        let client = IdbClient::connect(
+            driver.companion.socket(),
+            driver.companion.bin(),
+            driver.companion.build_info(),
+        )?;
         Ok(Some(crate::a11y::IosA11y::new(client)))
     }
 }

--- a/docs/how-to/setup-ios.md
+++ b/docs/how-to/setup-ios.md
@@ -9,8 +9,8 @@ Select the backend per launch with `glass_start`'s `backend: "ios"`, or make it 
 
 > The iOS backend captures, reads logs, drives the clipboard, and — with `idb_companion` installed
 > (see [Input & accessibility](#input--accessibility)) — taps, types, swipes, scrolls, and reads the
-> accessibility tree. Multi-touch gestures (`glass_gesture`) are the one exception, not yet supported
-> on the Simulator.
+> accessibility tree, and actuates a two-finger pinch. Other multi-touch gestures (rotation,
+> two-finger pan, three or more fingers) are not supported on the Simulator.
 
 ## Install Xcode and a Simulator runtime
 
@@ -96,9 +96,17 @@ With `idb_companion` on `PATH`, these tools work against the Simulator:
   `glass_set_value`, `glass_wait_for_element`, and `glass_scroll_to_element` read and drive the
   Simulator's accessibility tree.
 
-Multi-touch gestures (`glass_gesture` — pinch, rotate, two-finger swipe) are not supported on the
-Simulator yet. If `idb_companion` isn't installed, the input and accessibility tools return an
-unsupported error, while capture, logs, and clipboard keep working.
+- **Pinch** — `glass_gesture` with two pointers whose separation changes actuates a real
+  two-finger pinch. Rotation, two-finger pan and three-or-more-finger gestures are refused by name:
+  idb's only multi-contact primitive is a pinch, so there is nothing to map them onto.
+
+  A pinch also needs an `idb_companion` that implements idb's `HIDPinch` event. As of 2026-08,
+  Homebrew ships idb-companion 1.1.8 (built August 2022), which does not; prebuilt newer companions
+  are published on idb's GitHub releases. If yours does not implement it, glass names the binary and
+  quotes its `--version` output rather than failing opaquely.
+
+If `idb_companion` isn't installed, the input and accessibility tools return an unsupported error,
+while capture, logs, and clipboard keep working.
 
 glass finds `idb_companion` on `PATH`, and — because a `.app` / LaunchAgent launch runs with a
 minimal `PATH` that omits Homebrew's bindir — also probes the standard Homebrew locations

--- a/docs/reference/platforms.md
+++ b/docs/reference/platforms.md
@@ -90,8 +90,9 @@ non-goals.
 **§ iOS** is Simulator-only — macOS host required (`xcrun`/`simctl` ship with Xcode). Capture,
 clipboard, and logs work over `simctl`; pointer/keyboard input (tap, type, swipe, scroll) and the
 accessibility tree (snapshot, click-element, set-value) run over `idb_companion` (`brew install
-idb-companion`), which glass spawns and manages per Simulator. Multi-touch gestures (`glass_gesture`)
-are the exception — not supported on the Simulator yet. Without `idb_companion` the input and
+idb-companion`), which glass spawns and manages per Simulator. `glass_gesture` actuates a two-finger
+pinch, given a companion that implements idb's `HIDPinch`; other multi-touch gestures are refused by
+name. Without `idb_companion` the input and
 accessibility tools return an unsupported error; capture, logs, and clipboard keep working. Window
 support is geometry/focus only: resize and move are unsupported, since Simulator apps, like a real
 device, are always fullscreen. The host-independent logic — device resolution, `simctl`/`idb`
@@ -120,7 +121,7 @@ AccessibilityService for a Compose-rich a11y tree + high-fidelity `set_value`); 
 in CI and validated on-device. An **iOS** backend drives native apps on an iOS Simulator over `xcrun
 simctl` — capture, clipboard, logs, and a managed Simulator (attach-or-boot, matching the Android
 emulator's model); window support is geometry/focus only. Pointer/keyboard input and the accessibility
-tree run over `idb_companion` (multi-touch gestures excepted). Its host-independent logic is
+tree run over `idb_companion` (multi-touch is a two-finger pinch only). Its host-independent logic is
 unit-tested in CI; the on-box path against a real Simulator is exercised by `#[ignore]`d integration
 tests on a macOS host. The **macOS** backend
 (ScreenCaptureKit capture, CGEvent input, AXUIElement windows/logs, an AXUIElement accessibility tree,

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -390,9 +390,13 @@ do it.
 **Platform notes:** the Android backend (via the optional on-device companion agent) actuates
 arbitrary multi-pointer gestures. The **iOS** backend actuates a **two-finger pinch** — two pointers
 whose separation changes — and refuses anything else by name: a rotation, a two-finger pan, a
-stationary pair, or three or more pointers. The pinch is delivered about the midpoint of the two
-start points, so a gesture that holds one finger still still moves both; what is preserved is the
-scale, which is what a pinch recognizer reports. It also needs an `idb_companion` that implements
+stationary pair, three or more pointers, two pointers starting at the same point, or fingers
+starting closer than 8pt from the centre. The pinch is delivered about the midpoint of the two
+start points, so even a gesture that holds one finger still moves both. What glass preserves is the
+requested scale factor, not the individual finger paths; the delivered factor differs from the
+request by a few percent, and by more as the fingers start closer together. A separation change
+under 5% is refused rather than actuated, because it cannot be told apart from that delivery
+error. On iOS a `duration_ms` of 0 becomes 300ms, matching the backend's swipe default. It also needs an `idb_companion` that implements
 the event — glass reports the binary and its build info if yours does not. Other backends return
 `Unsupported`.
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -301,8 +301,8 @@ modified drags, and Ctrl+scroll.
 
 On the **iOS** backend `glass_click`, `glass_type`, `glass_key`, `glass_scroll`, and `glass_drag`
 drive the Simulator over `idb_companion` (install it — see
-[setup-ios.md](../how-to/setup-ios.md#input--accessibility)); only multi-touch `glass_gesture` is
-unsupported there.
+[setup-ios.md](../how-to/setup-ios.md#input--accessibility)). `glass_gesture` actuates a
+two-finger pinch there; other multi-touch gestures are unsupported.
 
 ### `glass_click`
 
@@ -387,8 +387,14 @@ do it.
 - `pointers` (array of `{ from{x,y}, to{x,y} }`, **required**) — 2–10 window-relative segments.
 - `duration_ms` (integer, default 250) — gesture span.
 
-**Platform notes:** multi-touch is currently implemented on the Android backend (via the optional
-on-device companion agent); other backends return `Unsupported`.
+**Platform notes:** the Android backend (via the optional on-device companion agent) actuates
+arbitrary multi-pointer gestures. The **iOS** backend actuates a **two-finger pinch** — two pointers
+whose separation changes — and refuses anything else by name: a rotation, a two-finger pan, a
+stationary pair, or three or more pointers. The pinch is delivered about the midpoint of the two
+start points, so a gesture that holds one finger still still moves both; what is preserved is the
+scale, which is what a pinch recognizer reports. It also needs an `idb_companion` that implements
+the event — glass reports the binary and its build info if yours does not. Other backends return
+`Unsupported`.
 
 ### `glass_do`
 


### PR DESCRIPTION
Closes part 1 of #117.

`glass_gesture` with two pointers whose separation changes now actuates a real two-finger pinch on the iOS Simulator, recognised as a pinch by the app under test. Anything else multi-touch is refused by name rather than actuated as something the caller did not ask for.

## Why this is possible now

#117 concluded that `HIDPinch` was declared in idb's proto but unimplemented by the released companion, and that 1.1.8 was the only tagged release. The second half expired: idb published `v1.5.0.b1`/`b2`/`b3` on 2026-08-14/17/19 with prebuilt companion tarballs, and `main` implements the handler.

**Part 2 (general N-finger) stays out of scope and is not reachable at any idb version** — `HIDTouch` is still bare `{Point}` with no contact id and no MOVE, and both of idb's transports cap at two contacts. That is a simulator-injection ceiling, not an iOS one; iOS itself supports five simultaneous touches on iPhone.

## What it does

- **`glass-core/src/pinch.rs`** classifies two `Segment`s into a `Pinch` (centre, start radius, scale) or a named `NotAPinch`. A change in separation makes a pinch; the axis does not. An asymmetric pair — one finger held — is still a pinch.
- **The iOS injector** maps that to one `HidPinch`, converting px to points, and refuses below an 8pt start radius.
- **A companion that does not implement the event** is named in the error along with the `--version` it printed at spawn, instead of the opaque `InvalidArgument` it produces today.
- `multi_touch` moves to `Degraded` with a companion and `RequiresSetup` without.

## Fidelity, stated plainly

`HIDPinch` carries centre, scale, radius and duration — there is no axis and no per-finger path. So a pinch is delivered symmetrically about the midpoint of the two start points: **the requested scale factor survives, the individual finger paths and the gesture's axis do not.** A gesture holding one finger still moves both. That is disclosed in the capability note, the tool reference, and the setup guide rather than left for someone to discover.

Measured delivery error is a few percent at a comfortable radius and worse as the fingers start closer (a requested 2.0 arrives as 1.905 at an 80pt radius, 1.333 at 8pt), which is why a separation change under 5% is refused instead of actuated.

## Verification

Local gate green: `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace` (91 binaries).

**CI cannot exercise the actuation.** GitHub's macOS runners install idb from Homebrew, which as of 2026-08 is the 2022 build that rejects the event — and that rejection is one of the things under test. The real acceptance is `a_pinch_is_accepted_by_a_companion_that_implements_it`, `#[ignore]`d, needing `GLASS_IOS_UDID` and a `GLASS_IDB_COMPANION` that implements `HIDPinch`. **This feature ships with a permanent manual verification step.**

Run on an iOS 26.5 Simulator (iPhone 17) against companion 1.5.0b3, with a UIKit fixture logging `event.allTouches.count` and `UIPinchGestureRecognizer` state:

```
touch=began n=2 max=2 pts=(121,437) (281,437)
pinch state=1 scale=1.071 touches=2
pinch state=3 scale=1.905 touches=2
```

and the control leg on Homebrew's companion:

```
the idb_companion at /opt/homebrew/bin/idb_companion does not implement this event:
it answered "Unrecognized request.event". Its --version reports:
{"build_time":"08:41:50","build_date":"Aug 12 2022"}.
See docs/how-to/setup-ios.md for companion requirements.
```

## Review

A five-agent panel ran before this PR existed and found real defects, all fixed in the last five commits — a too-small pinch reported to the agent as "a rotation", a rotation about a held finger reported as a pan, `build_info` re-exec'ing the on-disk binary at error time (so a user who replaced the companion saw a fresh build date quoted as evidence an old one was in the way), untested routing between the named error and the generic folding, and an overflow in `separation()` that a neighbouring comment promised could not happen.

Two constants were justified by reasoning and are now justified by measurement instead: the radius floor's original claim — that fingers below it "are not resolvable as two" — was **false**, since two contacts arrive down to 1pt. What actually fails below ~5pt is recognition.

One gap is documented in place rather than papered over: `hid()`'s single delegating call to `map_hid_outcome` is not covered off-device, and only the on-box leg catches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
