### PR TITLE
mcp: mirror server.json's title, description and website onto the initialize handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ internal refactors, CI, or test-only changes.
 ## [Unreleased]
 
 ### Added
+- The MCP `initialize` handshake now tells the connecting client what glass is and where to read about it: it carries the same title, description and website that the MCP registry lists, so a host's server list shows them whether glass was installed from the registry or connected to directly.
 - On iOS, `glass_gesture` actuates a two-finger pinch: two pointers whose separation changes become a real pinch on the Simulator, recognised as one by the app under test. It needs an `idb_companion` that implements idb's `HIDPinch` event — a companion that does not is named in the error, along with the `--version` it reported. Other multi-touch gestures (rotation, two-finger pan, three or more fingers) are refused by name rather than actuated as something else.
 
 ### Fixed

--- a/crates/glass-mcp/Cargo.toml
+++ b/crates/glass-mcp/Cargo.toml
@@ -76,6 +76,9 @@ rustix.workspace = true
 
 [build-dependencies]
 embed-manifest = "1"
+# Already a normal dependency of this crate (above), so build.rs parsing server.json adds no
+# crate to the lockfile — only a host-side build of one already in the graph.
+serde_json = "1"
 
 # Windows-host builds only: statically link just the VCRuntime, leaving the OS-provided
 # Universal CRT dynamic (so it still gets Windows Update security fixes). Pairs with the

--- a/crates/glass-mcp/build.rs
+++ b/crates/glass-mcp/build.rs
@@ -34,6 +34,68 @@ fn main() {
     println!("cargo:rerun-if-env-changed=GITHUB_REF_TYPE");
     println!("cargo:rerun-if-changed=build.rs");
     watch_git_head();
+    emit_server_json_identity();
+}
+
+/// Emit the `server.json` fields the MCP `initialize` handshake mirrors, as build-time env vars
+/// read back through `crate::TITLE`, `DESCRIPTION` and `WEBSITE_URL`.
+///
+/// `server.json` is the descriptor this repo publishes to the MCP registry, so these strings are
+/// written once. Same source, not same instant: the registry can be republished from master
+/// without a release, so a shipped binary carries what its own tag was built from.
+///
+/// Do not soften the panics into a fallback. The registry validates this descriptor at publish
+/// time, which on the release path is *after* the tag is cut and immutable.
+fn emit_server_json_identity() {
+    const SERVER_JSON: &str = "../../server.json";
+    let raw = std::fs::read_to_string(SERVER_JSON)
+        .unwrap_or_else(|e| panic!("failed to read {SERVER_JSON}: {e}"));
+    let descriptor: serde_json::Value = serde_json::from_str(&raw)
+        .unwrap_or_else(|e| panic!("{SERVER_JSON} is not valid JSON: {e}"));
+
+    // Both carry the registry schema's 1..=100 bound. glass requires `title` too, though the
+    // schema itself requires only `description`.
+    for (var, key) in [
+        ("GLASS_BUILD_TITLE", "title"),
+        ("GLASS_BUILD_DESCRIPTION", "description"),
+    ] {
+        let found = &descriptor[key];
+        let value = found
+            .as_str()
+            .unwrap_or_else(|| panic!("{SERVER_JSON}'s `{key}` must be a string, found {found}"));
+        assert!(
+            (1..=100).contains(&value.chars().count()),
+            "{SERVER_JSON}'s `{key}` must be 1..=100 characters, is {}",
+            value.chars().count()
+        );
+        emit_rustc_env(var, key, value);
+    }
+
+    // Optional in the registry schema, so a descriptor without one must not fail every build in
+    // the workspace. An empty value is how `crate::WEBSITE_URL` reads back the absence `env!`
+    // cannot represent.
+    let found = &descriptor["websiteUrl"];
+    let website_url = match found {
+        serde_json::Value::Null => "",
+        _ => found.as_str().unwrap_or_else(|| {
+            panic!("{SERVER_JSON}'s `websiteUrl` must be a string, found {found}")
+        }),
+    };
+    emit_rustc_env("GLASS_BUILD_WEBSITE_URL", "websiteUrl", website_url);
+
+    println!("cargo:rerun-if-changed={SERVER_JSON}");
+}
+
+/// Emit one `cargo:rustc-env`, rejecting a value the directive cannot carry intact.
+fn emit_rustc_env(var: &str, key: &str, value: &str) {
+    // cargo splits build-script output on '\n' and trims each line, so outer whitespace is
+    // silently stripped, an interior control character reaches rustc verbatim, and anything past a
+    // newline is read as a directive of its own.
+    assert!(
+        value.trim() == value && !value.chars().any(char::is_control),
+        "`{key}` must carry no control characters and no leading or trailing whitespace"
+    );
+    println!("cargo:rustc-env={var}={value}");
 }
 
 /// Declare the git files a local build's version is derived from, so cargo re-runs this script when

--- a/crates/glass-mcp/src/env.rs
+++ b/crates/glass-mcp/src/env.rs
@@ -334,8 +334,9 @@ pub(crate) const GLASS_ENV: &[EnvVarDoc] = &[
 /// `GLASS_*`-prefixed names read (or, for `GLASS_CLIP`, merely spelled) somewhere in the
 /// workspace that are deliberately **not** part of the user-facing override surface, so the
 /// `code_reads_match_registry_or_internal_allowlist` guard test below doesn't require them in
-/// [`GLASS_ENV`]. Each is a var glass **sets** for its own child/shim process (IPC plumbing) or
-/// reads only to force a code path in a test — never an operator override. Keep this list
+/// [`GLASS_ENV`]. Each is a var glass **sets** for its own child/shim process (IPC plumbing),
+/// reads only to force a code path in a test, or has `build.rs` emit as a `cargo:rustc-env` for
+/// the crate to read back with `env!` — never an operator override. Keep this list
 /// exact: an addition here should be accompanied by a one-line reason, same as the entries
 /// below.
 ///
@@ -372,6 +373,12 @@ pub(crate) const INTERNAL_ENV: &[&str] = &[
     // `cargo:rustc-env=GLASS_VERSION`, read via `env!` (see `crate::VERSION`). Not read from the
     // process environment and never an operator override.
     "GLASS_VERSION",
+    // Build-time only: `build.rs` reads them out of `server.json` and emits them as
+    // `cargo:rustc-env`, read via `env!` in the MCP `initialize` handshake. Keep the `BUILD`
+    // infix: without it they read as operator overrides that silently do nothing.
+    "GLASS_BUILD_TITLE",
+    "GLASS_BUILD_DESCRIPTION",
+    "GLASS_BUILD_WEBSITE_URL",
 ];
 
 /// Standard (non-`GLASS_*`) env glass reads at runtime — reference only.

--- a/crates/glass-mcp/src/lib.rs
+++ b/crates/glass-mcp/src/lib.rs
@@ -6,6 +6,21 @@
 /// `doctor`, and the MCP `initialize` handshake — the crate version itself is pinned at 0.0.0.
 pub const VERSION: &str = env!("GLASS_VERSION");
 
+/// glass's display title, mirrored from `server.json` at build time (see `build.rs`) so the MCP
+/// `initialize` handshake and the MCP registry entry are written once.
+pub(crate) const TITLE: &str = env!("GLASS_BUILD_TITLE");
+
+/// glass's one-line description, mirrored from `server.json` the same way as [`TITLE`].
+pub(crate) const DESCRIPTION: &str = env!("GLASS_BUILD_DESCRIPTION");
+
+/// The site to read about glass, or `None` where `server.json` carries no `websiteUrl` — the
+/// registry schema makes it optional, and an empty `cargo:rustc-env` is how `build.rs` spells the
+/// absence `env!` cannot.
+pub(crate) const WEBSITE_URL: Option<&str> = {
+    let url = env!("GLASS_BUILD_WEBSITE_URL");
+    if url.is_empty() { None } else { Some(url) }
+};
+
 pub mod audit;
 pub mod capabilities;
 pub mod cli;

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -770,10 +770,16 @@ impl ServerHandler for GlassServer {
         // Identify the server as glass in the MCP `initialize` handshake. The rmcp default
         // (`Implementation::from_build_env`) reports the transport crate's own name and version
         // (`rmcp` / its crate version), not glass's — so every connecting client would see the wrong
-        // server identity. Override with glass's name + build-time version.
+        // server identity. `name` stays glass-mcp rather than server.json's
+        // `io.github.fixed-width/glass`: the registry name is a namespaced identity token, and
+        // `Implementation.name` is not.
         info.server_info.name = "glass-mcp".to_string();
-        info.server_info.title = Some("glass".to_string());
         info.server_info.version = crate::VERSION.to_string();
+        // Mirrored from `server.json` by build.rs so the handshake and the registry entry are
+        // written once.
+        info.server_info.title = Some(crate::TITLE.to_string());
+        info.server_info.description = Some(crate::DESCRIPTION.to_string());
+        info.server_info.website_url = crate::WEBSITE_URL.map(str::to_string);
         info
     }
 }
@@ -895,6 +901,98 @@ mod tests {
             crate::VERSION,
             "handshake version must be glass's build-time version, not the crate's 0.0.0 or rmcp's"
         );
+    }
+
+    /// The descriptor this repo publishes to the MCP registry.
+    const SERVER_JSON: &str = include_str!("../../../server.json");
+
+    /// The `server.json` keys build.rs mirrors onto the handshake, split by whether the descriptor
+    /// must carry them: the registry schema makes `websiteUrl` optional, so the handshake omits it
+    /// rather than the build failing.
+    const MIRRORED_REQUIRED_KEYS: &[&str] = &["title", "description"];
+    const MIRRORED_OPTIONAL_KEYS: &[&str] = &["websiteUrl"];
+
+    fn server_json() -> serde_json::Value {
+        serde_json::from_str(SERVER_JSON).expect("server.json is valid JSON")
+    }
+
+    /// Compares against `server.json` rather than repeating its strings here: a literal copy would
+    /// go stale exactly when the handshake did, and pass.
+    #[test]
+    fn get_info_mirrors_server_jsons_title_description_and_website_url() {
+        let descriptor = server_json();
+
+        let glass =
+            crate::tools::testutil::glass_with(crate::tools::testutil::FakePlatform::new(10, 10));
+        let report = crate::audit::report_from_config(None, |_| None);
+        let info = GlassServer::new(glass, report).get_info();
+
+        for (key, got) in [
+            ("title", info.server_info.title.as_deref()),
+            ("description", info.server_info.description.as_deref()),
+        ] {
+            // Unwrap the expected value rather than comparing Option-to-Option: a missing key
+            // would otherwise match an unset handshake field and pass green with neither
+            // existing. `every_server_json_key_is_classified` keeps both present.
+            let want = descriptor[key]
+                .as_str()
+                .unwrap_or_else(|| panic!("server.json carries a `{key}`"));
+            assert_eq!(
+                got,
+                Some(want),
+                "the handshake must carry server.json's `{key}`, not omit it or echo another field"
+            );
+            // Reachable only if build.rs's length check is dropped; the MCP registry rejects an
+            // empty value at publish time (minLength 1).
+            assert!(!want.is_empty(), "server.json's `{key}` must not be empty");
+        }
+
+        // Option-to-Option is the contract here, not a weakened assertion: an absent `websiteUrl`
+        // must reach the handshake as an omitted field, not an empty string.
+        assert_eq!(
+            info.server_info.website_url.as_deref(),
+            descriptor["websiteUrl"].as_str(),
+            "the handshake must carry server.json's `websiteUrl` when it has one, and omit the \
+             field when it does not"
+        );
+    }
+
+    /// Partition every `server.json` key, so a key added later has to be classified rather than
+    /// silently left off the handshake — the omission #510 fixed, one field over.
+    #[test]
+    fn every_server_json_key_is_classified() {
+        // `name` is the registry's namespaced identity token, not `Implementation.name` (which
+        // stays `glass-mcp`); `version` is rewritten from the release tag at publish time while
+        // the handshake reports the running build's own git-derived version; `$schema` and
+        // `repository` have no handshake counterpart in any spec revision.
+        const REGISTRY_ONLY_KEYS: &[&str] = &["$schema", "name", "version", "repository"];
+
+        let descriptor = server_json();
+        let keys: Vec<&str> = descriptor
+            .as_object()
+            .expect("server.json is a JSON object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+
+        let classified = |k: &&str| {
+            MIRRORED_REQUIRED_KEYS.contains(k)
+                || MIRRORED_OPTIONAL_KEYS.contains(k)
+                || REGISTRY_ONLY_KEYS.contains(k)
+        };
+        let unclassified: Vec<&str> = keys.iter().copied().filter(|k| !classified(k)).collect();
+        assert!(
+            unclassified.is_empty(),
+            "server.json key(s) {unclassified:?} are neither mirrored onto the handshake nor \
+             registry-only: mirror them in build.rs's emit_server_json_identity, or add them to \
+             REGISTRY_ONLY_KEYS"
+        );
+        for key in MIRRORED_REQUIRED_KEYS {
+            assert!(
+                keys.contains(key),
+                "`{key}` is mirrored onto the handshake but server.json no longer carries it"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #510.

`get_info` set only `name`, `title` and `version`, so a client that installed glass from the MCP registry saw its description and website while a client connected to the running server saw neither.

`build.rs` now reads `server.json` — the descriptor this repo publishes to the registry — and emits `title`, `description` and `websiteUrl` as `cargo:rustc-env`, read back through `crate::TITLE` / `DESCRIPTION` / `WEBSITE_URL`. The strings are written once instead of retyped.

**Not mirrored, deliberately:** the registry `name` (`io.github.fixed-width/glass`) is a namespaced identity token, not `Implementation.name`; `version` is rewritten from the release tag at publish time while the handshake reports the running build's git-derived version; `$schema` and `repository` have no handshake counterpart.

**No `icons`.** `server.json` carries none, so adding one only to the handshake would re-create the split this closes.

## Validation at build time

The registry validates the descriptor at publish time — on the release path, *after* the tag is cut and immutable. So the bounds are checked during the build instead: `title` and `description` are held to the registry schema's `1..=100`, and values `cargo:rustc-env` cannot carry intact (control characters, outer whitespace) are rejected.

`websiteUrl` is optional in that schema, so a descriptor without one builds and the handshake omits the field rather than shipping `""` — a present-but-meaningless field is worse for a client than an absent one.

## Tests

- `get_info_mirrors_server_jsons_title_description_and_website_url` compares against `server.json` itself rather than repeating its strings; the expected values are unwrapped, so a missing key can't match an unset handshake field and pass green with neither existing.
- `every_server_json_key_is_classified` partitions every key into mirrored or registry-only, so a key added later has to be classified rather than silently left off the handshake — this bug, one field over.

## Verification

`cargo fmt --all --check`, `cargo clippy -p glass-mcp --all-targets -- -D warnings`, and `cargo test --workspace` (91 test targets) all clean. `Cargo.lock` is unchanged — `serde_json` was already a normal dependency of this crate.

Live `initialize` on both transports returns:

```
"serverInfo":{"name":"glass-mcp","title":"glass","version":"1.4.0-30-gcc07559-dirty",
"description":"MCP server giving a coding agent a build→see→interact→debug loop over native GUI apps.",
"websiteUrl":"https://fixedwidth.tech/glass"}
```

Each new guard was ablated to confirm it fires: a stray `server.json` key fails the partition test; an emptied or 101-character description fails the build; removing `websiteUrl` builds clean and omits the field from the wire; a drifted `title` fails `get_info_identifies_the_server_as_glass_not_the_transport_crate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)