### PR TITLE
refactor(a11y-macos): move the name/description precedence into mapping

### DIFF
--- a/crates/glass-a11y-macos/src/mapping.rs
+++ b/crates/glass-a11y-macos/src/mapping.rs
@@ -5,7 +5,7 @@
 //! `"AXButton"`/`"AXTextField"`/... constants; the reader passes the string so this
 //! module needs no macOS-only dependency.
 
-use glass_core::{AxRole, AxStates};
+use glass_core::{AxRole, AxStates, normalize_description};
 
 /// Every AX role string glass maps. AX role strings are canonical constants, so lookup is
 /// case-sensitive.
@@ -162,8 +162,53 @@ pub fn checkable_checked(role: AxRole, ax_value: Option<i64>) -> (bool, bool) {
     }
 }
 
+/// A node's `name`: its `AXTitle`, else its `AXDescription` (`setAccessibilityLabel` surfaces as
+/// `AXDescription`). Never `AXValue` — volatile content in a field that is half the `AxTarget`
+/// fingerprint `set_value`/`click_element` re-walk against.
+///
+/// The description arrives as a reader because each label costs an AX round-trip and a titled node
+/// never needs it.
+///
+/// The one place the rule lives: a second copy could read a name differently and reject an element
+/// that never moved. [`labels`] repeats it only because an `FnOnce` cannot fill both the name slot
+/// and the description fallback, and a test quantifies their agreement over every input.
+///
+/// Both labels arrive already empty-filtered by the reader; a whitespace-only one is a name,
+/// matching the Windows and Linux readers' `nonempty`.
+pub fn name(
+    title: Option<String>,
+    read_description: impl FnOnce() -> Option<String>,
+) -> Option<String> {
+    title.or_else(read_description)
+}
+
+/// A node's `(name, description)`, decided together because which attribute is left to describe a
+/// node depends on which one named it.
+///
+/// `AXDescription` costs at most one read per node either way: as the name when there is no title,
+/// as the description only when there IS a title and no `AXHelp`. Reading it unconditionally
+/// re-reads the string that is already the name on the untitled nodes that are most of a macOS
+/// tree, and [`glass_core::normalize_description`] drops the copy — so only a read count catches
+/// that edit.
+///
+/// The returned description is normalized: blank, or a repeat of `name`, becomes `None`.
+pub fn labels(
+    title: Option<String>,
+    read_description: impl FnOnce() -> Option<String>,
+    read_help: impl FnOnce() -> Option<String>,
+) -> (Option<String>, Option<String>) {
+    let (name, secondary) = match title {
+        Some(title) => (Some(title), read_help().or_else(read_description)),
+        None => (read_description(), read_help()),
+    };
+    let description = secondary.and_then(|raw| normalize_description(&raw, name.as_deref()));
+    (name, description)
+}
+
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
+
     use super::*;
     use glass_core::AxRole;
 
@@ -448,5 +493,165 @@ mod tests {
         assert_eq!(checkable_checked(CheckBox, None), (false, false));
         assert_eq!(checkable_checked(Button, Some(1)), (false, false));
         assert_eq!(checkable_checked(Slider, Some(1)), (false, false));
+    }
+
+    /// A label reader that counts its calls. Which attributes `labels` reads is invisible in its
+    /// return value, so a test that only inspects the tuple cannot tell the gated reader from one
+    /// that reads everything.
+    fn counted<'a>(
+        text: Option<&'a str>,
+        calls: &'a Cell<u32>,
+    ) -> impl FnOnce() -> Option<String> + 'a {
+        move || {
+            calls.set(calls.get() + 1);
+            text.map(str::to_string)
+        }
+    }
+
+    fn reader(text: Option<&str>) -> impl FnOnce() -> Option<String> + '_ {
+        move || text.map(str::to_string)
+    }
+
+    #[test]
+    fn a_titled_node_is_named_by_its_title_and_described_by_its_help() {
+        let (name, description) = labels(
+            Some("Save".to_string()),
+            reader(Some("a description")),
+            reader(Some("Saves the document")),
+        );
+        assert_eq!(name.as_deref(), Some("Save"));
+        assert_eq!(description.as_deref(), Some("Saves the document"));
+    }
+
+    #[test]
+    fn a_titled_node_without_help_is_described_by_its_description() {
+        let (name, description) = labels(
+            Some("Save".to_string()),
+            reader(Some("Saves the document")),
+            reader(None),
+        );
+        assert_eq!(name.as_deref(), Some("Save"));
+        assert_eq!(description.as_deref(), Some("Saves the document"));
+    }
+
+    #[test]
+    fn an_untitled_node_is_named_by_its_description() {
+        let (name, description) = labels(None, reader(Some("Close")), reader(Some("Closes it")));
+        assert_eq!(name.as_deref(), Some("Close"));
+        assert_eq!(description.as_deref(), Some("Closes it"));
+    }
+
+    #[test]
+    fn a_titled_node_with_help_never_reads_its_description() {
+        // The gate this extraction exists to keep verified: deleting the titled/untitled split
+        // leaves every output byte-identical, so this count is the only assertion that can fail.
+        let reads = Cell::new(0);
+        let (name, description) = labels(
+            Some("Save".to_string()),
+            counted(Some("a description"), &reads),
+            reader(Some("Saves the document")),
+        );
+        assert_eq!(reads.get(), 0, "AXDescription must not be read at all here");
+        assert_eq!(name.as_deref(), Some("Save"));
+        assert_eq!(description.as_deref(), Some("Saves the document"));
+    }
+
+    #[test]
+    fn an_untitled_node_reads_its_description_exactly_once() {
+        // The other half of the gate: the description already named the node, so consulting it
+        // again buys a second cross-process read of a string `normalize_description` drops.
+        let reads = Cell::new(0);
+        let (name, description) = labels(None, counted(Some("Close"), &reads), reader(None));
+        assert_eq!(
+            reads.get(),
+            1,
+            "AXDescription must be read once, as the name"
+        );
+        assert_eq!(name.as_deref(), Some("Close"));
+        assert_eq!(description, None);
+    }
+
+    #[test]
+    fn a_secondary_label_that_repeats_the_name_is_dropped() {
+        let (name, description) =
+            labels(Some("Save".to_string()), reader(None), reader(Some("Save")));
+        assert_eq!(name.as_deref(), Some("Save"));
+        assert_eq!(description, None);
+    }
+
+    #[test]
+    fn a_whitespace_only_secondary_label_is_dropped() {
+        let (name, description) =
+            labels(Some("Save".to_string()), reader(None), reader(Some("   ")));
+        assert_eq!(name.as_deref(), Some("Save"));
+        assert_eq!(description, None);
+    }
+
+    #[test]
+    fn a_whitespace_only_title_still_names_the_node() {
+        // `read_label` folds "" but not "   ", matching the Windows and Linux readers' `nonempty`.
+        // Pinned rather than trimmed: which strings may occupy the name slot is a cross-backend
+        // convention, not this function's call.
+        let (name, description) = labels(
+            Some("   ".to_string()),
+            reader(Some("a description")),
+            reader(Some("Closes it")),
+        );
+        assert_eq!(name.as_deref(), Some("   "));
+        assert_eq!(description.as_deref(), Some("Closes it"));
+    }
+
+    #[test]
+    fn every_title_description_help_combination_lands_where_the_reader_put_it() {
+        // Exhaustive over the eight inputs: a hand-picked sample cannot show that an arm was
+        // dropped rather than merely unexercised.
+        let cases = [
+            (Some("t"), Some("d"), Some("h"), Some("t"), Some("h")),
+            (Some("t"), Some("d"), None, Some("t"), Some("d")),
+            (Some("t"), None, Some("h"), Some("t"), Some("h")),
+            (Some("t"), None, None, Some("t"), None),
+            (None, Some("d"), Some("h"), Some("d"), Some("h")),
+            (None, Some("d"), None, Some("d"), None),
+            (None, None, Some("h"), None, Some("h")),
+            (None, None, None, None, None),
+        ];
+        for (title, description, help, want_name, want_description) in cases {
+            let got = labels(title.map(str::to_string), reader(description), reader(help));
+            assert_eq!(
+                (got.0.as_deref(), got.1.as_deref()),
+                (want_name, want_description),
+                "title={title:?} description={description:?} help={help:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_fingerprint_name_and_the_walked_name_agree_on_every_combination() {
+        // `set_value`/`invoke` re-derive a name through `name` to fingerprint the element `walk`
+        // recorded through `labels`; a divergence would reject an element that never moved.
+        for title in [Some("t"), None] {
+            for description in [Some("d"), None] {
+                for help in [Some("h"), None] {
+                    let walked =
+                        labels(title.map(str::to_string), reader(description), reader(help)).0;
+                    let fingerprint = name(title.map(str::to_string), reader(description));
+                    assert_eq!(
+                        walked, fingerprint,
+                        "title={title:?} description={description:?} help={help:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn a_titled_node_needs_no_description_read_to_be_named() {
+        // `set_value` and `invoke` pay these reads on the element they are about to act on.
+        let reads = Cell::new(0);
+        assert_eq!(
+            name(Some("Save".to_string()), counted(Some("d"), &reads)).as_deref(),
+            Some("Save")
+        );
+        assert_eq!(reads.get(), 0);
     }
 }

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -20,7 +20,7 @@ use glass_core::coords::pixel_geometry_from_content_rect;
 use glass_core::platform::WindowGeometry;
 use glass_core::{
     Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxTarget, AxTree, GlassError,
-    Result, WalkBudget, normalize_description, read_back_confirms, write_took_no_effect,
+    Result, WalkBudget, read_back_confirms, write_took_no_effect,
 };
 use objc2_application_services::AXUIElement;
 use objc2_core_foundation::CFRetained;
@@ -113,10 +113,9 @@ impl Accessibility for MacosA11y {
         // and it is rejected here rather than silently overwritten.
         let ax_role = ffi::attribute_string(&el, attr::ROLE).unwrap_or_default();
         let role = mapping::map_role(&ax_role, read_subrole(&el, &ax_role).as_deref());
-        // Same two reads, in the same order, that `walk` derived this element's `name` from —
-        // through the same helper, so a fingerprint can never be computed from a differently-read
-        // name and reject an element that never moved.
-        let name = read_label(&el, attr::TITLE).or_else(|| read_label(&el, attr::DESCRIPTION));
+        // Same rule `walk` derived this element's `name` from, so a fingerprint can never be
+        // computed from a differently-read name and reject an element that never moved.
+        let name = read_name(&el);
         let bounds = window_relative_rect(&el, scale, &ctx.window);
         if !target.matches(role, name.as_deref())
             || !target.bounds_consistent(bounds, SET_VALUE_BOUNDS_TOL)
@@ -188,7 +187,7 @@ impl Accessibility for MacosA11y {
         let ax_role = ffi::attribute_string(&el, attr::ROLE).unwrap_or_default();
         let role = mapping::map_role(&ax_role, read_subrole(&el, &ax_role).as_deref());
         // `name` derived exactly as in `walk` and `set_value` — see there.
-        let name = read_label(&el, attr::TITLE).or_else(|| read_label(&el, attr::DESCRIPTION));
+        let name = read_name(&el);
         let bounds = window_relative_rect(&el, scale, &ctx.window);
         if !target.matches(role, name.as_deref())
             || !target.bounds_consistent(bounds, SET_VALUE_BOUNDS_TOL)
@@ -379,6 +378,14 @@ fn read_label(el: &AXUIElement, attr_name: &str) -> Option<String> {
     }
 }
 
+/// `el`'s `name` as [`walk`] records it: the fingerprint `set_value`/`invoke` re-walk against has
+/// to come from the same reads, in the same order, that produced the name in the snapshot.
+fn read_name(el: &AXUIElement) -> Option<String> {
+    mapping::name(read_label(el, attr::TITLE), || {
+        read_label(el, attr::DESCRIPTION)
+    })
+}
+
 /// `el`'s `AXSubrole`, but only for the base roles whose subrole actually changes the mapped
 /// role ([`mapping::subrole_matters`]) — every other node skips the AX IPC round-trip and gets
 /// `None`.
@@ -459,25 +466,14 @@ fn walk(
             _ => ax_role,
         }
     };
-    // Name = title, else description — both stable labels (e.g. `setAccessibilityLabel`
-    // surfaces as `AXDescription`). Never fold in `AXValue`: it's volatile content, and a
-    // node's name must stay stable for the `AxTarget` fingerprint `set_value` relies on.
-    //
-    // Which attribute is left to describe the node depends on which one named it, so both
-    // labels are decided in one place. `AXDescription` costs at most one read per node either
-    // way: as the name when there is no title, as the description only when there IS a title
-    // and no `AXHelp`.
-    let (name, secondary) = match read_label(el, attr::TITLE) {
-        Some(title) => (
-            Some(title),
-            read_label(el, attr::HELP).or_else(|| read_label(el, attr::DESCRIPTION)),
-        ),
-        None => (
-            read_label(el, attr::DESCRIPTION),
-            read_label(el, attr::HELP),
-        ),
-    };
-    let description = secondary.and_then(|raw| normalize_description(&raw, name.as_deref()));
+    // Which attribute names the node and which is left to describe it is decided in
+    // `mapping::labels`, where the rule — and which reads it declines to make — is unit-tested on
+    // any host.
+    let (name, description) = mapping::labels(
+        read_label(el, attr::TITLE),
+        || read_label(el, attr::DESCRIPTION),
+        || read_label(el, attr::HELP),
+    );
     let value = ffi::attribute_string(el, attr::VALUE);
     let bounds = window_relative_rect(el, scale, win);
     let states = mapping::map_states(&gather_states(el, role));


### PR DESCRIPTION
Fixes #262.

The macOS reader decided a node's `name` and `description` inside `walk` — `cfg(target_os = "macos")`, over a live `AXUIElement` with no constructible stand-in — so none of the rule could be tested off macOS. The issue's point was that the gate at its heart is behaviourally invisible: hoist the `AXDescription` read above the titled/untitled decision and every output stays byte-identical while every titled node with help text pays an extra cross-process round-trip. Only a read count catches that.

## What moved

`mapping::labels(title, read_description, read_help) -> (name, description)` — the issue's form 2. The title is a value; the other two are `FnOnce` readers, so the extraction preserves the reads exactly (same attributes, same order, same counts) and a test can assert which attributes went **unread**.

`mapping::node_name(title, read_description)` holds the `AXTitle`-else-`AXDescription` precedence that `walk`, `set_value` and `invoke` each spelled out inline. `labels` delegates its name slot to it rather than restating the rule, so the walk and the two fingerprint sites cannot rank the two attributes differently and reject an element that never moved. The reader is one-shot: whichever slot spends the `AXDescription` read, the other finds it gone.

`normalize_description` moves with the decision, which brings the "description repeats the name" drop under test off macOS for the first time.

## Whitespace

Pinned as it was, not trimmed. `read_label` folds `""` but not `"   "`, matching `nonempty` in the Windows and Linux readers. The Android reader deliberately counts a blank label as absent — so this is a live divergence between backends, not a rule this crate settles, and the test says that rather than claiming a convention.

## Verification

Ablations, each run and restored:

| Ablation | Tests that go red |
|---|---|
| hoist the `AXDescription` read above the decision | `a_titled_node_with_help_never_reads_its_description` only |
| retry the help fallback on a label that normalizes away | the two `..._without_retrying_the_description` tests only |
| inline `normalize_description` lookalike: blankness, no trim | the combination table only |
| un-delegate `labels` and trim its own title arm | `the_fingerprint_name_and_the_walked_name_agree_on_every_combination` |

Also: `cargo test --workspace` green; `cargo clippy --workspace --all-targets --locked -- -D warnings` clean; `cargo clippy --target x86_64-apple-darwin -p glass-a11y-macos --all-targets --locked -- -D warnings` clean, which type-checks the `cfg(macos)` reader from Linux; `cargo fmt --all --check` clean.

Not run here: `crates/glass-macos/tests/a11y.rs`, the on-box output check — it needs a TCC-granted Mac. Unchanged by this branch.

No CHANGELOG entry: internal refactor, which the file's own maintenance note excludes.

## Known limits

- `labels`' two reader parameters are the same type, so transposing them at the call site compiles. One call site, and each closure names its `attr::` constant on its own line, so this was judged not worth a newtype.
- "half the `AxTarget` fingerprint" is imprecise — name is one of three facts the gate checks — but the phrasing is inherited from `glass-core/src/accessibility.rs` and `reader.rs`, so it is left consistent rather than fixed in one place.

## Follow-ups found while reviewing, not fixed here

- `read_label`'s `""` fold (`reader.rs:370`) and `read_subrole`'s gate (`reader.rs:411`) are the same "delete it and only a read count changes" invariant this issue was filed about, and are still `cfg(macos)`-only.
- A whitespace-only name is reachable on macOS, Windows, Linux and iOS, and it displaces a real label: no `name:` selector reaches it, and `outline::is_scaffolding` stops eliding the node.
- `walk` reads `attr::VALUE` as a string (`reader.rs:477`) and `gather_states` reads the same attribute as an `i64` (`reader.rs:621`), so every checkbox/radio/switch pays two round-trips on one attribute.