### PR TITLE
feat(a11y): Document role, and disclosure of web content the reader cannot enter (#506)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ internal refactors, CI, or test-only changes.
 
 ## [Unreleased]
 
+### Added
+- `Document` accessibility role: a browser page or embedded web view (AT-SPI `document web`/`document frame`, `AXWebArea`, Android `WebView`) now reads as a `Document` whose children are the page's elements.
+
+### Fixed
+- A web view whose content the platform has not published is disclosed in the snapshot with its bounds and the pixel path, instead of arriving as an indistinguishable empty group (#506).
+
 ## [1.5.0] - 2026-08-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,10 @@ internal refactors, CI, or test-only changes.
 ## [Unreleased]
 
 ### Added
-- `Document` accessibility role: a browser page or embedded web view (AT-SPI `document web`/`document frame`, `AXWebArea`, Android `WebView`) now reads as a `Document` whose children are the page's elements.
+- `Document` accessibility role: a browser page or embedded web view (AT-SPI `document web`/`document frame`, `AXWebArea`, Android `WebView`) now reads as a `Document` whose children are the page's elements, on Linux, macOS, Android and iOS (a Windows web document keeps reading as `TextArea` for now).
 
 ### Fixed
-- A web view whose content the platform has not published is disclosed in the snapshot with its bounds and the pixel path, instead of arriving as an indistinguishable empty group (#506).
+- A web view whose content the platform has not published is disclosed in the snapshot with its id, bounds and the pixel path, instead of arriving as an indistinguishable empty group.
 
 ## [1.5.0] - 2026-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ internal refactors, CI, or test-only changes.
 ## [Unreleased]
 
 ### Added
-- `Document` accessibility role: a browser page or embedded web view (AT-SPI `document web`/`document frame`, `AXWebArea`, Android `WebView`) now reads as a `Document` whose children are the page's elements, on Linux, macOS, Android and iOS (a Windows web document keeps reading as `TextArea` for now).
+- `Document` accessibility role: a browser page or embedded web view (AT-SPI `document web`/`document frame`, `AXWebArea`, Android `WebView`) now reads as a `Document` whose children are the page's elements, on Linux, macOS, Android and iOS.
 
 ### Fixed
 - A web view whose content the platform has not published is disclosed in the snapshot with its id, bounds and the pixel path, instead of arriving as an indistinguishable empty group.

--- a/crates/glass-a11y-linux/src/mapping.rs
+++ b/crates/glass-a11y-linux/src/mapping.rs
@@ -50,6 +50,7 @@ pub(crate) fn map_role(role: Role) -> AxRole {
         Role::ToolBar => AxRole::Toolbar,
         Role::StatusBar => AxRole::StatusBar,
         Role::Heading => AxRole::Heading,
+        Role::DocumentWeb | Role::DocumentFrame => AxRole::Document,
         _ => AxRole::Other,
     }
 }
@@ -106,6 +107,17 @@ mod tests {
     #[test]
     fn unknown_role_is_other() {
         assert_eq!(map_role(Role::Calendar), AxRole::Other);
+    }
+
+    #[test]
+    fn web_documents_map_to_document() {
+        // A browser's page root and an ARIA role=document region are both web documents;
+        // a text document (DocumentText) is a text area and stays one.
+        assert_eq!(map_role(Role::DocumentWeb), AxRole::Document);
+        assert_eq!(map_role(Role::DocumentFrame), AxRole::Document);
+        assert_eq!(map_role(Role::DocumentText), AxRole::TextArea);
+        // An embedded object (<embed>, <object>) is not a document.
+        assert_eq!(map_role(Role::Embedded), AxRole::Other);
     }
 
     #[test]
@@ -177,6 +189,7 @@ mod tests {
         (Role::ToolBar, AxRole::Toolbar),
         (Role::StatusBar, AxRole::StatusBar),
         (Role::Heading, AxRole::Heading),
+        (Role::DocumentWeb, AxRole::Document),
     ];
 
     #[test]

--- a/crates/glass-a11y-macos/src/mapping.rs
+++ b/crates/glass-a11y-macos/src/mapping.rs
@@ -40,6 +40,8 @@ pub const ROLE_TOKENS: &[(&str, AxRole)] = &[
     ("AXSplitter", AxRole::Separator),
     ("AXHeading", AxRole::Heading),
     ("AXMenuButton", AxRole::Button),
+    // The root of a web engine's subtree (WebKit and Chromium both report it).
+    ("AXWebArea", AxRole::Document),
 ];
 
 /// Subroles that decide a role, and the base roles that can carry one.
@@ -229,6 +231,11 @@ mod tests {
     fn unmapped_role_is_other() {
         assert_eq!(map_role("AXRuler", None), AxRole::Other);
         assert_eq!(map_role("", None), AxRole::Other);
+    }
+
+    #[test]
+    fn a_web_area_is_a_document() {
+        assert_eq!(map_role("AXWebArea", None), AxRole::Document);
     }
 
     #[test]

--- a/crates/glass-a11y-macos/src/mapping.rs
+++ b/crates/glass-a11y-macos/src/mapping.rs
@@ -40,7 +40,7 @@ pub const ROLE_TOKENS: &[(&str, AxRole)] = &[
     ("AXSplitter", AxRole::Separator),
     ("AXHeading", AxRole::Heading),
     ("AXMenuButton", AxRole::Button),
-    // The root of a web engine's subtree (WebKit and Chromium both report it).
+    // The root of a web engine's subtree.
     ("AXWebArea", AxRole::Document),
 ];
 

--- a/crates/glass-a11y-windows/src/mapping.rs
+++ b/crates/glass-a11y-windows/src/mapping.rs
@@ -329,9 +329,8 @@ mod tests {
     #[test]
     fn document_maps_from_an_observed_token() {
         // Observed on a stock text editor — see the probe test in
-        // crates/glass-windows/tests/onbox.rs. A web document arrives under the same control
-        // type; the role-support matrix records the Document cell as a gap until both are
-        // read on one host (tests/web_probe.rs).
+        // crates/glass-windows/tests/onbox.rs. What a web document reports here is unread, so
+        // the role-support matrix records the Document cell as a gap until one is read.
         assert_eq!(map_role(50030, false), AxRole::TextArea);
     }
 

--- a/crates/glass-a11y-windows/src/mapping.rs
+++ b/crates/glass-a11y-windows/src/mapping.rs
@@ -329,7 +329,9 @@ mod tests {
     #[test]
     fn document_maps_from_an_observed_token() {
         // Observed on a stock text editor — see the probe test in
-        // crates/glass-windows/tests/onbox.rs.
+        // crates/glass-windows/tests/onbox.rs. A web document arrives under the same control
+        // type; the role-support matrix records the Document cell as a gap until both are
+        // read on one host (tests/web_probe.rs).
         assert_eq!(map_role(50030, false), AxRole::TextArea);
     }
 

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -987,10 +987,7 @@ fn movement_candidates<'a>(tree: &'a AxTree, target: &AxTarget) -> Vec<&'a AxNod
 
 /// A rectangle as `(x,y wxh)`.
 fn rect(b: Option<AxRect>) -> String {
-    b.map_or_else(
-        || "(no bounds)".to_string(),
-        |r| format!("({},{} {}x{})", r.x, r.y, r.width, r.height),
-    )
+    b.map_or_else(|| "(no bounds)".to_string(), |r| r.to_string())
 }
 
 /// The refusal for a target more than one node now matches on everything but position, so its id

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -43,7 +43,7 @@ pub const CLASS_TOKENS: &[(&str, AxRole)] = &[
     ("RecyclerView", AxRole::List),
     ("ListView", AxRole::List),
     ("GridView", AxRole::List),
-    ("WebView", AxRole::Group),
+    ("WebView", AxRole::Document),
     // Containers the leaf-suffix rule below cannot catch, each observed in a real app's
     // tree: the AndroidX card container, the AppCompat linear layout (shipped under two
     // package names), the view that hosts a Compose hierarchy, and a swipe-paged container.
@@ -627,6 +627,13 @@ mod tests {
         ] {
             assert_eq!(class_to_role(class), AxRole::Group, "{class}");
         }
+    }
+
+    #[test]
+    fn a_webview_is_a_document_not_a_group() {
+        // glass#506: as a Group, a WebView whose content the reader could not enter was
+        // indistinguishable from an empty container.
+        assert_eq!(class_to_role("android.webkit.WebView"), AxRole::Document);
     }
 
     #[test]

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -224,8 +224,8 @@ pub struct AxRect {
 }
 
 impl std::fmt::Display for AxRect {
-    /// `(x,y wxh)` — the agent-facing bounds format, defined once so an outline line and the
-    /// notice that names the same element render it identically.
+    /// `(x,y wxh)` — the agent-facing bounds format, defined once so the outline and a notice
+    /// naming the same element cannot drift.
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "({},{} {}x{})", self.x, self.y, self.width, self.height)
     }
@@ -790,10 +790,9 @@ impl AxTree {
     /// truncated tree does. Aggregated like [`Self::unreadable_notice`] rather than repeated
     /// per document: a page of ad iframes would otherwise spend the budget `max_nodes` guards.
     ///
-    /// Only a complete walk names a cause. A bound or a failed child read empties a
-    /// `Document`'s child list exactly like an unpublished tree does (see
-    /// [`Self::is_complete`]), so on such a tree this hedges and leaves the cause to the
-    /// truncation/unreadable notice beside it.
+    /// A bound or a failed child read empties a `Document`'s child list exactly like an
+    /// unpublished tree does, so only a complete walk ([`Self::is_complete`]) names a cause;
+    /// otherwise this hedges and leaves the cause to the notice beside it.
     pub fn document_guidance(&self) -> Option<String> {
         let docs = self.unpublished_documents();
         if docs.is_empty() {
@@ -2351,8 +2350,7 @@ mod tests {
 
     #[test]
     fn bounds_render_as_origin_then_size() {
-        // The one definition of the agent-facing bounds format: the outline line and the
-        // document notice both render through it, so they cannot drift apart.
+        // The shared format the outline line and the document notice both render through.
         let r = AxRect {
             x: 40,
             y: 120,
@@ -2523,8 +2521,7 @@ mod tests {
 
     #[test]
     fn a_complete_walk_names_the_engine_and_the_empty_page() {
-        // Nothing stopped this walk, so the childless Document really is all there was —
-        // the one case where glass can name a cause.
+        // A complete walk is the one case where glass can name a cause.
         let hint = tree_with_a_childless_document()
             .document_guidance()
             .unwrap();
@@ -2537,8 +2534,8 @@ mod tests {
 
     #[test]
     fn a_document_emptied_by_a_bound_is_not_blamed_on_the_web_engine() {
-        // A bound leaves a Document childless too, so the notice must not claim the engine
-        // published nothing — the truncation notice beside it carries the real cause.
+        // A bound leaves a Document childless too, so the notice cannot claim the engine
+        // published nothing.
         let mut tree = tree_with_a_childless_document();
         tree.truncated = Some(Truncation {
             limit: TruncationLimit::Nodes,
@@ -2736,9 +2733,8 @@ mod tests {
             AxRole::Group,
             AxRole::Label,
             AxRole::Image,
-            // Clickable by bounds, but not addressable: making it interactable would chip
-            // every web page root in `marks` and widen `role:"Document"` onto any focusable
-            // Group/Other through `element_match`'s fallback.
+            // Making it interactable would chip every web page root in `marks` and widen
+            // `role:"Document"` onto any focusable Group/Other through `element_match`.
             AxRole::Document,
             AxRole::Other,
         ] {

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -466,6 +466,20 @@ impl Truncation {
     }
 }
 
+/// One line of [`AxTree::document_guidance`].
+fn document_notice(doc: &AxNode) -> String {
+    let bounds = match &doc.bounds {
+        Some(b) => format!("({},{} {}x{})", b.x, b.y, b.width, b.height),
+        None => "bounds unknown".to_string(),
+    };
+    format!(
+        "… #{} Document {bounds} has no readable content: the web engine has not published \
+         its accessibility tree, or the page is empty. Elements inside it cannot be addressed \
+         by id. Drive it by pixels: glass_screenshot, then glass_click at x,y inside it.",
+        doc.id.0
+    )
+}
+
 /// Bookkeeping for a bounded pre-order walk. Every backend threads one of these through its
 /// traversal so the caps and the truncation record are computed one way rather than five.
 #[derive(Debug, Default)]
@@ -756,6 +770,36 @@ impl AxTree {
              (some toolkits need it enabled, e.g. relaunch with a11y:true; canvas/game apps \
              never will). Drive it by pixels instead: glass_screenshot, then glass_click at x,y.",
         )
+    }
+
+    /// Every `Document` with no children, in pre-order. A web engine that has not published
+    /// its tree — or an empty page — arrives exactly like this, and the outline alone cannot
+    /// tell the two apart.
+    pub fn unpublished_documents(&self) -> Vec<&AxNode> {
+        fn walk<'a>(node: &'a AxNode, out: &mut Vec<&'a AxNode>) {
+            if node.role == AxRole::Document && node.children.is_empty() {
+                out.push(node);
+            }
+            for child in &node.children {
+                walk(child, out);
+            }
+        }
+        let mut out = Vec::new();
+        walk(&self.root, &mut out);
+        out
+    }
+
+    /// The disclosure for [`Self::unpublished_documents`]: one line per document, or `None`
+    /// when there is nothing to disclose. Same shape as [`Truncation::notice`] and
+    /// [`Self::empty_guidance`] — what is missing, then the pixel path — because a web page
+    /// the reader cannot enter fails the agent the same way a truncated tree does.
+    pub fn document_guidance(&self) -> Option<String> {
+        let docs = self.unpublished_documents();
+        if docs.is_empty() {
+            return None;
+        }
+        let lines: Vec<String> = docs.iter().map(|d| document_notice(d)).collect();
+        Some(lines.join("\n"))
     }
 }
 
@@ -2391,6 +2435,98 @@ mod tests {
         );
         // A tree with real elements has something to address — no hint.
         assert!(sample_tree().empty_guidance().is_none());
+    }
+
+    fn document(name: &str, children: Vec<AxNode>) -> AxNode {
+        let mut d = leaf(AxRole::Document, name);
+        d.bounds = Some(AxRect {
+            x: 40,
+            y: 120,
+            width: 800,
+            height: 600,
+        });
+        d.children = children;
+        d
+    }
+
+    #[test]
+    fn a_childless_document_is_reported_with_its_id_and_bounds() {
+        let mut tree = AxTree::new(AxNode {
+            children: vec![leaf(AxRole::Button, "Back"), document("page", vec![])],
+            ..leaf(AxRole::Window, "App")
+        });
+        tree.assign_ids();
+        let found = tree.unpublished_documents();
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].id, AxNodeId(2));
+        let hint = tree
+            .document_guidance()
+            .expect("a childless Document yields guidance");
+        assert!(hint.contains("#2 Document"), "{hint}");
+        assert!(
+            hint.contains("(40,120 800x600)"),
+            "names the bounds: {hint}"
+        );
+        assert!(
+            hint.contains("glass_screenshot"),
+            "names the pixel path: {hint}"
+        );
+    }
+
+    #[test]
+    fn a_populated_document_is_not_reported() {
+        let mut tree = AxTree::new(AxNode {
+            children: vec![document("page", vec![leaf(AxRole::Heading, "Hello")])],
+            ..leaf(AxRole::Window, "App")
+        });
+        tree.assign_ids();
+        assert!(tree.unpublished_documents().is_empty());
+        assert!(tree.document_guidance().is_none());
+    }
+
+    #[test]
+    fn every_childless_document_is_reported_in_pre_order() {
+        // A populated document with an empty iframe inside it, and an empty one after it.
+        let mut tree = AxTree::new(AxNode {
+            children: vec![
+                document(
+                    "outer",
+                    vec![leaf(AxRole::Heading, "H"), document("iframe", vec![])],
+                ),
+                document("second", vec![]),
+            ],
+            ..leaf(AxRole::Window, "App")
+        });
+        tree.assign_ids();
+        let ids: Vec<AxNodeId> = tree.unpublished_documents().iter().map(|n| n.id).collect();
+        assert_eq!(ids, vec![AxNodeId(3), AxNodeId(4)]);
+        let hint = tree.document_guidance().unwrap();
+        assert_eq!(hint.lines().count(), 2, "one line per document: {hint}");
+    }
+
+    #[test]
+    fn a_tree_without_documents_yields_no_document_guidance() {
+        assert!(sample_tree().document_guidance().is_none());
+        // An empty tree is the empty_guidance case, not this one.
+        assert!(
+            AxTree::new(leaf(AxRole::Window, "App"))
+                .document_guidance()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn a_document_without_bounds_still_names_the_pixel_path() {
+        let mut d = document("page", vec![]);
+        d.bounds = None;
+        let mut tree = AxTree::new(AxNode {
+            children: vec![d],
+            ..leaf(AxRole::Window, "App")
+        });
+        tree.assign_ids();
+        let hint = tree.document_guidance().unwrap();
+        assert!(hint.contains("bounds unknown"), "{hint}");
+        assert!(hint.contains("glass_screenshot"), "{hint}");
     }
 
     fn sample_tree() -> AxTree {

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -223,6 +223,14 @@ pub struct AxRect {
     pub height: u32,
 }
 
+impl std::fmt::Display for AxRect {
+    /// `(x,y wxh)` — the agent-facing bounds format, defined once so an outline line and the
+    /// notice that names the same element render it identically.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "({},{} {}x{})", self.x, self.y, self.width, self.height)
+    }
+}
+
 impl AxRect {
     /// Whether this rect shares any area with `other`.
     ///
@@ -794,7 +802,7 @@ impl AxTree {
         let list: Vec<String> = docs
             .iter()
             .map(|d| match &d.bounds {
-                Some(b) => format!("#{} ({},{} {}x{})", d.id.0, b.x, b.y, b.width, b.height),
+                Some(b) => format!("#{} {b}", d.id.0),
                 None => format!("#{} (bounds unknown)", d.id.0),
             })
             .collect();
@@ -2339,6 +2347,19 @@ mod tests {
             leaf(AxRole::TextField, "Note"),
         ]);
         assert!(matches!(drift_target().relocate(&tree), Located::AtId(n) if n.id == AxNodeId(1)));
+    }
+
+    #[test]
+    fn bounds_render_as_origin_then_size() {
+        // The one definition of the agent-facing bounds format: the outline line and the
+        // document notice both render through it, so they cannot drift apart.
+        let r = AxRect {
+            x: 40,
+            y: 120,
+            width: 800,
+            height: 600,
+        };
+        assert_eq!(r.to_string(), "(40,120 800x600)");
     }
 
     #[test]

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -792,7 +792,8 @@ impl AxTree {
     ///
     /// A bound or a failed child read empties a `Document`'s child list exactly like an
     /// unpublished tree does, so only a complete walk ([`Self::is_complete`]) names a cause;
-    /// otherwise this hedges and leaves the cause to the notice beside it.
+    /// otherwise this hedges and defers to the notice beside it, which owns the recourse —
+    /// core does not know that only a `Nodes` bound is raisable by `max_nodes`.
     pub fn document_guidance(&self) -> Option<String> {
         let docs = self.unpublished_documents();
         if docs.is_empty() {
@@ -822,10 +823,10 @@ impl AxTree {
         } else {
             format!(
                 "… {n} Document element{s} {have} no readable content in this snapshot: \
-                 {list}. The walk stopped early or dropped subtrees — the notice beside this \
-                 one says which — so {they} may hold content that was never reached. Raise \
-                 max_nodes, narrow the UI, or take a fresh glass_a11y_snapshot before driving \
-                 by pixels: glass_screenshot, then glass_click at x,y inside the bounds above."
+                 {list}, and the walk did not complete — see the notice beside this one — so \
+                 {they} may hold content that was never reached. Follow that notice, or take \
+                 a fresh glass_a11y_snapshot, before driving by pixels: glass_screenshot, \
+                 then glass_click at x,y inside the bounds above."
             )
         })
     }
@@ -2548,7 +2549,16 @@ mod tests {
             "a bounded walk cannot know that: {hint}"
         );
         assert!(hint.contains("in this snapshot"), "hedged: {hint}");
-        assert!(hint.contains("max_nodes"), "names the recourse: {hint}");
+        // Core stays tool-agnostic: only the MCP layer knows a Nodes hit is raisable, and it
+        // adds that recourse to the notice beside this one.
+        assert!(
+            !hint.contains("max_nodes"),
+            "not core's recourse to name: {hint}"
+        );
+        assert!(
+            hint.contains("the notice beside this one"),
+            "defers to the notice that knows the cause: {hint}"
+        );
     }
 
     #[test]

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -2736,6 +2736,10 @@ mod tests {
             AxRole::Group,
             AxRole::Label,
             AxRole::Image,
+            // Clickable by bounds, but not addressable: making it interactable would chip
+            // every web page root in `marks` and widen `role:"Document"` onto any focusable
+            // Group/Other through `element_match`'s fallback.
+            AxRole::Document,
             AxRole::Other,
         ] {
             assert!(!r.is_interactable(), "{r:?} should not be interactable");

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -466,20 +466,6 @@ impl Truncation {
     }
 }
 
-/// One line of [`AxTree::document_guidance`].
-fn document_notice(doc: &AxNode) -> String {
-    let bounds = match &doc.bounds {
-        Some(b) => format!("({},{} {}x{})", b.x, b.y, b.width, b.height),
-        None => "bounds unknown".to_string(),
-    };
-    format!(
-        "… #{} Document {bounds} has no readable content: the web engine has not published \
-         its accessibility tree, or the page is empty. Elements inside it cannot be addressed \
-         by id. Drive it by pixels: glass_screenshot, then glass_click at x,y inside it.",
-        doc.id.0
-    )
-}
-
 /// Bookkeeping for a bounded pre-order walk. Every backend threads one of these through its
 /// traversal so the caps and the truncation record are computed one way rather than five.
 #[derive(Debug, Default)]
@@ -789,17 +775,52 @@ impl AxTree {
         out
     }
 
-    /// The disclosure for [`Self::unpublished_documents`]: one line per document, or `None`
-    /// when there is nothing to disclose. Same shape as [`Truncation::notice`] and
-    /// [`Self::empty_guidance`] — what is missing, then the pixel path — because a web page
-    /// the reader cannot enter fails the agent the same way a truncated tree does.
+    /// The disclosure for [`Self::unpublished_documents`]: one notice naming every childless
+    /// `Document` by id and bounds, or `None` when there is nothing to disclose. Same shape as
+    /// [`Truncation::notice`] and [`Self::empty_guidance`] — what is missing, then the pixel
+    /// path — because a web page the reader cannot enter fails the agent the same way a
+    /// truncated tree does. Aggregated like [`Self::unreadable_notice`] rather than repeated
+    /// per document: a page of ad iframes would otherwise spend the budget `max_nodes` guards.
+    ///
+    /// Only a complete walk names a cause. A bound or a failed child read empties a
+    /// `Document`'s child list exactly like an unpublished tree does (see
+    /// [`Self::is_complete`]), so on such a tree this hedges and leaves the cause to the
+    /// truncation/unreadable notice beside it.
     pub fn document_guidance(&self) -> Option<String> {
         let docs = self.unpublished_documents();
         if docs.is_empty() {
             return None;
         }
-        let lines: Vec<String> = docs.iter().map(|d| document_notice(d)).collect();
-        Some(lines.join("\n"))
+        let list: Vec<String> = docs
+            .iter()
+            .map(|d| match &d.bounds {
+                Some(b) => format!("#{} ({},{} {}x{})", d.id.0, b.x, b.y, b.width, b.height),
+                None => format!("#{} (bounds unknown)", d.id.0),
+            })
+            .collect();
+        let one = docs.len() == 1;
+        let (s, have, they, them) = if one {
+            ("", "has", "it", "it")
+        } else {
+            ("s", "have", "they", "them")
+        };
+        let (n, list) = (docs.len(), list.join(", "));
+        Some(if self.is_complete() {
+            format!(
+                "… {n} Document element{s} {have} no readable content: {list}. The web engine \
+                 has not published its accessibility tree, or the page is empty. Elements \
+                 inside {them} cannot be addressed by id. Drive by pixels: glass_screenshot, \
+                 then glass_click at x,y inside the bounds above."
+            )
+        } else {
+            format!(
+                "… {n} Document element{s} {have} no readable content in this snapshot: \
+                 {list}. The walk stopped early or dropped subtrees — the notice beside this \
+                 one says which — so {they} may hold content that was never reached. Raise \
+                 max_nodes, narrow the UI, or take a fresh glass_a11y_snapshot before driving \
+                 by pixels: glass_screenshot, then glass_click at x,y inside the bounds above."
+            )
+        })
     }
 }
 
@@ -2449,28 +2470,79 @@ mod tests {
         d
     }
 
-    #[test]
-    fn a_childless_document_is_reported_with_its_id_and_bounds() {
+    /// A Window with a Back button and one childless `Document` (#2), walked completely.
+    fn tree_with_a_childless_document() -> AxTree {
         let mut tree = AxTree::new(AxNode {
             children: vec![leaf(AxRole::Button, "Back"), document("page", vec![])],
             ..leaf(AxRole::Window, "App")
         });
         tree.assign_ids();
+        tree
+    }
+
+    #[test]
+    fn a_childless_document_is_reported_with_its_id_and_bounds() {
+        let tree = tree_with_a_childless_document();
         let found = tree.unpublished_documents();
         assert_eq!(found.len(), 1);
         assert_eq!(found[0].id, AxNodeId(2));
         let hint = tree
             .document_guidance()
             .expect("a childless Document yields guidance");
-        assert!(hint.contains("#2 Document"), "{hint}");
         assert!(
-            hint.contains("(40,120 800x600)"),
-            "names the bounds: {hint}"
+            hint.contains("#2 (40,120 800x600)"),
+            "id and bounds: {hint}"
         );
         assert!(
             hint.contains("glass_screenshot"),
             "names the pixel path: {hint}"
         );
+        assert!(hint.contains("glass_click"), "names the pixel path: {hint}");
+    }
+
+    #[test]
+    fn a_complete_walk_names_the_engine_and_the_empty_page() {
+        // Nothing stopped this walk, so the childless Document really is all there was —
+        // the one case where glass can name a cause.
+        let hint = tree_with_a_childless_document()
+            .document_guidance()
+            .unwrap();
+        assert!(
+            hint.starts_with("… 1 Document element has no readable content:"),
+            "singular, aggregated: {hint}"
+        );
+        assert!(hint.contains("has not published"), "{hint}");
+    }
+
+    #[test]
+    fn a_document_emptied_by_a_bound_is_not_blamed_on_the_web_engine() {
+        // A bound leaves a Document childless too, so the notice must not claim the engine
+        // published nothing — the truncation notice beside it carries the real cause.
+        let mut tree = tree_with_a_childless_document();
+        tree.truncated = Some(Truncation {
+            limit: TruncationLimit::Nodes,
+            limit_value: 20,
+            nodes_walked: 20,
+        });
+        let hint = tree.document_guidance().unwrap();
+        assert!(
+            !hint.contains("has not published"),
+            "a bounded walk cannot know that: {hint}"
+        );
+        assert!(hint.contains("in this snapshot"), "hedged: {hint}");
+        assert!(hint.contains("max_nodes"), "names the recourse: {hint}");
+    }
+
+    #[test]
+    fn a_document_emptied_by_an_unread_subtree_is_not_blamed_on_the_web_engine() {
+        let mut tree = tree_with_a_childless_document();
+        tree.unreadable = 1;
+        let hint = tree.document_guidance().unwrap();
+        assert!(
+            !hint.contains("has not published"),
+            "a dropped subtree cannot know that: {hint}"
+        );
+        assert!(hint.contains("in this snapshot"), "hedged: {hint}");
     }
 
     #[test]
@@ -2500,8 +2572,14 @@ mod tests {
         tree.assign_ids();
         let ids: Vec<AxNodeId> = tree.unpublished_documents().iter().map(|n| n.id).collect();
         assert_eq!(ids, vec![AxNodeId(3), AxNodeId(4)]);
+        // One notice for both, ids listed in the same pre-order.
         let hint = tree.document_guidance().unwrap();
-        assert_eq!(hint.lines().count(), 2, "one line per document: {hint}");
+        assert!(
+            hint.starts_with("… 2 Document elements have no readable content:"),
+            "plural, aggregated: {hint}"
+        );
+        let (third, fourth) = (hint.find("#3").unwrap(), hint.find("#4").unwrap());
+        assert!(third < fourth, "pre-order: {hint}");
     }
 
     #[test]

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -2549,8 +2549,7 @@ mod tests {
             "a bounded walk cannot know that: {hint}"
         );
         assert!(hint.contains("in this snapshot"), "hedged: {hint}");
-        // Core stays tool-agnostic: only the MCP layer knows a Nodes hit is raisable, and it
-        // adds that recourse to the notice beside this one.
+        // `max_nodes` is an MCP-layer detail; core doesn't know a Nodes hit is raisable by it.
         assert!(
             !hint.contains("max_nodes"),
             "not core's recourse to name: {hint}"

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -48,6 +48,10 @@ pub enum AxRole {
     Toolbar,
     StatusBar,
     Heading,
+    /// A web document or web area — the root of a subtree a web engine publishes (a
+    /// browser tab's page, a WebView's content). Its children are the page's own elements;
+    /// a `Document` with no children is disclosed by [`AxTree::document_guidance`].
+    Document,
     Other,
 }
 
@@ -55,7 +59,7 @@ impl AxRole {
     /// Every role except [`AxRole::Other`], which is the sink for unmapped native tokens
     /// rather than a mapping target. Used by the per-backend role-parity tests and by
     /// [`crate::role_support::ROLE_SUPPORT`].
-    pub const ALL: [AxRole; 33] = [
+    pub const ALL: [AxRole; 34] = [
         AxRole::Application,
         AxRole::Window,
         AxRole::Dialog,
@@ -89,6 +93,7 @@ impl AxRole {
         AxRole::Toolbar,
         AxRole::StatusBar,
         AxRole::Heading,
+        AxRole::Document,
     ];
 
     /// Whether this role denotes an element a user acts on (clicks / types into) —
@@ -153,6 +158,7 @@ impl AxRole {
             "toolbar" => Toolbar,
             "statusbar" => StatusBar,
             "heading" => Heading,
+            "document" => Document,
             "other" => Other,
             _ => return None,
         })
@@ -1350,7 +1356,8 @@ mod tests {
             | AxRole::Separator
             | AxRole::Toolbar
             | AxRole::StatusBar
-            | AxRole::Heading => {}
+            | AxRole::Heading
+            | AxRole::Document => {}
             // Deliberately excluded from `ALL`: the sink for unmapped native tokens, not a
             // mapping target.
             AxRole::Other => {}
@@ -1692,7 +1699,7 @@ mod tests {
     #[test]
     fn every_role_parses_from_its_name() {
         use AxRole::*;
-        let pairs: [(&str, AxRole); 34] = [
+        let pairs: [(&str, AxRole); 35] = [
             ("application", Application),
             ("window", Window),
             ("dialog", Dialog),
@@ -1726,6 +1733,7 @@ mod tests {
             ("toolbar", Toolbar),
             ("statusbar", StatusBar),
             ("heading", Heading),
+            ("document", Document),
             ("other", Other),
         ];
 

--- a/crates/glass-core/src/outline.rs
+++ b/crates/glass-core/src/outline.rs
@@ -66,7 +66,7 @@ pub(crate) fn write_line(node: &AxNode, depth: usize, out: &mut String) {
         let _ = write!(out, " desc={description:?}");
     }
     if let Some(b) = &node.bounds {
-        let _ = write!(out, " ({},{} {}x{})", b.x, b.y, b.width, b.height);
+        let _ = write!(out, " {b}");
     }
     let states = node.states.active();
     if !states.is_empty() {

--- a/crates/glass-core/src/outline.rs
+++ b/crates/glass-core/src/outline.rs
@@ -259,16 +259,15 @@ mod tests {
 
     #[test]
     fn a_childless_document_under_a_wrapper_still_renders_its_own_line() {
-        // `document_guidance` names the Document by id; that id has to be a line the agent
-        // can see, even when the only thing holding it is a collapsed wrapper.
+        // `document_guidance` names the Document by id, so that id has to be a line the
+        // agent can see.
         let out = render_compact(&tree_of(wrap(node(AxRole::Document, None), 1)));
         assert!(out.contains("Document"), "{out}");
     }
 
     #[test]
     fn a_single_child_document_is_never_collapsed_as_scaffolding() {
-        // The shape that would be elided if `Document` joined the scaffolding roles: web
-        // content is content, and the docs promise the page's elements arrive under it.
+        // The shape that would be elided if `Document` joined the scaffolding roles.
         let mut doc = node(AxRole::Document, None);
         doc.children = vec![node(AxRole::Heading, Some("Title"))];
         let out = render_compact(&tree_of(doc));

--- a/crates/glass-core/src/outline.rs
+++ b/crates/glass-core/src/outline.rs
@@ -258,6 +258,24 @@ mod tests {
     }
 
     #[test]
+    fn a_childless_document_under_a_wrapper_still_renders_its_own_line() {
+        // `document_guidance` names the Document by id; that id has to be a line the agent
+        // can see, even when the only thing holding it is a collapsed wrapper.
+        let out = render_compact(&tree_of(wrap(node(AxRole::Document, None), 1)));
+        assert!(out.contains("Document"), "{out}");
+    }
+
+    #[test]
+    fn a_single_child_document_is_never_collapsed_as_scaffolding() {
+        // The shape that would be elided if `Document` joined the scaffolding roles: web
+        // content is content, and the docs promise the page's elements arrive under it.
+        let mut doc = node(AxRole::Document, None);
+        doc.children = vec![node(AxRole::Heading, Some("Title"))];
+        let out = render_compact(&tree_of(doc));
+        assert!(out.contains("Document"), "{out}");
+    }
+
+    #[test]
     fn a_semantic_role_is_never_elided() {
         let mut list = node(AxRole::List, None);
         list.children = vec![node(AxRole::ListItem, Some("Row"))];

--- a/crates/glass-core/src/role_support.rs
+++ b/crates/glass-core/src/role_support.rs
@@ -622,6 +622,22 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
             ],
         ),
+        (
+            R::Document,
+            [
+                Mapped,
+                Gap {
+                    unmapped: Some("Document"),
+                    why: "UIA's Document control type is what a web document arrives as, and it \
+                     maps to TextArea because a stock text editor's edit surface reports the same \
+                     token (see glass-a11y-windows's document_maps_from_an_observed_token); \
+                     telling the two apart waits on a reading of both on one host",
+                },
+                Mapped,
+                Mapped,
+                Mapped,
+            ],
+        ),
     ]
 };
 
@@ -875,5 +891,23 @@ mod tests {
                 "{role:?} unmapped on the reference backend"
             );
         }
+    }
+
+    #[test]
+    fn document_row_declares_every_backend() {
+        for backend in AxBackend::ALL {
+            assert!(
+                support(AxRole::Document, backend).is_some(),
+                "{backend:?} has no Document cell"
+            );
+        }
+        // Windows keeps UIA Document on TextArea until both readings exist on one host.
+        assert!(matches!(
+            support(AxRole::Document, AxBackend::Windows),
+            Some(RoleSupport::Gap {
+                unmapped: Some("Document"),
+                ..
+            })
+        ));
     }
 }

--- a/crates/glass-core/src/role_support.rs
+++ b/crates/glass-core/src/role_support.rs
@@ -627,11 +627,10 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
             [
                 Mapped,
                 Gap {
-                    unmapped: Some("Document"),
-                    why: "UIA's Document control type is what a web document arrives as, and it \
-                     maps to TextArea because a stock text editor's edit surface reports the same \
-                     token (see glass-a11y-windows's document_maps_from_an_observed_token); \
-                     telling the two apart waits on a reading of both on one host",
+                    unmapped: None,
+                    why: "UIA's Document control type maps to TextArea, read from a text \
+                     editor's edit surface; what a web document reports on this backend has \
+                     not been read, so the cell waits on that reading",
                 },
                 Mapped,
                 Mapped,
@@ -901,13 +900,12 @@ mod tests {
                 "{backend:?} has no Document cell"
             );
         }
-        // Windows keeps UIA Document on TextArea until both readings exist on one host.
+        // Windows keeps UIA Document on TextArea until a web document is read there. The
+        // cell names no unmapped token: UIA's Document IS mapped, just to another role, so
+        // "`Document` arrives unmapped" would send a reader hunting for `Other(Document)`.
         assert!(matches!(
             support(AxRole::Document, AxBackend::Windows),
-            Some(RoleSupport::Gap {
-                unmapped: Some("Document"),
-                ..
-            })
+            Some(RoleSupport::Gap { unmapped: None, .. })
         ));
     }
 }

--- a/crates/glass-core/src/role_support.rs
+++ b/crates/glass-core/src/role_support.rs
@@ -900,8 +900,8 @@ mod tests {
                 "{backend:?} has no Document cell"
             );
         }
-        // Windows keeps UIA Document on TextArea until a web document is read there. The
-        // cell names no unmapped token: UIA's Document IS mapped, just to another role, so
+        // Windows keeps UIA Document on TextArea until a web document is read there.
+        // `unmapped` stays `None`: UIA's Document IS mapped, just to another role, so
         // "`Document` arrives unmapped" would send a reader hunting for `Other(Document)`.
         assert!(matches!(
             support(AxRole::Document, AxBackend::Windows),

--- a/crates/glass-core/tests/role_support_doc.rs
+++ b/crates/glass-core/tests/role_support_doc.rs
@@ -46,3 +46,13 @@ fn crlf_normalization_works() {
     let extracted = normalized[start..end].trim();
     assert_eq!(extracted, generated.trim());
 }
+
+/// Prints the generated block so it can be pasted between the markers. Ignored: it is a
+/// tool, not a check.
+///
+/// `cargo test -p glass-core --test role_support_doc print_generated -- --ignored --nocapture`
+#[test]
+#[ignore = "prints the block for docs/reference/a11y-roles.md; run on demand"]
+fn print_generated() {
+    print!("{}", glass_core::role_support::render_markdown());
+}

--- a/crates/glass-ios/src/axmap.rs
+++ b/crates/glass-ios/src/axmap.rs
@@ -52,7 +52,7 @@ pub const ROLE_TOKENS: &[(&str, AxRole)] = &[
     ("AXGroup", AxRole::Group),
     // A screen or section title.
     ("AXHeading", AxRole::Heading),
-    // The root of a web engine's subtree (WebKit and Chromium both report it).
+    // The root of a web engine's subtree.
     ("AXWebArea", AxRole::Document),
 ];
 

--- a/crates/glass-ios/src/axmap.rs
+++ b/crates/glass-ios/src/axmap.rs
@@ -52,6 +52,8 @@ pub const ROLE_TOKENS: &[(&str, AxRole)] = &[
     ("AXGroup", AxRole::Group),
     // A screen or section title.
     ("AXHeading", AxRole::Heading),
+    // The root of a web engine's subtree (WebKit and Chromium both report it).
+    ("AXWebArea", AxRole::Document),
 ];
 
 /// Map an idb AX role string (e.g. `AXButton`) to a normalized [`AxRole`].
@@ -316,6 +318,11 @@ mod tests {
         // The checkable roles the toggle-state derivation depends on.
         assert_eq!(ax_role("AXCheckBox"), AxRole::CheckBox);
         assert_eq!(ax_role("AXWhatever"), AxRole::Other);
+    }
+
+    #[test]
+    fn a_web_area_is_a_document() {
+        assert_eq!(ax_role("AXWebArea"), AxRole::Document);
     }
 
     #[test]

--- a/crates/glass-mcp/src/params.rs
+++ b/crates/glass-mcp/src/params.rs
@@ -168,6 +168,8 @@ pub struct SetValueArgs {
 }
 
 /// Arguments for `glass_a11y_snapshot`.
+/// Web content inside the app arrives under a `Document` element; a `Document` with no
+/// children is disclosed with the pixel path.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct A11ySnapshotArgs {
     /// Maximum number of elements to include. Omit for the default cap (protects the token
@@ -333,7 +335,7 @@ pub struct WaitStableArgs {
 pub struct WaitForElementArgs {
     /// Substring of the element's accessible name (selector).
     pub name: Option<String>,
-    /// Element role filter, e.g. "Button", "ProgressBar" (selector).
+    /// Element role filter, e.g. "Button", "ProgressBar", "Document" (selector).
     pub role: Option<String>,
     /// What to wait for (default "appears"): appears|disappears|enabled|disabled|
     /// checked|unchecked|selected|unselected|expanded|collapsed|focused|visible|hidden.
@@ -354,7 +356,7 @@ pub struct ScrollToElementArgs {
     /// Substring of the target element's accessible name (selector). `name` and/or
     /// `role` is required.
     pub name: Option<String>,
-    /// Element role filter, e.g. "ListItem", "Button" (selector).
+    /// Element role filter, e.g. "ListItem", "Button", "Document" (selector).
     pub role: Option<String>,
     /// Additionally require the matched element's `value` to contain this substring.
     /// Not a standalone selector — `name` and/or `role` is still required.

--- a/crates/glass-mcp/src/params.rs
+++ b/crates/glass-mcp/src/params.rs
@@ -168,8 +168,6 @@ pub struct SetValueArgs {
 }
 
 /// Arguments for `glass_a11y_snapshot`.
-/// Web content inside the app arrives under a `Document` element; a `Document` with no
-/// children is disclosed with the pixel path.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct A11ySnapshotArgs {
     /// Maximum number of elements to include. Omit for the default cap (protects the token

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -504,8 +504,10 @@ impl GlassServer {
                        glass_scroll_to_element select on name, not description. Pass an #id to \
                        glass_click_element. Errors if the backend or app exposes no \
                        accessibility tree (e.g. a canvas/black-box app) — fall back to \
-                       glass_screenshot then. Optional max_nodes: raise the element cap, or 0 \
-                       to remove the element-count limit (default caps protect the token budget)."
+                       glass_screenshot then. Web content arrives under a `Document` element, \
+                       and a childless `Document` is disclosed with the pixel path. Optional \
+                       max_nodes: raise the element cap, or 0 to remove the element-count limit \
+                       (default caps protect the token budget)."
     )]
     async fn glass_a11y_snapshot(
         &self,

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -1836,8 +1836,7 @@ mod tests {
             a11y: false,
         })
         .unwrap();
-        // Populates the id cache click_element resolves against, and is the tree the fold
-        // is checked for parity with.
+        // Populates the id cache click_element resolves against, and is the parity tree.
         let tree = g.a11y_snapshot(None).unwrap();
         let out = click_element(
             &mut g,

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -289,13 +289,14 @@ fn a11y_truncation_steer(tree: &glass_core::AxTree) -> Option<String> {
     })
 }
 
-/// Every disclosure a snapshot owes the agent: the elements it does not show, and what it turned
-/// out to describe. One function, not three call-site lists, so `a11y_snapshot` and the
-/// `return:"snapshot"` fold disclose identically.
+/// Every disclosure a snapshot owes the agent: the elements it does not show, the web content
+/// it could not enter, and what it turned out to describe. One function, not three call-site
+/// lists, so `a11y_snapshot` and the `return:"snapshot"` fold disclose identically.
 fn a11y_steers(tree: &glass_core::AxTree) -> Vec<String> {
     [
         a11y_truncation_steer(tree),
         tree.unreadable_notice(),
+        tree.document_guidance(),
         tree.subject_notice(),
     ]
     .into_iter()
@@ -816,6 +817,29 @@ pub(crate) mod testutil {
         t
     }
 
+    /// `fake_tree` with a childless `Document` child — the unpublished-web-content shape.
+    pub fn unpublished_document_tree() -> AxTree {
+        let mut t = fake_tree();
+        t.root.children.push(AxNode {
+            id: AxNodeId(0),
+            role: AxRole::Document,
+            raw_role: "document web".into(),
+            name: Some("page".into()),
+            description: None,
+            value: None,
+            states: AxStates::default(),
+            bounds: Some(AxRect {
+                x: 0,
+                y: 40,
+                width: 100,
+                height: 60,
+            }),
+            children: vec![],
+        });
+        t.assign_ids();
+        t
+    }
+
     pub fn glass_with_a11y(platform: FakePlatform, tree: AxTree) -> Glass {
         glass_with_a11y_outcome(platform, tree, SetOutcome::Ok)
     }
@@ -1245,6 +1269,40 @@ mod tests {
                 );
             }
             _ => panic!("expected the trusted truncation-steer text"),
+        }
+    }
+
+    #[test]
+    fn a11y_snapshot_discloses_an_unpublished_document_as_a_trusted_block() {
+        let mut g = glass_with_a11y(FakePlatform::new(100, 100), unpublished_document_tree());
+        g.start(&AppSpec {
+            build: None,
+            run: vec!["x".into()],
+            cwd: None,
+            env: vec![],
+            window_hint: None,
+            timeout_ms: 1,
+            sandbox: SandboxLevel::Off,
+            a11y: false,
+        })
+        .unwrap();
+        let out = a11y_snapshot(&mut g, &A11ySnapshotArgs { max_nodes: None }).unwrap();
+        assert_envelope(&out, "glass_a11y_snapshot");
+        assert_eq!(
+            out.0.len(),
+            3,
+            "envelope + wrapped outline + document guidance"
+        );
+        match (&out.0[1], &out.0[2]) {
+            (OutContent::Text(body), OutContent::Text(steer)) => {
+                assert!(
+                    !body.contains("has no readable content"),
+                    "guidance must not be inside the untrusted body: {body}"
+                );
+                assert!(steer.contains("Document"), "{steer}");
+                assert!(steer.contains("glass_screenshot"), "{steer}");
+            }
+            other => panic!("unexpected blocks: {other:?}"),
         }
     }
 

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -1821,6 +1821,60 @@ mod tests {
     }
 
     #[test]
+    fn return_snapshot_discloses_an_unpublished_document_the_same_way_a_snapshot_does() {
+        // The fold's steer wiring, not `a11y_steers` itself: every fold test until now used a
+        // tree with nothing to disclose, so dropping the `extend` broke nothing.
+        let mut g = glass_with_a11y(FakePlatform::new(100, 100), unpublished_document_tree());
+        g.start(&AppSpec {
+            build: None,
+            run: vec!["x".into()],
+            cwd: None,
+            env: vec![],
+            window_hint: None,
+            timeout_ms: 1,
+            sandbox: SandboxLevel::Off,
+            a11y: false,
+        })
+        .unwrap();
+        // Populates the id cache click_element resolves against, and is the tree the fold
+        // is checked for parity with.
+        let tree = g.a11y_snapshot(None).unwrap();
+        let out = click_element(
+            &mut g,
+            &ClickElementArgs {
+                id: 1,
+                return_: Some("snapshot".into()),
+            },
+        )
+        .unwrap();
+        let texts: Vec<&String> = out
+            .0
+            .iter()
+            .filter_map(|c| match c {
+                OutContent::Text(t) => Some(t),
+                _ => None,
+            })
+            .collect();
+        let steer = texts
+            .iter()
+            .find(|t| t.contains("has no readable content"))
+            .unwrap_or_else(|| panic!("the fold owes the document guidance: {texts:?}"));
+        assert!(
+            !steer.starts_with(crate::untrusted::NOTE) && !steer.contains("⟦untrusted:"),
+            "glass's own guidance, outside the untrusted envelope: {steer}"
+        );
+        assert!(steer.contains("glass_screenshot"), "{steer}");
+        // Parity with `a11y_snapshot`: a fifth steer added to one call site and not the
+        // other fails here too.
+        for expected in a11y_steers(&tree) {
+            assert!(
+                texts.iter().any(|t| **t == expected),
+                "the fold dropped a steer: {expected}"
+            );
+        }
+    }
+
+    #[test]
     fn return_snapshot_settles_before_folding() {
         use glass_core::Frame;
         use std::sync::{Arc, Mutex};

--- a/docs/reference/a11y-roles.md
+++ b/docs/reference/a11y-roles.md
@@ -96,6 +96,7 @@ now, and the outline only names the token of an element that has none.
 | `Toolbar` | yes | yes | yes | unmarked | yes |
 | `StatusBar` | yes | yes | unmarked | elsewhere | elsewhere |
 | `Heading` | yes | gap | yes | gap | yes |
+| `Document` | yes | gap | yes | yes | yes |
 
 ### Why a cell is not `yes`
 
@@ -146,4 +147,5 @@ now, and the outline only names the token of an element that has none.
 - `StatusBar` / iOS — elsewhere: the system status bar is outside the app tree
 - `Heading` / Windows (UIA) — gap: UIA marks a heading with the HeadingLevel property — an h1 arrives as Text carrying level 80051 — and the reader maps by control type alone, so it never sees it. Header and HeaderItem are a grid's column headers, a different concept the normalized set has no role for
 - `Heading` / Android — gap: AccessibilityNodeInfo's isHeading marks a heading, and neither reader carries it: the uiautomator dump has no such attribute and the service reader parses only class, text, description and bounds
+- `Document` / Windows (UIA) — gap (`Document` arrives unmapped): UIA's Document control type is what a web document arrives as, and it maps to TextArea because a stock text editor's edit surface reports the same token (see glass-a11y-windows's document_maps_from_an_observed_token); telling the two apart waits on a reading of both on one host
 <!-- END GENERATED: role-support -->

--- a/docs/reference/a11y-roles.md
+++ b/docs/reference/a11y-roles.md
@@ -62,9 +62,9 @@ now, and the outline only names the token of an element that has none.
 
 **A web document is a `Document`.** A browser page or an embedded web view arrives as one
 `Document` element with the page's elements as its children; an `<iframe>` is a `Document`
-inside it. Web engines build that tree lazily — only once they believe an assistive technology is
-present — so a `Document` can arrive with no children at all. glass discloses that case in the
-snapshot rather than leaving an empty container to be read as an empty page.
+inside it. A web engine may publish its tree only after it detects an assistive technology, so a
+`Document` can arrive with no children at all. glass discloses that case in the snapshot rather
+than leaving an empty container to be read as an empty page.
 
 <!-- BEGIN GENERATED: role-support -->
 | Role | Linux (AT-SPI) | Windows (UIA) | macOS (AX) | Android | iOS |

--- a/docs/reference/a11y-roles.md
+++ b/docs/reference/a11y-roles.md
@@ -60,6 +60,12 @@ window root sized to the app window, and the accessibility-service reader labels
 window's own root node. The outline does not name that node's widget class — the root has a role
 now, and the outline only names the token of an element that has none.
 
+**A web document is a `Document`.** A browser page or an embedded web view arrives as one
+`Document` element with the page's elements as its children; an `<iframe>` is a `Document`
+inside it. Web engines build that tree lazily — only once they believe an assistive technology is
+present — so a `Document` can arrive with no children at all. glass discloses that case in the
+snapshot rather than leaving an empty container to be read as an empty page.
+
 <!-- BEGIN GENERATED: role-support -->
 | Role | Linux (AT-SPI) | Windows (UIA) | macOS (AX) | Android | iOS |
 |---|---|---|---|---|---|

--- a/docs/reference/a11y-roles.md
+++ b/docs/reference/a11y-roles.md
@@ -153,5 +153,5 @@ snapshot rather than leaving an empty container to be read as an empty page.
 - `StatusBar` / iOS — elsewhere: the system status bar is outside the app tree
 - `Heading` / Windows (UIA) — gap: UIA marks a heading with the HeadingLevel property — an h1 arrives as Text carrying level 80051 — and the reader maps by control type alone, so it never sees it. Header and HeaderItem are a grid's column headers, a different concept the normalized set has no role for
 - `Heading` / Android — gap: AccessibilityNodeInfo's isHeading marks a heading, and neither reader carries it: the uiautomator dump has no such attribute and the service reader parses only class, text, description and bounds
-- `Document` / Windows (UIA) — gap (`Document` arrives unmapped): UIA's Document control type is what a web document arrives as, and it maps to TextArea because a stock text editor's edit surface reports the same token (see glass-a11y-windows's document_maps_from_an_observed_token); telling the two apart waits on a reading of both on one host
+- `Document` / Windows (UIA) — gap: UIA's Document control type maps to TextArea, read from a text editor's edit surface; what a web document reports on this backend has not been read, so the cell waits on that reading
 <!-- END GENERATED: role-support -->

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -524,9 +524,10 @@ visible; a bare `Other` means the platform named no token at all.
 Web content — a browser's page, a WebView's content — arrives under a `Document` element whose
 children are the page's own elements (headings, links, fields), addressable like any other. A
 `Document` with **no** children has nothing inside to address: the web engine has not published
-its accessibility tree, the page is empty, or — on a truncated snapshot — the walk stopped before
-reaching its content. The snapshot says so in a separate notice naming the element's id, bounds
-and the pixel path, the same way a truncated tree is disclosed.
+its accessibility tree, the page is empty, or the walk did not complete — whether a bound cut it
+short or it dropped a subtree it could not read — before reaching its content. The snapshot says
+so in a separate notice naming the element's id, bounds and the pixel path, the same way a
+truncated tree is disclosed.
 
 - `max_nodes` (integer) — raise the element cap above the default (which protects the token
   budget), or `0` to remove the element-count limit. Omit for the default cap. (Structural

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -523,9 +523,10 @@ visible; a bare `Other` means the platform named no token at all.
 
 Web content — a browser's page, a WebView's content — arrives under a `Document` element whose
 children are the page's own elements (headings, links, fields), addressable like any other. A
-`Document` with **no** children means the web engine has not published its accessibility tree, or
-the page is empty; the snapshot says so in a separate notice naming the element's bounds and the
-pixel path, the same way a truncated tree is disclosed.
+`Document` with **no** children has nothing inside to address: the web engine has not published
+its accessibility tree, the page is empty, or — on a truncated snapshot — the walk stopped before
+reaching its content. The snapshot says so in a separate notice naming the element's id, bounds
+and the pixel path, the same way a truncated tree is disclosed.
 
 - `max_nodes` (integer) — raise the element cap above the default (which protects the token
   budget), or `0` to remove the element-count limit. Omit for the default cap. (Structural

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -521,6 +521,12 @@ An element whose platform role glass has no mapping for renders as `Other(<nativ
 `#4 Other(AXDisclosureTriangle) "Details" [enabled]` — so the platform's own token is still
 visible; a bare `Other` means the platform named no token at all.
 
+Web content — a browser's page, a WebView's content — arrives under a `Document` element whose
+children are the page's own elements (headings, links, fields), addressable like any other. A
+`Document` with **no** children means the web engine has not published its accessibility tree, or
+the page is empty; the snapshot says so in a separate notice naming the element's bounds and the
+pixel path, the same way a truncated tree is disclosed.
+
 - `max_nodes` (integer) — raise the element cap above the default (which protects the token
   budget), or `0` to remove the element-count limit. Omit for the default cap. (Structural
   depth/sibling safety rails still apply, so a pathologically deep tree can still truncate — the


### PR DESCRIPTION
Web content inside a driven app now reads as a `Document` element — AT-SPI `document web`/`document frame`, `AXWebArea` on macOS and iOS, Android `WebView` — with the page's own elements as its children. UIA `Document` stays `TextArea` until a web document is read on Windows; the role-support matrix records that cell as a gap.

A `Document` with no children is disclosed in the snapshot as a separate notice naming its id, bounds and the pixel path (#506). When the walk did not complete, the notice says so instead of blaming the web engine.

`AxRect` renders its bounds through one `Display` impl (outline, notice, Android service diagnostics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
