### PR TITLE
ci: drop the Miri job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,27 +46,6 @@ jobs:
       - run: cargo clippy --workspace --all-targets --locked -- -D warnings
       - run: cargo test --workspace --locked
 
-  miri:
-    name: Miri (UB check · pure crates)
-    runs-on: ubuntu-latest
-    # Miri interprets the MIR to catch undefined behaviour in the byte-level / unsafe-adjacent
-    # logic we own. Scoped to the crates whose tests are Miri-clean: glass-clip-shim-windows (the private-
-    # clipboard wire protocol + store) and glass-windows (pure pixel/dpi/jobpids byte parsing).
-    # Miri cannot execute FFI / foreign functions, so the Win32 named-pipe server and the injected
-    # user32 detours (cfg(windows)) are out of Miri's reach — those are covered on-box + by review.
-    # The `miri` component is added here (not pinned in rust-toolchain.toml) so a future nightly
-    # bump that lacks it fails only this job, not every job's `rustup show`.
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Install pinned toolchain
-        run: rustup show
-      - name: Add miri component
-        run: rustup component add miri
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          workspaces: .
-      - run: cargo miri test -p glass-clip-shim-windows -p glass-windows --locked
-
   x11:
     name: X11 integration (Xvfb)
     runs-on: ubuntu-latest

--- a/crates/glass-clip-shim-windows/src/dib.rs
+++ b/crates/glass-clip-shim-windows/src/dib.rs
@@ -1,4 +1,4 @@
-//! Pure DIB / DIBV5 byte-layout parsing + validation + header rewrite (no Win32, Miri-checked).
+//! Pure DIB / DIBV5 byte-layout parsing + validation + header rewrite (no Win32).
 //!
 //! `CF_DIB`/`CF_DIBV5` blobs are attacker-influenced (they come from a boxed app's clipboard), so
 //! every size is computed with checked arithmetic and validated against the actual buffer length —

--- a/crates/glass-clip-shim-windows/src/lib.rs
+++ b/crates/glass-clip-shim-windows/src/lib.rs
@@ -19,8 +19,7 @@ pub mod proto;
 pub mod store;
 
 // Pure clipboard text codecs the windows hook defers to. Compiled for windows (the hook) and for
-// test (so the suite runs + Miri-checks on any host); unused on a non-test non-windows
-// build, hence the cfg gate.
+// test (so the suite runs on any host); unused on a non-test non-windows build, hence the cfg gate.
 #[cfg(any(windows, test))]
 mod text;
 

--- a/crates/glass-clip-shim-windows/src/proto.rs
+++ b/crates/glass-clip-shim-windows/src/proto.rs
@@ -350,7 +350,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)] // ~96 MiB buffer — too slow under the Miri interpreter
     fn rejects_oversize_total() {
         // 3 items each just under MAX_ITEM_BYTES → aggregate exceeds MAX_TOTAL_BYTES.
         let chunk = MAX_ITEM_BYTES - 1;

--- a/crates/glass-clip-shim-windows/src/synth.rs
+++ b/crates/glass-clip-shim-windows/src/synth.rs
@@ -1,4 +1,4 @@
-//! Pure synthesis *decisions* (no Win32, Miri-checked): which formats are available given the
+//! Pure synthesis *decisions* (no Win32): which formats are available given the
 //! stored set (canonical + synthesizable, canonical-first), and which stored format synthesizes a
 //! requested one. The actual byte conversions live in the `cfg(windows)` hook (code page via
 //! `WideCharToMultiByte`; `CF_BITMAP` via GDI; `CF_DIBV5` via `dib.rs`).

--- a/crates/glass-clip-shim-windows/src/text.rs
+++ b/crates/glass-clip-shim-windows/src/text.rs
@@ -1,10 +1,10 @@
-//! Pure clipboard text codecs (no Win32), unit-tested + Miri-checked on any host.
+//! Pure clipboard text codecs (no Win32), unit-tested on any host.
 //!
 //! The `cfg(windows)` hook does the `unsafe` FFI — locking an `HGLOBAL` into a slice *bounded by
 //! `GlobalSize`* — and defers the actual NUL-terminated parse/encode to these helpers. So the
 //! UB-prone slicing/decoding lives in safe, tested code; only the FFI lock itself stays `unsafe`.
 //!
-//! Compiled for `windows` (the hook uses it) and for `test` (so the suite runs on Linux + Miri).
+//! Compiled for `windows` (the hook uses it) and for `test` (so the suite runs on any host).
 
 /// Decode a `CF_UNICODETEXT` block (the whole locked buffer, as UTF-16 code units) to a `String`,
 /// stopping at the first NUL terminator — or consuming the whole buffer if it is unterminated.

--- a/crates/glass-windows/src/jobpids.rs
+++ b/crates/glass-windows/src/jobpids.rs
@@ -1,6 +1,6 @@
 //! Pure parser for the JOBOBJECT_BASIC_PROCESS_ID_LIST byte buffer (x64 layout). Kept ungated +
-//! free of `windows` types so it runs on the host under Miri — the buffer handling is the part with
-//! the alignment/UB risk; the QueryInformationJobObject syscall that fills the buffer can't be Miri'd.
+//! free of `windows` types so the buffer handling — the part carrying the alignment/UB risk — is
+//! unit-tested on any host; the QueryInformationJobObject syscall that fills it is cfg(windows).
 
 /// Parse a JOBOBJECT_BASIC_PROCESS_ID_LIST byte buffer into its PID list. x64 layout:
 /// `[0..4]` NumberOfAssignedProcesses (u32) · `[4..8]` NumberOfProcessIdsInList (u32) ·

--- a/crates/glass-windows/src/lib.rs
+++ b/crates/glass-windows/src/lib.rs
@@ -19,7 +19,7 @@ pub mod discovery; // pure window-discovery poll-loop decision — cross-platfor
 pub mod doctor; // pure check-mapping cross-platform; Windows fact-gathering is cfg(windows)
 pub mod dpi; // pure coordinate math — cross-platform, unit-tested on any host
 pub mod jobcfg; // pure SandboxLevel -> job-limit descriptor — unit-tested on any host
-pub mod jobpids; // pure JOBOBJECT_BASIC_PROCESS_ID_LIST byte parser — Miri'd on the host
+pub mod jobpids; // pure JOBOBJECT_BASIC_PROCESS_ID_LIST byte parser — host-tested
 pub mod logtap; // pure line splitting — cross-platform, host-tested; the reader is cfg(windows)
 #[doc(hidden)]
 pub mod onbox_support; // env-resolved paths shared by the on-box examples + tests; host-tested


### PR DESCRIPTION
On the Linux runner every `unsafe` block in `glass-clip-shim-windows` and `glass-windows` sits behind `#[cfg(windows)]`, so `cargo miri test` was interpreting 117 tests' worth of entirely safe code — the same tests `check` already runs, with no UB available for Miri to find. The Win32 hook, the user32 detours and the named-pipe server are FFI, which Miri cannot execute at all; those stay covered on-box and by review.

Also removes the now-dead `#[cfg_attr(miri, ignore)]` and the doc comments that claimed Miri coverage.

**Needs a ruleset edit before merge:** `Miri (UB check · pure crates)` is still a required status check, so this PR will sit unmergeable until it is dropped from the ruleset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)