### PR TITLE
feat(a11y): read web content where the platform publishes it (#506)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ internal refactors, CI, or test-only changes.
 ## [Unreleased]
 
 ### Added
-- `Document` accessibility role: a browser page or embedded web view (AT-SPI `document web`/`document frame`, `AXWebArea`, Android `WebView`) now reads as a `Document` whose children are the page's elements, on Linux, macOS and Android.
+- `Document` accessibility role: a browser page or embedded web view (AT-SPI `document web`/`document frame`, `AXWebArea`, Android `WebView`, UIA `Document` from a web engine) now reads as a `Document` whose children are the page's elements, on Linux, Windows, macOS and Android.
 
 ### Fixed
 - A web view whose content the platform has not published is disclosed in the snapshot with its id, bounds and the pixel path, instead of arriving as an indistinguishable empty group.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ internal refactors, CI, or test-only changes.
 ## [Unreleased]
 
 ### Added
-- `Document` accessibility role: a browser page or embedded web view (AT-SPI `document web`/`document frame`, `AXWebArea`, Android `WebView`) now reads as a `Document` whose children are the page's elements, on Linux, macOS, Android and iOS.
+- `Document` accessibility role: a browser page or embedded web view (AT-SPI `document web`/`document frame`, `AXWebArea`, Android `WebView`) now reads as a `Document` whose children are the page's elements, on Linux, macOS and Android.
 
 ### Fixed
 - A web view whose content the platform has not published is disclosed in the snapshot with its id, bounds and the pixel path, instead of arriving as an indistinguishable empty group.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ internal refactors, CI, or test-only changes.
 - `Document` accessibility role: a browser page or embedded web view (AT-SPI `document web`/`document frame`, `AXWebArea`, Android `WebView`, UIA `Document` from a web engine) now reads as a `Document` whose children are the page's elements, on Linux, Windows, macOS and Android.
 
 ### Fixed
-- A web view whose content the platform has not published is disclosed in the snapshot with its id, bounds and the pixel path, instead of arriving as an indistinguishable empty group.
+- A web view whose content the platform has not published is disclosed in the snapshot instead of arriving as an indistinguishable empty group: a childless `Document` is named by id and bounds and steers to a re-snapshot before pixels, while a placeholder the app published for content it withheld steers straight to pixels.
 
 ## [1.5.0] - 2026-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ internal refactors, CI, or test-only changes.
 
 ### Fixed
 - A web view whose content the platform has not published is disclosed in the snapshot instead of arriving as an indistinguishable empty group: a childless `Document` is named by id and bounds and steers to a re-snapshot before pixels, while a placeholder the app published for content it withheld steers straight to pixels.
+- On Linux, `glass_set_value` now confirms a write actually landed instead of trusting the AT-SPI toolkit's own acknowledgment of it, the way the Windows and macOS readers already did: it reads the element back (polling briefly, since the toolkit applies the write on a later main-loop pass), and an element that acknowledges a write without applying it — as web content can — now reports that instead of a silent false success.
 
 ## [1.5.0] - 2026-08-22
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1386,6 +1386,7 @@ dependencies = [
  "glass-clip-shim-windows",
  "glass-core",
  "tempfile",
+ "uiautomation",
  "windows",
  "windows-capture",
 ]

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -356,8 +356,7 @@ async fn find_nth(
             break;
         }
         // Both skips are counted in `walk` too, so the two traversals report the same drops.
-        if child_ref.is_null() {
-            budget.note_unexposed();
+        if claim_unexposed(&child_ref, budget) {
             continue;
         }
         let Ok(child) = child_ref.as_accessible_proxy(conn).await else {
@@ -469,11 +468,7 @@ async fn walk(
             if !budget.may_visit_sibling(scanned) {
                 break;
             }
-            // AT-SPI's null ref stands in for content the app has not exposed; Brave 151's
-            // window published exactly one while renderer accessibility was off (read
-            // 2026-08-24). Building a proxy from it only errors, which read as a lost subtree.
-            if child_ref.is_null() {
-                budget.note_unexposed();
+            if claim_unexposed(&child_ref, budget) {
                 continue;
             }
             let Ok(child) = child_ref.as_accessible_proxy(conn).await else {
@@ -819,6 +814,20 @@ fn nonempty(s: String) -> Option<String> {
     (!s.is_empty()).then_some(s)
 }
 
+/// Records a null `child_ref` on `budget` as content the app has not exposed, and says whether it
+/// was one. Brave 151's window published exactly one while renderer accessibility was off (read
+/// 2026-08-24).
+///
+/// Called before the proxy is built, in both traversals: building one from a null ref only errors,
+/// and that error read as a subtree lost mid-walk.
+fn claim_unexposed(child_ref: &ObjectRefOwned, budget: &mut WalkBudget) -> bool {
+    let null = child_ref.is_null();
+    if null {
+        budget.note_unexposed();
+    }
+    null
+}
+
 #[cfg(test)]
 mod toggle_label_tests {
     use super::toggle_state_label;
@@ -834,7 +843,37 @@ mod toggle_label_tests {
 
 #[cfg(test)]
 mod tests {
+    use atspi_common::ObjectRef;
+
     use super::*;
+
+    /// The reading behind the skip (Brave 151 on X11, 2026-08-24): the browser window's one child
+    /// is a null ObjectRef while renderer accessibility is off, and the proxy build's error read
+    /// as an element that had gone away mid-walk.
+    #[test]
+    fn a_null_child_ref_is_claimed_as_unexposed_not_as_a_failed_read() {
+        let mut budget = WalkBudget::new();
+        assert!(claim_unexposed(
+            &ObjectRefOwned::new(ObjectRef::Null),
+            &mut budget
+        ));
+        assert_eq!(budget.unexposed(), 1);
+        assert_eq!(
+            budget.unreadable(),
+            0,
+            "no read was attempted, let alone failed"
+        );
+    }
+
+    #[test]
+    fn an_ordinary_child_ref_is_claimed_by_neither_count() {
+        let mut budget = WalkBudget::new();
+        let child =
+            ObjectRefOwned::from_static_str_unchecked(":1.42", "/org/a11y/atspi/accessible/7");
+        assert!(!claim_unexposed(&child, &mut budget));
+        assert_eq!(budget.unexposed(), 0);
+        assert_eq!(budget.unreadable(), 0);
+    }
 
     #[test]
     fn no_matching_app_message_is_developer_framed() {

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -153,6 +153,7 @@ async fn snapshot_async(ctx: &AxContext) -> Result<AxTree> {
     let mut tree = AxTree::new(root_node);
     tree.truncated = budget.truncation();
     tree.unreadable = budget.unreadable();
+    tree.unexposed = budget.unexposed();
     tree.assign_ids();
     Ok(tree)
 }
@@ -260,8 +261,11 @@ async fn find_nth(
         if !budget.may_visit_sibling(scanned) {
             break;
         }
+        // Both branches are counted in `walk` too, so the two traversals report the same drops.
+        if unexposed_child(&child_ref, budget) {
+            continue;
+        }
         let Ok(child) = child_ref.as_accessible_proxy(conn).await else {
-            // Counted in `walk` too, so the two traversals report the same drop.
             budget.note_unreadable();
             continue;
         };
@@ -369,6 +373,9 @@ async fn walk(
         for (scanned, child_ref) in child_refs.into_iter().enumerate() {
             if !budget.may_visit_sibling(scanned) {
                 break;
+            }
+            if unexposed_child(&child_ref, budget) {
+                continue;
             }
             let Ok(child) = child_ref.as_accessible_proxy(conn).await else {
                 budget.note_unreadable();
@@ -710,6 +717,20 @@ fn nonempty(s: String) -> Option<String> {
     (!s.is_empty()).then_some(s)
 }
 
+/// Whether `child_ref` is AT-SPI's null reference — the placeholder an app publishes for content
+/// it has not exposed to accessibility — counting it on `budget` when it is. A Chromium window
+/// publishes exactly one while renderer accessibility is off (read on Brave 151, 2026-08-24).
+///
+/// Consulted before the proxy is built, in both traversals: building one from a null ref only
+/// errors, and that error read as a subtree lost mid-walk.
+fn unexposed_child(child_ref: &ObjectRefOwned, budget: &mut WalkBudget) -> bool {
+    let null = child_ref.is_null();
+    if null {
+        budget.note_unexposed();
+    }
+    null
+}
+
 #[cfg(test)]
 mod toggle_label_tests {
     use super::toggle_state_label;
@@ -725,6 +746,8 @@ mod toggle_label_tests {
 
 #[cfg(test)]
 mod tests {
+    use atspi_common::ObjectRef;
+
     use super::*;
 
     #[test]
@@ -740,6 +763,33 @@ mod tests {
             !msg.contains("relaunch with a11y:true"),
             "distinct from the bus/opt-in error"
         );
+    }
+
+    /// The reading behind this (Brave 151 on X11, 2026-08-24): the browser window's one child is
+    /// a null ObjectRef while renderer accessibility is off, and the proxy build's error read as
+    /// an element that had gone away mid-walk.
+    #[test]
+    fn a_null_child_ref_is_content_the_app_has_not_exposed_rather_than_a_failed_read() {
+        let mut budget = WalkBudget::new();
+        assert!(unexposed_child(
+            &ObjectRefOwned::new(ObjectRef::Null),
+            &mut budget
+        ));
+        assert_eq!(budget.unexposed(), 1);
+        assert_eq!(
+            budget.unreadable(),
+            0,
+            "no read was attempted, let alone failed"
+        );
+    }
+
+    #[test]
+    fn an_ordinary_child_ref_is_left_to_the_proxy_build() {
+        let mut budget = WalkBudget::new();
+        let child =
+            ObjectRefOwned::from_static_str_unchecked(":1.42", "/org/a11y/atspi/accessible/7");
+        assert!(!unexposed_child(&child, &mut budget));
+        assert_eq!(budget.unexposed(), 0);
     }
 
     #[test]

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -11,7 +11,7 @@ use atspi::proxy::component::ComponentProxy;
 use atspi_common::{CoordType, ObjectRefOwned};
 use glass_core::{
     A11yThread, Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxTarget, AxTree, GlassError,
-    Result, WalkBudget, normalize_description,
+    Result, WalkBudget, normalize_description, read_back_confirms, write_took_no_effect,
 };
 
 use crate::mapping::{map_role, map_states};
@@ -168,6 +168,21 @@ fn writes_value_only(role: glass_core::AxRole, text: &str) -> bool {
     matches!(role, Slider | SpinButton | ScrollBar) && text.parse::<f64>().is_ok()
 }
 
+/// Poll bound for confirming a write actually landed — a value written, or a toggle moved: the
+/// toolkit applies it on a later main-loop pass, so the first read after dispatch is expected to
+/// be stale. Generous enough for a loaded headless session without letting a real failure hang
+/// the tool.
+const VERIFY_POLLS: usize = 6;
+/// See [`VERIFY_POLLS`].
+const VERIFY_INTERVAL: Duration = Duration::from_millis(120);
+
+/// What a write that took no effect looks like on this backend: the element's `EditableText`
+/// answers the write with `true` and keeps the text it had (read on Firefox 153 web content,
+/// 2026-08-24). The AT-SPI sibling of the `READ_ONLY_PROJECTION` consts in the Windows and macOS
+/// readers.
+const ACKNOWLEDGED_NOT_APPLIED: &str = "this element's accessibility interface acknowledged the write without applying it — focus the \
+     element and type into it instead";
+
 async fn set_value_async(ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
     let (app_ref, conn) = find_app(ctx).await?;
     let app = app_ref.as_accessible_proxy(&conn).await.map_err(bus_err)?;
@@ -211,8 +226,21 @@ async fn set_value_async(ctx: &AxContext, target: &AxTarget, text: &str) -> Resu
         if let Some(b) = editable
             && let Ok(et) = b.build().await
         {
+            // The baseline for the confirmation below: without one, only an exact read-back
+            // confirms.
+            let before = read_text(&node, &conn).await;
             match et.set_text_contents(text).await {
-                Ok(true) => return Ok(()),
+                Ok(true) => {
+                    return confirm_write(
+                        &node,
+                        &conn,
+                        WrittenVia::EditableText,
+                        before,
+                        text,
+                        target.id.0,
+                    )
+                    .await;
+                }
                 // EditableText is present but rejected the write — don't try Value.
                 Ok(false) => return Err(GlassError::AxElementNotEditable(target.id.0)),
                 Err(_) => {} // interface absent / call failed — fall through to Value
@@ -226,12 +254,77 @@ async fn set_value_async(ctx: &AxContext, target: &AxTarget, text: &str) -> Resu
             .and_then(|b| b.path(path).ok());
         if let Some(b) = value_proxy
             && let Ok(vp) = b.build().await
-            && vp.set_current_value(v).await.is_ok()
         {
-            return Ok(());
+            let before = read_number(&node, &conn).await;
+            if vp.set_current_value(v).await.is_ok() {
+                return confirm_write(&node, &conn, WrittenVia::Value, before, text, target.id.0)
+                    .await;
+            }
         }
     }
     Err(GlassError::AxElementNotEditable(target.id.0))
+}
+
+/// Which interface a write went through, and so which read confirms it.
+#[derive(Clone, Copy)]
+enum WrittenVia {
+    EditableText,
+    Value,
+}
+
+/// Confirm a dispatched write landed, by reading the element back through the interface it was
+/// written to (`before` is what that read returned beforehand, `None` when it failed). Polls,
+/// because the toolkit applies the write on a later main-loop pass.
+///
+/// Without it the toolkit's own answer is the only evidence, and an engine can acknowledge a write
+/// it never applies — see [`ACKNOWLEDGED_NOT_APPLIED`].
+async fn confirm_write(
+    node: &AccessibleProxy<'_>,
+    conn: &zbus::Connection,
+    via: WrittenVia,
+    before: Option<String>,
+    requested: &str,
+    id: u32,
+) -> Result<()> {
+    let mut observed = None;
+    for poll in 0..VERIFY_POLLS {
+        if poll > 0 {
+            tokio::time::sleep(VERIFY_INTERVAL).await;
+        }
+        observed = match via {
+            WrittenVia::EditableText => read_text(node, conn).await,
+            WrittenVia::Value => read_number(node, conn).await,
+        };
+        if read_back_confirms(observed.as_deref(), before.as_deref(), requested) {
+            return Ok(());
+        }
+    }
+    Err(write_verdict(
+        id,
+        requested,
+        before.as_deref(),
+        observed.as_deref(),
+    ))
+}
+
+/// The verdict for a write whose read-back never held the request. [`ACKNOWLEDGED_NOT_APPLIED`]
+/// only where the element still holds exactly what it held before — a read that failed, or one
+/// showing a value the element reformatted, is not evidence the write never arrived.
+fn write_verdict(
+    id: u32,
+    requested: &str,
+    before: Option<&str>,
+    observed: Option<&str>,
+) -> GlassError {
+    match observed {
+        Some(seen) if write_took_no_effect(seen, before) => GlassError::value_not_applied_because(
+            id,
+            requested,
+            Some(seen),
+            ACKNOWLEDGED_NOT_APPLIED,
+        ),
+        seen => GlassError::value_not_applied(id, requested, seen),
+    }
 }
 
 /// Pre-order DFS to the node at index `target`, mirroring `walk` exactly: visit the node (its
@@ -485,13 +578,6 @@ fn toggle_state_flag(role: glass_core::AxRole) -> atspi_common::State {
     }
 }
 
-/// Poll bound for confirming a toggle actually moved: the toolkit applies the action on a
-/// later main-loop pass, so the first read after firing is expected to be stale. Generous
-/// enough for a loaded headless session without letting a real failure hang the tool.
-const TOGGLE_VERIFY_POLLS: usize = 6;
-/// See [`TOGGLE_VERIFY_POLLS`].
-const TOGGLE_VERIFY_INTERVAL: Duration = Duration::from_millis(120);
-
 /// Set a boolean widget (switch/checkbox/toggle/radio) to `target_on`, as the caller spelled it in
 /// `requested`. Idempotent:
 /// only invokes the toggle action when the boolean state differs, then confirms the
@@ -524,8 +610,8 @@ async fn set_toggle(
     }
     // Poll until the toolkit applies it; a no-op activation never converges.
     let mut last_on = None;
-    for _ in 0..TOGGLE_VERIFY_POLLS {
-        tokio::time::sleep(TOGGLE_VERIFY_INTERVAL).await;
+    for _ in 0..VERIFY_POLLS {
+        tokio::time::sleep(VERIFY_INTERVAL).await;
         let on = node.get_state().await.map_err(bus_err)?.contains(flag);
         last_on = Some(on);
         if on == target_on {
@@ -582,8 +668,8 @@ async fn verify_toggle_flipped(
     was_on: bool,
     id: u32,
 ) -> Result<()> {
-    for _ in 0..TOGGLE_VERIFY_POLLS {
-        tokio::time::sleep(TOGGLE_VERIFY_INTERVAL).await;
+    for _ in 0..VERIFY_POLLS {
+        tokio::time::sleep(VERIFY_INTERVAL).await;
         if node.get_state().await.map_err(bus_err)?.contains(flag) != was_on {
             return Ok(());
         }
@@ -677,40 +763,50 @@ async fn extents(proxy: &AccessibleProxy<'_>, conn: &zbus::Connection) -> Option
 /// Read the element's current value/text for value-bearing roles, or `None`.
 /// Text-editable roles read the `Text` interface; numeric roles read `Value`.
 /// Gated by role so the walk adds at most one D-Bus call on relevant nodes.
+///
+/// An empty text field carries no value here, unlike [`read_text`]'s read-back: the outline
+/// renders what an element holds, and `""` is nothing to show.
 async fn read_value(
     proxy: &AccessibleProxy<'_>,
     conn: &zbus::Connection,
     role: glass_core::AxRole,
 ) -> Option<String> {
     use glass_core::AxRole::*;
-    let dest = proxy.inner().destination().to_owned();
-    let path = proxy.inner().path().to_owned();
     match role {
-        TextField | TextArea | ComboBox => {
-            let text = atspi::proxy::text::TextProxy::builder(conn)
-                .destination(dest)
-                .ok()?
-                .path(path)
-                .ok()?
-                .build()
-                .await
-                .ok()?;
-            let n = text.character_count().await.ok()?;
-            text.get_text(0, n).await.ok().and_then(nonempty)
-        }
-        Slider | SpinButton | ProgressBar => {
-            let val = atspi::proxy::value::ValueProxy::builder(conn)
-                .destination(dest)
-                .ok()?
-                .path(path)
-                .ok()?
-                .build()
-                .await
-                .ok()?;
-            val.current_value().await.ok().map(|v| v.to_string())
-        }
+        TextField | TextArea | ComboBox => read_text(proxy, conn).await.and_then(nonempty),
+        Slider | SpinButton | ProgressBar => read_number(proxy, conn).await,
         _ => None,
     }
+}
+
+/// The element's text over the AT-SPI `Text` interface. `Some("")` is an element holding nothing;
+/// `None` is no reading at all — the interface is absent, or the call failed — which
+/// [`read_back_confirms`] must never mistake for a value.
+async fn read_text(proxy: &AccessibleProxy<'_>, conn: &zbus::Connection) -> Option<String> {
+    let text = atspi::proxy::text::TextProxy::builder(conn)
+        .destination(proxy.inner().destination().to_owned())
+        .ok()?
+        .path(proxy.inner().path().to_owned())
+        .ok()?
+        .build()
+        .await
+        .ok()?;
+    let n = text.character_count().await.ok()?;
+    text.get_text(0, n).await.ok()
+}
+
+/// The element's number over the AT-SPI `Value` interface, spelled as a caller spells a value.
+/// `None` when the interface is absent or the call failed.
+async fn read_number(proxy: &AccessibleProxy<'_>, conn: &zbus::Connection) -> Option<String> {
+    let val = atspi::proxy::value::ValueProxy::builder(conn)
+        .destination(proxy.inner().destination().to_owned())
+        .ok()?
+        .path(proxy.inner().path().to_owned())
+        .ok()?
+        .build()
+        .await
+        .ok()?;
+    val.current_value().await.ok().map(|v| v.to_string())
 }
 
 fn nonempty(s: String) -> Option<String> {
@@ -790,6 +886,30 @@ mod tests {
             ObjectRefOwned::from_static_str_unchecked(":1.42", "/org/a11y/atspi/accessible/7");
         assert!(!unexposed_child(&child, &mut budget));
         assert_eq!(budget.unexposed(), 0);
+    }
+
+    /// The remedy is for a write that never arrived. Attached to a value the element transformed,
+    /// it would send the caller to type text the element already has in another form.
+    #[test]
+    fn only_a_value_the_element_still_holds_carries_the_write_never_arrived_remedy() {
+        let unchanged = write_verdict(3, "typed", Some("old"), Some("old"));
+        assert!(
+            matches!(
+                unchanged,
+                GlassError::AxValueNotApplied { why: Some(_), .. }
+            ),
+            "got: {unchanged:?}"
+        );
+        let transformed = write_verdict(3, "50", Some("1"), Some("50.0"));
+        assert!(
+            matches!(transformed, GlassError::AxValueNotApplied { why: None, .. }),
+            "got: {transformed:?}"
+        );
+        let unread = write_verdict(3, "typed", Some("old"), None);
+        assert!(
+            matches!(unread, GlassError::AxValueNotApplied { why: None, .. }),
+            "a read-back that failed is no evidence about the write; got: {unread:?}"
+        );
     }
 
     #[test]

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -10,8 +10,9 @@ use atspi::proxy::accessible::{AccessibleProxy, ObjectRefExt};
 use atspi::proxy::component::ComponentProxy;
 use atspi_common::{CoordType, ObjectRefOwned};
 use glass_core::{
-    A11yThread, Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxTarget, AxTree, GlassError,
-    Result, WalkBudget, normalize_description, read_back_confirms, write_took_no_effect,
+    A11yThread, Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxTarget, AxTree, Deadline,
+    GlassError, Result, WalkBudget, normalize_description, read_back_confirms,
+    write_took_no_effect,
 };
 
 use crate::mapping::{map_role, map_states};
@@ -172,8 +173,16 @@ fn writes_value_only(role: glass_core::AxRole, text: &str) -> bool {
 /// toolkit applies it on a later main-loop pass, so the first read after dispatch is expected to
 /// be stale. Generous enough for a loaded headless session without letting a real failure hang
 /// the tool.
+///
+/// A fixed count is safe here: `set_value` and `invoke` are bounded by [`BUS`]'s ceiling alone —
+/// the session builds their context with `Deadline::UNBOUNDED` — and 6 × 120 ms sits well inside
+/// it. [`confirm_write`] stops earlier where a caller does name a deadline.
+///
+/// Two loop shapes use them: [`confirm_write`] reads first (the write may already have landed);
+/// [`set_toggle`] and [`verify_toggle_flipped`] sleep first, having just dispatched an action.
 const VERIFY_POLLS: usize = 6;
-/// See [`VERIFY_POLLS`].
+/// See [`VERIFY_POLLS`]. Coarser than the Windows and macOS readers' 20 ms: a poll here is a D-Bus
+/// round trip, not an in-process call.
 const VERIFY_INTERVAL: Duration = Duration::from_millis(120);
 
 /// What a write that took no effect looks like on this backend: the element's `EditableText`
@@ -238,6 +247,7 @@ async fn set_value_async(ctx: &AxContext, target: &AxTarget, text: &str) -> Resu
                         before,
                         text,
                         target.id.0,
+                        ctx.deadline,
                     )
                     .await;
                 }
@@ -257,8 +267,16 @@ async fn set_value_async(ctx: &AxContext, target: &AxTarget, text: &str) -> Resu
         {
             let before = read_number(&node, &conn).await;
             if vp.set_current_value(v).await.is_ok() {
-                return confirm_write(&node, &conn, WrittenVia::Value, before, text, target.id.0)
-                    .await;
+                return confirm_write(
+                    &node,
+                    &conn,
+                    WrittenVia::Value,
+                    before,
+                    text,
+                    target.id.0,
+                    ctx.deadline,
+                )
+                .await;
             }
         }
     }
@@ -272,9 +290,13 @@ enum WrittenVia {
     Value,
 }
 
-/// Confirm a dispatched write landed, by reading the element back through the interface it was
-/// written to (`before` is what that read returned beforehand, `None` when it failed). Polls,
-/// because the toolkit applies the write on a later main-loop pass.
+/// Confirm a dispatched write landed, by reading the element back (`before` is what that read
+/// returned beforehand, `None` when it failed). Polls, because the toolkit applies the write on a
+/// later main-loop pass, and stops early once `deadline` has passed.
+///
+/// An `EditableText` write reads back through `Text` ([`read_text`]), that interface having no read
+/// side of its own; a `Value` write reads back through `Value`. An element exposing `EditableText`
+/// without `Text` therefore confirms nothing, and the verdict says it could not be read back.
 ///
 /// Without it the toolkit's own answer is the only evidence, and an engine can acknowledge a write
 /// it never applies — see [`ACKNOWLEDGED_NOT_APPLIED`].
@@ -285,10 +307,14 @@ async fn confirm_write(
     before: Option<String>,
     requested: &str,
     id: u32,
+    deadline: Deadline,
 ) -> Result<()> {
     let mut observed = None;
     for poll in 0..VERIFY_POLLS {
         if poll > 0 {
+            if deadline.has_passed() {
+                break;
+            }
             tokio::time::sleep(VERIFY_INTERVAL).await;
         }
         observed = match via {
@@ -912,6 +938,31 @@ mod tests {
             matches!(unread, GlassError::AxValueNotApplied { why: None, .. }),
             "a read-back that failed is no evidence about the write; got: {unread:?}"
         );
+    }
+
+    /// Both arms build the error separately, and the request and the reading are adjacent string
+    /// arguments there — swapping them still compiles, and the message would then tell the caller
+    /// it asked for what the element holds.
+    #[test]
+    fn both_verdict_arms_carry_the_request_and_the_reading_apart() {
+        for (arm, before) in [
+            ("the write never arrived", Some("seen")),
+            ("the element transformed it", Some("old")),
+        ] {
+            match write_verdict(3, "asked", before, Some("seen")) {
+                GlassError::AxValueNotApplied {
+                    id,
+                    requested,
+                    observed,
+                    ..
+                } => assert_eq!(
+                    (id, requested.as_str(), observed.as_deref()),
+                    (3, "asked", Some("seen")),
+                    "{arm}"
+                ),
+                other => panic!("{arm}: expected AxValueNotApplied, got {other:?}"),
+            }
+        }
     }
 
     #[test]

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -329,7 +329,8 @@ fn write_verdict(
 
 /// Pre-order DFS to the node at index `target`, mirroring `walk` exactly: visit the node (its
 /// id is the arrival count), then recurse each child in `get_children` order, skipping children
-/// whose proxy fails to build — **and stopping at the same depth/node/sibling bounds**. The
+/// published as a null ref and those whose proxy fails to build — **and stopping at the same
+/// depth/node/sibling bounds**. The
 /// bounds must stay in lockstep with `walk`: if this traversal visited nodes `walk` skipped,
 /// a `set_value` id would resolve against a different tree and write to the wrong element.
 async fn find_nth(
@@ -354,8 +355,9 @@ async fn find_nth(
         if !budget.may_visit_sibling(scanned) {
             break;
         }
-        // Both branches are counted in `walk` too, so the two traversals report the same drops.
-        if unexposed_child(&child_ref, budget) {
+        // Both skips are counted in `walk` too, so the two traversals report the same drops.
+        if child_ref.is_null() {
+            budget.note_unexposed();
             continue;
         }
         let Ok(child) = child_ref.as_accessible_proxy(conn).await else {
@@ -467,7 +469,11 @@ async fn walk(
             if !budget.may_visit_sibling(scanned) {
                 break;
             }
-            if unexposed_child(&child_ref, budget) {
+            // AT-SPI's null ref stands in for content the app has not exposed; Brave 151's
+            // window published exactly one while renderer accessibility was off (read
+            // 2026-08-24). Building a proxy from it only errors, which read as a lost subtree.
+            if child_ref.is_null() {
+                budget.note_unexposed();
                 continue;
             }
             let Ok(child) = child_ref.as_accessible_proxy(conn).await else {
@@ -813,20 +819,6 @@ fn nonempty(s: String) -> Option<String> {
     (!s.is_empty()).then_some(s)
 }
 
-/// Whether `child_ref` is AT-SPI's null reference — the placeholder an app publishes for content
-/// it has not exposed to accessibility — counting it on `budget` when it is. A Chromium window
-/// publishes exactly one while renderer accessibility is off (read on Brave 151, 2026-08-24).
-///
-/// Consulted before the proxy is built, in both traversals: building one from a null ref only
-/// errors, and that error read as a subtree lost mid-walk.
-fn unexposed_child(child_ref: &ObjectRefOwned, budget: &mut WalkBudget) -> bool {
-    let null = child_ref.is_null();
-    if null {
-        budget.note_unexposed();
-    }
-    null
-}
-
 #[cfg(test)]
 mod toggle_label_tests {
     use super::toggle_state_label;
@@ -842,8 +834,6 @@ mod toggle_label_tests {
 
 #[cfg(test)]
 mod tests {
-    use atspi_common::ObjectRef;
-
     use super::*;
 
     #[test]
@@ -859,33 +849,6 @@ mod tests {
             !msg.contains("relaunch with a11y:true"),
             "distinct from the bus/opt-in error"
         );
-    }
-
-    /// The reading behind this (Brave 151 on X11, 2026-08-24): the browser window's one child is
-    /// a null ObjectRef while renderer accessibility is off, and the proxy build's error read as
-    /// an element that had gone away mid-walk.
-    #[test]
-    fn a_null_child_ref_is_content_the_app_has_not_exposed_rather_than_a_failed_read() {
-        let mut budget = WalkBudget::new();
-        assert!(unexposed_child(
-            &ObjectRefOwned::new(ObjectRef::Null),
-            &mut budget
-        ));
-        assert_eq!(budget.unexposed(), 1);
-        assert_eq!(
-            budget.unreadable(),
-            0,
-            "no read was attempted, let alone failed"
-        );
-    }
-
-    #[test]
-    fn an_ordinary_child_ref_is_left_to_the_proxy_build() {
-        let mut budget = WalkBudget::new();
-        let child =
-            ObjectRefOwned::from_static_str_unchecked(":1.42", "/org/a11y/atspi/accessible/7");
-        assert!(!unexposed_child(&child, &mut budget));
-        assert_eq!(budget.unexposed(), 0);
     }
 
     /// The remedy is for a write that never arrived. Attached to a value the element transformed,

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -940,9 +940,8 @@ mod tests {
         );
     }
 
-    /// Both arms build the error separately, and the request and the reading are adjacent string
-    /// arguments there — swapping them still compiles, and the message would then tell the caller
-    /// it asked for what the element holds.
+    /// `before` and `observed` are adjacent `Option<&str>` parameters in `write_verdict` —
+    /// swapping them still compiles, and the error would report the pre-write value as observed.
     #[test]
     fn both_verdict_arms_carry_the_request_and_the_reading_apart() {
         for (arm, before) in [

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -169,17 +169,12 @@ fn writes_value_only(role: glass_core::AxRole, text: &str) -> bool {
     matches!(role, Slider | SpinButton | ScrollBar) && text.parse::<f64>().is_ok()
 }
 
-/// Poll bound for confirming a write actually landed — a value written, or a toggle moved: the
-/// toolkit applies it on a later main-loop pass, so the first read after dispatch is expected to
-/// be stale. Generous enough for a loaded headless session without letting a real failure hang
-/// the tool.
-///
-/// A fixed count is safe here: `set_value` and `invoke` are bounded by [`BUS`]'s ceiling alone —
-/// the session builds their context with `Deadline::UNBOUNDED` — and 6 × 120 ms sits well inside
-/// it. [`confirm_write`] stops earlier where a caller does name a deadline.
-///
-/// Two loop shapes use them: [`confirm_write`] reads first (the write may already have landed);
-/// [`set_toggle`] and [`verify_toggle_flipped`] sleep first, having just dispatched an action.
+/// Poll bound for confirming a write or toggle landed — the toolkit applies it on a later
+/// main-loop pass, so the first read after dispatch is expected to be stale. [`confirm_write`]
+/// reads first and stops early once its `deadline` passes; [`set_toggle`] and
+/// [`verify_toggle_flipped`] sleep first, having just dispatched the action, and loop the full
+/// count regardless of deadline — safe only because `set_value` and `invoke` run under [`BUS`]'s
+/// bounded ceiling with `Deadline::UNBOUNDED` context, where 6 × 120 ms sits well inside it.
 const VERIFY_POLLS: usize = 6;
 /// See [`VERIFY_POLLS`]. Coarser than the Windows and macOS readers' 20 ms: a poll here is a D-Bus
 /// round trip, not an in-process call.

--- a/crates/glass-a11y-linux/tests/web_probe.rs
+++ b/crates/glass-a11y-linux/tests/web_probe.rs
@@ -17,8 +17,12 @@
 //! `--include-ignored` run never needs a browser.
 //!
 //! A probe, not a mapping test: it prints evidence and does not assert what a browser ought to
-//! publish. After `start` it reports failures instead of panicking, so `stop` always runs and
-//! no browser is left behind.
+//! publish — a browser that launches but shows no page content is a reading, not a failure
+//! (`arrived: false` plus whatever disclosure rendered). What does fail the run: a browser that
+//! never launches, or an accessibility bus that never answers at all. Each backend's `Drop`
+//! impl tears its session down even through a panic, so failures are collected per (backend,
+//! browser, lever) and the test panics once at the end, after every browser it started has
+//! already been stopped.
 
 #![cfg(target_os = "linux")]
 
@@ -62,6 +66,35 @@ fn page_url() -> String {
     )
 }
 
+fn is_gecko(browser: &str) -> bool {
+    browser.contains("firefox")
+}
+
+/// Gecko's onboarding, turned off in the profile. A fresh Firefox profile renders
+/// `about:welcome` over the requested page, so the reader's subject is the onboarding content
+/// and the fixture is never read. `--profile` is honoured before these are needed, and
+/// `user.js` is applied on every startup, so writing it into the fresh directory is enough.
+/// Matches the Windows probe's `GECKO_PREFS` so both probes see the same browser.
+const GECKO_PREFS: &str = r#"user_pref("browser.aboutwelcome.enabled", false);
+user_pref("browser.migrate.content-modal.enabled", false);
+user_pref("browser.startup.homepage_override.mstone", "ignore");
+user_pref("browser.startup.upgradeDialog.enabled", false);
+user_pref("browser.shell.checkDefaultBrowser", false);
+user_pref("datareporting.policy.dataSubmissionPolicyBypassNotification", true);
+user_pref("toolkit.telemetry.reportingpolicy.firstRun", false);
+"#;
+
+/// Seed a fresh Gecko profile with [`GECKO_PREFS`]; a no-op for every other engine.
+fn prepare_profile(browser: &str, profile: &Path) {
+    if !is_gecko(browser) {
+        return;
+    }
+    let path = profile.join("user.js");
+    if let Err(e) = std::fs::write(&path, GECKO_PREFS) {
+        println!("could not write {}: {e}", path.display());
+    }
+}
+
 /// Which candidate enable lever the launch carries: environment variables, or the
 /// Chromium-family command-line switch.
 #[derive(Clone, Copy, Debug)]
@@ -74,13 +107,23 @@ enum Lever {
 }
 
 impl Lever {
+    /// # Panics
+    ///
+    /// Panics when the variable is set to a value (trimmed) that names none of the accepted
+    /// levers. Falling back to the baseline on a typo would silently run the probe without the
+    /// lever the caller meant to test.
     fn from_env() -> Self {
-        match std::env::var(LEVER_VAR).unwrap_or_default().as_str() {
+        let raw = std::env::var(LEVER_VAR).unwrap_or_default();
+        match raw.trim() {
+            "" => Lever::None,
             "1" | "both" => Lever::Both,
             "gnome" => Lever::Gnome,
             "enabled" => Lever::Enabled,
             "flag" => Lever::RendererFlag,
-            _ => Lever::None,
+            other => panic!(
+                "{LEVER_VAR}={other:?} is not a recognised lever — set it to one of: 1, both, \
+                 gnome, enabled, flag, or leave it unset for the baseline reading"
+            ),
         }
     }
 
@@ -127,7 +170,7 @@ fn glass_for(backend: &str) -> Glass {
 /// A fresh, isolated profile per launch: no first-run prompts, no session restore, and no
 /// already-running instance adopting the URL instead of starting a process glass owns.
 fn browser_spec(browser: &str, profile: &Path, lever: Lever) -> AppSpec {
-    let run = if browser.contains("firefox") {
+    let run = if is_gecko(browser) {
         vec![
             browser.to_string(),
             "--no-remote".into(),
@@ -236,9 +279,14 @@ fn documents(tree: &AxTree) -> Vec<&AxNode> {
 ///
 /// Every error is retried until the deadline, not just `AccessibilityNotReady`: a browser
 /// re-execs during startup, and the bus error its first process leaves behind resolves itself
-/// once the second one registers. Each distinct error is printed once — a probe that stops at
-/// the first one reads "nothing published" for a browser that had not started yet.
-fn snapshot_until_page(glass: &mut Glass) -> (Option<AxTree>, Duration, bool) {
+/// once the second one registers. Each distinct error is printed once and recorded into
+/// `failures` — a caller not yet answering is expected during startup, but every other error is
+/// evidence the a11y bus itself broke, not a reading about the page.
+fn snapshot_until_page(
+    glass: &mut Glass,
+    label: &str,
+    failures: &mut Vec<String>,
+) -> (Option<AxTree>, Duration, bool) {
     let start = Instant::now();
     let mut last = None;
     let mut reported = Vec::new();
@@ -256,6 +304,7 @@ fn snapshot_until_page(glass: &mut Glass) -> (Option<AxTree>, Duration, bool) {
                 let text = e.to_string();
                 if !reported.contains(&text) {
                     println!("snapshot error at {:?}: {text}", start.elapsed());
+                    failures.push(format!("{label}: snapshot error: {text}"));
                     reported.push(text);
                 }
             }
@@ -308,14 +357,24 @@ fn report_tree(tree: &AxTree) {
 /// retrying reads the button's clickability rather than the retry's luck.
 const CLICK_ATTEMPTS: usize = 4;
 
+/// Push `e` into `failures` unless it is [`GlassError::AccessibilityNotReady`] — a caller not
+/// yet answering is expected here just as it is in `snapshot_until_page`; every other snapshot
+/// error means the a11y bus broke after it had already been serving this session.
+fn record_snapshot_failure(failures: &mut Vec<String>, label: &str, context: &str, e: &GlassError) {
+    if !matches!(e, GlassError::AccessibilityNotReady(_)) {
+        failures.push(format!("{label}: {context}: {e}"));
+    }
+}
+
 /// The actuation readings. Each step re-snapshots first: `click_element` and `set_value` resolve
 /// ids against the session's most recent tree, so an id from an older one addresses nothing.
-fn exercise(glass: &mut Glass) {
+fn exercise(glass: &mut Glass, label: &str, failures: &mut Vec<String>) {
     for attempt in 1..=CLICK_ATTEMPTS {
         let before = match glass.a11y_snapshot(Some(0)) {
             Ok(tree) => tree,
             Err(e) => {
                 println!("snapshot before the click failed: {e} — no click reading");
+                record_snapshot_failure(failures, label, "snapshot before the click failed", &e);
                 return;
             }
         };
@@ -342,12 +401,21 @@ fn exercise(glass: &mut Glass) {
                          {CLICKED:?}: {}",
                         valued(&after, CLICKED).is_some()
                     ),
-                    Err(e) => println!("click_element: {method:?} → re-snapshot failed: {e}"),
+                    Err(e) => {
+                        println!("click_element: {method:?} → re-snapshot failed: {e}");
+                        record_snapshot_failure(
+                            failures,
+                            label,
+                            "re-snapshot after click_element failed",
+                            &e,
+                        );
+                    }
                 }
                 break;
             }
             Err(e) => {
                 println!("click_element (attempt {attempt}) failed: {e}");
+                record_snapshot_failure(failures, label, "click_element failed", &e);
                 std::thread::sleep(Duration::from_millis(500));
             }
         }
@@ -357,6 +425,7 @@ fn exercise(glass: &mut Glass) {
         Ok(tree) => tree,
         Err(e) => {
             println!("snapshot before set_value failed: {e} — no set_value reading");
+            record_snapshot_failure(failures, label, "snapshot before set_value failed", &e);
             return;
         }
     };
@@ -374,6 +443,7 @@ fn exercise(glass: &mut Glass) {
         Ok(tree) => tree,
         Err(e) => {
             println!("set_value: {set:?} → re-snapshot failed: {e}");
+            record_snapshot_failure(failures, label, "re-snapshot after set_value failed", &e);
             return;
         }
     };
@@ -395,7 +465,10 @@ fn exercise(glass: &mut Glass) {
                 "control — click {focus:?} then key {keyed:?} → text input value={:?}",
                 text_input(&after).and_then(|n| n.value.clone())
             ),
-            Err(e) => println!("control — re-snapshot failed: {e}"),
+            Err(e) => {
+                println!("control — re-snapshot failed: {e}");
+                record_snapshot_failure(failures, label, "control re-snapshot failed", &e);
+            }
         }
     }
 
@@ -411,15 +484,24 @@ fn exercise(glass: &mut Glass) {
             println!("--- tree after actuation ---");
             report_tree(&after);
         }
-        Err(e) => println!("final snapshot failed: {e}"),
+        Err(e) => {
+            println!("final snapshot failed: {e}");
+            record_snapshot_failure(failures, label, "final snapshot failed", &e);
+        }
     }
 }
 
-fn probe(backend: &str, browser: &str, lever: Lever) {
-    println!("=== {backend} / {browser} / lever={lever:?} ===");
+/// One backend/browser/lever combination. Failures that mean the a11y bus itself broke — a
+/// launch that never happened, or a snapshot channel that never answered — are appended to
+/// `failures` rather than panicking, so the rest of the requested browsers still get their turn
+/// and this browser's `stop` still runs.
+fn probe(backend: &str, browser: &str, lever: Lever, failures: &mut Vec<String>) {
+    let label = format!("{backend}/{browser}/lever={lever:?}");
+    println!("=== {label} ===");
     println!("engine: {}", version_of(browser));
 
     let profile = tempfile::tempdir().expect("profile dir");
+    prepare_profile(browser, profile.path());
     let spec = browser_spec(browser, profile.path(), lever);
     println!("run: {:?}", spec.run);
     println!("env: {:?}", spec.env);
@@ -428,17 +510,21 @@ fn probe(backend: &str, browser: &str, lever: Lever) {
     let started = Instant::now();
     if let Err(e) = glass.start(&spec) {
         println!("start failed after {:?}: {e}", started.elapsed());
+        failures.push(format!(
+            "{label}: start failed after {:?}: {e}",
+            started.elapsed()
+        ));
         return;
     }
     println!("window mapped after {:?}", started.elapsed());
 
-    let (tree, settle, arrived) = snapshot_until_page(&mut glass);
+    let (tree, settle, arrived) = snapshot_until_page(&mut glass, &label, failures);
     println!("page content arrived: {arrived} after {settle:?}");
     match tree {
         Some(tree) => {
             report_tree(&tree);
             if arrived {
-                exercise(&mut glass);
+                exercise(&mut glass, &label, failures);
             } else if let Some(hint) = tree.document_guidance() {
                 println!("disclosure rendered:\n{hint}");
             } else {
@@ -450,25 +536,29 @@ fn probe(backend: &str, browser: &str, lever: Lever) {
     println!("stop: {:?}", glass.stop());
 }
 
-fn run_probes(backend: &str) {
+fn run_probes(backend: &str, failures: &mut Vec<String>) {
     let Ok(list) = std::env::var(BROWSERS_VAR) else {
         println!("skipped: set {BROWSERS_VAR}=firefox,brave-browser");
         return;
     };
     let lever = Lever::from_env();
     for browser in list.split(',').map(str::trim).filter(|s| !s.is_empty()) {
-        probe(backend, browser, lever);
+        probe(backend, browser, lever, failures);
     }
 }
 
 #[test]
 #[ignore = "needs a browser and the a11y prerequisites; see the module doc"]
 fn x11_browsers() {
-    run_probes("x11");
+    let mut failures = Vec::new();
+    run_probes("x11", &mut failures);
+    assert!(failures.is_empty(), "{}", failures.join("\n\n"));
 }
 
 #[test]
 #[ignore = "needs sway, a browser and the a11y prerequisites; see the module doc"]
 fn wayland_browsers() {
-    run_probes("wayland");
+    let mut failures = Vec::new();
+    run_probes("wayland", &mut failures);
+    assert!(failures.is_empty(), "{}", failures.join("\n\n"));
 }

--- a/crates/glass-a11y-linux/tests/web_probe.rs
+++ b/crates/glass-a11y-linux/tests/web_probe.rs
@@ -19,10 +19,11 @@
 //! A probe, not a mapping test: it prints evidence and does not assert what a browser ought to
 //! publish — a browser that launches but shows no page content is a reading, not a failure
 //! (`arrived: false` plus whatever disclosure rendered). What does fail the run: a browser that
-//! never launches, or an accessibility bus that never answers at all. Each backend's `Drop`
-//! impl tears its session down even through a panic, so failures are collected per (backend,
-//! browser, lever) and the test panics once at the end, after every browser it started has
-//! already been stopped.
+//! never launches, an accessibility bus that never answers at all, or a `set_value` whose verdict
+//! disagrees with the value the field reads back — the last is a claim about glass, which owes the
+//! same answer on every engine. Each backend's `Drop` impl tears its session down even through a
+//! panic, so failures are collected per (backend, browser, lever) and the test panics once at the
+//! end, after every browser it started has already been stopped.
 
 #![cfg(target_os = "linux")]
 
@@ -457,10 +458,18 @@ fn exercise(glass: &mut Glass, label: &str, failures: &mut Vec<String>) {
             return;
         }
     };
-    println!(
-        "set_value: {set:?} → text input value={:?}",
-        text_input(&after).and_then(|n| n.value.clone())
-    );
+    let held = text_input(&after).and_then(|n| n.value.clone());
+    println!("set_value: {set:?} → text input value={held:?}");
+    // A claim about glass, not about the engine: whatever this browser does with the write, the
+    // verdict has to agree with the read-back — `Ok` without the text is a false success, `Err`
+    // with it a false failure.
+    let holds = held.as_deref() == Some(TYPED);
+    if set.is_ok() != holds {
+        failures.push(format!(
+            "{label}: set_value returned {set:?} while the field reads back {held:?} — a verdict \
+             that disagrees with the read-back"
+        ));
+    }
 
     // The control for the line above. An empty readback has two causes — the write never
     // landed, or this engine never reports a web input's text over AT-SPI — and only text

--- a/crates/glass-a11y-linux/tests/web_probe.rs
+++ b/crates/glass-a11y-linux/tests/web_probe.rs
@@ -415,7 +415,16 @@ fn exercise(glass: &mut Glass, label: &str, failures: &mut Vec<String>) {
             }
             Err(e) => {
                 println!("click_element (attempt {attempt}) failed: {e}");
-                record_snapshot_failure(failures, label, "click_element failed", &e);
+                // A retry that lands is a reading, not a failure — only the exhausted attempt
+                // means click_element never worked at all.
+                if attempt == CLICK_ATTEMPTS {
+                    record_snapshot_failure(
+                        failures,
+                        label,
+                        &format!("click_element failed after {CLICK_ATTEMPTS} attempts"),
+                        &e,
+                    );
+                }
                 std::thread::sleep(Duration::from_millis(500));
             }
         }

--- a/crates/glass-a11y-linux/tests/web_probe.rs
+++ b/crates/glass-a11y-linux/tests/web_probe.rs
@@ -341,6 +341,7 @@ fn report_tree(tree: &AxTree) {
     for notice in [
         tree.truncation_notice(),
         tree.unreadable_notice(),
+        tree.unexposed_notice(),
         tree.subject_notice(),
         tree.empty_guidance().map(str::to_string),
     ]
@@ -534,10 +535,11 @@ fn probe(backend: &str, browser: &str, lever: Lever, failures: &mut Vec<String>)
             report_tree(&tree);
             if arrived {
                 exercise(&mut glass, &label, failures);
-            } else if let Some(hint) = tree.document_guidance() {
+            } else if let Some(hint) = tree.document_guidance().or_else(|| tree.unexposed_notice())
+            {
                 println!("disclosure rendered:\n{hint}");
             } else {
-                println!("NO DOCUMENT AND NO DISCLOSURE — the blind spot");
+                println!("NOTHING ARRIVED AND NOTHING DISCLOSED — the blind spot");
             }
         }
         None => println!("no tree at all — nothing was published within {SETTLE:?}"),

--- a/crates/glass-a11y-linux/tests/web_probe.rs
+++ b/crates/glass-a11y-linux/tests/web_probe.rs
@@ -1,0 +1,474 @@
+//! Web-content PROBE for the Linux backends — prints what a browser publishes over AT-SPI
+//! under glass's private bus, with and without the candidate enable levers. `#[ignore]`d:
+//! it needs a browser installed and the same prerequisites as `scripts/test-a11y.sh`.
+//!
+//! ```sh
+//! GLASS_WEB_PROBE_BROWSERS=firefox,brave-browser \
+//!   cargo test -p glass-a11y-linux --test web_probe -- --ignored --nocapture
+//! ```
+//!
+//! `GLASS_WEB_PROBE_LEVER` picks a candidate enable lever, carried by the launch spec alone so
+//! no product code is involved: `1` (or `both`) puts `GNOME_ACCESSIBILITY=1` and
+//! `ACCESSIBILITY_ENABLED=1` in the environment, `gnome` and `enabled` set one each (to tell
+//! which of the two a browser reads), and `flag` passes the Chromium-family
+//! `--force-renderer-accessibility` switch instead. Unset is the baseline reading.
+//!
+//! With `GLASS_WEB_PROBE_BROWSERS` unset both tests print a skip line and return, so an
+//! `--include-ignored` run never needs a browser.
+//!
+//! A probe, not a mapping test: it prints evidence and does not assert what a browser ought to
+//! publish. After `start` it reports failures instead of panicking, so `stop` always runs and
+//! no browser is left behind.
+
+#![cfg(target_os = "linux")]
+
+use std::path::Path;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use glass_core::{
+    AppSpec, AxNode, AxRole, AxTree, Backend, BaselineStore, Glass, GlassError, KeyEvent,
+    PlatformFactory, SandboxLevel, WindowHint, role_histogram,
+};
+
+const BROWSERS_VAR: &str = "GLASS_WEB_PROBE_BROWSERS";
+const LEVER_VAR: &str = "GLASS_WEB_PROBE_LEVER";
+
+/// How long to keep re-reading the tree for the page's own elements before calling the content
+/// missing. The reading this bounds is "time to content", so it is deliberately generous.
+const SETTLE: Duration = Duration::from_secs(20);
+
+/// Window-discovery budget. A cold browser opening a fresh profile under a software renderer
+/// maps its window far later than the GTK fixture does.
+const LAUNCH_TIMEOUT_MS: u64 = 30_000;
+
+/// The fixture button's accessible name — the page content the probe waits for, then clicks.
+const BUTTON: &str = "click me";
+/// The fixture text input's accessible name, from its `<label for>`.
+const INPUT: &str = "text input";
+/// What the page's result paragraph reads before the button fires, and after.
+const NOT_CLICKED: &str = "not clicked";
+/// See [`NOT_CLICKED`].
+const CLICKED: &str = "clicked";
+/// What `set_value` writes into the text input.
+const TYPED: &str = "typed by glass";
+/// What the keyboard control types into the text input — a second route to the same field.
+const KEYED: &str = "keyed by glass";
+
+fn page_url() -> String {
+    format!(
+        "file://{}/../../examples/web-role-fixture/index.html",
+        env!("CARGO_MANIFEST_DIR")
+    )
+}
+
+/// Which candidate enable lever the launch carries: environment variables, or the
+/// Chromium-family command-line switch.
+#[derive(Clone, Copy, Debug)]
+enum Lever {
+    None,
+    Gnome,
+    Enabled,
+    Both,
+    RendererFlag,
+}
+
+impl Lever {
+    fn from_env() -> Self {
+        match std::env::var(LEVER_VAR).unwrap_or_default().as_str() {
+            "1" | "both" => Lever::Both,
+            "gnome" => Lever::Gnome,
+            "enabled" => Lever::Enabled,
+            "flag" => Lever::RendererFlag,
+            _ => Lever::None,
+        }
+    }
+
+    fn vars(self) -> Vec<(String, String)> {
+        let gnome = ("GNOME_ACCESSIBILITY".to_string(), "1".to_string());
+        let enabled = ("ACCESSIBILITY_ENABLED".to_string(), "1".to_string());
+        match self {
+            Lever::None | Lever::RendererFlag => Vec::new(),
+            Lever::Gnome => vec![gnome],
+            Lever::Enabled => vec![enabled],
+            Lever::Both => vec![gnome, enabled],
+        }
+    }
+
+    /// The Chromium-family switch that turns the renderer's accessibility on without waiting
+    /// for a client to be detected. Nothing for the other levers, and nothing for Firefox —
+    /// Gecko has no equivalent switch.
+    fn chromium_args(self) -> Vec<String> {
+        match self {
+            Lever::RendererFlag => vec!["--force-renderer-accessibility".to_string()],
+            _ => Vec::new(),
+        }
+    }
+}
+
+fn glass_for(backend: &str) -> Glass {
+    let name = backend.to_string();
+    let factory: PlatformFactory = Box::new(move |_| {
+        let platform: Box<dyn glass_core::Platform + Send> = match name.as_str() {
+            "x11" => Box::new(glass_x11::X11Platform::from_env()?),
+            _ => Box::new(glass_wayland::WaylandPlatform::new()?),
+        };
+        Ok(Backend {
+            platform,
+            accessibility: Some(Box::new(glass_a11y_linux::LinuxA11y::new())),
+        })
+    });
+    let dir = tempfile::tempdir().expect("baseline dir");
+    let root = dir.path().join("baselines");
+    std::mem::forget(dir);
+    Glass::new(factory, backend.into(), BaselineStore::new(root), 100)
+}
+
+/// A fresh, isolated profile per launch: no first-run prompts, no session restore, and no
+/// already-running instance adopting the URL instead of starting a process glass owns.
+fn browser_spec(browser: &str, profile: &Path, lever: Lever) -> AppSpec {
+    let run = if browser.contains("firefox") {
+        vec![
+            browser.to_string(),
+            "--no-remote".into(),
+            "--new-instance".into(),
+            "--profile".into(),
+            profile.display().to_string(),
+            page_url(),
+        ]
+    } else {
+        let mut run = vec![
+            browser.to_string(),
+            format!("--user-data-dir={}", profile.display()),
+            "--no-first-run".into(),
+            "--no-default-browser-check".into(),
+            "--disable-gpu".into(),
+        ];
+        run.extend(lever.chromium_args());
+        run.push(page_url());
+        run
+    };
+    let mut env = vec![("LIBGL_ALWAYS_SOFTWARE".to_string(), "1".to_string())];
+    env.extend(lever.vars());
+    AppSpec {
+        build: None,
+        run,
+        cwd: None,
+        env,
+        // The title hint is a fallback only: window discovery matches the launched process
+        // tree's `_NET_WM_PID` first, and a browser appends its own name to the page title.
+        window_hint: Some(WindowHint {
+            title: Some("Glass web fixture".into()),
+            class: None,
+        }),
+        timeout_ms: LAUNCH_TIMEOUT_MS,
+        sandbox: SandboxLevel::Off,
+        a11y: true,
+    }
+}
+
+fn find<'a>(tree: &'a AxTree, pred: &dyn Fn(&AxNode) -> bool) -> Option<&'a AxNode> {
+    fn walk<'a>(node: &'a AxNode, pred: &dyn Fn(&AxNode) -> bool) -> Option<&'a AxNode> {
+        if pred(node) {
+            return Some(node);
+        }
+        node.children.iter().find_map(|c| walk(c, pred))
+    }
+    walk(&tree.root, pred)
+}
+
+/// The first node whose accessible name is exactly `name`.
+fn named<'a>(tree: &'a AxTree, name: &str) -> Option<&'a AxNode> {
+    find(tree, &|n| n.name.as_deref() == Some(name))
+}
+
+/// The fixture's text input, not its `<label for>`: both carry the same accessible name, and
+/// the label comes first in pre-order, so `named` alone writes to the wrong element.
+fn text_input(tree: &AxTree) -> Option<&AxNode> {
+    find(tree, &|n| {
+        n.name.as_deref() == Some(INPUT) && n.states.editable
+    })
+}
+
+/// The fixture's result paragraph, found by the text it carries. The text of a `<p>` is a
+/// node's `value` (the reader reads the AT-SPI `Text` interface for text-bearing roles), not
+/// its name, and the outline render does not print values — so this is the only place the
+/// before/after of the click is visible.
+fn valued<'a>(tree: &'a AxTree, value: &str) -> Option<&'a AxNode> {
+    find(tree, &|n| n.value.as_deref() == Some(value))
+}
+
+/// Every editable node in the tree, in pre-order.
+fn editable(tree: &AxTree) -> Vec<&AxNode> {
+    fn walk<'a>(node: &'a AxNode, out: &mut Vec<&'a AxNode>) {
+        if node.states.editable {
+            out.push(node);
+        }
+        for child in &node.children {
+            walk(child, out);
+        }
+    }
+    let mut out = Vec::new();
+    walk(&tree.root, &mut out);
+    out
+}
+
+/// Every `Document` in the tree, in pre-order — the web-content boundary this probe reads.
+fn documents(tree: &AxTree) -> Vec<&AxNode> {
+    fn walk<'a>(node: &'a AxNode, out: &mut Vec<&'a AxNode>) {
+        if node.role == AxRole::Document {
+            out.push(node);
+        }
+        for child in &node.children {
+            walk(child, out);
+        }
+    }
+    let mut out = Vec::new();
+    walk(&tree.root, &mut out);
+    out
+}
+
+/// Re-snapshot until the page's own elements arrive or `SETTLE` elapses. Returns the last tree
+/// read, how long it took (the settle reading), and whether the content arrived.
+///
+/// Arrival requires the button to carry bounds, not merely to exist: the engine publishes the
+/// node before it has laid the page out, and a click on a node with no bounds is refused.
+///
+/// Every error is retried until the deadline, not just `AccessibilityNotReady`: a browser
+/// re-execs during startup, and the bus error its first process leaves behind resolves itself
+/// once the second one registers. Each distinct error is printed once — a probe that stops at
+/// the first one reads "nothing published" for a browser that had not started yet.
+fn snapshot_until_page(glass: &mut Glass) -> (Option<AxTree>, Duration, bool) {
+    let start = Instant::now();
+    let mut last = None;
+    let mut reported = Vec::new();
+    loop {
+        match glass.a11y_snapshot(Some(0)) {
+            Ok(tree) => {
+                let arrived = named(&tree, BUTTON).is_some_and(|n| n.bounds.is_some());
+                last = Some(tree);
+                if arrived {
+                    return (last, start.elapsed(), true);
+                }
+            }
+            Err(GlassError::AccessibilityNotReady(_)) => {}
+            Err(e) => {
+                let text = e.to_string();
+                if !reported.contains(&text) {
+                    println!("snapshot error at {:?}: {text}", start.elapsed());
+                    reported.push(text);
+                }
+            }
+        }
+        if start.elapsed() > SETTLE {
+            return (last, start.elapsed(), false);
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    }
+}
+
+fn version_of(browser: &str) -> String {
+    match Command::new(browser).arg("--version").output() {
+        Ok(out) => String::from_utf8_lossy(&out.stdout).trim().to_string(),
+        Err(e) => format!("(unreadable: {e})"),
+    }
+}
+
+fn report_tree(tree: &AxTree) {
+    for doc in documents(tree) {
+        println!(
+            "document: #{} raw_role={:?} name={:?} children={} bounds={:?}",
+            doc.id.0,
+            doc.raw_role,
+            doc.name,
+            doc.children.len(),
+            doc.bounds
+        );
+    }
+    println!("role histogram (role, count, native token):");
+    for tally in role_histogram(tree) {
+        println!("  {:?} {:>4}  {}", tally.role, tally.count, tally.raw_role);
+    }
+    for notice in [
+        tree.truncation_notice(),
+        tree.unreadable_notice(),
+        tree.subject_notice(),
+        tree.empty_guidance().map(str::to_string),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        println!("notice: {notice}");
+    }
+    println!("outline:\n{}", tree.to_outline());
+}
+
+/// How many times to re-snapshot-and-click. A browser's tree keeps changing while its other
+/// tabs load, and an id whose node has moved since the snapshot is rejected as changed —
+/// retrying reads the button's clickability rather than the retry's luck.
+const CLICK_ATTEMPTS: usize = 4;
+
+/// The actuation readings. Each step re-snapshots first: `click_element` and `set_value` resolve
+/// ids against the session's most recent tree, so an id from an older one addresses nothing.
+fn exercise(glass: &mut Glass) {
+    for attempt in 1..=CLICK_ATTEMPTS {
+        let before = match glass.a11y_snapshot(Some(0)) {
+            Ok(tree) => tree,
+            Err(e) => {
+                println!("snapshot before the click failed: {e} — no click reading");
+                return;
+            }
+        };
+        let Some(button) = named(&before, BUTTON) else {
+            println!("no node named {BUTTON:?} — no click reading");
+            return;
+        };
+        if attempt == 1 {
+            println!(
+                "button: #{} role={:?} raw_role={} bounds={:?}",
+                button.id.0, button.role, button.raw_role, button.bounds
+            );
+            println!(
+                "result paragraph before the click: {:?}",
+                valued(&before, NOT_CLICKED).map(|n| (n.id.0, n.role, n.raw_role.clone()))
+            );
+        }
+        match glass.click_element(button.id) {
+            Ok(method) => {
+                std::thread::sleep(Duration::from_millis(500));
+                match glass.a11y_snapshot(Some(0)) {
+                    Ok(after) => println!(
+                        "click_element (attempt {attempt}): {method:?} → result paragraph reads \
+                         {CLICKED:?}: {}",
+                        valued(&after, CLICKED).is_some()
+                    ),
+                    Err(e) => println!("click_element: {method:?} → re-snapshot failed: {e}"),
+                }
+                break;
+            }
+            Err(e) => {
+                println!("click_element (attempt {attempt}) failed: {e}");
+                std::thread::sleep(Duration::from_millis(500));
+            }
+        }
+    }
+
+    let after = match glass.a11y_snapshot(Some(0)) {
+        Ok(tree) => tree,
+        Err(e) => {
+            println!("snapshot before set_value failed: {e} — no set_value reading");
+            return;
+        }
+    };
+    let Some(field) = text_input(&after) else {
+        println!("no editable node named {INPUT:?} — no set_value reading");
+        return;
+    };
+    println!(
+        "text input: #{} role={:?} raw_role={} value={:?}",
+        field.id.0, field.role, field.raw_role, field.value
+    );
+    let set = glass.set_value(field.id, TYPED);
+    std::thread::sleep(Duration::from_millis(500));
+    let after = match glass.a11y_snapshot(Some(0)) {
+        Ok(tree) => tree,
+        Err(e) => {
+            println!("set_value: {set:?} → re-snapshot failed: {e}");
+            return;
+        }
+    };
+    println!(
+        "set_value: {set:?} → text input value={:?}",
+        text_input(&after).and_then(|n| n.value.clone())
+    );
+
+    // The control for the line above. An empty readback has two causes — the write never
+    // landed, or this engine never reports a web input's text over AT-SPI — and only text
+    // that reached the field by another route tells them apart. Typed through the pointer
+    // and keyboard, which do not touch the accessibility write path.
+    if let Some(field) = text_input(&after) {
+        let focus = glass.click_element(field.id);
+        let keyed = glass.key(&KeyEvent::Text(KEYED.to_string()));
+        std::thread::sleep(Duration::from_millis(500));
+        match glass.a11y_snapshot(Some(0)) {
+            Ok(after) => println!(
+                "control — click {focus:?} then key {keyed:?} → text input value={:?}",
+                text_input(&after).and_then(|n| n.value.clone())
+            ),
+            Err(e) => println!("control — re-snapshot failed: {e}"),
+        }
+    }
+
+    match glass.a11y_snapshot(Some(0)) {
+        Ok(after) => {
+            println!("every editable node at the end:");
+            for node in editable(&after) {
+                println!(
+                    "  #{} role={:?} raw_role={} name={:?} value={:?}",
+                    node.id.0, node.role, node.raw_role, node.name, node.value
+                );
+            }
+            println!("--- tree after actuation ---");
+            report_tree(&after);
+        }
+        Err(e) => println!("final snapshot failed: {e}"),
+    }
+}
+
+fn probe(backend: &str, browser: &str, lever: Lever) {
+    println!("=== {backend} / {browser} / lever={lever:?} ===");
+    println!("engine: {}", version_of(browser));
+
+    let profile = tempfile::tempdir().expect("profile dir");
+    let spec = browser_spec(browser, profile.path(), lever);
+    println!("run: {:?}", spec.run);
+    println!("env: {:?}", spec.env);
+
+    let mut glass = glass_for(backend);
+    let started = Instant::now();
+    if let Err(e) = glass.start(&spec) {
+        println!("start failed after {:?}: {e}", started.elapsed());
+        return;
+    }
+    println!("window mapped after {:?}", started.elapsed());
+
+    let (tree, settle, arrived) = snapshot_until_page(&mut glass);
+    println!("page content arrived: {arrived} after {settle:?}");
+    match tree {
+        Some(tree) => {
+            report_tree(&tree);
+            if arrived {
+                exercise(&mut glass);
+            } else if let Some(hint) = tree.document_guidance() {
+                println!("disclosure rendered:\n{hint}");
+            } else {
+                println!("NO DOCUMENT AND NO DISCLOSURE — the blind spot");
+            }
+        }
+        None => println!("no tree at all — nothing was published within {SETTLE:?}"),
+    }
+    println!("stop: {:?}", glass.stop());
+}
+
+fn run_probes(backend: &str) {
+    let Ok(list) = std::env::var(BROWSERS_VAR) else {
+        println!("skipped: set {BROWSERS_VAR}=firefox,brave-browser");
+        return;
+    };
+    let lever = Lever::from_env();
+    for browser in list.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+        probe(backend, browser, lever);
+    }
+}
+
+#[test]
+#[ignore = "needs a browser and the a11y prerequisites; see the module doc"]
+fn x11_browsers() {
+    run_probes("x11");
+}
+
+#[test]
+#[ignore = "needs sway, a browser and the a11y prerequisites; see the module doc"]
+fn wayland_browsers() {
+    run_probes("wayland");
+}

--- a/crates/glass-a11y-linux/tests/web_probe.rs
+++ b/crates/glass-a11y-linux/tests/web_probe.rs
@@ -33,7 +33,7 @@ use std::time::{Duration, Instant};
 
 use glass_core::{
     AppSpec, AxNode, AxRole, AxTree, Backend, BaselineStore, Glass, GlassError, KeyEvent,
-    PlatformFactory, SandboxLevel, WindowHint, role_histogram,
+    PlatformFactory, SandboxLevel, WindowHint, read_back_confirms, role_histogram,
 };
 
 const BROWSERS_VAR: &str = "GLASS_WEB_PROBE_BROWSERS";
@@ -448,6 +448,8 @@ fn exercise(glass: &mut Glass, label: &str, failures: &mut Vec<String>) {
         "text input: #{} role={:?} raw_role={} value={:?}",
         field.id.0, field.role, field.raw_role, field.value
     );
+    // The baseline glass's own rule compares against — read before the write, not after.
+    let before = field.value.clone();
     let set = glass.set_value(field.id, TYPED);
     std::thread::sleep(Duration::from_millis(500));
     let after = match glass.a11y_snapshot(Some(0)) {
@@ -461,13 +463,15 @@ fn exercise(glass: &mut Glass, label: &str, failures: &mut Vec<String>) {
     let held = text_input(&after).and_then(|n| n.value.clone());
     println!("set_value: {set:?} → text input value={held:?}");
     // A claim about glass, not about the engine: whatever this browser does with the write, the
-    // verdict has to agree with the read-back — `Ok` without the text is a false success, `Err`
-    // with it a false failure.
-    let holds = held.as_deref() == Some(TYPED);
-    if set.is_ok() != holds {
+    // verdict has to agree with `read_back_confirms`, the readers' own rule — `Ok` it cannot
+    // confirm is a false success, `Err` it can a false failure. Do not tighten this to
+    // `held == TYPED`: that fails the probe for an engine that reformatted the value and that
+    // glass accepts.
+    let confirms = read_back_confirms(held.as_deref(), before.as_deref(), TYPED);
+    if set.is_ok() != confirms {
         failures.push(format!(
-            "{label}: set_value returned {set:?} while the field reads back {held:?} — a verdict \
-             that disagrees with the read-back"
+            "{label}: set_value returned {set:?} while the field reads back {held:?} (was \
+             {before:?}) — a verdict that disagrees with glass's own read-back rule"
         ));
     }
 

--- a/crates/glass-a11y-windows/src/mapping.rs
+++ b/crates/glass-a11y-windows/src/mapping.rs
@@ -47,6 +47,7 @@ pub const CONTROL_TYPES: &[(u32, &str, Option<AxRole>)] = &[
     (50027, "Thumb", None),
     (50028, "DataGrid", Some(AxRole::Table)),
     (50029, "DataItem", None),
+    // A web engine's Document reads as `Document` instead — see `map_role_with_framework`.
     (50030, "Document", Some(AxRole::TextArea)),
     // A split button is an actionable button carrying a dropdown.
     (50031, "SplitButton", Some(AxRole::Button)),
@@ -62,6 +63,12 @@ pub const CONTROL_TYPES: &[(u32, &str, Option<AxRole>)] = &[
     (50039, "SemanticZoom", None),
     (50040, "AppBar", None),
 ];
+
+/// The `FrameworkId`s a web engine publishes its content under, case-sensitive as UIA reports
+/// them. Read 2026-08-24 on Windows 11: Chromium (Edge, Brave) reports `Chrome` and Gecko
+/// (Firefox) `Gecko`, while a stock text editor's edit surface reports `Win32` and a console
+/// host's `Document` reports an empty id.
+const WEB_ENGINE_FRAMEWORK_IDS: [&str; 2] = ["Chrome", "Gecko"];
 
 /// The [`CONTROL_TYPES`] row for an id, shared by [`map_role`] and [`canonical_name`] so the two
 /// can never disagree about which ids are known.
@@ -86,7 +93,27 @@ fn control_type(control_type_id: u32) -> Option<&'static (u32, &'static str, Opt
 ///
 /// A control type glass does not map — known or not — becomes `AxRole::Other` (the reader keeps
 /// the control type's name in `raw_role`).
+///
+/// Framework-blind: a `Document` (50030) maps to `TextArea` here — the reader calls
+/// [`map_role_with_framework`].
 pub fn map_role(control_type_id: u32, toggleable: bool) -> AxRole {
+    map_role_with_framework(control_type_id, toggleable, None)
+}
+
+/// [`map_role`] plus the element's UIA `FrameworkId`, which tells a web page's `Document`
+/// (50030) from a text editor's: an id in [`WEB_ENGINE_FRAMEWORK_IDS`] maps to
+/// [`AxRole::Document`], any other id — including an empty one, which the reader passes as
+/// `None` — keeps the `TextArea` mapping.
+pub fn map_role_with_framework(
+    control_type_id: u32,
+    toggleable: bool,
+    framework_id: Option<&str>,
+) -> AxRole {
+    if control_type_id == 50030
+        && framework_id.is_some_and(|id| WEB_ENGINE_FRAMEWORK_IDS.contains(&id))
+    {
+        return AxRole::Document;
+    }
     if control_type_id == 50000 && toggleable {
         return AxRole::ToggleButton;
     }
@@ -328,10 +355,38 @@ mod tests {
 
     #[test]
     fn document_maps_from_an_observed_token() {
-        // Observed on a stock text editor — see the probe test in
-        // crates/glass-windows/tests/onbox.rs. What a web document reports here is unread, so
-        // the role-support matrix records the Document cell as a gap until one is read.
-        assert_eq!(map_role(50030, false), AxRole::TextArea);
+        // Observed on a stock text editor whose edit surface reported FrameworkId `Win32` —
+        // see the probe test in crates/glass-windows/tests/onbox.rs.
+        assert_eq!(
+            map_role_with_framework(50030, false, Some("Win32")),
+            AxRole::TextArea
+        );
+    }
+
+    #[test]
+    fn a_web_engines_document_is_a_document() {
+        assert_eq!(
+            map_role_with_framework(50030, false, Some("Chrome")),
+            AxRole::Document
+        );
+        assert_eq!(
+            map_role_with_framework(50030, false, Some("Gecko")),
+            AxRole::Document
+        );
+    }
+
+    #[test]
+    fn a_document_with_no_web_engine_framework_id_stays_a_text_area() {
+        // A console host publishes a `Document` with an EMPTY FrameworkId, which the reader
+        // passes as `None`.
+        assert_eq!(
+            map_role_with_framework(50030, false, Some("")),
+            AxRole::TextArea
+        );
+        assert_eq!(
+            map_role_with_framework(50030, false, None),
+            AxRole::TextArea
+        );
     }
 
     #[test]
@@ -448,12 +503,14 @@ mod tests {
         use glass_core::role_support::{AxBackend, RoleSupport, support};
         for role in AxRole::ALL {
             // Only a row carrying `Some(role)` produces a role; a named-but-unmapped control
-            // type yields `Other` and must not count as coverage. `ToggleButton` is the one
-            // role no `CONTROL_TYPES` row produces on its own — it comes from `map_role`'s
-            // Button-plus-Toggle-pattern rule — so it is checked by calling the real function
+            // type yields `Other` and must not count as coverage. `ToggleButton` and
+            // `Document` are the two roles no `CONTROL_TYPES` row produces on its own — they
+            // come from `map_role_with_framework`'s Button-plus-Toggle-pattern and
+            // Document-plus-web-engine rules — so each is checked by calling the real function
             // with the fact that triggers it, not by a hardcoded exception.
             let mapped = CONTROL_TYPES.iter().any(|(_, _, r)| *r == Some(role))
-                || map_role(50000, true) == role;
+                || map_role(50000, true) == role
+                || map_role_with_framework(50030, false, Some("Chrome")) == role;
             match support(role, AxBackend::Windows).expect("declared in ROLE_SUPPORT") {
                 RoleSupport::Mapped => {
                     assert!(

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -147,6 +147,7 @@ fn walk(
     let raw_role = crate::mapping::canonical_name(ct_id)
         .map(str::to_string)
         .unwrap_or_else(|| format!("UIA:{ct_id}"));
+    let framework = framework_id(el, ct_id);
     let name = nonempty(el.get_name().unwrap_or_default());
     let description = normalize_description(&help_text(el, ct_id), name.as_deref());
     let bounds = window_relative_bounds(el, origin);
@@ -184,7 +185,7 @@ fn walk(
 
     Ok(AxNode {
         id: AxNodeId(0), // assigned by glass_core::AxTree::assign_ids
-        role: crate::mapping::map_role(ct_id, facts.checkable),
+        role: crate::mapping::map_role_with_framework(ct_id, facts.checkable, framework.as_deref()),
         raw_role,
         name,
         description,
@@ -343,6 +344,18 @@ fn nonempty(s: String) -> Option<String> {
     (!s.is_empty()).then_some(s)
 }
 
+/// The element's UIA `FrameworkId`, which `map_role_with_framework` decides a `Document` on.
+/// Gated by control type like `toggle_pattern`: only 50030 is decided by it, so no other node
+/// spends a cross-process property read. Read per node, never per app — a browser's window
+/// element reports `Win32` while the page inside it carries the engine's id. An empty id and a
+/// failed read both yield `None`.
+fn framework_id(el: &UIElement, ct_id: u32) -> Option<String> {
+    if ct_id != 50030 {
+        return None;
+    }
+    nonempty(el.get_framework_id().unwrap_or_default())
+}
+
 fn run_set_value(ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
     let automation = UIAutomation::new().map_err(|e| {
         GlassError::AccessibilityUnavailable(format!("UI Automation unavailable: {e}"))
@@ -362,7 +375,11 @@ fn run_set_value(ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
     // bounds fingerprint — the element sits elsewhere — rejects it. A target
     // without captured bounds falls back to role+name only.
     let ct_id = el.get_control_type().map_err(uia_err)? as i32 as u32;
-    let role = crate::mapping::map_role(ct_id, toggle_pattern(&el, ct_id).is_some());
+    let role = crate::mapping::map_role_with_framework(
+        ct_id,
+        toggle_pattern(&el, ct_id).is_some(),
+        framework_id(&el, ct_id).as_deref(),
+    );
     let name = nonempty(el.get_name().unwrap_or_default());
     let bounds = window_relative_bounds(&el, (ctx.window.x, ctx.window.y));
     if !target.matches(role, name.as_deref())
@@ -447,7 +464,11 @@ fn run_invoke(ctx: &AxContext, target: &AxTarget) -> Result<()> {
 
     // Same fingerprint gate as run_set_value: role + name + bounds.
     let ct_id = el.get_control_type().map_err(uia_err)? as i32 as u32;
-    let role = crate::mapping::map_role(ct_id, toggle_pattern(&el, ct_id).is_some());
+    let role = crate::mapping::map_role_with_framework(
+        ct_id,
+        toggle_pattern(&el, ct_id).is_some(),
+        framework_id(&el, ct_id).as_deref(),
+    );
     let name = nonempty(el.get_name().unwrap_or_default());
     let bounds = window_relative_bounds(&el, (ctx.window.x, ctx.window.y));
     if !target.matches(role, name.as_deref())

--- a/crates/glass-android/tests/a11y_loop.rs
+++ b/crates/glass-android/tests/a11y_loop.rs
@@ -9,8 +9,8 @@
 //! live field — and a clear that cannot be confirmed here at all, because this platform reports
 //! the emptied field's hint as its text; that a read takes its dump file with it; that a read
 //! stops at the deadline its caller named; that a snapshot taken while another app is foreground
-//! says which app it describes; and that a test which fails mid-interaction still hands the
-//! device back launchable.
+//! says which app it describes; that a WebView page's button and text field respond to a tap and
+//! a write; and that a test which fails mid-interaction still hands the device back launchable.
 
 use glass_core::Deadline;
 use glass_core::accessibility::{Accessibility, AxContext, AxNode, AxTarget, AxTree, WalkLimits};
@@ -650,6 +650,11 @@ const WEB_FIXTURE_PACKAGE: &str = "tech.fixedwidth.glassrolefixture";
 const WEB_CONTENT_BUDGET: std::time::Duration = std::time::Duration::from_secs(8);
 const WEB_CONTENT_POLL: std::time::Duration = std::time::Duration::from_millis(500);
 
+/// How long to give the page's JS handler after a tap before re-reading the tree. Shares
+/// [`WEB_CONTENT_POLL`]'s value by coincidence, not by relationship — a settle and a poll
+/// interval answer different questions.
+const POST_TAP_SETTLE: std::time::Duration = std::time::Duration::from_millis(500);
+
 fn web_fixture_spec() -> AppSpec {
     AppSpec {
         build: None,
@@ -705,14 +710,12 @@ fn matching(tree: &AxTree, needle: &str) -> Vec<String> {
 #[test]
 #[ignore = "requires a booted AVD + GLASS_ANDROID_SERIAL/GLASS_ADB, and the role fixture installed"]
 fn web_fixture_button_and_field_respond() {
-    if !web_fixture_installed() {
-        println!(
-            "skipped: {WEB_FIXTURE_PACKAGE} is not installed — build and install it with \
-             `cd examples/android-role-fixture && ./build.sh && adb install -r \
-             build/role-fixture.apk`"
-        );
-        return;
-    }
+    assert!(
+        web_fixture_installed(),
+        "{WEB_FIXTURE_PACKAGE} is not installed — build and install it with `cd \
+         examples/android-role-fixture && ./build.sh && adb install -r \
+         build/role-fixture.apk`"
+    );
     let mut session = Session::start_spec(web_fixture_spec());
     let ctx = session.ctx();
     let mut a11y = glass_android::AndroidA11y::new();
@@ -763,7 +766,7 @@ fn web_fixture_button_and_field_respond() {
         }
         None => println!("no node named \"click me\" to tap"),
     }
-    std::thread::sleep(WEB_CONTENT_POLL);
+    std::thread::sleep(POST_TAP_SETTLE);
     let mut after_tap = a11y.snapshot(&ctx).expect("snapshot after the tap");
     after_tap.assign_ids();
     println!(
@@ -771,8 +774,8 @@ fn web_fixture_button_and_field_respond() {
         matching(&after_tap, "click")
     );
 
-    // The page's text input. `set_value` reports its own verdict; the read-back is what says
-    // whether the value took.
+    // The first editable element on the page (input or textarea) — its identity isn't pinned.
+    // `set_value` reports its own verdict; the read-back is what says whether the value took.
     let field = find(&after_tap.root, &|n| n.states.editable).map(|n| AxTarget {
         id: n.id,
         role: n.role,

--- a/crates/glass-android/tests/a11y_loop.rs
+++ b/crates/glass-android/tests/a11y_loop.rs
@@ -15,7 +15,7 @@
 use glass_core::Deadline;
 use glass_core::accessibility::{Accessibility, AxContext, AxNode, AxTarget, AxTree, WalkLimits};
 use glass_core::{
-    AppSpec, GlassError, MouseButton, Platform, PointerEvent, SandboxLevel, WindowGeometry,
+    AppSpec, AxRole, GlassError, MouseButton, Platform, PointerEvent, SandboxLevel, WindowGeometry,
 };
 
 fn settings_spec() -> AppSpec {
@@ -48,6 +48,11 @@ struct Session {
 impl Session {
     /// Attach to the device and launch Settings.
     fn start() -> Self {
+        Self::start_spec(settings_spec())
+    }
+
+    /// Attach to the device and launch `spec`'s component.
+    fn start_spec(spec: AppSpec) -> Self {
         let agents = glass_android::AgentRegistry::new();
         let platform = glass_android::AndroidPlatform::from_env(
             &glass_android::EmulatorRegistry::new(),
@@ -65,8 +70,8 @@ impl Session {
         };
         session.window = session
             .platform()
-            .start_app(&settings_spec())
-            .expect("launch settings");
+            .start_app(&spec)
+            .expect("launch the app under test");
         session
     }
 
@@ -631,4 +636,168 @@ fn a_snapshot_taken_while_another_app_is_foreground_says_so() {
         .expect("the service must disclose it answered about the foreground app, not Settings");
     assert_eq!(subject.asked, "com.android.settings");
     assert_eq!(subject.actual, "com.google.android.deskclock");
+}
+
+/// The role fixture's WebView screen (`examples/android-role-fixture`), and the package that
+/// holds it.
+const WEB_FIXTURE: &str = "tech.fixedwidth.glassrolefixture/.WebActivity";
+const WEB_FIXTURE_PACKAGE: &str = "tech.fixedwidth.glassrolefixture";
+
+/// How long to wait for the WebView to publish the page's own nodes, and how often to look.
+///
+/// A poll, not a sleep: on this fixture the first read after a launch has come back a `Document`
+/// with nothing under it, with the next read holding the whole page.
+const WEB_CONTENT_BUDGET: std::time::Duration = std::time::Duration::from_secs(8);
+const WEB_CONTENT_POLL: std::time::Duration = std::time::Duration::from_millis(500);
+
+fn web_fixture_spec() -> AppSpec {
+    AppSpec {
+        build: None,
+        run: vec![WEB_FIXTURE.to_string()],
+        cwd: None,
+        env: vec![],
+        window_hint: None,
+        timeout_ms: 15_000,
+        sandbox: SandboxLevel::Off,
+        a11y: true,
+    }
+}
+
+/// Whether the fixture is installed on the device this run attached to.
+fn web_fixture_installed() -> bool {
+    let adb = std::env::var("GLASS_ADB").unwrap_or_else(|_| "adb".to_string());
+    let out = std::process::Command::new(adb)
+        .args(["shell", "pm", "list", "packages", WEB_FIXTURE_PACKAGE])
+        .output()
+        .expect("adb shell pm list packages");
+    String::from_utf8_lossy(&out.stdout).contains(WEB_FIXTURE_PACKAGE)
+}
+
+/// The first `Document` in `tree`, with how many children it published.
+fn first_document(tree: &AxTree) -> Option<(&AxNode, usize)> {
+    find(&tree.root, &|n| n.role == AxRole::Document).map(|d| (d, d.children.len()))
+}
+
+/// Every node whose name or value contains `needle`, as `#id role name=… value=…` lines.
+fn matching(tree: &AxTree, needle: &str) -> Vec<String> {
+    fn walk(node: &AxNode, needle: &str, into: &mut Vec<String>) {
+        let hit = |s: &Option<String>| s.as_deref().is_some_and(|s| s.contains(needle));
+        if hit(&node.name) || hit(&node.value) {
+            into.push(format!(
+                "#{} {:?} name={:?} value={:?} bounds={:?}",
+                node.id.0, node.role, node.name, node.value, node.bounds
+            ));
+        }
+        node.children.iter().for_each(|c| walk(c, needle, into));
+    }
+    let mut found = Vec::new();
+    walk(&tree.root, needle, &mut found);
+    found
+}
+
+/// What the web fixture's page reports through the `uiautomator` reader: whether its nodes
+/// arrive at all, whether a tap on its button reaches the page, and whether `set_value` on its
+/// text input lands.
+///
+/// A probe, not a pass/fail test of the page: it asserts only that the app launched and a tree
+/// came back, and prints the rest. What a WebView publishes is the engine's to change, so pinning
+/// today's answer here would fail a run for an update glass did not make.
+#[test]
+#[ignore = "requires a booted AVD + GLASS_ANDROID_SERIAL/GLASS_ADB, and the role fixture installed"]
+fn web_fixture_button_and_field_respond() {
+    if !web_fixture_installed() {
+        println!(
+            "skipped: {WEB_FIXTURE_PACKAGE} is not installed — build and install it with \
+             `cd examples/android-role-fixture && ./build.sh && adb install -r \
+             build/role-fixture.apk`"
+        );
+        return;
+    }
+    let mut session = Session::start_spec(web_fixture_spec());
+    let ctx = session.ctx();
+    let mut a11y = glass_android::AndroidA11y::new();
+
+    // Every attempt is printed, not just the one that settled: whether the FIRST read of a
+    // WebView holds the page is the reading this probe exists for (glass#506).
+    let started = std::time::Instant::now();
+    let tree = loop {
+        let mut tree = a11y.snapshot(&ctx).expect("snapshot the web fixture");
+        tree.assign_ids();
+        let doc = first_document(&tree);
+        println!(
+            "read at {:?}: {} nodes, document={:?}, guidance={:?}",
+            started.elapsed(),
+            tree.count,
+            doc.map(|(d, kids)| format!("#{} {} child(ren)", d.id.0, kids)),
+            tree.document_guidance()
+        );
+        if doc.is_some_and(|(_, kids)| kids > 0) || started.elapsed() >= WEB_CONTENT_BUDGET {
+            break tree;
+        }
+        std::thread::sleep(WEB_CONTENT_POLL);
+    };
+    println!(
+        "\n===== the page as the uiautomator reader sees it =====\n{}",
+        tree.to_outline()
+    );
+    assert!(tree.count > 0, "a launched app must yield a tree");
+
+    // The page's button, tapped through the platform's pointer rather than an accessibility
+    // action: what is being read is whether a tap reaches web content at all.
+    match find(&tree.root, &|n| n.name.as_deref() == Some("click me"))
+        .and_then(|n| n.bounds.map(|b| (n.id, n.role, b)))
+        .and_then(|(id, role, b)| {
+            b.clamped_center(ctx.window.width, ctx.window.height)
+                .map(|c| (id, role, c))
+        }) {
+        Some((id, role, (x, y))) => {
+            println!("tapping #{} {role:?} at {x},{y}", id.0);
+            let sent = session.platform().send_pointer(&PointerEvent::Click {
+                x,
+                y,
+                button: MouseButton::Left,
+                count: 1,
+                modifiers: vec![],
+            });
+            println!("send_pointer: {sent:?}");
+        }
+        None => println!("no node named \"click me\" to tap"),
+    }
+    std::thread::sleep(WEB_CONTENT_POLL);
+    let mut after_tap = a11y.snapshot(&ctx).expect("snapshot after the tap");
+    after_tap.assign_ids();
+    println!(
+        "after the tap, nodes matching \"click\": {:#?}",
+        matching(&after_tap, "click")
+    );
+
+    // The page's text input. `set_value` reports its own verdict; the read-back is what says
+    // whether the value took.
+    let field = find(&after_tap.root, &|n| n.states.editable).map(|n| AxTarget {
+        id: n.id,
+        role: n.role,
+        name: n.name.clone(),
+        bounds: n.bounds,
+        value: n.value.clone(),
+    });
+    match field {
+        Some(target) => {
+            println!(
+                "writing into #{} {:?} {:?}",
+                target.id.0, target.role, target.bounds
+            );
+            println!(
+                "set_value: {:?}",
+                a11y.set_value(&ctx, &target, "typed by glass")
+            );
+            let mut after_write = a11y.snapshot(&ctx).expect("snapshot after the write");
+            after_write.assign_ids();
+            println!(
+                "the field reads back {:?}; nodes matching \"typed\": {:#?}",
+                after_write.find(target.id).and_then(|n| n.value.clone()),
+                matching(&after_write, "typed")
+            );
+        }
+        None => println!("no editable node in the page to write into"),
+    }
 }

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -833,6 +833,10 @@ impl AxTree {
     /// truncated tree does. Aggregated like [`Self::unreadable_notice`] rather than repeated
     /// per document: a page of ad iframes would otherwise spend the budget `max_nodes` guards.
     ///
+    /// A childless `Document` on a complete walk is most often *not yet*: an Android WebView's
+    /// first snapshot after a launch was childless and its next held the whole page (read
+    /// 2026-08-24), so that branch steers to a re-read before the pixel path.
+    ///
     /// A bound or a failed child read empties a `Document`'s child list exactly like an
     /// unpublished tree does, so only a complete walk ([`Self::is_complete`]) names a cause;
     /// otherwise this hedges and defers to the notice beside it, which owns the recourse —
@@ -850,18 +854,18 @@ impl AxTree {
             })
             .collect();
         let one = docs.len() == 1;
-        let (s, have, they, them) = if one {
-            ("", "has", "it", "it")
+        let (s, have, they) = if one {
+            ("", "has", "it")
         } else {
-            ("s", "have", "they", "them")
+            ("s", "have", "they")
         };
         let (n, list) = (docs.len(), list.join(", "));
         Some(if self.is_complete() {
             format!(
                 "… {n} Document element{s} {have} no readable content: {list}. The web engine \
-                 has not published its accessibility tree, or the page is empty. Elements \
-                 inside {them} cannot be addressed by id. Drive by pixels: glass_screenshot, \
-                 then glass_click at x,y inside the bounds above."
+                 has not published its accessibility tree yet, or the page is empty. Take a \
+                 fresh glass_a11y_snapshot after a moment; if it stays empty, drive it by \
+                 pixels: glass_screenshot, then glass_click at x,y inside the bounds above."
             )
         } else {
             format!(
@@ -2574,6 +2578,23 @@ mod tests {
             "singular, aggregated: {hint}"
         );
         assert!(hint.contains("has not published"), "{hint}");
+    }
+
+    /// The reading behind this (Android emulator, 2026-08-24): the first snapshot after a launch
+    /// holds a childless Document and the next holds the whole page, so childless on a complete
+    /// walk is most often *not yet*.
+    #[test]
+    fn a_complete_walk_steers_to_a_fresh_snapshot_before_pixels() {
+        let hint = tree_with_a_childless_document()
+            .document_guidance()
+            .unwrap();
+        let fresh = hint
+            .find("fresh glass_a11y_snapshot")
+            .unwrap_or_else(|| panic!("re-reading is the first recourse: {hint}"));
+        let pixels = hint
+            .find("glass_screenshot")
+            .unwrap_or_else(|| panic!("the pixel path is still named: {hint}"));
+        assert!(fresh < pixels, "the re-read comes first: {hint}");
     }
 
     #[test]

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -481,6 +481,7 @@ pub struct WalkBudget {
     count: usize,
     truncated: Option<Truncation>,
     unreadable: usize,
+    unexposed: usize,
     limits: WalkLimits,
 }
 
@@ -496,6 +497,7 @@ impl WalkBudget {
             count: 0,
             truncated: None,
             unreadable: 0,
+            unexposed: 0,
             limits,
         }
     }
@@ -584,6 +586,20 @@ impl WalkBudget {
         self.unreadable
     }
 
+    /// Record a placeholder the app published in place of content it has not exposed to
+    /// accessibility.
+    ///
+    /// Distinct from [`WalkBudget::note_unreadable`]: nothing failed and nothing vanished, so
+    /// re-reading is no recourse — the app is withholding the subtree, not losing it.
+    pub fn note_unexposed(&mut self) {
+        self.unexposed += 1;
+    }
+
+    /// How many placeholders stood in for content the app has not exposed.
+    pub fn unexposed(&self) -> usize {
+        self.unexposed
+    }
+
     /// Record that a bound stopped the walk. Only the FIRST hit is kept: it is the cause,
     /// while any later hit is a consequence of having continued.
     pub fn hit(&mut self, limit: TruncationLimit) {
@@ -628,6 +644,10 @@ pub struct AxTree {
     /// Subtrees dropped because a child read failed. Independent of [`AxTree::truncated`]: a
     /// tree can hit no bound at all and still be missing elements this way.
     pub unreadable: usize,
+    /// Placeholders the app published in place of content it has not exposed to accessibility —
+    /// on AT-SPI, a null child ref. Not [`AxTree::unreadable`]: the walk reached these and the
+    /// app was withholding what is behind them, so the walk itself still completed.
+    pub unexposed: usize,
     /// `Some` when the backend answered about something other than what it was asked about —
     /// see [`Subject`].
     pub subject: Option<Subject>,
@@ -635,7 +655,8 @@ pub struct AxTree {
 
 impl AxTree {
     /// Whether this tree describes everything the backend walked — no bound stopped it early and
-    /// no child read dropped a subtree.
+    /// no child read dropped a subtree. [`AxTree::unexposed`] does not count: the walk finished
+    /// and the app withheld the content.
     #[must_use]
     pub fn is_complete(&self) -> bool {
         self.truncated.is_none() && self.unreadable == 0
@@ -649,6 +670,7 @@ impl AxTree {
             count: 0,
             truncated: None,
             unreadable: 0,
+            unexposed: 0,
             subject: None,
         }
     }
@@ -736,6 +758,27 @@ impl AxTree {
                  show them; otherwise drive that area by pixels: glass_screenshot, then \
                  glass_click at x,y.",
                 if self.unreadable == 1 { "is" } else { "are" },
+            )
+        })
+    }
+
+    /// Disclosure for placeholders the app published in place of content it has not exposed —
+    /// [`AxTree::unexposed`]. Separate from [`AxTree::unreadable_notice`] because the recourse
+    /// differs: the walk reached these and nothing failed, so a fresh snapshot returns the same
+    /// placeholder and only the pixel path is left.
+    pub fn unexposed_notice(&self) -> Option<String> {
+        (self.unexposed > 0).then(|| {
+            let n = self.unexposed;
+            let (s, are, they) = if n == 1 {
+                ("", "is a placeholder", "It")
+            } else {
+                ("s", "are placeholders", "They")
+            };
+            format!(
+                "… {n} element{s} {are} the app published for content it has not exposed to \
+                 accessibility (a web view whose accessibility is off reads like this). {they} \
+                 cannot be addressed by id; drive that area by pixels: glass_screenshot, then \
+                 glass_click at x,y."
             )
         })
     }
@@ -3274,6 +3317,76 @@ mod tests {
             None,
             "an unreadable read is not a bound hit"
         );
+    }
+
+    /// The reading behind this (Brave 151 on X11, 2026-08-24): the browser window's one child is
+    /// a null AT-SPI ref while renderer accessibility is off. Counted as unreadable, the agent
+    /// was told the element went away mid-walk and to re-snapshot — advice that never helps.
+    #[test]
+    fn a_withheld_placeholder_is_disclosed_as_unexposed_not_as_a_vanished_element() {
+        let mut t = AxTree::new(leaf(AxRole::Window, "w"));
+        t.unexposed = 1;
+        let n = t
+            .unexposed_notice()
+            .expect("a placeholder for withheld content must disclose");
+        assert!(n.contains("placeholder"), "{n}");
+        assert!(n.contains("has not exposed"), "{n}");
+        assert!(
+            n.contains("glass_screenshot") && n.contains("glass_click"),
+            "the pixel path is the only recourse: {n}"
+        );
+        assert!(
+            !n.contains("went away"),
+            "nothing vanished, so a re-snapshot is not the recourse: {n}"
+        );
+    }
+
+    #[test]
+    fn a_tree_withholding_nothing_yields_no_unexposed_notice() {
+        assert_eq!(
+            AxTree::new(leaf(AxRole::Window, "w")).unexposed_notice(),
+            None
+        );
+    }
+
+    /// Singular and plural both read as English, since the count is agent-facing text.
+    #[test]
+    fn the_unexposed_notice_agrees_in_number() {
+        let mut t = AxTree::new(leaf(AxRole::Window, "w"));
+        t.unexposed = 1;
+        let one = t.unexposed_notice().unwrap();
+        assert!(one.contains("1 element is a placeholder"), "{one}");
+        assert!(one.contains("It cannot be addressed"), "{one}");
+        t.unexposed = 2;
+        let many = t.unexposed_notice().unwrap();
+        assert!(many.contains("2 elements are placeholders"), "{many}");
+        assert!(many.contains("They cannot be addressed"), "{many}");
+    }
+
+    /// A withheld placeholder is not an incomplete walk, which is what lets `document_guidance`
+    /// still name the engine instead of hedging.
+    #[test]
+    fn a_withheld_placeholder_leaves_the_walk_complete() {
+        let mut t = AxTree::new(leaf(AxRole::Window, "w"));
+        t.unexposed = 1;
+        assert!(
+            t.is_complete(),
+            "the app withheld content; the walk finished"
+        );
+    }
+
+    #[test]
+    fn the_budget_counts_a_withheld_placeholder_separately_from_an_unreadable_subtree() {
+        let mut b = WalkBudget::new();
+        assert_eq!(b.unexposed(), 0);
+        b.note_unexposed();
+        assert_eq!(b.unexposed(), 1);
+        assert_eq!(
+            b.unreadable(),
+            0,
+            "a placeholder is not a failed read: the recourses differ"
+        );
+        assert_eq!(b.truncation(), None, "nor is it a bound hit");
     }
 
     #[test]

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -762,6 +762,17 @@ impl AxTree {
         })
     }
 
+    /// Whether this tree can support a claim that something is *not* there: the walk completed
+    /// **and** nothing was withheld ([`Self::unexposed`]).
+    ///
+    /// A placeholder hides an unknown number of elements, so "no node carries this role and name"
+    /// describes only what the app published. Relocation asks this, not [`Self::is_complete`],
+    /// which answers the narrower question of whether the walk itself finished.
+    #[must_use]
+    pub fn can_prove_absence(&self) -> bool {
+        self.is_complete() && self.unexposed == 0
+    }
+
     /// Disclosure for placeholders the app published in place of content it has not exposed —
     /// [`AxTree::unexposed`]. Separate from [`AxTree::unreadable_notice`] because the recourse
     /// differs: the walk reached these and nothing failed, so a fresh snapshot returns the same
@@ -854,18 +865,19 @@ impl AxTree {
             })
             .collect();
         let one = docs.len() == 1;
-        let (s, have, they) = if one {
-            ("", "has", "it")
+        let (s, have, they, them) = if one {
+            ("", "has", "it", "it")
         } else {
-            ("s", "have", "they")
+            ("s", "have", "they", "them")
         };
         let (n, list) = (docs.len(), list.join(", "));
         Some(if self.is_complete() {
             format!(
                 "… {n} Document element{s} {have} no readable content: {list}. The web engine \
-                 has not published its accessibility tree yet, or the page is empty. Take a \
-                 fresh glass_a11y_snapshot after a moment; if it stays empty, drive it by \
-                 pixels: glass_screenshot, then glass_click at x,y inside the bounds above."
+                 has not published its accessibility tree yet, or the page is empty. Elements \
+                 inside {them} cannot be addressed by id. Take a fresh glass_a11y_snapshot \
+                 after a moment; if it stays empty, drive it by pixels: glass_screenshot, then \
+                 glass_click at x,y inside the bounds above."
             )
         } else {
             format!(
@@ -992,8 +1004,9 @@ impl AxTarget {
     /// usually its resource-id leaf, which names a *layout* and so repeats across every screen
     /// built from it — so [`Located::Moved`] is not granted on the search alone. It also needs:
     ///
-    /// * [`AxTree::is_complete`], because "one node matches" is a claim about the whole tree and a
-    ///   read that stopped early can only make it about the part it kept; and
+    /// * [`AxTree::can_prove_absence`], because "one node matches" is a claim about the whole
+    ///   tree, and a read that stopped early — or one the app withheld a subtree from — can only
+    ///   make it about the part it kept; and
     /// * the candidate's bounds to *overlap* the target's, so a same-named field on a screen the
     ///   write navigated to is not mistaken for the one that was written into.
     ///
@@ -1013,10 +1026,10 @@ impl AxTarget {
         let mut candidates = Vec::new();
         collect_matches(&tree.root, self, &mut candidates);
         match candidates.len() {
-            1 if tree.is_complete() && self.bounds_overlap(candidates[0].bounds) => {
+            1 if tree.can_prove_absence() && self.bounds_overlap(candidates[0].bounds) => {
                 Located::Moved(candidates[0])
             }
-            0 if tree.is_complete() => Located::Gone,
+            0 if tree.can_prove_absence() => Located::Gone,
             0 | 1 => Located::Unproven,
             _ => Located::Ambiguous(candidates),
         }
@@ -1029,8 +1042,9 @@ impl AxTarget {
     /// was replaced or the app that drew it restarted (glass#323); telling that caller to
     /// re-address the id is how a `set_value` read-back retypes a write that already landed.
     ///
-    /// An incomplete tree cannot support that second answer: it shows absence only for the part it
-    /// kept, so one that is not [`AxTree::is_complete`] gets the recoverable `AxElementChanged`.
+    /// A tree that cannot prove absence cannot support that second answer: it shows absence only
+    /// for the part it kept, so one failing [`AxTree::can_prove_absence`] — stopped early, or
+    /// missing what the app withheld — gets the recoverable `AxElementChanged`.
     ///
     /// Lives in core rather than in its caller because the question is not Android's: any reader
     /// holding an `AxTree` asks it before a write, and the desktop ones would if they had a tree
@@ -1041,7 +1055,7 @@ impl AxTarget {
     /// [`GlassError::AxWriteUnconfirmed`], which says the text went out.
     #[must_use]
     pub fn drift_error(&self, tree: &AxTree) -> GlassError {
-        if self.still_present(tree) || !tree.is_complete() {
+        if self.still_present(tree) || !tree.can_prove_absence() {
             GlassError::AxElementChanged(self.id.0)
         } else {
             GlassError::AxElementGone(self.id.0)
@@ -2293,6 +2307,28 @@ mod tests {
         assert!(matches!(drift_target().relocate(&tree), Located::Unproven));
     }
 
+    #[test]
+    fn a_withheld_subtree_cannot_prove_the_target_absent() {
+        let mut tree = drift_tree(vec![leaf(AxRole::Label, "No Results")]);
+        tree.unexposed = 1;
+        assert!(
+            tree.is_complete(),
+            "the walk finished; only the app withheld"
+        );
+        assert!(matches!(drift_target().relocate(&tree), Located::Unproven));
+    }
+
+    #[test]
+    fn a_lone_match_is_not_accepted_as_moved_while_a_subtree_is_withheld() {
+        // "Exactly one node matches" is a claim about the whole tree, and a placeholder hides an
+        // unknown number of nodes behind it.
+        let mut occupied = leaf(AxRole::Button, "Cancel");
+        occupied.children = vec![leaf(AxRole::TextField, "Note")];
+        let mut tree = drift_tree(vec![occupied]);
+        tree.unexposed = 1;
+        assert!(matches!(drift_target().relocate(&tree), Located::Unproven));
+    }
+
     /// Where the measured iOS field sat before the write: origin `(99,2409)`, 1008px wide.
     const CAPTURED: AxRect = AxRect {
         x: 99,
@@ -2511,6 +2547,18 @@ mod tests {
     }
 
     #[test]
+    fn a_withheld_subtree_never_reports_the_target_gone() {
+        // Complete, so `is_complete` cannot catch it — the element may be behind the placeholder.
+        let mut withheld = drift_tree(vec![leaf(AxRole::Label, "No Results")]);
+        withheld.unexposed = 1;
+        assert!(withheld.is_complete(), "the walk finished");
+        assert!(matches!(
+            drift_target().drift_error(&withheld),
+            GlassError::AxElementChanged(1)
+        ));
+    }
+
+    #[test]
     fn empty_guidance_flags_a_treeless_snapshot() {
         // Only the window root, no children → nothing to address → steer to pixels.
         let empty = AxTree::new(leaf(AxRole::Window, "App"));
@@ -2565,6 +2613,10 @@ mod tests {
             "names the pixel path: {hint}"
         );
         assert!(hint.contains("glass_click"), "names the pixel path: {hint}");
+        assert!(
+            hint.contains("cannot be addressed by id"),
+            "nothing inside is addressable: {hint}"
+        );
     }
 
     #[test]

--- a/crates/glass-core/src/role_support.rs
+++ b/crates/glass-core/src/role_support.rs
@@ -626,12 +626,7 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
             R::Document,
             [
                 Mapped,
-                Gap {
-                    unmapped: None,
-                    why: "UIA's Document control type maps to TextArea, read from a text \
-                     editor's edit surface; what a web document reports on this backend has \
-                     not been read, so the cell waits on that reading",
-                },
+                Mapped,
                 Mapped,
                 Mapped,
                 NotApplicable {
@@ -906,13 +901,12 @@ mod tests {
                 "{backend:?} has no Document cell"
             );
         }
-        // Windows keeps UIA Document on TextArea until a web document is read there.
-        // `unmapped` stays `None`: UIA's Document IS mapped, just to another role, so
-        // "`Document` arrives unmapped" would send a reader hunting for `Other(Document)`.
-        assert!(matches!(
+        // Windows tells a web page's Document from a text editor's by the FrameworkId the
+        // element reports.
+        assert_eq!(
             support(AxRole::Document, AxBackend::Windows),
-            Some(RoleSupport::Gap { unmapped: None, .. })
-        ));
+            Some(RoleSupport::Mapped)
+        );
         // iOS reads nothing at all for a WKWebView, so no token stands in for the role.
         assert!(matches!(
             support(AxRole::Document, AxBackend::Ios),

--- a/crates/glass-core/src/role_support.rs
+++ b/crates/glass-core/src/role_support.rs
@@ -634,7 +634,13 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 },
                 Mapped,
                 Mapped,
-                Mapped,
+                NotApplicable {
+                    basis: Unmarked,
+                    instead: None,
+                    why: "a WKWebView page exposes no element at all through idb — neither the \
+                     view nor its content (read on the iOS 26.5 Simulator, companions 1.5.0b3 \
+                     and 1.1.8)",
+                },
             ],
         ),
     ]
@@ -906,6 +912,15 @@ mod tests {
         assert!(matches!(
             support(AxRole::Document, AxBackend::Windows),
             Some(RoleSupport::Gap { unmapped: None, .. })
+        ));
+        // iOS reads nothing at all for a WKWebView, so no token stands in for the role.
+        assert!(matches!(
+            support(AxRole::Document, AxBackend::Ios),
+            Some(RoleSupport::NotApplicable {
+                basis: Basis::Unmarked,
+                instead: None,
+                ..
+            })
         ));
     }
 }

--- a/crates/glass-core/src/set_value.rs
+++ b/crates/glass-core/src/set_value.rs
@@ -11,7 +11,7 @@
 //! An *atomic platform write* (UIA `SetValue`, AX `AXValue`) either happens or does not, and may be
 //! reformatted on the way in — a slider set to `"50"` reads back `"50.0"`. So a value that merely
 //! differs from the old one is evidence it landed: [`read_back_confirms`]. The macOS and Windows
-//! readers had each grown their own copy of that rule; it is theirs.
+//! readers had each grown their own copy of that rule; it is theirs, and the AT-SPI reader's.
 //!
 //! A *typed write* (tap, select-all, delete, type) is not atomic. A dropped key, a `maxLength`, an
 //! input filter or autocorrect all leave the field holding something that is neither the request nor
@@ -19,9 +19,8 @@
 //! typed write must read back exactly what was asked: [`typed_text_landed`]. Android's on-device
 //! service reader reached the same conclusion independently (`a11y_service.rs`).
 //!
-//! Two write paths deliberately do not use either rule: the AT-SPI (Linux) reader trusts the
-//! toolkit's own `set_text_contents` answer without reading back, and Android's service reader keeps
-//! its own exact-match loop.
+//! One write path deliberately uses neither rule: Android's service reader keeps its own
+//! exact-match loop.
 //!
 //! [`verify_typed_write`] applies the typed rule to a whole tree read back after the keystrokes,
 //! and is what the tap-and-type backends (Android's `uiautomator` reader, iOS) call;

--- a/crates/glass-core/src/set_value.rs
+++ b/crates/glass-core/src/set_value.rs
@@ -195,9 +195,9 @@ pub fn verify_typed_write(
             ));
         }
         Located::Unproven => {
-            // Keep the cap in the message: it is what tells a caller to raise `max_nodes`. A
-            // complete tree has no hole to blame, so the one way it
-            // reaches here is a lone match drawn clear of where the element was.
+            // Keep the cap in the message: it is what tells a caller to raise `max_nodes`. With
+            // no hole to blame — no cap, no dropped subtree, no withheld placeholder — the one way
+            // it reaches here is a lone match drawn clear of where the element was.
             let why = if let Some(t) = &after_tree.truncated {
                 format!(
                     "the tree was truncated at {} {}, so the element — or a second one matching \
@@ -208,6 +208,10 @@ pub fn verify_typed_write(
             } else if after_tree.unreadable > 0 {
                 "a subtree could not be read, so the element — or a second one matching it — may \
                  be inside it"
+                    .to_string()
+            } else if after_tree.unexposed > 0 {
+                "the app published a placeholder for content it has not exposed, so the element \
+                 — or a second one matching it — may be behind it"
                     .to_string()
             } else {
                 "the only element carrying its role and name is drawn clear of where this one \
@@ -963,6 +967,21 @@ mod tests {
             assert!(matches!(err, GlassError::AxWriteUnconfirmed(1, _)), "{err}");
             assert!(err.set_value_failed_after_writing(), "{err}");
             assert!(err.to_string().contains("could not be read"), "{err}");
+        }
+
+        #[test]
+        fn a_withheld_subtree_cannot_confirm_a_write_against_its_one_match() {
+            // A complete tree with a placeholder in it: the second match can hide behind the
+            // placeholder, and neither the cap message nor the drifted-element one fits.
+            let mut moved = leaf(AxRole::TextField, "Note", FIELD);
+            moved.value = Some("world".into());
+            let mut after = tree_with(vec![leaf(AxRole::Label, "Suggestions", FIELD), moved]);
+            after.unexposed = 1;
+            let err = verify_typed_write(&after, &matching_target(), "world", TAP_MAY_HAVE_MISSED)
+                .unwrap_err();
+            assert!(matches!(err, GlassError::AxWriteUnconfirmed(1, _)), "{err}");
+            assert!(err.set_value_failed_after_writing(), "{err}");
+            assert!(err.to_string().contains("has not exposed"), "{err}");
         }
 
         #[test]

--- a/crates/glass-ios/src/axmap.rs
+++ b/crates/glass-ios/src/axmap.rs
@@ -52,8 +52,6 @@ pub const ROLE_TOKENS: &[(&str, AxRole)] = &[
     ("AXGroup", AxRole::Group),
     // A screen or section title.
     ("AXHeading", AxRole::Heading),
-    // The root of a web engine's subtree.
-    ("AXWebArea", AxRole::Document),
 ];
 
 /// Map an idb AX role string (e.g. `AXButton`) to a normalized [`AxRole`].
@@ -320,9 +318,12 @@ mod tests {
         assert_eq!(ax_role("AXWhatever"), AxRole::Other);
     }
 
+    /// Read on the iOS 26.5 Simulator (2026-08-24, companions 1.5.0b3 and 1.1.8): a WKWebView
+    /// page exposes no element through idb — not the page, not an empty web area, not the view
+    /// itself. `AXWebArea` came from the macOS token table and was never seen here.
     #[test]
-    fn a_web_area_is_a_document() {
-        assert_eq!(ax_role("AXWebArea"), AxRole::Document);
+    fn no_token_stands_for_a_web_page_on_this_backend() {
+        assert_eq!(ax_role("AXWebArea"), AxRole::Other);
     }
 
     #[test]

--- a/crates/glass-ios/tests/drive_integration.rs
+++ b/crates/glass-ios/tests/drive_integration.rs
@@ -25,13 +25,25 @@
 //! READY, flips to TAPPED when the button is tapped), `tapButton`, `inputField`, and
 //! `echoLabel` (mirrors the field's text, or `(empty)`) — see
 //! `examples/ios-fixture/README.md`.
+//!
+//! [`web_fixture_button_and_field_respond`] drives a different app — the role fixture's `web`
+//! tab, a stock `WKWebView` on `examples/web-role-fixture/index.html` — to read whether web
+//! content can be driven the same way at all:
+//!
+//! ```sh
+//! ./examples/ios-role-fixture/build.sh
+//! GLASS_IOS_ROLE_FIXTURE="$PWD/examples/ios-role-fixture/build/RoleFixture.app" \
+//!   cargo test -p glass-ios --test drive_integration -- --ignored --nocapture
+//! ```
 
 #![cfg(unix)]
 
 use std::time::Duration;
 
 use glass_core::Deadline;
-use glass_core::accessibility::{Accessibility, AxContext, AxNode, AxTarget, AxTree, WalkLimits};
+use glass_core::accessibility::{
+    Accessibility, AxContext, AxNode, AxRole, AxTarget, AxTree, WalkLimits,
+};
 use glass_core::{AppSpec, KeyEvent, MouseButton, Platform, PointerEvent, SandboxLevel};
 use glass_ios::{IosA11y, IosPlatform, SimulatorRegistry};
 
@@ -217,6 +229,214 @@ fn drive_fixture_snapshot_tap_and_type_end_to_end() {
          \"helloworld\" means the clear step failed",
         named_value(&replaced, "echoLabel")
     );
+
+    platform.stop_app().expect("stop_app");
+}
+
+/// The page's own elements, by the accessible name each carries on a platform that exposes web
+/// content at all. Shared with every other platform's web reading — the page is one file.
+const WEB_BUTTON: &str = "click me";
+/// See [`WEB_BUTTON`]; the text input's name comes from its `<label for>`.
+const WEB_INPUT: &str = "text input";
+/// What the page's result paragraph reads after the button fires.
+const WEB_CLICKED: &str = "clicked";
+/// What `set_value` writes into the text input.
+const WEB_TYPED: &str = "typed by glass";
+/// What the keyboard control types into the same field — a second route to it.
+const WEB_KEYED: &str = "keyed by glass";
+/// The `WKWebView`'s own `accessibilityIdentifier`, so the tree can be asked whether the web
+/// view itself arrived even when its content did not.
+const WEB_VIEW_ID: &str = "the-web-view";
+
+/// How long to let the page load before the first read. A `file://` page in a fresh web view is
+/// quick, but "the tree is empty" and "the page had not painted" are the two readings this test
+/// must never confuse, and the screenshot in `examples/ios-role-fixture/README.md` is what says
+/// which one this is.
+const WEB_LOAD_SETTLE: Duration = Duration::from_secs(3);
+
+/// The first node carrying `text` as its whole name or value. Exact rather than a substring: the
+/// page's result paragraph reads "not clicked" before the button fires, which contains
+/// "clicked".
+fn carries<'a>(tree: &'a AxTree, text: &str) -> Option<&'a AxNode> {
+    fn walk<'a>(node: &'a AxNode, text: &str) -> Option<&'a AxNode> {
+        if node.name.as_deref() == Some(text) || node.value.as_deref() == Some(text) {
+            return Some(node);
+        }
+        node.children.iter().find_map(|c| walk(c, text))
+    }
+    walk(&tree.root, text)
+}
+
+/// How many `Document` nodes the tree holds — the web-content boundary, and what
+/// `AxTree::document_guidance` discloses when one arrives with no children.
+fn document_count(tree: &AxTree) -> usize {
+    fn walk(node: &AxNode) -> usize {
+        usize::from(node.role == AxRole::Document) + node.children.iter().map(walk).sum::<usize>()
+    }
+    walk(&tree.root)
+}
+
+/// `node`'s window-pixel click centre, or `None` when it has no on-screen geometry.
+fn center_or_none(node: &AxNode, win: &glass_core::WindowGeometry) -> Option<(i32, i32)> {
+    node.bounds?.clamped_center(win.width, win.height)
+}
+
+/// Everything the tree says about itself, so a run that reads nothing still says what it read.
+fn report(label: &str, tree: &AxTree) {
+    println!(
+        "--- {label}: {} nodes, {} Document(s), complete={} ---",
+        tree.count,
+        document_count(tree),
+        tree.is_complete()
+    );
+    for notice in [
+        tree.truncation_notice(),
+        tree.unreadable_notice(),
+        tree.subject_notice(),
+        tree.empty_guidance().map(str::to_string),
+        tree.document_guidance(),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        println!("notice: {notice}");
+    }
+    println!("{}", tree.to_outline());
+}
+
+/// Read what a `WKWebView`'s page offers the driving path on iOS: whether the page's elements
+/// are in the tree at all, and if they are, whether a tap on the button and a `set_value` on the
+/// text input take.
+///
+/// A probe, not a mapping test. Only `start_app` and `snapshot` are asserted — both must FAIL the
+/// test rather than return quietly, since a launch that never happened would otherwise print an
+/// empty tree that reads exactly like "the engine published nothing". Everything after that is
+/// printed: an element the tree does not carry is a finding, and the test says so instead of
+/// panicking on it.
+#[test]
+#[ignore = "on-box only: needs a macOS host with Xcode + idb_companion + a booted iOS \
+            Simulator, and GLASS_IOS_ROLE_FIXTURE pointing at the examples/ios-role-fixture \
+            .app"]
+fn web_fixture_button_and_field_respond() {
+    let app = std::env::var("GLASS_IOS_ROLE_FIXTURE").expect(
+        "GLASS_IOS_ROLE_FIXTURE must be set to the examples/ios-role-fixture RoleFixture.app path",
+    );
+
+    // The web tab is chosen at launch: the tab bar's items are not accessibility elements and a
+    // synthetic tap on one does not switch tabs (see the fixture's README).
+    let spec = AppSpec {
+        build: None,
+        run: vec![app, "--tab".into(), "web".into()],
+        cwd: None,
+        env: vec![],
+        window_hint: None,
+        timeout_ms: 30_000,
+        sandbox: SandboxLevel::Off,
+        a11y: true,
+    };
+
+    let reg = SimulatorRegistry::new();
+    let mut platform = IosPlatform::from_env(&reg)
+        .expect("from_env: resolve/boot a Simulator and open the idb_companion input client");
+    let window = platform
+        .start_app(&spec)
+        .expect("start_app: install, launch, discover the point→pixel scale, report geometry");
+
+    let mut a11y = platform
+        .accessibility()
+        .expect("accessibility(): connect a second idb client to the same companion socket")
+        .expect("companion present on this on-box run, so a reader is available");
+    let ctx = AxContext {
+        pids: vec![],
+        window: window.clone(),
+        window_handle: None,
+        a11y_bus_addr: None,
+        // The node cap lifted: a page's tree is the thing being read, and a truncated walk would
+        // make an absent element indistinguishable from an unreached one.
+        limits: WalkLimits::from_max_nodes(Some(0)),
+        deadline: Deadline::UNBOUNDED,
+    };
+
+    std::thread::sleep(WEB_LOAD_SETTLE);
+    let mut initial = snapshot_until(&mut a11y, &ctx, 20, |t| carries(t, WEB_BUTTON).is_some());
+    initial.assign_ids();
+    report("initial", &initial);
+    println!(
+        "web view element {WEB_VIEW_ID:?} present: {}",
+        find_named(&initial.root, WEB_VIEW_ID).is_some()
+    );
+
+    match find_named(&initial.root, WEB_BUTTON) {
+        Some(button) => match center_or_none(button, &window) {
+            Some((bx, by)) => {
+                println!("tapping {WEB_BUTTON:?} at window-pixel ({bx},{by})");
+                platform.send_pointer(&tap(bx, by)).expect("send tap");
+                let mut after =
+                    snapshot_until(&mut a11y, &ctx, 12, |t| carries(t, WEB_CLICKED).is_some());
+                after.assign_ids();
+                println!(
+                    "after the tap, the result paragraph reads {WEB_CLICKED:?}: {}",
+                    carries(&after, WEB_CLICKED).is_some()
+                );
+                report("after the tap", &after);
+            }
+            None => println!("{WEB_BUTTON:?} is in the tree with no on-screen bounds: no tap"),
+        },
+        None => println!(
+            "no node named {WEB_BUTTON:?} — the page's elements are not in the tree, so there is \
+             nothing to address: no tap reading, and no set_value reading either"
+        ),
+    }
+
+    let mut for_target = a11y
+        .snapshot(&ctx)
+        .expect("snapshot for the set_value target");
+    for_target.assign_ids();
+    match find_named(&for_target.root, WEB_INPUT) {
+        Some(field) => {
+            let target = AxTarget {
+                id: field.id,
+                role: field.role,
+                name: field.name.clone(),
+                bounds: field.bounds,
+                value: field.value.clone(),
+            };
+            println!(
+                "set_value({WEB_INPUT:?}): {:?}",
+                a11y.set_value(&ctx, &target, WEB_TYPED)
+            );
+            let mut after =
+                snapshot_until(&mut a11y, &ctx, 12, |t| carries(t, WEB_TYPED).is_some());
+            after.assign_ids();
+            println!(
+                "text input value after set_value: {:?}",
+                find_named(&after.root, WEB_INPUT).and_then(|n| n.value.clone())
+            );
+
+            // The control. An empty read-back has two causes — the write never landed, or this
+            // reader never reports a web input's text — and only text that reached the field by
+            // another route tells them apart.
+            if let Some(field) = find_named(&after.root, WEB_INPUT)
+                && let Some((fx, fy)) = center_or_none(field, &window)
+            {
+                platform
+                    .send_pointer(&tap(fx, fy))
+                    .expect("focus the field");
+                std::thread::sleep(Duration::from_millis(700));
+                platform
+                    .send_key(&KeyEvent::Text(WEB_KEYED.into()))
+                    .expect("send_key type");
+                let mut keyed =
+                    snapshot_until(&mut a11y, &ctx, 12, |t| carries(t, WEB_KEYED).is_some());
+                keyed.assign_ids();
+                println!(
+                    "control — tap then type → text input value: {:?}",
+                    find_named(&keyed.root, WEB_INPUT).and_then(|n| n.value.clone())
+                );
+            }
+        }
+        None => println!("no node named {WEB_INPUT:?} — no set_value reading"),
+    }
 
     platform.stop_app().expect("stop_app");
 }

--- a/crates/glass-macos/Cargo.toml
+++ b/crates/glass-macos/Cargo.toml
@@ -61,6 +61,18 @@ harness = false
 name = "role_probe"
 harness = false
 
+# Mac-gated web-content PROBE (crates/glass-macos/tests/web_probe.rs) — not a pass/fail
+# assertion test. Same harness=false main-thread requirement as `role_probe` above
+# (`MacosPlatform::start_app` reaches AppKit's `ffi::app_kit_init()`). Launches whatever
+# browsers `GLASS_WEB_PROBE_BROWSERS` names on the `examples/web-role-fixture` page and prints
+# what each engine publishes through `AXUIElement`, with the enable lever
+# `GLASS_WEB_PROBE_LEVER` names (`enhanced`/`manual`) set on the application element. With the
+# browser variable unset it times snapshots of an ordinary AppKit app either side of the lever
+# instead — the side-effect reading. See that file's module doc.
+[[test]]
+name = "web_probe"
+harness = false
+
 # Mac-gated window-adoption PROBE (crates/glass-macos/tests/window_adopt_probe.rs) — not a
 # pass/fail assertion test. Same harness=false main-thread requirement as the targets above
 # (`MacosPlatform::start_app` reaches AppKit's `ffi::app_kit_init()`). Launches the app named

--- a/crates/glass-macos/tests/web_probe.rs
+++ b/crates/glass-macos/tests/web_probe.rs
@@ -8,10 +8,15 @@
 //! ```
 //!
 //! `GLASS_WEB_PROBE_BROWSERS` is a comma-separated list of launch commands — `.app` bundle
-//! paths or plain executables, exactly what `AppSpec::run[0]` accepts. Each is launched with
-//! the `examples/web-role-fixture/index.html` page as `run[1]`; when the launch path drops
-//! that argument (an app LaunchServices opens by bundle rather than by command line), the
-//! probe navigates by typing the URL into the address bar instead, and says which route ran.
+//! paths or plain executables, exactly what `AppSpec::run[0]` accepts. Each is launched on a
+//! fresh profile directory with the `examples/web-role-fixture/index.html` page as the last
+//! element of `run`.
+//!
+//! The argument does reach the app: a bundle launch carries `run[1..]` through
+//! `NSWorkspaceOpenConfiguration.setArguments`. An app can still decline to *open* it — Safari
+//! answers a `file://` URL given as `argv` with its own "Failed to open page" — so when the
+//! window title does not show the page, the probe types the URL into the address bar instead.
+//! It prints which of the two routes delivered the page.
 //!
 //! `GLASS_WEB_PROBE_LEVER` picks the enable lever set on the *application* element after the
 //! launch: `enhanced` → `AXEnhancedUserInterface`, `manual` → `AXManualAccessibility`,
@@ -52,6 +57,7 @@ fn main() {
 
 #[cfg(target_os = "macos")]
 mod macos_main {
+    use std::path::Path;
     use std::ptr::NonNull;
     use std::time::{Duration, Instant};
 
@@ -152,6 +158,10 @@ mod macos_main {
         let name = CFString::from_str(attr);
         // `objc2-core-foundation` has no `CFBoolean` constructor; the two singletons are the
         // documented way to name a CF boolean, as `glass-macos::session`'s tests do.
+        //
+        // SAFETY: `kCFBooleanTrue` is an immortal Core Foundation singleton — reading the extern
+        // static is a plain load of a pointer CF keeps valid for the process's lifetime, and the
+        // binding hands it back as an `Option` so a null is handled rather than dereferenced.
         let value: &CFType = match unsafe { kCFBooleanTrue } {
             Some(v) => v,
             None => return Err("kCFBooleanTrue was null".to_string()),
@@ -791,10 +801,82 @@ mod macos_main {
         }
     }
 
-    fn browser_spec(browser: &str, url: &str) -> AppSpec {
-        AppSpec {
+    /// Which browser family a launch command names, decided from the executable or bundle
+    /// name. Nothing else in the launch says which engine this is, and the profile flag and the
+    /// first-run suppression differ per family.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum Engine {
+        Gecko,
+        Chromium,
+        /// Anything else — including a `.app` bundle glass hands to LaunchServices. It gets no
+        /// profile flag, and the page reaches it by the address bar (see the module doc).
+        Other,
+    }
+
+    impl Engine {
+        fn of(browser: &str) -> Self {
+            let name = Path::new(browser)
+                .file_name()
+                .map(|n| n.to_string_lossy().to_lowercase())
+                .unwrap_or_default();
+            if ["firefox", "librewolf", "waterfox"]
+                .iter()
+                .any(|n| name.contains(n))
+            {
+                Engine::Gecko
+            } else if ["chrome", "chromium", "brave", "edge", "vivaldi", "opera"]
+                .iter()
+                .any(|n| name.contains(n))
+            {
+                Engine::Chromium
+            } else {
+                Engine::Other
+            }
+        }
+    }
+
+    /// The prefs a fresh Gecko profile needs, so the reading is of the page rather than of a
+    /// welcome tab, a migration modal or a data-policy notification sitting in front of it.
+    const GECKO_USER_JS: &str = concat!(
+        "user_pref(\"browser.aboutwelcome.enabled\", false);\n",
+        "user_pref(\"browser.migrate.content-modal.enabled\", false);\n",
+        "user_pref(\"browser.startup.homepage_override.mstone\", \"ignore\");\n",
+        "user_pref(\"browser.startup.upgradeDialog.enabled\", false);\n",
+        "user_pref(\"browser.shell.checkDefaultBrowser\", false);\n",
+        "user_pref(\"datareporting.policy.dataSubmissionPolicyBypassNotification\", true);\n",
+        "user_pref(\"toolkit.telemetry.reportingpolicy.firstRun\", false);\n",
+    );
+
+    /// The launch spec for `browser`, on the fresh `profile` directory the caller owns.
+    ///
+    /// A fresh profile per launch is what keeps the reading repeatable: no first-run prompts, no
+    /// session restore, and no already-running instance adopting the URL instead of starting a
+    /// process glass owns. The caller must hold the directory for the life of the launch —
+    /// dropping it deletes the profile out from under a running browser.
+    fn browser_spec(browser: &str, url: &str, profile: &Path) -> Result<AppSpec, String> {
+        let mut run = vec![browser.to_string()];
+        match Engine::of(browser) {
+            Engine::Gecko => {
+                std::fs::write(profile.join("user.js"), GECKO_USER_JS)
+                    .map_err(|e| format!("writing the Gecko profile's user.js: {e}"))?;
+                run.extend([
+                    "--no-remote".to_string(),
+                    "--new-instance".to_string(),
+                    "--profile".to_string(),
+                    profile.display().to_string(),
+                ]);
+            }
+            Engine::Chromium => run.extend([
+                format!("--user-data-dir={}", profile.display()),
+                "--no-first-run".to_string(),
+                "--no-default-browser-check".to_string(),
+            ]),
+            Engine::Other => {}
+        }
+        run.push(url.to_string());
+        Ok(AppSpec {
             build: None,
-            run: vec![browser.to_string(), url.to_string()],
+            run,
             cwd: None,
             env: vec![],
             window_hint: Some(WindowHint {
@@ -804,17 +886,30 @@ mod macos_main {
             timeout_ms: LAUNCH_TIMEOUT_MS,
             sandbox: SandboxLevel::Off,
             a11y: true,
-        }
+        })
     }
 
-    fn probe_browser(browser: &str, lever: Lever, url: &str) -> Result<(), String> {
+    /// Probe one browser. `Ok` carries the blind spots this run found — content that never
+    /// arrived *and* no disclosure explaining it, which is a reading about glass rather than a
+    /// breakage — so [`run`] can repeat them in its summary. `Err` is reserved for the run
+    /// itself breaking: a launch that failed, or a reader that never answered.
+    fn probe_browser(browser: &str, lever: Lever, url: &str) -> Result<Vec<String>, String> {
         println!("\n=== macos / {browser} / lever={lever:?} ===");
-        let spec = browser_spec(browser, url);
+        // Held for the whole launch: dropping it deletes the profile out from under the browser.
+        let profile = tempfile::tempdir().map_err(|e| format!("profile dir for {browser}: {e}"))?;
+        let spec = browser_spec(browser, url, profile.path())?;
+        println!("engine family: {:?}", Engine::of(browser));
         println!("run: {:?}", spec.run);
         let mut platform =
             MacosPlatform::new().map_err(|e| format!("MacosPlatform::new(): {e}"))?;
 
         with_stop_app(&mut platform, browser, |platform| {
+            // Breakage is collected rather than returned at the first sign of it: the readings
+            // after it are still worth printing, and `with_stop_app` must reap the browser
+            // either way. Returned at the end of this closure so `run` can fail the process
+            // once, after every target has been probed and stopped.
+            let mut broke: Vec<String> = Vec::new();
+            let mut blind: Vec<String> = Vec::new();
             let started = Instant::now();
             let geometry = platform
                 .start_app(&spec)
@@ -824,11 +919,15 @@ mod macos_main {
 
             let carried = wait_for_page_title(platform, Duration::from_secs(6));
             if carried {
-                println!("url delivery: the launch carried AppSpec::run[1] to the browser");
+                println!("url delivery: the launch's own argument opened the page");
             } else {
+                // The argument reached the app — a bundle launch carries `run[1..]` through
+                // `NSWorkspaceOpenConfiguration.setArguments` — and the app declined to open
+                // it. Safari's decline is visible in the window title above: "Failed to open
+                // page", its own error page for a `file://` URL handed over as `argv`.
                 println!(
-                    "url delivery: the launch did not carry AppSpec::run[1] — navigating by \
-                     address bar"
+                    "url delivery: the launch carried AppSpec::run's tail, but the app did not \
+                     open the page from it — navigating by address bar"
                 );
                 navigate_by_address_bar(platform, url)?;
                 let loaded = wait_for_page_title(platform, Duration::from_secs(10));
@@ -852,7 +951,12 @@ mod macos_main {
                     documents(&tree).len(),
                     page_marker(&tree)
                 ),
-                Err(e) => println!("first snapshot after load failed: {e}"),
+                Err(e) => {
+                    println!("first snapshot after load failed: {e}");
+                    broke.push(format!(
+                        "{browser}: the first snapshot after the page loaded failed: {e}"
+                    ));
+                }
             }
             report_raw("after the first snapshot, before the lever", &raw_scan(pid));
 
@@ -869,19 +973,44 @@ mod macos_main {
                     report_iframe(&tree);
                     if arrived {
                         exercise(platform, &mut a11y, &ctx);
-                        if let Ok(after) = snapshot(&mut a11y, &ctx) {
-                            println!("--- tree after actuation ---");
-                            report_tree(&after);
+                        match snapshot(&mut a11y, &ctx) {
+                            Ok(after) => {
+                                println!("--- tree after actuation ---");
+                                report_tree(&after);
+                            }
+                            Err(e) => {
+                                println!("snapshot after actuation failed: {e}");
+                                broke.push(format!(
+                                    "{browser}: the snapshot after actuation failed: {e}"
+                                ));
+                            }
                         }
                     } else if let Some(hint) = tree.document_guidance() {
                         println!("disclosure rendered:\n{hint}");
                     } else {
+                        // A reading, not a breakage — finding this is why the probe exists. It
+                        // goes to `run`'s summary so it cannot be lost in the output above.
                         println!("NO DOCUMENT AND NO DISCLOSURE — the blind spot");
+                        blind.push(format!(
+                            "{browser} (lever={lever:?}): no page content arrived within \
+                             {SETTLE:?}, and the tree carried no Document to disclose — an \
+                             agent reading this app is told nothing"
+                        ));
                     }
                 }
-                None => println!("no tree at all — nothing was published within {SETTLE:?}"),
+                None => {
+                    println!("no tree at all — nothing was published within {SETTLE:?}");
+                    broke.push(format!(
+                        "{browser}: no snapshot succeeded within {SETTLE:?} — the reader never \
+                         answered, so this run read nothing"
+                    ));
+                }
             }
-            Ok(())
+            if broke.is_empty() {
+                Ok(blind)
+            } else {
+                Err(broke.join("\n"))
+            }
         })
     }
 
@@ -890,8 +1019,9 @@ mod macos_main {
 
     /// Five snapshot wall-clocks, printed individually beside the mean so one slow outlier is
     /// visible rather than averaged away.
-    fn time_snapshots(label: &str, a11y: &mut MacosA11y, ctx: &AxContext) {
+    fn time_snapshots(label: &str, a11y: &mut MacosA11y, ctx: &AxContext) -> Result<(), String> {
         let mut samples = Vec::with_capacity(TIMING_REPEATS);
+        let mut broke = None;
         for repeat in 0..TIMING_REPEATS {
             let started = Instant::now();
             match a11y.snapshot(ctx) {
@@ -901,8 +1031,14 @@ mod macos_main {
                     std::hint::black_box(&tree);
                     samples.push(started.elapsed().as_secs_f64() * 1000.0);
                 }
+                // The samples taken so far still print below — "the first one failed" and "they
+                // grew and then failed" are different findings — but a timing block that could
+                // not finish is read breakage, and the run must not pass on it.
                 Err(e) => {
                     println!("  {label}: repeat {repeat} failed: {e}");
+                    broke = Some(format!(
+                        "{label}: snapshot {repeat} of {TIMING_REPEATS} failed: {e}"
+                    ));
                     break;
                 }
             }
@@ -914,6 +1050,7 @@ mod macos_main {
             samples.iter().sum::<f64>() / samples.len() as f64
         };
         println!("  {label}: mean {mean:.0}ms over {rendered:?}");
+        broke.map_or(Ok(()), Err)
     }
 
     /// The side-effect reading: what leaving a lever set costs an ordinary AppKit app. Both
@@ -935,6 +1072,8 @@ mod macos_main {
             MacosPlatform::new().map_err(|e| format!("MacosPlatform::new(): {e}"))?;
 
         with_stop_app(&mut platform, TIMING_APP, |platform| {
+            // Collected, not returned early: see `probe_browser`'s closure for why.
+            let mut broke: Vec<String> = Vec::new();
             let geometry = platform
                 .start_app(&spec)
                 .map_err(|e| format!("start_app({TIMING_APP}): {e}"))?;
@@ -943,10 +1082,16 @@ mod macos_main {
 
             let ctx = context(platform, &geometry);
             let mut a11y = MacosA11y::new();
-            if let Ok(tree) = snapshot(&mut a11y, &ctx) {
-                println!("tree before the lever: {} nodes", tree.count);
+            match snapshot(&mut a11y, &ctx) {
+                Ok(tree) => println!("tree before the lever: {} nodes", tree.count),
+                Err(e) => {
+                    println!("tree before the lever: snapshot failed: {e}");
+                    broke.push(format!(
+                        "{TIMING_APP}: the snapshot before the lever failed: {e}"
+                    ));
+                }
             }
-            time_snapshots("before the lever", &mut a11y, &ctx);
+            broke.extend(time_snapshots("before the lever", &mut a11y, &ctx).err());
 
             let pid = app_pid(platform)?;
             // With no lever, the block below is the measurement's own noise — the control for a
@@ -954,11 +1099,21 @@ mod macos_main {
             apply_lever(pid, lever);
             std::thread::sleep(ACTION_SETTLE);
 
-            if let Ok(tree) = snapshot(&mut a11y, &ctx) {
-                println!("tree after the lever: {} nodes", tree.count);
+            match snapshot(&mut a11y, &ctx) {
+                Ok(tree) => println!("tree after the lever: {} nodes", tree.count),
+                Err(e) => {
+                    println!("tree after the lever: snapshot failed: {e}");
+                    broke.push(format!(
+                        "{TIMING_APP}: the snapshot after the lever failed: {e}"
+                    ));
+                }
             }
-            time_snapshots("after the lever", &mut a11y, &ctx);
-            Ok(())
+            broke.extend(time_snapshots("after the lever", &mut a11y, &ctx).err());
+            if broke.is_empty() {
+                Ok(())
+            } else {
+                Err(broke.join("\n"))
+            }
         })
     }
 
@@ -969,11 +1124,13 @@ mod macos_main {
         println!("page: {url}");
 
         let mut failures = Vec::new();
+        let mut blind_spots: Vec<String> = Vec::new();
         match std::env::var(BROWSERS_VAR) {
             Ok(list) if !list.trim().is_empty() => {
                 for browser in list.split(',').map(str::trim).filter(|s| !s.is_empty()) {
-                    if let Err(e) = probe_browser(browser, lever, &url) {
-                        failures.push(e);
+                    match probe_browser(browser, lever, &url) {
+                        Ok(blind) => blind_spots.extend(blind),
+                        Err(e) => failures.push(e),
                     }
                 }
             }
@@ -988,12 +1145,21 @@ mod macos_main {
             }
         }
 
+        // Repeated here so a blind spot found halfway up a long run is not lost in the
+        // scrollback. It does not fail the run: a browser that published nothing is the reading
+        // this probe was written to take.
+        if !blind_spots.is_empty() {
+            println!("\nWEB_PROBE_BLIND_SPOTS:\n{}", blind_spots.join("\n"));
+        }
         if failures.is_empty() {
             println!("\nWEB_PROBE_DONE");
             std::process::exit(0);
         }
-        // Printed, not `fail`ed through stderr alone: the evidence above is the point, and a
-        // launch that never happened is the one thing worth a non-zero exit.
+        // Printed to stdout as well as failed through stderr: the granted run's harness reports
+        // the two separately, and the evidence above is what a reader needs beside the verdict.
+        // Only breakage gets here — a launch that never happened, or a reader that never
+        // answered — so a non-zero exit always means the run read nothing, never that an engine
+        // exposed nothing.
         println!("\nWEB_PROBE_FAILURES:\n{}", failures.join("\n"));
         crate::common::fail(failures.join("\n"));
     }

--- a/crates/glass-macos/tests/web_probe.rs
+++ b/crates/glass-macos/tests/web_probe.rs
@@ -489,6 +489,16 @@ mod macos_main {
         Ok(tree)
     }
 
+    /// Record a snapshot failure as breakage, deduped: an AX channel that breaks mid-run breaks
+    /// for every read after it. Recorded at all because a run whose reader stopped answering
+    /// otherwise prints the errors and exits 0.
+    fn record(broke: &mut Vec<String>, label: &str, context: &str, e: &GlassError) {
+        let msg = format!("{label}: {context}: {e}");
+        if !broke.contains(&msg) {
+            broke.push(msg);
+        }
+    }
+
     /// What proves the page's own content is in the tree, described — or `None` while it is
     /// not there.
     ///
@@ -514,15 +524,16 @@ mod macos_main {
 
     /// Re-snapshot until [`page_marker`] finds the page's own content or [`SETTLE`] elapses.
     /// Returns the last tree read, how long it took, and whether the content arrived. Each
-    /// distinct error is printed once — a probe that stops at the first reads "nothing
+    /// distinct error is reported once — a probe that stops at the first reads "nothing
     /// published" for a page that had not loaded yet.
     fn snapshot_until_page(
         a11y: &mut MacosA11y,
         ctx: &AxContext,
+        label: &str,
+        broke: &mut Vec<String>,
     ) -> (Option<AxTree>, Duration, bool) {
         let start = Instant::now();
         let mut last = None;
-        let mut reported: Vec<String> = Vec::new();
         loop {
             match snapshot(a11y, ctx) {
                 Ok(tree) => {
@@ -534,10 +545,15 @@ mod macos_main {
                     }
                 }
                 Err(e) => {
-                    let text = e.to_string();
-                    if !reported.contains(&text) {
-                        println!("snapshot error at {:?}: {text}", start.elapsed());
-                        reported.push(text);
+                    let before = broke.len();
+                    record(
+                        broke,
+                        label,
+                        "snapshot error while waiting for the page",
+                        &e,
+                    );
+                    if broke.len() != before {
+                        println!("snapshot error at {:?}: {e}", start.elapsed());
                     }
                 }
             }
@@ -619,11 +635,18 @@ mod macos_main {
     /// The actuation readings: click the fixture's button and check the page reacted, write the
     /// text input through `set_value` and read it back, then type into the same field by
     /// keyboard as the control that tells a failed write from a value this engine never reports.
-    fn exercise(platform: &mut MacosPlatform, a11y: &mut MacosA11y, ctx: &AxContext) {
+    fn exercise(
+        platform: &mut MacosPlatform,
+        a11y: &mut MacosA11y,
+        ctx: &AxContext,
+        label: &str,
+        broke: &mut Vec<String>,
+    ) {
         let before = match snapshot(a11y, ctx) {
             Ok(tree) => tree,
             Err(e) => {
                 println!("snapshot before the click failed: {e} — no click reading");
+                record(broke, label, "the snapshot before the click failed", &e);
                 return;
             }
         };
@@ -641,7 +664,10 @@ mod macos_main {
                                 "click_element: {method} → result paragraph reads {CLICKED:?}: {}",
                                 carries(&after, CLICKED).is_some()
                             ),
-                            Err(e) => println!("click_element: {method} → re-snapshot failed: {e}"),
+                            Err(e) => {
+                                println!("click_element: {method} → re-snapshot failed: {e}");
+                                record(broke, label, "the re-snapshot after the click failed", &e);
+                            }
                         }
                     }
                     Err(e) => println!("click_element failed: {e}"),
@@ -654,6 +680,7 @@ mod macos_main {
             Ok(tree) => tree,
             Err(e) => {
                 println!("snapshot before set_value failed: {e} — no set_value reading");
+                record(broke, label, "the snapshot before set_value failed", &e);
                 return;
             }
         };
@@ -672,7 +699,10 @@ mod macos_main {
                 "set_value: {set:?} → text input value={:?}",
                 text_input(&after).and_then(|n| n.value.clone())
             ),
-            Err(e) => println!("set_value: {set:?} → re-snapshot failed: {e}"),
+            Err(e) => {
+                println!("set_value: {set:?} → re-snapshot failed: {e}");
+                record(broke, label, "the re-snapshot after set_value failed", &e);
+            }
         }
 
         // The control for the line above. An empty readback has two causes — the write never
@@ -683,6 +713,12 @@ mod macos_main {
             Ok(tree) => tree,
             Err(e) => {
                 println!("snapshot before the keyboard control failed: {e}");
+                record(
+                    broke,
+                    label,
+                    "the snapshot before the keyboard control failed",
+                    &e,
+                );
                 return;
             }
         };
@@ -695,7 +731,10 @@ mod macos_main {
                     "control — click {focus:?} then key {keyed:?} → text input value={:?}",
                     text_input(&after).and_then(|n| n.value.clone())
                 ),
-                Err(e) => println!("control — re-snapshot failed: {e}"),
+                Err(e) => {
+                    println!("control — re-snapshot failed: {e}");
+                    record(broke, label, "the control's re-snapshot failed", &e);
+                }
             }
         }
     }
@@ -963,7 +1002,7 @@ mod macos_main {
             apply_lever(pid, lever);
             std::thread::sleep(ACTION_SETTLE);
 
-            let (tree, settle, arrived) = snapshot_until_page(&mut a11y, &ctx);
+            let (tree, settle, arrived) = snapshot_until_page(&mut a11y, &ctx, browser, &mut broke);
             println!("page content arrived: {arrived} after {settle:?}");
             report_raw("after the lever", &raw_scan(pid));
 
@@ -972,7 +1011,7 @@ mod macos_main {
                     report_tree(&tree);
                     report_iframe(&tree);
                     if arrived {
-                        exercise(platform, &mut a11y, &ctx);
+                        exercise(platform, &mut a11y, &ctx, browser, &mut broke);
                         match snapshot(&mut a11y, &ctx) {
                             Ok(after) => {
                                 println!("--- tree after actuation ---");

--- a/crates/glass-macos/tests/web_probe.rs
+++ b/crates/glass-macos/tests/web_probe.rs
@@ -1,0 +1,1000 @@
+//! Web-content PROBE for the macOS backend — prints what a browser publishes through
+//! `AXUIElement`, with and without the candidate AX "enable" levers. Not a pass/fail mapping
+//! test: it prints evidence and asserts nothing about what an engine ought to expose.
+//!
+//! ```sh
+//! GLASS_WEB_PROBE_BROWSERS=/Applications/Safari.app GLASS_WEB_PROBE_LEVER=enhanced \
+//!   cargo test -p glass-macos --test web_probe
+//! ```
+//!
+//! `GLASS_WEB_PROBE_BROWSERS` is a comma-separated list of launch commands — `.app` bundle
+//! paths or plain executables, exactly what `AppSpec::run[0]` accepts. Each is launched with
+//! the `examples/web-role-fixture/index.html` page as `run[1]`; when the launch path drops
+//! that argument (an app LaunchServices opens by bundle rather than by command line), the
+//! probe navigates by typing the URL into the address bar instead, and says which route ran.
+//!
+//! `GLASS_WEB_PROBE_LEVER` picks the enable lever set on the *application* element after the
+//! launch: `enhanced` → `AXEnhancedUserInterface`, `manual` → `AXManualAccessibility`,
+//! anything else (including unset) → no lever, the baseline reading.
+//!
+//! With `GLASS_WEB_PROBE_BROWSERS` unset the probe reads the **side effect** of the lever
+//! instead: it launches TextEdit and prints five snapshot wall-clocks before the lever and
+//! five after, so the cost of leaving `AXEnhancedUserInterface` set on an ordinary AppKit app
+//! is a measured number rather than a guess.
+//!
+//! Two readings need the AX API raw, so this file carries `unsafe` where the rest of the
+//! tests do not (`#![allow(unsafe_code)]`, mirroring the crate-wide opt-in in `lib.rs`):
+//! setting the lever is a write no reader exposes, and the pre-lever web-area reading has to
+//! see elements `glass-a11y-macos`'s walk prunes — `should_skip` drops a zero-geometry
+//! element, which is exactly the shape a lazily-built web area is expected to have before it
+//! is disclosed.
+//!
+//! **`harness = false`** (see `Cargo.toml`'s `[[test]] name = "web_probe"` entry): same
+//! main-thread requirement as `a11y`/`role_probe` — `MacosPlatform::start_app` reaches
+//! AppKit's `ffi::app_kit_init()`, which libtest's per-test worker threads cannot provide.
+//!
+//! Needs the Accessibility and Screen Recording TCC grants, so it only reads anything through
+//! the granted-bundle run described in `tests/a11y.rs`'s module doc.
+
+#![allow(unsafe_code)]
+
+mod common;
+
+#[cfg(not(target_os = "macos"))]
+fn main() {
+    println!("skipped (not macOS): test");
+}
+
+#[cfg(target_os = "macos")]
+fn main() {
+    macos_main::run();
+}
+
+#[cfg(target_os = "macos")]
+mod macos_main {
+    use std::ptr::NonNull;
+    use std::time::{Duration, Instant};
+
+    use glass_a11y_macos::MacosA11y;
+    use glass_core::{
+        Accessibility, AppSpec, AxContext, AxNode, AxRole, AxTarget, AxTree, Deadline, GlassError,
+        KeyEvent, MouseButton, Platform, PointerEvent, SandboxLevel, WalkLimits, WindowHint,
+        WindowOp, role_histogram,
+    };
+    use glass_macos::MacosPlatform;
+    use objc2_application_services::{AXError, AXUIElement, AXValue, AXValueType};
+    use objc2_core_foundation::{
+        CFArray, CFBoolean, CFRetained, CFString, CFType, CGPoint, CGSize, kCFBooleanTrue,
+    };
+
+    use crate::common::with_stop_app;
+
+    const BROWSERS_VAR: &str = "GLASS_WEB_PROBE_BROWSERS";
+    const LEVER_VAR: &str = "GLASS_WEB_PROBE_LEVER";
+
+    /// The app the side-effect reading times when no browser is named — a plain AppKit app
+    /// with a real tree, and one every Mac has.
+    const TIMING_APP: &str = "/System/Applications/TextEdit.app";
+
+    /// How long to keep re-reading the tree for the page's own elements before calling the
+    /// content missing.
+    const SETTLE: Duration = Duration::from_secs(8);
+
+    /// Window-discovery budget. A cold browser launch is slower than the AppKit fixture's.
+    const LAUNCH_TIMEOUT_MS: u64 = 30_000;
+
+    /// After `start_app`, before anything is read: AppKit finishes building the tree behind a
+    /// window a beat after the window appears (same settle `tests/a11y.rs` uses).
+    const STARTUP_SETTLE: Duration = Duration::from_millis(1200);
+
+    /// After an actuation, before the re-read that looks for its effect.
+    const ACTION_SETTLE: Duration = Duration::from_millis(600);
+
+    /// The page's `<h1>` — what "the page is readable" means for this probe.
+    const HEADING: &str = "Glass web fixture";
+    /// The fixture button's accessible name.
+    const BUTTON: &str = "click me";
+    /// The fixture text input's accessible name, from its `<label for>`.
+    const INPUT: &str = "text input";
+    /// What the result paragraph reads after the button fires.
+    const CLICKED: &str = "clicked";
+    /// What `set_value` writes into the text input.
+    const TYPED: &str = "typed by glass";
+    /// What the keyboard control types into the same field — a second route to it.
+    const KEYED: &str = "keyed by glass";
+    /// The `<iframe>`'s title, so the nested document is identifiable in the outline.
+    const FRAME: &str = "nested document";
+
+    fn page_url() -> String {
+        format!(
+            "file://{}/../../examples/web-role-fixture/index.html",
+            env!("CARGO_MANIFEST_DIR")
+        )
+    }
+
+    /// The AX attribute a run sets on the application element to try to make the app publish
+    /// more than it does by default.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum Lever {
+        None,
+        Enhanced,
+        Manual,
+    }
+
+    impl Lever {
+        fn from_env() -> Self {
+            match std::env::var(LEVER_VAR).unwrap_or_default().as_str() {
+                "enhanced" => Lever::Enhanced,
+                "manual" => Lever::Manual,
+                _ => Lever::None,
+            }
+        }
+
+        /// The attribute name, or `None` for the baseline run that sets nothing.
+        fn attribute(self) -> Option<&'static str> {
+            match self {
+                Lever::None => None,
+                Lever::Enhanced => Some(ENHANCED),
+                Lever::Manual => Some(MANUAL),
+            }
+        }
+    }
+
+    /// The lever AppKit historically read as "an assistive client is attached".
+    const ENHANCED: &str = "AXEnhancedUserInterface";
+    /// The lever Electron/Chromium-family hosts read for the same purpose.
+    const MANUAL: &str = "AXManualAccessibility";
+
+    /// Set `attr` to true on `app`. Both levers are write-only switches an assistive client is
+    /// expected to set on the app it reads — no reader API exposes them, so this is the one
+    /// place the probe writes AX directly.
+    fn set_lever(app: &AXUIElement, attr: &str) -> Result<(), String> {
+        let name = CFString::from_str(attr);
+        // `objc2-core-foundation` has no `CFBoolean` constructor; the two singletons are the
+        // documented way to name a CF boolean, as `glass-macos::session`'s tests do.
+        let value: &CFType = match unsafe { kCFBooleanTrue } {
+            Some(v) => v,
+            None => return Err("kCFBooleanTrue was null".to_string()),
+        };
+        // SAFETY: `app` is a live `AXUIElement`, `name` a valid `CFString`, and `value` a
+        // valid `CFType` — matching `set_attribute_value`'s documented parameters, the same
+        // call `glass-a11y-macos::ffi::set_string_value` makes.
+        let err = unsafe { app.set_attribute_value(&name, value) };
+        if err == AXError::Success {
+            Ok(())
+        } else {
+            Err(format!("AXError {}", err.0))
+        }
+    }
+
+    /// Every name in `el`'s `AXAttributeNames`, or an empty list on any failure.
+    fn attribute_names(el: &AXUIElement) -> Vec<String> {
+        let mut raw: *const CFArray = std::ptr::null();
+        // SAFETY: `el` is a live `AXUIElement` and `raw` a valid local out-param slot matching
+        // `AXUIElementCopyAttributeNames`'s documented signature.
+        let err = unsafe { el.copy_attribute_names(NonNull::from(&mut raw)) };
+        if err != AXError::Success {
+            return Vec::new();
+        }
+        let Some(nn) = NonNull::new(raw.cast_mut()) else {
+            return Vec::new();
+        };
+        // SAFETY: the Copy call returned an already-retained (+1) array per Core Foundation's
+        // Copy/Create rule, and `AXAttributeNames` is documented to hold `CFString`s — the cast
+        // only attaches compile-time element-type information.
+        let names: CFRetained<CFArray<CFString>> =
+            unsafe { CFRetained::cast_unchecked(CFRetained::from_raw(nn)) };
+        names.iter().map(|n| n.to_string()).collect()
+    }
+
+    /// What the application element says about a lever before anything writes it: whether AX
+    /// lists it at all, what it currently reads as, and whether AX calls it settable.
+    ///
+    /// Printed on every run because a refused write means three different things depending on
+    /// this — an attribute the app never declares, one it declares read-only, and one it
+    /// declares settable and then rejects are three different findings, and the `AXError` alone
+    /// does not separate them.
+    fn describe_lever(el: &AXUIElement, attr: &str) -> String {
+        let listed = attribute_names(el).iter().any(|name| name == attr);
+        let value = copy_attr(el, attr)
+            .and_then(|v| v.downcast::<CFBoolean>().ok())
+            .map(|b| b.value());
+        let name = CFString::from_str(attr);
+        let mut settable: u8 = 0;
+        // SAFETY: `el` is a live `AXUIElement`, `name` a valid `CFString`, and `settable` a
+        // valid local out-param matching the documented `Boolean *` parameter (mirrors
+        // `glass-a11y-macos::ffi::is_settable`).
+        let err = unsafe { el.is_attribute_settable(&name, NonNull::from(&mut settable)) };
+        let settable = if err == AXError::Success {
+            format!("{}", settable != 0)
+        } else {
+            format!("unreadable (AXError {})", err.0)
+        };
+        format!("listed={listed} value={value:?} settable={settable}")
+    }
+
+    /// Report both levers' state on `pid`'s application element, then set the one this run asked
+    /// for.
+    fn apply_lever(pid: i32, lever: Lever) {
+        // SAFETY: `AXUIElementCreateApplication` never returns NULL per Apple's documented
+        // contract (the binding `.expect()`s it), and `pid` is a plain process id with no
+        // aliasing or lifetime preconditions — the shape `glass-a11y-macos::ffi::app_element`
+        // uses.
+        let app = unsafe { AXUIElement::new_application(pid) };
+        for attr in [ENHANCED, MANUAL] {
+            println!("lever {attr}: {}", describe_lever(&app, attr));
+        }
+        match lever.attribute() {
+            Some(attr) => println!("set {attr}: {:?}", set_lever(&app, attr)),
+            None => println!("set: nothing — this run is the baseline"),
+        }
+    }
+
+    /// Copy one attribute as an owned CF value, or `None` for any failure or a null result.
+    /// The probe's raw reads collapse absent and failed alike — every caller here prints what
+    /// it got and moves on.
+    fn copy_attr(el: &AXUIElement, name: &str) -> Option<CFRetained<CFType>> {
+        let attr = CFString::from_str(name);
+        let mut raw: *const CFType = std::ptr::null();
+        // SAFETY: `el` is a live `AXUIElement` and `raw` a valid local out-param slot,
+        // matching `AXUIElementCopyAttributeValue`'s documented signature (mirrors
+        // `glass-a11y-macos::ffi::copy_attribute_checked`).
+        let err = unsafe { el.copy_attribute_value(&attr, NonNull::from(&mut raw)) };
+        if err != AXError::Success {
+            return None;
+        }
+        let nn = NonNull::new(raw.cast_mut())?;
+        // SAFETY: the Copy call returned an already-retained (+1) value per Core Foundation's
+        // Copy/Create rule, so taking ownership here releases it on drop without an extra
+        // retain.
+        Some(unsafe { CFRetained::from_raw(nn) })
+    }
+
+    fn attr_string(el: &AXUIElement, name: &str) -> Option<String> {
+        copy_attr(el, name)?
+            .downcast::<CFString>()
+            .ok()
+            .map(|s| s.to_string())
+    }
+
+    /// `AXPosition` as a point pair.
+    fn attr_position(el: &AXUIElement) -> Option<(f64, f64)> {
+        let value = copy_attr(el, "AXPosition")?.downcast::<AXValue>().ok()?;
+        let mut point = CGPoint { x: 0.0, y: 0.0 };
+        // SAFETY: `value` was downcast-verified to be a real `AXValue`, and `point` is a valid
+        // local out-param whose type matches the requested `AXValueType::CGPoint`.
+        let ok = unsafe { value.value(AXValueType::CGPoint, NonNull::from(&mut point).cast()) };
+        ok.then_some((point.x, point.y))
+    }
+
+    /// `AXSize` as a width/height pair, in points.
+    fn attr_size(el: &AXUIElement) -> Option<(f64, f64)> {
+        let value = copy_attr(el, "AXSize")?.downcast::<AXValue>().ok()?;
+        let mut size = CGSize {
+            width: 0.0,
+            height: 0.0,
+        };
+        // SAFETY: as in `attr_position`, with `AXValueType::CGSize`/`CGSize`.
+        let ok = unsafe { value.value(AXValueType::CGSize, NonNull::from(&mut size).cast()) };
+        ok.then_some((size.width, size.height))
+    }
+
+    fn ax_children(el: &AXUIElement) -> Vec<CFRetained<AXUIElement>> {
+        let Some(value) = copy_attr(el, "AXChildren") else {
+            return Vec::new();
+        };
+        let Ok(array) = value.downcast::<CFArray>() else {
+            return Vec::new();
+        };
+        // SAFETY: `AXChildren` is documented to hold `AXUIElementRef`s; the cast only attaches
+        // compile-time element-type information, with no runtime effect (the technique
+        // `glass-a11y-macos::ffi::array_of_elements` uses).
+        let typed: CFRetained<CFArray<AXUIElement>> = unsafe { CFRetained::cast_unchecked(array) };
+        typed.iter().collect()
+    }
+
+    /// Node and depth bounds for the raw walk. It descends where the reader would not, so it
+    /// needs its own rails; both are generous for one browser window.
+    const MAX_RAW_NODES: usize = 4000;
+    const MAX_RAW_DEPTH: usize = 40;
+
+    /// One element on the way to a web area: how it prints, and whether
+    /// `glass-a11y-macos`'s `should_skip` would have pruned it.
+    #[derive(Clone)]
+    struct PathStep {
+        label: String,
+        skipped: bool,
+    }
+
+    /// One `AXWebArea` the raw walk found, with the ancestry that reached it.
+    struct WebArea {
+        /// The chain from the application element down to the web area, root first.
+        path: Vec<PathStep>,
+        position: Option<(f64, f64)>,
+        size: Option<(f64, f64)>,
+        children: usize,
+    }
+
+    /// What the raw walk saw, beside the web areas themselves.
+    #[derive(Default)]
+    struct RawScan {
+        web_areas: Vec<WebArea>,
+        scanned: usize,
+        zero_area: usize,
+        truncated: bool,
+    }
+
+    /// Walk `pid`'s application element with no pruning at all, collecting every `AXWebArea`.
+    ///
+    /// The reader cannot answer this: `glass-a11y-macos`'s `should_skip` drops any element
+    /// whose `AXSize` has a non-positive dimension before descending into it, so a web area
+    /// that exists but has not been laid out yet — and every element beneath it — is absent
+    /// from the tree rather than present-and-childless. Only a walk that ignores geometry can
+    /// tell "the engine never published a web area" from "the reader pruned the one it did".
+    fn raw_scan(pid: i32) -> RawScan {
+        // SAFETY: as in `set_lever` — `AXUIElementCreateApplication` never returns NULL and
+        // takes a plain pid.
+        let app = unsafe { AXUIElement::new_application(pid) };
+        let mut scan = RawScan::default();
+        let mut path = Vec::new();
+        raw_walk(&app, 0, &mut path, &mut scan);
+        scan
+    }
+
+    fn raw_walk(el: &AXUIElement, depth: usize, path: &mut Vec<PathStep>, scan: &mut RawScan) {
+        if scan.scanned >= MAX_RAW_NODES || depth > MAX_RAW_DEPTH {
+            scan.truncated = true;
+            return;
+        }
+        scan.scanned += 1;
+        let role = attr_string(el, "AXRole").unwrap_or_else(|| "(no AXRole)".to_string());
+        let size = attr_size(el);
+        // The reader's own predicate, restated: a readable non-positive dimension prunes; an
+        // unreadable size keeps the element (`glass-a11y-macos::reader::should_skip`).
+        let skipped = matches!(size, Some((w, h)) if w <= 0.0 || h <= 0.0);
+        if skipped {
+            scan.zero_area += 1;
+        }
+        let children = ax_children(el);
+        path.push(PathStep {
+            label: match size {
+                Some((w, h)) => format!("{role}[{w:.0}x{h:.0}]"),
+                None => format!("{role}[size unreadable]"),
+            },
+            skipped,
+        });
+        if role == "AXWebArea" {
+            scan.web_areas.push(WebArea {
+                path: path.clone(),
+                position: attr_position(el),
+                size,
+                children: children.len(),
+            });
+        }
+        for child in &children {
+            raw_walk(child, depth + 1, path, scan);
+        }
+        path.pop();
+    }
+
+    /// Print a raw scan under `label`, saying for each web area whether the reader's
+    /// zero-geometry prune would have reached it — at the web area itself, or at an ancestor.
+    fn report_raw(label: &str, scan: &RawScan) {
+        println!(
+            "raw AX scan ({label}): {} elements walked, {} of them zero-area, truncated={}, \
+             AXWebArea count={}",
+            scan.scanned,
+            scan.zero_area,
+            scan.truncated,
+            scan.web_areas.len()
+        );
+        for area in &scan.web_areas {
+            let pruned = area
+                .path
+                .iter()
+                .find(|step| step.skipped)
+                .map(|step| step.label.as_str());
+            let path: Vec<&str> = area.path.iter().map(|step| step.label.as_str()).collect();
+            println!(
+                "  AXWebArea position={:?} size={:?} children={} \
+                 pruned_by_should_skip_at={pruned:?}\n    path: {}",
+                area.position,
+                area.size,
+                area.children,
+                path.join(" > ")
+            );
+        }
+    }
+
+    fn find<'a>(tree: &'a AxTree, pred: &dyn Fn(&AxNode) -> bool) -> Option<&'a AxNode> {
+        fn walk<'a>(node: &'a AxNode, pred: &dyn Fn(&AxNode) -> bool) -> Option<&'a AxNode> {
+            if pred(node) {
+                return Some(node);
+            }
+            node.children.iter().find_map(|c| walk(c, pred))
+        }
+        walk(&tree.root, pred)
+    }
+
+    /// The first node whose accessible name is exactly `name`.
+    fn named<'a>(tree: &'a AxTree, name: &str) -> Option<&'a AxNode> {
+        find(tree, &|n| n.name.as_deref() == Some(name))
+    }
+
+    /// The first node carrying `text` as its whole name or value. Exact, not a substring: the
+    /// fixture's result paragraph reads "not clicked" before the click, which contains
+    /// "clicked".
+    fn carries<'a>(tree: &'a AxTree, text: &str) -> Option<&'a AxNode> {
+        find(tree, &|n| {
+            n.name.as_deref() == Some(text) || n.value.as_deref() == Some(text)
+        })
+    }
+
+    /// The fixture's text input. Matched by the label first; failing that, the first editable
+    /// `TextField` **inside a `Document`**, which keeps the browser's own address bar — also an
+    /// editable text field — out of the answer.
+    fn text_input(tree: &AxTree) -> Option<&AxNode> {
+        fn editable_field(node: &AxNode) -> Option<&AxNode> {
+            if node.states.editable && node.role == AxRole::TextField {
+                return Some(node);
+            }
+            node.children.iter().find_map(editable_field)
+        }
+        find(tree, &|n| {
+            n.states.editable
+                && (n.name.as_deref() == Some(INPUT) || n.description.as_deref() == Some(INPUT))
+        })
+        .or_else(|| documents(tree).into_iter().find_map(editable_field))
+    }
+
+    /// Every `Document` in the tree, in pre-order — the web-content boundary this probe reads.
+    fn documents(tree: &AxTree) -> Vec<&AxNode> {
+        fn walk<'a>(node: &'a AxNode, out: &mut Vec<&'a AxNode>) {
+            if node.role == AxRole::Document {
+                out.push(node);
+            }
+            for child in &node.children {
+                walk(child, out);
+            }
+        }
+        let mut out = Vec::new();
+        walk(&tree.root, &mut out);
+        out
+    }
+
+    fn target_of(node: &AxNode) -> AxTarget {
+        AxTarget {
+            id: node.id,
+            role: node.role,
+            name: node.name.clone(),
+            bounds: node.bounds,
+            value: node.value.clone(),
+        }
+    }
+
+    /// One snapshot with node ids assigned, as every reader's caller takes it.
+    fn snapshot(a11y: &mut MacosA11y, ctx: &AxContext) -> Result<AxTree, GlassError> {
+        let mut tree = a11y.snapshot(ctx)?;
+        tree.assign_ids();
+        Ok(tree)
+    }
+
+    /// What proves the page's own content is in the tree, described — or `None` while it is
+    /// not there.
+    ///
+    /// The heading has to be matched by role as well as name: the browser puts the page's
+    /// title on its *window* too, so a name-only match reports the page as readable the
+    /// instant it loads, whatever the engine published. The button is the second marker, for
+    /// an engine that publishes the content without mapping `<h1>` to `AXHeading` — content
+    /// that arrived under an unexpected role is still content that arrived.
+    fn page_marker(tree: &AxTree) -> Option<String> {
+        if let Some(node) = find(tree, &|n| {
+            n.role == AxRole::Heading && n.name.as_deref() == Some(HEADING)
+        }) {
+            return Some(format!("Heading {HEADING:?} (#{})", node.id.0));
+        }
+        named(tree, BUTTON).map(|node| {
+            format!(
+                "Button {BUTTON:?} (#{}) — the page arrived, but its <h1> did not come back as \
+                 a Heading",
+                node.id.0
+            )
+        })
+    }
+
+    /// Re-snapshot until [`page_marker`] finds the page's own content or [`SETTLE`] elapses.
+    /// Returns the last tree read, how long it took, and whether the content arrived. Each
+    /// distinct error is printed once — a probe that stops at the first reads "nothing
+    /// published" for a page that had not loaded yet.
+    fn snapshot_until_page(
+        a11y: &mut MacosA11y,
+        ctx: &AxContext,
+    ) -> (Option<AxTree>, Duration, bool) {
+        let start = Instant::now();
+        let mut last = None;
+        let mut reported: Vec<String> = Vec::new();
+        loop {
+            match snapshot(a11y, ctx) {
+                Ok(tree) => {
+                    let marker = page_marker(&tree);
+                    last = Some(tree);
+                    if let Some(marker) = marker {
+                        println!("page marker: {marker}");
+                        return (last, start.elapsed(), true);
+                    }
+                }
+                Err(e) => {
+                    let text = e.to_string();
+                    if !reported.contains(&text) {
+                        println!("snapshot error at {:?}: {text}", start.elapsed());
+                        reported.push(text);
+                    }
+                }
+            }
+            if start.elapsed() > SETTLE {
+                return (last, start.elapsed(), false);
+            }
+            std::thread::sleep(Duration::from_millis(250));
+        }
+    }
+
+    fn report_tree(tree: &AxTree) {
+        println!("{} nodes, complete={}", tree.count, tree.is_complete());
+        for doc in documents(tree) {
+            println!(
+                "document: #{} raw_role={:?} name={:?} children={} bounds={:?}",
+                doc.id.0,
+                doc.raw_role,
+                doc.name,
+                doc.children.len(),
+                doc.bounds
+            );
+        }
+        println!("role histogram (role, count, native token):");
+        for tally in role_histogram(tree) {
+            println!("  {:?} {:>4}  {}", tally.role, tally.count, tally.raw_role);
+        }
+        for notice in [
+            tree.truncation_notice(),
+            tree.unreadable_notice(),
+            tree.subject_notice(),
+            tree.empty_guidance().map(str::to_string),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            println!("notice: {notice}");
+        }
+        println!("outline:\n{}", tree.to_outline());
+    }
+
+    /// `Glass::click_element`'s actuation, at the seam this probe drives directly: the native
+    /// AX action first, and a synthetic pointer click at the node's own bounds when the element
+    /// exposes no action. Returns the label of the path that ran.
+    fn click_like_glass(
+        platform: &mut MacosPlatform,
+        a11y: &mut MacosA11y,
+        ctx: &AxContext,
+        node: &AxNode,
+    ) -> Result<String, String> {
+        let target = target_of(node);
+        match a11y.invoke(ctx, &target) {
+            Ok(actuated) => return Ok(format!("native-action (actuated {actuated:?})")),
+            Err(GlassError::AxUnsupported | GlassError::AxActionUnavailable(_)) => {}
+            Err(e) => return Err(format!("invoke failed: {e}")),
+        }
+        let bounds = node.bounds.ok_or_else(|| {
+            format!(
+                "#{} has no bounds, so the pointer fallback has no point",
+                node.id.0
+            )
+        })?;
+        let (x, y) = bounds
+            .clamped_center(ctx.window.width, ctx.window.height)
+            .ok_or_else(|| format!("bounds {bounds:?} have zero area against {:?}", ctx.window))?;
+        platform
+            .send_pointer(&PointerEvent::Click {
+                x,
+                y,
+                button: MouseButton::Left,
+                count: 1,
+                modifiers: vec![],
+            })
+            .map_err(|e| format!("pointer fallback at ({x},{y}) failed: {e}"))?;
+        Ok(format!(
+            "pointer at ({x},{y}) (element exposes no AX action)"
+        ))
+    }
+
+    /// The actuation readings: click the fixture's button and check the page reacted, write the
+    /// text input through `set_value` and read it back, then type into the same field by
+    /// keyboard as the control that tells a failed write from a value this engine never reports.
+    fn exercise(platform: &mut MacosPlatform, a11y: &mut MacosA11y, ctx: &AxContext) {
+        let before = match snapshot(a11y, ctx) {
+            Ok(tree) => tree,
+            Err(e) => {
+                println!("snapshot before the click failed: {e} — no click reading");
+                return;
+            }
+        };
+        match named(&before, BUTTON) {
+            Some(button) => {
+                println!(
+                    "button: #{} role={:?} raw_role={} bounds={:?}",
+                    button.id.0, button.role, button.raw_role, button.bounds
+                );
+                match click_like_glass(platform, a11y, ctx, button) {
+                    Ok(method) => {
+                        std::thread::sleep(ACTION_SETTLE);
+                        match snapshot(a11y, ctx) {
+                            Ok(after) => println!(
+                                "click_element: {method} → result paragraph reads {CLICKED:?}: {}",
+                                carries(&after, CLICKED).is_some()
+                            ),
+                            Err(e) => println!("click_element: {method} → re-snapshot failed: {e}"),
+                        }
+                    }
+                    Err(e) => println!("click_element failed: {e}"),
+                }
+            }
+            None => println!("no node named {BUTTON:?} — no click reading"),
+        }
+
+        let after = match snapshot(a11y, ctx) {
+            Ok(tree) => tree,
+            Err(e) => {
+                println!("snapshot before set_value failed: {e} — no set_value reading");
+                return;
+            }
+        };
+        let Some(field) = text_input(&after) else {
+            println!("no editable node named {INPUT:?} — no set_value reading");
+            return;
+        };
+        println!(
+            "text input: #{} role={:?} raw_role={} name={:?} value={:?}",
+            field.id.0, field.role, field.raw_role, field.name, field.value
+        );
+        let set = a11y.set_value(ctx, &target_of(field), TYPED);
+        std::thread::sleep(ACTION_SETTLE);
+        match snapshot(a11y, ctx) {
+            Ok(after) => println!(
+                "set_value: {set:?} → text input value={:?}",
+                text_input(&after).and_then(|n| n.value.clone())
+            ),
+            Err(e) => println!("set_value: {set:?} → re-snapshot failed: {e}"),
+        }
+
+        // The control for the line above. An empty readback has two causes — the write never
+        // landed, or this engine never reports a web input's text — and only text that reached
+        // the field by another route tells them apart. The pointer and keyboard do not touch
+        // the accessibility write path.
+        let after = match snapshot(a11y, ctx) {
+            Ok(tree) => tree,
+            Err(e) => {
+                println!("snapshot before the keyboard control failed: {e}");
+                return;
+            }
+        };
+        if let Some(field) = text_input(&after) {
+            let focus = click_like_glass(platform, a11y, ctx, field);
+            let keyed = platform.send_key(&KeyEvent::Text(KEYED.to_string()));
+            std::thread::sleep(ACTION_SETTLE);
+            match snapshot(a11y, ctx) {
+                Ok(after) => println!(
+                    "control — click {focus:?} then key {keyed:?} → text input value={:?}",
+                    text_input(&after).and_then(|n| n.value.clone())
+                ),
+                Err(e) => println!("control — re-snapshot failed: {e}"),
+            }
+        }
+    }
+
+    /// Report the nested `<iframe>`: whether its own `Document` arrived, and what is inside it.
+    fn report_iframe(tree: &AxTree) {
+        let docs = documents(tree);
+        println!("Document count: {}", docs.len());
+        match named(tree, FRAME) {
+            Some(node) => println!(
+                "iframe: #{} role={:?} raw_role={} children={} bounds={:?}",
+                node.id.0,
+                node.role,
+                node.raw_role,
+                node.children.len(),
+                node.bounds
+            ),
+            None => println!("no node named {FRAME:?} — the iframe did not arrive"),
+        }
+        println!(
+            "iframe content: heading {:?}, button {:?}",
+            carries(tree, "inside the frame").map(|n| (n.id.0, n.role)),
+            named(tree, "frame button").map(|n| (n.id.0, n.role)),
+        );
+    }
+
+    /// A window whose title carries `HEADING`, which is how the probe learns the page loaded
+    /// without asking the accessibility tree — the very thing under test.
+    fn page_titled_window(platform: &mut MacosPlatform) -> bool {
+        match platform.list_windows() {
+            Ok(windows) => {
+                println!(
+                    "windows: {:?}",
+                    windows.iter().map(|w| w.title.clone()).collect::<Vec<_>>()
+                );
+                windows
+                    .iter()
+                    .any(|w| w.title.as_deref().is_some_and(|t| t.contains(HEADING)))
+            }
+            Err(e) => {
+                println!("list_windows failed: {e}");
+                false
+            }
+        }
+    }
+
+    /// Poll [`page_titled_window`] until the page's title appears or `budget` elapses.
+    fn wait_for_page_title(platform: &mut MacosPlatform, budget: Duration) -> bool {
+        let start = Instant::now();
+        loop {
+            if page_titled_window(platform) {
+                return true;
+            }
+            if start.elapsed() > budget {
+                return false;
+            }
+            std::thread::sleep(Duration::from_millis(500));
+        }
+    }
+
+    /// Type `url` into the browser's address bar (⌘L, the URL, Return) — the fallback for a
+    /// launch path that cannot carry the URL as an argument.
+    fn navigate_by_address_bar(platform: &mut MacosPlatform, url: &str) -> Result<(), String> {
+        platform
+            .send_key(&KeyEvent::Chord("cmd+l".to_string()))
+            .map_err(|e| format!("cmd+l: {e}"))?;
+        std::thread::sleep(Duration::from_millis(400));
+        platform
+            .send_key(&KeyEvent::Text(url.to_string()))
+            .map_err(|e| format!("typing the url: {e}"))?;
+        std::thread::sleep(Duration::from_millis(400));
+        platform
+            .send_key(&KeyEvent::Chord("Return".to_string()))
+            .map_err(|e| format!("Return: {e}"))
+    }
+
+    /// The pid the lever is set on and the raw walk starts from: the launched app's own
+    /// process, which is the AX server for its whole window even when the engine renders in a
+    /// child process.
+    fn app_pid(platform: &MacosPlatform) -> Result<i32, String> {
+        let pids = platform.app_pids();
+        let pid = pids
+            .first()
+            .ok_or_else(|| "the backend reported no pid for the launched app".to_string())?;
+        i32::try_from(*pid).map_err(|e| format!("pid {pid} does not fit an i32: {e}"))
+    }
+
+    fn context(platform: &mut MacosPlatform, fallback: &glass_core::WindowGeometry) -> AxContext {
+        // Re-read rather than reuse the launch geometry: the window moves while the page loads,
+        // and every bound in the tree — and so every pointer fallback — is relative to it.
+        let window = platform
+            .window(&WindowOp::Geometry)
+            .unwrap_or_else(|_| fallback.clone());
+        AxContext {
+            pids: platform.app_pids(),
+            window,
+            window_handle: None,
+            a11y_bus_addr: None,
+            // Cap lifted: a browser's chrome alone spends the default budget, and a truncated
+            // walk makes the disclosure hedge instead of naming a cause.
+            limits: WalkLimits::from_max_nodes(Some(0)),
+            deadline: Deadline::UNBOUNDED,
+        }
+    }
+
+    fn browser_spec(browser: &str, url: &str) -> AppSpec {
+        AppSpec {
+            build: None,
+            run: vec![browser.to_string(), url.to_string()],
+            cwd: None,
+            env: vec![],
+            window_hint: Some(WindowHint {
+                title: Some(HEADING.to_string()),
+                class: None,
+            }),
+            timeout_ms: LAUNCH_TIMEOUT_MS,
+            sandbox: SandboxLevel::Off,
+            a11y: true,
+        }
+    }
+
+    fn probe_browser(browser: &str, lever: Lever, url: &str) -> Result<(), String> {
+        println!("\n=== macos / {browser} / lever={lever:?} ===");
+        let spec = browser_spec(browser, url);
+        println!("run: {:?}", spec.run);
+        let mut platform =
+            MacosPlatform::new().map_err(|e| format!("MacosPlatform::new(): {e}"))?;
+
+        with_stop_app(&mut platform, browser, |platform| {
+            let started = Instant::now();
+            let geometry = platform
+                .start_app(&spec)
+                .map_err(|e| format!("start_app({browser}): {e}"))?;
+            println!("window mapped after {:?}: {geometry:?}", started.elapsed());
+            std::thread::sleep(STARTUP_SETTLE);
+
+            let carried = wait_for_page_title(platform, Duration::from_secs(6));
+            if carried {
+                println!("url delivery: the launch carried AppSpec::run[1] to the browser");
+            } else {
+                println!(
+                    "url delivery: the launch did not carry AppSpec::run[1] — navigating by \
+                     address bar"
+                );
+                navigate_by_address_bar(platform, url)?;
+                let loaded = wait_for_page_title(platform, Duration::from_secs(10));
+                println!("address-bar navigation reached the page: {loaded}");
+            }
+
+            let pid = app_pid(platform)?;
+            // Three raw walks bracket the reads, because a web area that is built lazily and
+            // one that is never built look identical from a single scan. This first one runs
+            // before anything has snapshotted the app, so it says what the engine published on
+            // its own once the page finished loading.
+            report_raw("before any snapshot", &raw_scan(pid));
+
+            let ctx = context(platform, &geometry);
+            let mut a11y = MacosA11y::new();
+            // The first read a caller would take.
+            match snapshot(&mut a11y, &ctx) {
+                Ok(tree) => println!(
+                    "first snapshot after load: {} nodes, {} Document(s), marker {:?}",
+                    tree.count,
+                    documents(&tree).len(),
+                    page_marker(&tree)
+                ),
+                Err(e) => println!("first snapshot after load failed: {e}"),
+            }
+            report_raw("after the first snapshot, before the lever", &raw_scan(pid));
+
+            apply_lever(pid, lever);
+            std::thread::sleep(ACTION_SETTLE);
+
+            let (tree, settle, arrived) = snapshot_until_page(&mut a11y, &ctx);
+            println!("page content arrived: {arrived} after {settle:?}");
+            report_raw("after the lever", &raw_scan(pid));
+
+            match tree {
+                Some(tree) => {
+                    report_tree(&tree);
+                    report_iframe(&tree);
+                    if arrived {
+                        exercise(platform, &mut a11y, &ctx);
+                        if let Ok(after) = snapshot(&mut a11y, &ctx) {
+                            println!("--- tree after actuation ---");
+                            report_tree(&after);
+                        }
+                    } else if let Some(hint) = tree.document_guidance() {
+                        println!("disclosure rendered:\n{hint}");
+                    } else {
+                        println!("NO DOCUMENT AND NO DISCLOSURE — the blind spot");
+                    }
+                }
+                None => println!("no tree at all — nothing was published within {SETTLE:?}"),
+            }
+            Ok(())
+        })
+    }
+
+    /// How many snapshots each side of the side-effect reading takes.
+    const TIMING_REPEATS: usize = 5;
+
+    /// Five snapshot wall-clocks, printed individually beside the mean so one slow outlier is
+    /// visible rather than averaged away.
+    fn time_snapshots(label: &str, a11y: &mut MacosA11y, ctx: &AxContext) {
+        let mut samples = Vec::with_capacity(TIMING_REPEATS);
+        for repeat in 0..TIMING_REPEATS {
+            let started = Instant::now();
+            match a11y.snapshot(ctx) {
+                Ok(tree) => {
+                    // Inside the timed window, so no future laziness can move walk work out
+                    // from under the timer.
+                    std::hint::black_box(&tree);
+                    samples.push(started.elapsed().as_secs_f64() * 1000.0);
+                }
+                Err(e) => {
+                    println!("  {label}: repeat {repeat} failed: {e}");
+                    break;
+                }
+            }
+        }
+        let rendered: Vec<String> = samples.iter().map(|ms| format!("{ms:.0}ms")).collect();
+        let mean = if samples.is_empty() {
+            f64::NAN
+        } else {
+            samples.iter().sum::<f64>() / samples.len() as f64
+        };
+        println!("  {label}: mean {mean:.0}ms over {rendered:?}");
+    }
+
+    /// The side-effect reading: what leaving a lever set costs an ordinary AppKit app. Both
+    /// halves run against one launch, so the difference between them is the lever and not two
+    /// different app startups.
+    fn probe_timing(lever: Lever) -> Result<(), String> {
+        println!("\n=== macos / {TIMING_APP} / lever={lever:?} (side-effect reading) ===");
+        let spec = AppSpec {
+            build: None,
+            run: vec![TIMING_APP.to_string()],
+            cwd: None,
+            env: vec![],
+            window_hint: None,
+            timeout_ms: LAUNCH_TIMEOUT_MS,
+            sandbox: SandboxLevel::Off,
+            a11y: false,
+        };
+        let mut platform =
+            MacosPlatform::new().map_err(|e| format!("MacosPlatform::new(): {e}"))?;
+
+        with_stop_app(&mut platform, TIMING_APP, |platform| {
+            let geometry = platform
+                .start_app(&spec)
+                .map_err(|e| format!("start_app({TIMING_APP}): {e}"))?;
+            println!("started {TIMING_APP}: {geometry:?}");
+            std::thread::sleep(STARTUP_SETTLE);
+
+            let ctx = context(platform, &geometry);
+            let mut a11y = MacosA11y::new();
+            if let Ok(tree) = snapshot(&mut a11y, &ctx) {
+                println!("tree before the lever: {} nodes", tree.count);
+            }
+            time_snapshots("before the lever", &mut a11y, &ctx);
+
+            let pid = app_pid(platform)?;
+            // With no lever, the block below is the measurement's own noise — the control for a
+            // run where one was actually set.
+            apply_lever(pid, lever);
+            std::thread::sleep(ACTION_SETTLE);
+
+            if let Ok(tree) = snapshot(&mut a11y, &ctx) {
+                println!("tree after the lever: {} nodes", tree.count);
+            }
+            time_snapshots("after the lever", &mut a11y, &ctx);
+            Ok(())
+        })
+    }
+
+    pub(super) fn run() {
+        let lever = Lever::from_env();
+        let url = page_url();
+        println!("lever: {lever:?}");
+        println!("page: {url}");
+
+        let mut failures = Vec::new();
+        match std::env::var(BROWSERS_VAR) {
+            Ok(list) if !list.trim().is_empty() => {
+                for browser in list.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+                    if let Err(e) = probe_browser(browser, lever, &url) {
+                        failures.push(e);
+                    }
+                }
+            }
+            _ => {
+                println!(
+                    "{BROWSERS_VAR} unset — reading the lever's side effect on {TIMING_APP} \
+                     instead"
+                );
+                if let Err(e) = probe_timing(lever) {
+                    failures.push(e);
+                }
+            }
+        }
+
+        if failures.is_empty() {
+            println!("\nWEB_PROBE_DONE");
+            std::process::exit(0);
+        }
+        // Printed, not `fail`ed through stderr alone: the evidence above is the point, and a
+        // launch that never happened is the one thing worth a non-zero exit.
+        println!("\nWEB_PROBE_FAILURES:\n{}", failures.join("\n"));
+        crate::common::fail(failures.join("\n"));
+    }
+}

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -505,7 +505,9 @@ impl GlassServer {
                        glass_click_element. Errors if the backend or app exposes no \
                        accessibility tree (e.g. a canvas/black-box app) — fall back to \
                        glass_screenshot then. Web content arrives under a `Document` element, \
-                       and a childless `Document` is disclosed with the pixel path. Optional \
+                       and a childless `Document` is disclosed in its own notice: take a fresh \
+                       snapshot first, then pixels. A placeholder the app published for content \
+                       it has not exposed gets its own notice — only pixels reach it. Optional \
                        max_nodes: raise the element cap, or 0 to remove the element-count limit \
                        (default caps protect the token budget)."
     )]

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -294,8 +294,7 @@ fn a11y_truncation_steer(tree: &glass_core::AxTree) -> Option<String> {
 /// not four call-site lists, so `a11y_snapshot` and the `return:"snapshot"` fold disclose
 /// identically.
 ///
-/// Ordered by how much the recourse can still change: a re-read first, then the two that leave
-/// only pixels.
+/// Order: truncation, unreadable, unexposed, document, subject.
 fn a11y_steers(tree: &glass_core::AxTree) -> Vec<String> {
     [
         a11y_truncation_steer(tree),

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -289,13 +289,18 @@ fn a11y_truncation_steer(tree: &glass_core::AxTree) -> Option<String> {
     })
 }
 
-/// Every disclosure a snapshot owes the agent: the elements it does not show, the web content
-/// it could not enter, and what it turned out to describe. One function, not three call-site
-/// lists, so `a11y_snapshot` and the `return:"snapshot"` fold disclose identically.
+/// Every disclosure a snapshot owes the agent: the elements it does not show, the content the app
+/// withheld, the web content it could not enter, and what it turned out to describe. One function,
+/// not four call-site lists, so `a11y_snapshot` and the `return:"snapshot"` fold disclose
+/// identically.
+///
+/// Ordered by how much the recourse can still change: a re-read first, then the two that leave
+/// only pixels.
 fn a11y_steers(tree: &glass_core::AxTree) -> Vec<String> {
     [
         a11y_truncation_steer(tree),
         tree.unreadable_notice(),
+        tree.unexposed_notice(),
         tree.document_guidance(),
         tree.subject_notice(),
     ]
@@ -1304,6 +1309,69 @@ mod tests {
             }
             other => panic!("unexpected blocks: {other:?}"),
         }
+    }
+
+    #[test]
+    fn a11y_snapshot_discloses_withheld_content_as_a_trusted_block() {
+        let mut tree = fake_tree();
+        tree.unexposed = 1;
+        let mut g = glass_with_a11y(FakePlatform::new(100, 100), tree);
+        g.start(&AppSpec {
+            build: None,
+            run: vec!["x".into()],
+            cwd: None,
+            env: vec![],
+            window_hint: None,
+            timeout_ms: 1,
+            sandbox: SandboxLevel::Off,
+            a11y: false,
+        })
+        .unwrap();
+        let out = a11y_snapshot(&mut g, &A11ySnapshotArgs { max_nodes: None }).unwrap();
+        assert_envelope(&out, "glass_a11y_snapshot");
+        assert_eq!(
+            out.0.len(),
+            3,
+            "envelope + wrapped outline + the withheld-content steer"
+        );
+        match (&out.0[1], &out.0[2]) {
+            (OutContent::Text(body), OutContent::Text(steer)) => {
+                assert!(
+                    !body.contains("placeholder"),
+                    "the steer must not be inside the untrusted body: {body}"
+                );
+                assert!(steer.contains("has not exposed"), "{steer}");
+                assert!(steer.contains("glass_screenshot"), "{steer}");
+                assert!(
+                    !steer.starts_with(crate::untrusted::NOTE) && !steer.contains("⟦untrusted:"),
+                    "glass's own guidance stays outside the untrusted markers: {steer}"
+                );
+            }
+            other => panic!("unexpected blocks: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn the_withheld_content_steer_sits_between_the_unreadable_one_and_the_document_one() {
+        // All three can fire on one tree.
+        let mut tree = unpublished_document_tree();
+        tree.unreadable = 1;
+        tree.unexposed = 1;
+        let steers = a11y_steers(&tree);
+        let at = |needle: &str| {
+            steers
+                .iter()
+                .position(|s| s.contains(needle))
+                .unwrap_or_else(|| panic!("no steer contains {needle:?}: {steers:?}"))
+        };
+        assert!(
+            at("could not be read") < at("has not exposed"),
+            "{steers:?}"
+        );
+        assert!(
+            at("has not exposed") < at("no readable content"),
+            "{steers:?}"
+        );
     }
 
     #[test]

--- a/crates/glass-windows/Cargo.toml
+++ b/crates/glass-windows/Cargo.toml
@@ -46,6 +46,9 @@ windows = { version = "0.62", features = [
 windows = { version = "0.62", features = ["Win32_Foundation", "Win32_UI_HiDpi", "Win32_UI_WindowsAndMessaging"] }
 # onbox.rs's Glass-session harness (glass_windows_with_a11y) needs a scratch baseline dir.
 tempfile.workspace = true
+# web_probe.rs reads `Document` elements' FrameworkId directly, below glass's reader. Same version
+# and features as glass-a11y-windows depends on, so no new crate enters the lockfile.
+uiautomation = { version = "0.25", features = ["process", "event"] }
 
 # The pixel conversion is cross-platform, so its bench builds and runs everywhere.
 [dev-dependencies]

--- a/crates/glass-windows/tests/web_probe.rs
+++ b/crates/glass-windows/tests/web_probe.rs
@@ -14,8 +14,10 @@
 //! `.windows-artifacts/web-probe.txt`, which the harness copies back — see [`transcript`].
 //!
 //! A probe, not a mapping test: it prints evidence and does not assert what an engine ought to
-//! publish. Whether `stop` reached each browser is one of the readings; the one assertion is that
-//! nothing the probe launched is left running on the box afterwards.
+//! publish — a browser that starts but never shows the page's own content is a reading, not a
+//! failure (`arrived: false`, plus whatever disclosure rendered). What does fail the run: a
+//! browser that never launches, an accessibility channel that never answers, or a process this
+//! probe launched that outlives both `stop` and its own cleanup kill.
 #![cfg(windows)]
 
 use std::path::Path;
@@ -325,8 +327,14 @@ fn documents(tree: &AxTree) -> Vec<&AxNode> {
 ///
 /// Every error is retried until the deadline: a browser re-execs during startup and the reader
 /// has nothing to bind to until the second process owns the window. Each distinct error prints
-/// once.
-fn snapshot_until_page(glass: &mut Glass, budget: Duration) -> (Option<AxTree>, Duration, bool) {
+/// once and is recorded into `failures` — a caller not yet answering is expected during startup,
+/// but every other error is evidence the accessibility channel itself broke.
+fn snapshot_until_page(
+    glass: &mut Glass,
+    budget: Duration,
+    label: &str,
+    failures: &mut Vec<String>,
+) -> (Option<AxTree>, Duration, bool) {
     let start = Instant::now();
     let mut last = None;
     let mut reported: Vec<String> = Vec::new();
@@ -344,6 +352,7 @@ fn snapshot_until_page(glass: &mut Glass, budget: Duration) -> (Option<AxTree>, 
                 let text = e.to_string();
                 if !reported.contains(&text) {
                     say!("snapshot error at {:?}: {text}", start.elapsed());
+                    failures.push(format!("{label}: snapshot error: {text}"));
                     reported.push(text);
                 }
             }
@@ -395,16 +404,27 @@ fn report_tree(tree: &AxTree) {
 /// settles, and an id whose node has moved since the snapshot is rejected as changed.
 const CLICK_ATTEMPTS: usize = 4;
 
+/// Push a formatted `{label}: {context}: {e}` into `failures` unless `e` is
+/// [`GlassError::AccessibilityNotReady`] — a caller not yet answering is expected during
+/// startup and settles on retry; every other error means the accessibility channel broke after
+/// it had already been serving this session.
+fn record_snapshot_failure(failures: &mut Vec<String>, label: &str, context: &str, e: &GlassError) {
+    if !matches!(e, GlassError::AccessibilityNotReady(_)) {
+        failures.push(format!("{label}: {context}: {e}"));
+    }
+}
+
 /// The actuation readings. Each step re-snapshots first: `click_element` and `set_value` resolve
 /// ids against the session's most recent tree, so an id from an older one addresses nothing.
 /// Returns whether the click landed and whether the written value read back.
-fn exercise(glass: &mut Glass) -> (bool, bool) {
+fn exercise(glass: &mut Glass, label: &str, failures: &mut Vec<String>) -> (bool, bool) {
     let mut clicked = false;
     for attempt in 1..=CLICK_ATTEMPTS {
         let before = match glass.a11y_snapshot(Some(0)) {
             Ok(tree) => tree,
             Err(e) => {
                 say!("snapshot before the click failed: {e} — no click reading");
+                record_snapshot_failure(failures, label, "snapshot before the click failed", &e);
                 return (false, false);
             }
         };
@@ -432,12 +452,21 @@ fn exercise(glass: &mut Glass) -> (bool, bool) {
                              reads {CLICKED:?}: {clicked}"
                         );
                     }
-                    Err(e) => say!("click_element: {method:?} → re-snapshot failed: {e}"),
+                    Err(e) => {
+                        say!("click_element: {method:?} → re-snapshot failed: {e}");
+                        record_snapshot_failure(
+                            failures,
+                            label,
+                            "re-snapshot after click_element failed",
+                            &e,
+                        );
+                    }
                 }
                 break;
             }
             Err(e) => {
                 say!("click_element (attempt {attempt}) failed: {e}");
+                record_snapshot_failure(failures, label, "click_element failed", &e);
                 std::thread::sleep(Duration::from_millis(500));
             }
         }
@@ -447,6 +476,7 @@ fn exercise(glass: &mut Glass) -> (bool, bool) {
         Ok(tree) => tree,
         Err(e) => {
             say!("snapshot before set_value failed: {e} — no set_value reading");
+            record_snapshot_failure(failures, label, "snapshot before set_value failed", &e);
             return (clicked, false);
         }
     };
@@ -467,6 +497,7 @@ fn exercise(glass: &mut Glass) -> (bool, bool) {
         Ok(tree) => tree,
         Err(e) => {
             say!("set_value: {set:?} → re-snapshot failed: {e}");
+            record_snapshot_failure(failures, label, "re-snapshot after set_value failed", &e);
             return (clicked, false);
         }
     };
@@ -489,7 +520,10 @@ fn exercise(glass: &mut Glass) -> (bool, bool) {
                 raised.is_ok(),
                 text_input(&after).and_then(|n| n.value.clone())
             ),
-            Err(e) => say!("control — re-snapshot failed: {e}"),
+            Err(e) => {
+                say!("control — re-snapshot failed: {e}");
+                record_snapshot_failure(failures, label, "control re-snapshot failed", &e);
+            }
         }
     }
 
@@ -509,7 +543,10 @@ fn exercise(glass: &mut Glass) -> (bool, bool) {
             say!("--- tree after actuation ---");
             report_tree(&after);
         }
-        Err(e) => say!("final snapshot failed: {e}"),
+        Err(e) => {
+            say!("final snapshot failed: {e}");
+            record_snapshot_failure(failures, label, "final snapshot failed", &e);
+        }
     }
     (clicked, value_took)
 }
@@ -556,11 +593,17 @@ fn documents_under(automation: &UIAutomation, root: UIElement, label: &str) -> V
 
 /// The app's top-level window as a UIA element, bound by handle exactly as the reader itself
 /// binds it — so the scoped walk sees the window glass drives, not a peer app's.
-fn app_window_element(glass: &mut Glass, automation: &UIAutomation) -> Option<UIElement> {
+fn app_window_element(
+    glass: &mut Glass,
+    automation: &UIAutomation,
+    label: &str,
+    failures: &mut Vec<String>,
+) -> Option<UIElement> {
     let windows = match glass.list_windows() {
         Ok(w) => w,
         Err(e) => {
             say!("list_windows failed: {e}");
+            record_snapshot_failure(failures, label, "list_windows failed", &e);
             return None;
         }
     };
@@ -595,6 +638,7 @@ fn app_window_element(glass: &mut Glass, automation: &UIAutomation) -> Option<UI
         }
         Err(e) => {
             say!("element_from_handle failed: {e}");
+            failures.push(format!("{label}: element_from_handle failed: {e}"));
             None
         }
     }
@@ -603,15 +647,16 @@ fn app_window_element(glass: &mut Glass, automation: &UIAutomation) -> Option<UI
 /// The `FrameworkId` reading for a running app: scoped to its own window first (precise), then
 /// the whole-desktop walk the recipe calls for, which also shows what else on the box publishes
 /// a `Document`. Returns the framework ids seen under the app's own window.
-fn framework_reading(glass: &mut Glass, label: &str) -> Vec<String> {
+fn framework_reading(glass: &mut Glass, label: &str, failures: &mut Vec<String>) -> Vec<String> {
     let automation = match UIAutomation::new() {
         Ok(a) => a,
         Err(e) => {
             say!("UIAutomation::new failed: {e}");
+            failures.push(format!("{label}: UIAutomation::new failed: {e}"));
             return Vec::new();
         }
     };
-    let scoped = match app_window_element(glass, &automation) {
+    let scoped = match app_window_element(glass, &automation, label, failures) {
         Some(window) => documents_under(&automation, window, &format!("{label}, from its window")),
         None => Vec::new(),
     };
@@ -623,15 +668,20 @@ fn framework_reading(glass: &mut Glass, label: &str) -> Vec<String> {
                 &format!("{label}, from the desktop root"),
             );
         }
-        Err(e) => say!("get_root_element failed: {e}"),
+        Err(e) => {
+            say!("get_root_element failed: {e}");
+            failures.push(format!("{label}: get_root_element failed: {e}"));
+        }
     }
     scoped
 }
 
 /// Pids of processes named `exe` whose command line carries `marker` — our isolated profile — so
 /// the box's own browsers are never matched. An empty vec also covers a failed query, which is
-/// why the teardown check kills what this returns rather than trusting a count.
-fn our_pids(exe: &str, marker: &str) -> Vec<u32> {
+/// why the teardown check kills what this returns rather than trusting a count — and why a
+/// failed query is recorded into `failures` rather than trusted silently: a query that never
+/// works would otherwise report every survivor as "gone" for the rest of the run.
+fn our_pids(exe: &str, marker: &str, failures: &mut Vec<String>) -> Vec<u32> {
     let ps = format!(
         "Get-CimInstance Win32_Process -Filter \"Name='{exe}'\" | \
          Where-Object {{ $_.CommandLine -like '*{marker}*' }} | \
@@ -647,6 +697,10 @@ fn our_pids(exe: &str, marker: &str) -> Vec<u32> {
             .collect(),
         Err(e) => {
             say!("pid query for {exe} failed: {e}");
+            let msg = format!("{exe}: pid query failed: {e}");
+            if !failures.contains(&msg) {
+                failures.push(msg);
+            }
             Vec::new()
         }
     }
@@ -655,10 +709,15 @@ fn our_pids(exe: &str, marker: &str) -> Vec<u32> {
 /// Poll until nothing carrying `marker` is left or `budget` elapses, returning what is still
 /// there. A browser tree takes seconds to unwind, so an immediate read would call a normal
 /// shutdown a leak.
-fn wait_for_no_process(exe: &str, marker: &str, budget: Duration) -> Vec<u32> {
+fn wait_for_no_process(
+    exe: &str,
+    marker: &str,
+    budget: Duration,
+    failures: &mut Vec<String>,
+) -> Vec<u32> {
     let deadline = Instant::now() + budget;
     loop {
-        let pids = our_pids(exe, marker);
+        let pids = our_pids(exe, marker, failures);
         if pids.is_empty() || Instant::now() >= deadline {
             return pids;
         }
@@ -670,8 +729,14 @@ fn wait_for_no_process(exe: &str, marker: &str, budget: Duration) -> Vec<u32> {
 const TEARDOWN_BUDGET: Duration = Duration::from_secs(15);
 
 /// One engine's whole reading: launch on the fixture, wait for content, actuate, then read the
-/// `Document` control types. Never panics after `start` — `stop` has to run.
-fn probe_browser(engine: &'static str, exe: &str, marker: &str) -> Reading {
+/// `Document` control types. Never panics after `start` — `stop` has to run; genuine breakage is
+/// recorded into `failures` instead, for the test to panic on once every browser has had its turn.
+fn probe_browser(
+    engine: &'static str,
+    exe: &str,
+    marker: &str,
+    failures: &mut Vec<String>,
+) -> Reading {
     say!("\n=== {engine} — {exe} ===");
     let profile = glass_windows::onbox_support::scratch_dir(marker);
     let _ = std::fs::remove_dir_all(&profile);
@@ -689,18 +754,23 @@ fn probe_browser(engine: &'static str, exe: &str, marker: &str) -> Reading {
     let started = Instant::now();
     if let Err(e) = glass.start(&spec) {
         say!("start failed after {:?}: {e}", started.elapsed());
+        failures.push(format!(
+            "{engine}: start failed after {:?}: {e}",
+            started.elapsed()
+        ));
         let _ = std::fs::remove_dir_all(&profile);
         return reading;
     }
     say!("window mapped after {:?}", started.elapsed());
 
-    let (tree, settle, arrived) = snapshot_until_page(&mut glass, SETTLE);
+    let (tree, settle, arrived) = snapshot_until_page(&mut glass, SETTLE, engine, failures);
     say!("page content arrived within {SETTLE:?}: {arrived} after {settle:?}");
     let (tree, arrived) = if arrived {
         (tree, true)
     } else {
         // A second, longer read so "slow" is not recorded as "never".
-        let (tree, settle, arrived) = snapshot_until_page(&mut glass, EXTENDED_SETTLE);
+        let (tree, settle, arrived) =
+            snapshot_until_page(&mut glass, EXTENDED_SETTLE, engine, failures);
         say!("extended read: arrived={arrived} after a further {settle:?}");
         (tree, arrived)
     };
@@ -710,7 +780,7 @@ fn probe_browser(engine: &'static str, exe: &str, marker: &str) -> Reading {
         Some(tree) => {
             report_tree(&tree);
             if arrived {
-                let (clicked, value_took) = exercise(&mut glass);
+                let (clicked, value_took) = exercise(&mut glass, engine, failures);
                 reading.clicked = clicked;
                 reading.value_took = value_took;
             } else if let Some(hint) = tree.document_guidance() {
@@ -722,7 +792,7 @@ fn probe_browser(engine: &'static str, exe: &str, marker: &str) -> Reading {
         None => say!("no tree at all — nothing was published"),
     }
 
-    reading.frameworks = framework_reading(&mut glass, engine);
+    reading.frameworks = framework_reading(&mut glass, engine, failures);
     say!("stop: {:?}", glass.stop());
     let _ = std::fs::remove_dir_all(&profile);
     reading
@@ -730,11 +800,12 @@ fn probe_browser(engine: &'static str, exe: &str, marker: &str) -> Reading {
 
 /// The text-editor half of the `FrameworkId` reading: a stock editor's `Document` is the thing a
 /// web document has to be told apart from.
-fn probe_notepad() -> Vec<String> {
+fn probe_notepad(failures: &mut Vec<String>) -> Vec<String> {
     say!("\n=== notepad ===");
     let mut glass = glass_windows_with_a11y();
     if let Err(e) = glass.start(&notepad_spec()) {
         say!("start notepad failed: {e}");
+        failures.push(format!("notepad: start failed: {e}"));
         return Vec::new();
     }
     let raised = glass.window(&WindowOp::Focus);
@@ -743,9 +814,12 @@ fn probe_notepad() -> Vec<String> {
     std::thread::sleep(Duration::from_millis(800));
     match glass.a11y_snapshot(Some(0)) {
         Ok(tree) => report_tree(&tree),
-        Err(e) => say!("notepad snapshot failed: {e}"),
+        Err(e) => {
+            say!("notepad snapshot failed: {e}");
+            record_snapshot_failure(failures, "notepad", "snapshot failed", &e);
+        }
     }
-    let frameworks = framework_reading(&mut glass, "notepad");
+    let frameworks = framework_reading(&mut glass, "notepad", failures);
     say!("stop: {:?}", glass.stop());
     frameworks
 }
@@ -755,6 +829,10 @@ fn probe_notepad() -> Vec<String> {
 fn web_probe() {
     let mut readings = Vec::new();
     let mut launched = Vec::new();
+    // Breakage in the accessibility channel itself, not what a browser published — collected
+    // per browser so every requested browser still gets its turn (and its `stop`), with the run
+    // failing once at the end rather than on whichever browser happened to hit it first.
+    let mut failures: Vec<String> = Vec::new();
     for (engine, relative) in BROWSERS {
         let Some(exe) = locate(relative) else {
             say!("\n=== {engine} — not installed at {relative}; skipped ===");
@@ -772,10 +850,10 @@ fn web_probe() {
             .unwrap_or("")
             .to_string();
         let marker = format!("glass-web-probe-{stem}");
-        readings.push(probe_browser(engine, &exe, &marker));
+        readings.push(probe_browser(engine, &exe, &marker, &mut failures));
         launched.push((exe_name, marker));
     }
-    let notepad = probe_notepad();
+    let notepad = probe_notepad(&mut failures);
 
     say!("\n== aggregate: web-content probe ==");
     for r in &readings {
@@ -799,7 +877,7 @@ fn web_probe() {
     // own profile marker, so it kills those by exact pid rather than leaving them on the box.
     let mut left_behind = Vec::new();
     for (exe, marker) in &launched {
-        let survivors = wait_for_no_process(exe, marker, TEARDOWN_BUDGET);
+        let survivors = wait_for_no_process(exe, marker, TEARDOWN_BUDGET, &mut failures);
         say!("  survived stop by {TEARDOWN_BUDGET:?} — {exe}: {survivors:?}");
         for pid in &survivors {
             let killed = std::process::Command::new("taskkill")
@@ -809,15 +887,24 @@ fn web_probe() {
             say!("  killed {exe} pid {pid}: {killed}");
         }
         if !survivors.is_empty() {
-            left_behind.extend(wait_for_no_process(exe, marker, TEARDOWN_BUDGET));
+            left_behind.extend(wait_for_no_process(
+                exe,
+                marker,
+                TEARDOWN_BUDGET,
+                &mut failures,
+            ));
         }
         let _ = std::fs::remove_dir_all(glass_windows::onbox_support::scratch_dir(marker));
     }
 
-    // The only assertion: nothing this probe launched is left running on the box.
+    // Nothing this probe launched may still be running on the box.
     assert!(
         left_behind.is_empty(),
         "processes carrying our profile marker outlived both stop and the probe's own kill: \
          {left_behind:?}"
     );
+    // Genuine breakage — a browser that never launched, or an accessibility channel that never
+    // answered — collected while every browser still got its turn; asserted last, so the
+    // teardown above always runs first.
+    assert!(failures.is_empty(), "{}", failures.join("\n\n"));
 }

--- a/crates/glass-windows/tests/web_probe.rs
+++ b/crates/glass-windows/tests/web_probe.rs
@@ -692,10 +692,11 @@ fn framework_reading(glass: &mut Glass, label: &str, failures: &mut Vec<String>)
 }
 
 /// Pids of processes named `exe` whose command line carries `marker` — our isolated profile, or
-/// the directory holding the file Notepad was opened on — so the box's own apps are never matched. An empty vec also covers a failed query, which is
-/// why the teardown check kills what this returns rather than trusting a count — and why a
-/// failed query is recorded into `failures` rather than trusted silently: a query that never
-/// works would otherwise report every survivor as "gone" for the rest of the run.
+/// the directory holding the file Notepad was opened on — so the box's own apps are never
+/// matched. An empty vec also covers a failed query, which is why the teardown check kills what
+/// this returns rather than trusting a count — and why a failed query is recorded into
+/// `failures` rather than trusted silently: a query that never works would otherwise report
+/// every survivor as "gone" for the rest of the run.
 fn our_pids(exe: &str, marker: &str, failures: &mut Vec<String>) -> Vec<u32> {
     let ps = format!(
         "Get-CimInstance Win32_Process -Filter \"Name='{exe}'\" | \

--- a/crates/glass-windows/tests/web_probe.rs
+++ b/crates/glass-windows/tests/web_probe.rs
@@ -466,7 +466,16 @@ fn exercise(glass: &mut Glass, label: &str, failures: &mut Vec<String>) -> (bool
             }
             Err(e) => {
                 say!("click_element (attempt {attempt}) failed: {e}");
-                record_snapshot_failure(failures, label, "click_element failed", &e);
+                // A retry that lands is a reading, not a failure — only the exhausted attempt
+                // means click_element never worked at all.
+                if attempt == CLICK_ATTEMPTS {
+                    record_snapshot_failure(
+                        failures,
+                        label,
+                        &format!("click_element failed after {CLICK_ATTEMPTS} attempts"),
+                        &e,
+                    );
+                }
                 std::thread::sleep(Duration::from_millis(500));
             }
         }

--- a/crates/glass-windows/tests/web_probe.rs
+++ b/crates/glass-windows/tests/web_probe.rs
@@ -10,7 +10,8 @@
 //!
 //! The harness's session-1 bounce forwards no environment, so browsers are located by their
 //! per-machine install paths and the fixture path derives from `CARGO_MANIFEST_DIR`. A browser
-//! that isn't installed prints a skip line.
+//! that isn't installed prints a skip line. Every reading is also written to
+//! `.windows-artifacts/web-probe.txt`, which the harness copies back — see [`transcript`].
 //!
 //! A probe, not a mapping test: it prints evidence and does not assert what an engine ought to
 //! publish. Whether `stop` reached each browser is one of the readings; the one assertion is that
@@ -111,14 +112,50 @@ fn glass_windows_with_a11y() -> Glass {
     Glass::new(factory, "windows".into(), BaselineStore::new(root), 100)
 }
 
+/// The repo root the box built from, two levels above this crate's manifest dir.
+fn repo_root() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("repo root is two levels above crates/glass-windows")
+        .to_path_buf()
+}
+
+/// The transcript the harness ships back. `None` if the directory cannot be created.
+fn transcript_path() -> Option<std::path::PathBuf> {
+    let dir = repo_root().join(".windows-artifacts");
+    std::fs::create_dir_all(&dir).ok()?;
+    Some(dir.join("web-probe.txt"))
+}
+
+/// Write one reading to stdout and to the transcript. libtest discards a passing test's stdout and
+/// the harness runs the test binary without `--nocapture`, so the file is the only copy of the
+/// reading that survives a green run.
+fn transcript(line: &str) {
+    println!("{line}");
+    let Some(path) = transcript_path() else {
+        return;
+    };
+    if let Ok(mut file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+    {
+        use std::io::Write;
+        let _ = writeln!(file, "{line}");
+    }
+}
+
+/// The probe's only output call — see [`transcript`].
+macro_rules! say {
+    ($($arg:tt)*) => { transcript(&format!($($arg)*)) };
+}
+
 /// The shared web fixture as a `file://` URL, derived from this crate's manifest dir so it points
 /// at whatever checkout the box built. Backslashes are swapped for forward slashes: a browser
 /// takes the URL form, not the Windows path form.
 fn page_url() -> String {
-    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .ancestors()
-        .nth(2)
-        .expect("repo root is two levels above crates/glass-windows")
+    let path = repo_root()
         .join("examples")
         .join("web-role-fixture")
         .join("index.html");
@@ -154,13 +191,13 @@ user_pref("toolkit.telemetry.reportingpolicy.firstRun", false);
 /// Create the profile directory, seeding a Gecko one with [`GECKO_PREFS`].
 fn prepare_profile(exe: &str, profile: &str) {
     if let Err(e) = std::fs::create_dir_all(profile) {
-        println!("could not create the profile dir {profile}: {e}");
+        say!("could not create the profile dir {profile}: {e}");
         return;
     }
     if is_gecko(exe) {
         let path = Path::new(profile).join("user.js");
         if let Err(e) = std::fs::write(&path, GECKO_PREFS) {
-            println!("could not write {}: {e}", path.display());
+            say!("could not write {}: {e}", path.display());
         }
     }
 }
@@ -306,7 +343,7 @@ fn snapshot_until_page(glass: &mut Glass, budget: Duration) -> (Option<AxTree>, 
             Err(e) => {
                 let text = e.to_string();
                 if !reported.contains(&text) {
-                    println!("snapshot error at {:?}: {text}", start.elapsed());
+                    say!("snapshot error at {:?}: {text}", start.elapsed());
                     reported.push(text);
                 }
             }
@@ -320,7 +357,7 @@ fn snapshot_until_page(glass: &mut Glass, budget: Duration) -> (Option<AxTree>, 
 
 fn report_tree(tree: &AxTree) {
     for doc in documents(tree) {
-        println!(
+        say!(
             "document: #{} role={:?} raw_role={:?} name={:?} children={} bounds={:?}",
             doc.id.0,
             doc.role,
@@ -330,15 +367,15 @@ fn report_tree(tree: &AxTree) {
             doc.bounds
         );
     }
-    println!(
+    say!(
         "heading {HEADING:?} present: {}",
         find(tree, &|n| n.role == AxRole::Heading
             && n.name.as_deref() == Some(HEADING))
         .is_some()
     );
-    println!("role histogram (role, count, native token):");
+    say!("role histogram (role, count, native token):");
     for tally in role_histogram(tree) {
-        println!("  {:?} {:>4}  {}", tally.role, tally.count, tally.raw_role);
+        say!("  {:?} {:>4}  {}", tally.role, tally.count, tally.raw_role);
     }
     for notice in [
         tree.truncation_notice(),
@@ -349,9 +386,9 @@ fn report_tree(tree: &AxTree) {
     .into_iter()
     .flatten()
     {
-        println!("notice: {notice}");
+        say!("notice: {notice}");
     }
-    println!("outline:\n{}", tree.to_outline());
+    say!("outline:\n{}", tree.to_outline());
 }
 
 /// How many times to re-snapshot-and-click. A browser's tree keeps changing while the page
@@ -367,18 +404,21 @@ fn exercise(glass: &mut Glass) -> (bool, bool) {
         let before = match glass.a11y_snapshot(Some(0)) {
             Ok(tree) => tree,
             Err(e) => {
-                println!("snapshot before the click failed: {e} — no click reading");
+                say!("snapshot before the click failed: {e} — no click reading");
                 return (false, false);
             }
         };
         let Some(button) = named(&before, BUTTON) else {
-            println!("no node named {BUTTON:?} — no click reading");
+            say!("no node named {BUTTON:?} — no click reading");
             return (false, false);
         };
         if attempt == 1 {
-            println!(
+            say!(
                 "button: #{} role={:?} raw_role={} bounds={:?}",
-                button.id.0, button.role, button.raw_role, button.bounds
+                button.id.0,
+                button.role,
+                button.raw_role,
+                button.bounds
             );
         }
         match glass.click_element(button.id) {
@@ -387,17 +427,17 @@ fn exercise(glass: &mut Glass) -> (bool, bool) {
                 match glass.a11y_snapshot(Some(0)) {
                     Ok(after) => {
                         clicked = carrying(&after, CLICKED).is_some();
-                        println!(
+                        say!(
                             "click_element (attempt {attempt}): {method:?} → result paragraph \
                              reads {CLICKED:?}: {clicked}"
                         );
                     }
-                    Err(e) => println!("click_element: {method:?} → re-snapshot failed: {e}"),
+                    Err(e) => say!("click_element: {method:?} → re-snapshot failed: {e}"),
                 }
                 break;
             }
             Err(e) => {
-                println!("click_element (attempt {attempt}) failed: {e}");
+                say!("click_element (attempt {attempt}) failed: {e}");
                 std::thread::sleep(Duration::from_millis(500));
             }
         }
@@ -406,30 +446,33 @@ fn exercise(glass: &mut Glass) -> (bool, bool) {
     let after = match glass.a11y_snapshot(Some(0)) {
         Ok(tree) => tree,
         Err(e) => {
-            println!("snapshot before set_value failed: {e} — no set_value reading");
+            say!("snapshot before set_value failed: {e} — no set_value reading");
             return (clicked, false);
         }
     };
     let Some(field) = text_input(&after) else {
-        println!("no editable node named {INPUT:?} — no set_value reading");
+        say!("no editable node named {INPUT:?} — no set_value reading");
         return (clicked, false);
     };
-    println!(
+    say!(
         "text input: #{} role={:?} raw_role={} value={:?}",
-        field.id.0, field.role, field.raw_role, field.value
+        field.id.0,
+        field.role,
+        field.raw_role,
+        field.value
     );
     let set = glass.set_value(field.id, TYPED);
     std::thread::sleep(Duration::from_millis(500));
     let after = match glass.a11y_snapshot(Some(0)) {
         Ok(tree) => tree,
         Err(e) => {
-            println!("set_value: {set:?} → re-snapshot failed: {e}");
+            say!("set_value: {set:?} → re-snapshot failed: {e}");
             return (clicked, false);
         }
     };
     let read_back = text_input(&after).and_then(|n| n.value.clone());
     let value_took = read_back.as_deref() == Some(TYPED);
-    println!("set_value: {set:?} → text input value={read_back:?}");
+    say!("set_value: {set:?} → text input value={read_back:?}");
 
     // The control for the line above. An empty read-back has two causes — the write never landed,
     // or this engine never reports a web input's text — and only text that reached the field by
@@ -441,28 +484,32 @@ fn exercise(glass: &mut Glass) -> (bool, bool) {
         let keyed = glass.key(&KeyEvent::Text(KEYED.to_string()));
         std::thread::sleep(Duration::from_millis(500));
         match glass.a11y_snapshot(Some(0)) {
-            Ok(after) => println!(
+            Ok(after) => say!(
                 "control — click {focus:?}, focus {:?}, key {keyed:?} → text input value={:?}",
                 raised.is_ok(),
                 text_input(&after).and_then(|n| n.value.clone())
             ),
-            Err(e) => println!("control — re-snapshot failed: {e}"),
+            Err(e) => say!("control — re-snapshot failed: {e}"),
         }
     }
 
     match glass.a11y_snapshot(Some(0)) {
         Ok(after) => {
-            println!("every editable node at the end:");
+            say!("every editable node at the end:");
             for node in collect(&after, &|n| n.states.editable) {
-                println!(
+                say!(
                     "  #{} role={:?} raw_role={} name={:?} value={:?}",
-                    node.id.0, node.role, node.raw_role, node.name, node.value
+                    node.id.0,
+                    node.role,
+                    node.raw_role,
+                    node.name,
+                    node.value
                 );
             }
-            println!("--- tree after actuation ---");
+            say!("--- tree after actuation ---");
             report_tree(&after);
         }
-        Err(e) => println!("final snapshot failed: {e}"),
+        Err(e) => say!("final snapshot failed: {e}"),
     }
     (clicked, value_took)
 }
@@ -480,14 +527,14 @@ fn documents_under(automation: &UIAutomation, root: UIElement, label: &str) -> V
     let mut frameworks: Vec<String> = Vec::new();
     match found {
         Ok(elements) => {
-            println!(
+            say!(
                 "{label}: {} Document element(s) in {:?}",
                 elements.len(),
                 started.elapsed()
             );
             for el in &elements {
                 let framework = el.get_framework_id().unwrap_or_default();
-                println!(
+                say!(
                     "  Document: framework={framework:?} class={:?} name={:?} pid={:?}",
                     el.get_classname(),
                     el.get_name(),
@@ -499,7 +546,7 @@ fn documents_under(automation: &UIAutomation, root: UIElement, label: &str) -> V
             }
         }
         // `find_all` reports "nothing matched" as an error, so this is the no-Document case too.
-        Err(e) => println!(
+        Err(e) => say!(
             "{label}: no Document element after {:?} ({e})",
             started.elapsed()
         ),
@@ -513,19 +560,22 @@ fn app_window_element(glass: &mut Glass, automation: &UIAutomation) -> Option<UI
     let windows = match glass.list_windows() {
         Ok(w) => w,
         Err(e) => {
-            println!("list_windows failed: {e}");
+            say!("list_windows failed: {e}");
             return None;
         }
     };
     if windows.is_empty() {
-        println!(
+        say!(
             "list_windows returned no window — the adopted window's process is not in the pid set glass tracks, so there is no scoped walk"
         );
     }
     for w in &windows {
-        println!(
+        say!(
             "window: handle=0x{:x} title={:?} class={:?} active={}",
-            w.id.0, w.title, w.class, w.active
+            w.id.0,
+            w.title,
+            w.class,
+            w.active
         );
     }
     let target = windows
@@ -534,7 +584,7 @@ fn app_window_element(glass: &mut Glass, automation: &UIAutomation) -> Option<UI
         .or_else(|| windows.first())?;
     match automation.element_from_handle(Handle::from(target.id.0 as isize)) {
         Ok(el) => {
-            println!(
+            say!(
                 "window element: framework={:?} class={:?} name={:?} pid={:?}",
                 el.get_framework_id(),
                 el.get_classname(),
@@ -544,7 +594,7 @@ fn app_window_element(glass: &mut Glass, automation: &UIAutomation) -> Option<UI
             Some(el)
         }
         Err(e) => {
-            println!("element_from_handle failed: {e}");
+            say!("element_from_handle failed: {e}");
             None
         }
     }
@@ -557,7 +607,7 @@ fn framework_reading(glass: &mut Glass, label: &str) -> Vec<String> {
     let automation = match UIAutomation::new() {
         Ok(a) => a,
         Err(e) => {
-            println!("UIAutomation::new failed: {e}");
+            say!("UIAutomation::new failed: {e}");
             return Vec::new();
         }
     };
@@ -573,7 +623,7 @@ fn framework_reading(glass: &mut Glass, label: &str) -> Vec<String> {
                 &format!("{label}, from the desktop root"),
             );
         }
-        Err(e) => println!("get_root_element failed: {e}"),
+        Err(e) => say!("get_root_element failed: {e}"),
     }
     scoped
 }
@@ -596,7 +646,7 @@ fn our_pids(exe: &str, marker: &str) -> Vec<u32> {
             .filter_map(|s| s.parse().ok())
             .collect(),
         Err(e) => {
-            println!("pid query for {exe} failed: {e}");
+            say!("pid query for {exe} failed: {e}");
             Vec::new()
         }
     }
@@ -622,13 +672,13 @@ const TEARDOWN_BUDGET: Duration = Duration::from_secs(15);
 /// One engine's whole reading: launch on the fixture, wait for content, actuate, then read the
 /// `Document` control types. Never panics after `start` — `stop` has to run.
 fn probe_browser(engine: &'static str, exe: &str, marker: &str) -> Reading {
-    println!("\n=== {engine} — {exe} ===");
+    say!("\n=== {engine} — {exe} ===");
     let profile = glass_windows::onbox_support::scratch_dir(marker);
     let _ = std::fs::remove_dir_all(&profile);
     prepare_profile(exe, &profile);
 
     let spec = browser_spec(exe, &profile);
-    println!("run: {:?}", spec.run);
+    say!("run: {:?}", spec.run);
 
     let mut reading = Reading {
         engine,
@@ -638,20 +688,20 @@ fn probe_browser(engine: &'static str, exe: &str, marker: &str) -> Reading {
     let mut glass = glass_windows_with_a11y();
     let started = Instant::now();
     if let Err(e) = glass.start(&spec) {
-        println!("start failed after {:?}: {e}", started.elapsed());
+        say!("start failed after {:?}: {e}", started.elapsed());
         let _ = std::fs::remove_dir_all(&profile);
         return reading;
     }
-    println!("window mapped after {:?}", started.elapsed());
+    say!("window mapped after {:?}", started.elapsed());
 
     let (tree, settle, arrived) = snapshot_until_page(&mut glass, SETTLE);
-    println!("page content arrived within {SETTLE:?}: {arrived} after {settle:?}");
+    say!("page content arrived within {SETTLE:?}: {arrived} after {settle:?}");
     let (tree, arrived) = if arrived {
         (tree, true)
     } else {
         // A second, longer read so "slow" is not recorded as "never".
         let (tree, settle, arrived) = snapshot_until_page(&mut glass, EXTENDED_SETTLE);
-        println!("extended read: arrived={arrived} after a further {settle:?}");
+        say!("extended read: arrived={arrived} after a further {settle:?}");
         (tree, arrived)
     };
     reading.arrived = arrived;
@@ -664,16 +714,16 @@ fn probe_browser(engine: &'static str, exe: &str, marker: &str) -> Reading {
                 reading.clicked = clicked;
                 reading.value_took = value_took;
             } else if let Some(hint) = tree.document_guidance() {
-                println!("disclosure rendered:\n{hint}");
+                say!("disclosure rendered:\n{hint}");
             } else {
-                println!("NO DOCUMENT DISCLOSURE — content missing and nothing said so");
+                say!("NO DOCUMENT DISCLOSURE — content missing and nothing said so");
             }
         }
-        None => println!("no tree at all — nothing was published"),
+        None => say!("no tree at all — nothing was published"),
     }
 
     reading.frameworks = framework_reading(&mut glass, engine);
-    println!("stop: {:?}", glass.stop());
+    say!("stop: {:?}", glass.stop());
     let _ = std::fs::remove_dir_all(&profile);
     reading
 }
@@ -681,22 +731,22 @@ fn probe_browser(engine: &'static str, exe: &str, marker: &str) -> Reading {
 /// The text-editor half of the `FrameworkId` reading: a stock editor's `Document` is the thing a
 /// web document has to be told apart from.
 fn probe_notepad() -> Vec<String> {
-    println!("\n=== notepad ===");
+    say!("\n=== notepad ===");
     let mut glass = glass_windows_with_a11y();
     if let Err(e) = glass.start(&notepad_spec()) {
-        println!("start notepad failed: {e}");
+        say!("start notepad failed: {e}");
         return Vec::new();
     }
     let raised = glass.window(&WindowOp::Focus);
     let typed = glass.key(&KeyEvent::Text(NOTEPAD_LINE.to_string()));
-    println!("focus {:?}, typed a line: {typed:?}", raised.is_ok());
+    say!("focus {:?}, typed a line: {typed:?}", raised.is_ok());
     std::thread::sleep(Duration::from_millis(800));
     match glass.a11y_snapshot(Some(0)) {
         Ok(tree) => report_tree(&tree),
-        Err(e) => println!("notepad snapshot failed: {e}"),
+        Err(e) => say!("notepad snapshot failed: {e}"),
     }
     let frameworks = framework_reading(&mut glass, "notepad");
-    println!("stop: {:?}", glass.stop());
+    say!("stop: {:?}", glass.stop());
     frameworks
 }
 
@@ -707,7 +757,7 @@ fn web_probe() {
     let mut launched = Vec::new();
     for (engine, relative) in BROWSERS {
         let Some(exe) = locate(relative) else {
-            println!("\n=== {engine} — not installed at {relative}; skipped ===");
+            say!("\n=== {engine} — not installed at {relative}; skipped ===");
             readings.push(Reading::absent(engine));
             continue;
         };
@@ -727,18 +777,22 @@ fn web_probe() {
     }
     let notepad = probe_notepad();
 
-    println!("\n== aggregate: web-content probe ==");
+    say!("\n== aggregate: web-content probe ==");
     for r in &readings {
         if !r.installed {
-            println!("  {}: unread (not installed)", r.engine);
+            say!("  {}: unread (not installed)", r.engine);
             continue;
         }
-        println!(
+        say!(
             "  {}: arrived={} clicked={} set_value_took={} frameworks={:?}",
-            r.engine, r.arrived, r.clicked, r.value_took, r.frameworks
+            r.engine,
+            r.arrived,
+            r.clicked,
+            r.value_took,
+            r.frameworks
         );
     }
-    println!("  notepad: frameworks={notepad:?}");
+    say!("  notepad: frameworks={notepad:?}");
 
     // Whether `stop` reached each browser is a reading, printed above the cleanup so a leak is
     // visible even though the probe then repairs it. The probe owns every process carrying its
@@ -746,13 +800,13 @@ fn web_probe() {
     let mut left_behind = Vec::new();
     for (exe, marker) in &launched {
         let survivors = wait_for_no_process(exe, marker, TEARDOWN_BUDGET);
-        println!("  survived stop by {TEARDOWN_BUDGET:?} — {exe}: {survivors:?}");
+        say!("  survived stop by {TEARDOWN_BUDGET:?} — {exe}: {survivors:?}");
         for pid in &survivors {
             let killed = std::process::Command::new("taskkill")
                 .args(["/PID", &pid.to_string(), "/T", "/F"])
                 .output()
                 .is_ok();
-            println!("  killed {exe} pid {pid}: {killed}");
+            say!("  killed {exe} pid {pid}: {killed}");
         }
         if !survivors.is_empty() {
             left_behind.extend(wait_for_no_process(exe, marker, TEARDOWN_BUDGET));

--- a/crates/glass-windows/tests/web_probe.rs
+++ b/crates/glass-windows/tests/web_probe.rs
@@ -13,7 +13,8 @@
 //! that isn't installed prints a skip line.
 //!
 //! A probe, not a mapping test: it prints evidence and does not assert what an engine ought to
-//! publish. The one assertion is teardown — nothing it launched may survive `stop`.
+//! publish. Whether `stop` reached each browser is one of the readings; the one assertion is that
+//! nothing the probe launched is left running on the box afterwards.
 #![cfg(windows)]
 
 use std::path::Path;
@@ -137,11 +138,42 @@ fn locate(relative: &str) -> Option<String> {
     })
 }
 
+/// Gecko's onboarding, turned off in the profile. Read on 2026-08-24: a fresh Firefox profile
+/// renders `about:welcome` over the requested page, so the reader's subject is the onboarding
+/// content and the fixture is never read. `--profile` is honoured before these are needed, and
+/// `user.js` is applied on every startup, so writing it into the fresh directory is enough.
+const GECKO_PREFS: &str = r#"user_pref("browser.aboutwelcome.enabled", false);
+user_pref("browser.migrate.content-modal.enabled", false);
+user_pref("browser.startup.homepage_override.mstone", "ignore");
+user_pref("browser.startup.upgradeDialog.enabled", false);
+user_pref("browser.shell.checkDefaultBrowser", false);
+user_pref("datareporting.policy.dataSubmissionPolicyBypassNotification", true);
+user_pref("toolkit.telemetry.reportingpolicy.firstRun", false);
+"#;
+
+/// Create the profile directory, seeding a Gecko one with [`GECKO_PREFS`].
+fn prepare_profile(exe: &str, profile: &str) {
+    if let Err(e) = std::fs::create_dir_all(profile) {
+        println!("could not create the profile dir {profile}: {e}");
+        return;
+    }
+    if is_gecko(exe) {
+        let path = Path::new(profile).join("user.js");
+        if let Err(e) = std::fs::write(&path, GECKO_PREFS) {
+            println!("could not write {}: {e}", path.display());
+        }
+    }
+}
+
+fn is_gecko(exe: &str) -> bool {
+    exe.to_ascii_lowercase().contains("firefox")
+}
+
 /// A fresh, isolated profile per launch: no first-run prompts, no session restore, and no
 /// already-running instance adopting the URL instead of starting a process glass owns. The
 /// profile path carries `marker`, which is also how the teardown check finds our processes.
 fn browser_spec(exe: &str, profile: &str) -> AppSpec {
-    let run = if exe.to_ascii_lowercase().contains("firefox") {
+    let run = if is_gecko(exe) {
         vec![
             exe.to_string(),
             "--no-remote".into(),
@@ -485,6 +517,11 @@ fn app_window_element(glass: &mut Glass, automation: &UIAutomation) -> Option<UI
             return None;
         }
     };
+    if windows.is_empty() {
+        println!(
+            "list_windows returned no window — the adopted window's process is not in the pid set glass tracks, so there is no scoped walk"
+        );
+    }
     for w in &windows {
         println!(
             "window: handle=0x{:x} title={:?} class={:?} active={}",
@@ -541,24 +578,46 @@ fn framework_reading(glass: &mut Glass, label: &str) -> Vec<String> {
     scoped
 }
 
-/// Count processes named `exe` whose command line carries `marker` — our isolated profile — so
-/// the box's own browsers are not counted. `-1` means the query itself failed.
-fn our_process_count(exe: &str, marker: &str) -> i32 {
+/// Pids of processes named `exe` whose command line carries `marker` — our isolated profile — so
+/// the box's own browsers are never matched. An empty vec also covers a failed query, which is
+/// why the teardown check kills what this returns rather than trusting a count.
+fn our_pids(exe: &str, marker: &str) -> Vec<u32> {
     let ps = format!(
-        "@(Get-CimInstance Win32_Process -Filter \"Name='{exe}'\" | \
-         Where-Object {{ $_.CommandLine -like '*{marker}*' }}).Count"
+        "Get-CimInstance Win32_Process -Filter \"Name='{exe}'\" | \
+         Where-Object {{ $_.CommandLine -like '*{marker}*' }} | \
+         ForEach-Object {{ $_.ProcessId }}"
     );
     match std::process::Command::new("powershell")
         .args(["-NoProfile", "-Command", &ps])
         .output()
     {
         Ok(o) => String::from_utf8_lossy(&o.stdout)
-            .trim()
-            .parse()
-            .unwrap_or(-1),
-        Err(_) => -1,
+            .split_whitespace()
+            .filter_map(|s| s.parse().ok())
+            .collect(),
+        Err(e) => {
+            println!("pid query for {exe} failed: {e}");
+            Vec::new()
+        }
     }
 }
+
+/// Poll until nothing carrying `marker` is left or `budget` elapses, returning what is still
+/// there. A browser tree takes seconds to unwind, so an immediate read would call a normal
+/// shutdown a leak.
+fn wait_for_no_process(exe: &str, marker: &str, budget: Duration) -> Vec<u32> {
+    let deadline = Instant::now() + budget;
+    loop {
+        let pids = our_pids(exe, marker);
+        if pids.is_empty() || Instant::now() >= deadline {
+            return pids;
+        }
+        std::thread::sleep(Duration::from_millis(500));
+    }
+}
+
+/// How long teardown is given before a survivor counts as one.
+const TEARDOWN_BUDGET: Duration = Duration::from_secs(15);
 
 /// One engine's whole reading: launch on the fixture, wait for content, actuate, then read the
 /// `Document` control types. Never panics after `start` — `stop` has to run.
@@ -566,6 +625,7 @@ fn probe_browser(engine: &'static str, exe: &str, marker: &str) -> Reading {
     println!("\n=== {engine} — {exe} ===");
     let profile = glass_windows::onbox_support::scratch_dir(marker);
     let _ = std::fs::remove_dir_all(&profile);
+    prepare_profile(exe, &profile);
 
     let spec = browser_spec(exe, &profile);
     println!("run: {:?}", spec.run);
@@ -680,15 +740,30 @@ fn web_probe() {
     }
     println!("  notepad: frameworks={notepad:?}");
 
-    // The only assertion: a browser this probe launched may not outlive it.
-    let survivors: Vec<(String, i32)> = launched
-        .iter()
-        .map(|(exe, marker)| (exe.clone(), our_process_count(exe, marker)))
-        .filter(|(_, n)| *n != 0)
-        .collect();
-    println!("  survivors after stop: {survivors:?}");
+    // Whether `stop` reached each browser is a reading, printed above the cleanup so a leak is
+    // visible even though the probe then repairs it. The probe owns every process carrying its
+    // own profile marker, so it kills those by exact pid rather than leaving them on the box.
+    let mut left_behind = Vec::new();
+    for (exe, marker) in &launched {
+        let survivors = wait_for_no_process(exe, marker, TEARDOWN_BUDGET);
+        println!("  survived stop by {TEARDOWN_BUDGET:?} — {exe}: {survivors:?}");
+        for pid in &survivors {
+            let killed = std::process::Command::new("taskkill")
+                .args(["/PID", &pid.to_string(), "/T", "/F"])
+                .output()
+                .is_ok();
+            println!("  killed {exe} pid {pid}: {killed}");
+        }
+        if !survivors.is_empty() {
+            left_behind.extend(wait_for_no_process(exe, marker, TEARDOWN_BUDGET));
+        }
+        let _ = std::fs::remove_dir_all(glass_windows::onbox_support::scratch_dir(marker));
+    }
+
+    // The only assertion: nothing this probe launched is left running on the box.
     assert!(
-        survivors.is_empty(),
-        "processes carrying our profile marker survived stop: {survivors:?}"
+        left_behind.is_empty(),
+        "processes carrying our profile marker outlived both stop and the probe's own kill: \
+         {left_behind:?}"
     );
 }

--- a/crates/glass-windows/tests/web_probe.rs
+++ b/crates/glass-windows/tests/web_probe.rs
@@ -1,0 +1,694 @@
+//! Web-content PROBE for the Windows backend — what a browser publishes over UI Automation for
+//! the shared web fixture, and what `FrameworkId` a `Document` control type carries there versus
+//! in a stock text editor. `#[ignore]`d and `#![cfg(windows)]` like `tests/onbox.rs`: it needs the
+//! interactive desktop session, so it runs through the harness.
+//!
+//! ```sh
+//! GLASS_WIN_HOST=user@host GLASS_WIN_REPO=C:/path/to/glass \
+//!   ./scripts/test-windows.sh --tests web_probe
+//! ```
+//!
+//! The harness's session-1 bounce forwards no environment, so browsers are located by their
+//! per-machine install paths and the fixture path derives from `CARGO_MANIFEST_DIR`. A browser
+//! that isn't installed prints a skip line.
+//!
+//! A probe, not a mapping test: it prints evidence and does not assert what an engine ought to
+//! publish. The one assertion is teardown — nothing it launched may survive `stop`.
+#![cfg(windows)]
+
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use glass_a11y_windows::WindowsA11y;
+use glass_core::{
+    AppSpec, AxNode, AxRole, AxTree, Backend, BaselineStore, Glass, GlassError, KeyEvent,
+    PlatformFactory, SandboxLevel, WindowHint, WindowOp, role_histogram,
+};
+use glass_windows::WindowsPlatform;
+use uiautomation::controls::ControlType;
+use uiautomation::types::Handle;
+use uiautomation::{UIAutomation, UIElement};
+
+/// The headline "time to content" bound: how long the probe re-reads the tree for the page's own
+/// elements before calling the content missing.
+const SETTLE: Duration = Duration::from_secs(8);
+/// A second read taken only when [`SETTLE`] expired, so a slow arrival is told apart from no
+/// arrival at all — a missing mapping must not be reported as missing content.
+const EXTENDED_SETTLE: Duration = Duration::from_secs(20);
+/// Window-discovery budget. A cold browser opening a fresh profile maps its window far later
+/// than a native fixture does.
+const LAUNCH_TIMEOUT_MS: u64 = 30_000;
+/// Depth of the `Document` search, per the UIA reading recipe.
+const DOC_DEPTH: u32 = 30;
+
+/// The fixture button's accessible name — the page content the probe waits for, then clicks.
+const BUTTON: &str = "click me";
+/// The fixture text input's accessible name, from its `<label for>`.
+const INPUT: &str = "text input";
+/// The fixture's `<h1>`, and the page `<title>`.
+const HEADING: &str = "Glass web fixture";
+/// What the page's result paragraph reads after the button fires.
+const CLICKED: &str = "clicked";
+/// What `set_value` writes into the text input.
+const TYPED: &str = "typed by glass";
+/// What the keyboard control types into the text input — a second route to the same field.
+const KEYED: &str = "keyed by glass";
+/// What the Notepad leg types, so its `Document` has content to expose.
+const NOTEPAD_LINE: &str = "glass web probe";
+
+/// Each engine's per-machine install path, relative to a Program Files root, with the label the
+/// findings table uses. Gecko is listed so a box that has it reads it.
+const BROWSERS: [(&str, &str); 3] = [
+    (
+        "Edge (Chromium/WebView2)",
+        r"Microsoft\Edge\Application\msedge.exe",
+    ),
+    (
+        "Brave (Chromium)",
+        r"BraveSoftware\Brave-Browser\Application\brave.exe",
+    ),
+    ("Firefox (Gecko)", r"Mozilla Firefox\firefox.exe"),
+];
+
+/// One engine's headline readings, for the aggregate line.
+struct Reading {
+    engine: &'static str,
+    installed: bool,
+    arrived: bool,
+    clicked: bool,
+    value_took: bool,
+    frameworks: Vec<String>,
+}
+
+impl Reading {
+    fn absent(engine: &'static str) -> Reading {
+        Reading {
+            engine,
+            installed: false,
+            arrived: false,
+            clicked: false,
+            value_took: false,
+            frameworks: Vec::new(),
+        }
+    }
+}
+
+/// A `Glass` session wired to the real Windows backend + UIA reader, so the probe reads through
+/// the production `click_element`/`set_value` orchestration rather than the reader alone. Same
+/// shape as `tests/onbox.rs`'s `glass_windows_with_a11y`; the baseline dir is leaked deliberately,
+/// this being a short-lived on-box test process.
+fn glass_windows_with_a11y() -> Glass {
+    let factory: PlatformFactory = Box::new(|_backend| {
+        Ok(Backend {
+            platform: Box::new(WindowsPlatform::new()?),
+            accessibility: Some(Box::new(WindowsA11y::new())),
+        })
+    });
+    let dir = tempfile::tempdir().expect("tempdir for baseline store");
+    let root = dir.path().join("baselines");
+    std::mem::forget(dir);
+    Glass::new(factory, "windows".into(), BaselineStore::new(root), 100)
+}
+
+/// The shared web fixture as a `file://` URL, derived from this crate's manifest dir so it points
+/// at whatever checkout the box built. Backslashes are swapped for forward slashes: a browser
+/// takes the URL form, not the Windows path form.
+fn page_url() -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("repo root is two levels above crates/glass-windows")
+        .join("examples")
+        .join("web-role-fixture")
+        .join("index.html");
+    format!("file:///{}", path.display().to_string().replace('\\', "/"))
+}
+
+/// Locate an install under either Program Files root. The roots fall back to their standard
+/// paths so the lookup holds even in a session that carries no environment.
+fn locate(relative: &str) -> Option<String> {
+    let roots = [
+        std::env::var("ProgramFiles(x86)").unwrap_or_else(|_| r"C:\Program Files (x86)".into()),
+        std::env::var("ProgramFiles").unwrap_or_else(|_| r"C:\Program Files".into()),
+    ];
+    roots.into_iter().find_map(|base| {
+        let candidate = format!("{base}\\{relative}");
+        Path::new(&candidate).exists().then_some(candidate)
+    })
+}
+
+/// A fresh, isolated profile per launch: no first-run prompts, no session restore, and no
+/// already-running instance adopting the URL instead of starting a process glass owns. The
+/// profile path carries `marker`, which is also how the teardown check finds our processes.
+fn browser_spec(exe: &str, profile: &str) -> AppSpec {
+    let run = if exe.to_ascii_lowercase().contains("firefox") {
+        vec![
+            exe.to_string(),
+            "--no-remote".into(),
+            "--new-instance".into(),
+            "--profile".into(),
+            profile.to_string(),
+            page_url(),
+        ]
+    } else {
+        vec![
+            exe.to_string(),
+            format!("--user-data-dir={profile}"),
+            "--no-first-run".into(),
+            "--no-default-browser-check".into(),
+            page_url(),
+        ]
+    };
+    AppSpec {
+        build: None,
+        run,
+        cwd: None,
+        env: vec![],
+        // A fallback only: window discovery matches the launched process tree first, and a
+        // browser appends its own name to the page title.
+        window_hint: Some(WindowHint {
+            title: Some(HEADING.into()),
+            class: None,
+        }),
+        timeout_ms: LAUNCH_TIMEOUT_MS,
+        sandbox: SandboxLevel::Off,
+        a11y: true,
+    }
+}
+
+/// Notepad, for the text-editor `Document` reading. No `window_hint`: its own process (or the
+/// descendant its launcher hands the UI to) is found by pid-set membership.
+fn notepad_spec() -> AppSpec {
+    AppSpec {
+        build: None,
+        run: vec!["notepad.exe".to_string()],
+        cwd: None,
+        env: vec![],
+        window_hint: None,
+        timeout_ms: 15_000,
+        sandbox: SandboxLevel::Off,
+        a11y: true,
+    }
+}
+
+fn find<'a>(tree: &'a AxTree, pred: &dyn Fn(&AxNode) -> bool) -> Option<&'a AxNode> {
+    fn walk<'a>(node: &'a AxNode, pred: &dyn Fn(&AxNode) -> bool) -> Option<&'a AxNode> {
+        if pred(node) {
+            return Some(node);
+        }
+        node.children.iter().find_map(|c| walk(c, pred))
+    }
+    walk(&tree.root, pred)
+}
+
+fn collect<'a>(tree: &'a AxTree, pred: &dyn Fn(&AxNode) -> bool) -> Vec<&'a AxNode> {
+    fn walk<'a>(node: &'a AxNode, pred: &dyn Fn(&AxNode) -> bool, out: &mut Vec<&'a AxNode>) {
+        if pred(node) {
+            out.push(node);
+        }
+        for child in &node.children {
+            walk(child, pred, out);
+        }
+    }
+    let mut out = Vec::new();
+    walk(&tree.root, pred, &mut out);
+    out
+}
+
+/// The first node whose accessible name is exactly `name`.
+fn named<'a>(tree: &'a AxTree, name: &str) -> Option<&'a AxNode> {
+    find(tree, &|n| n.name.as_deref() == Some(name))
+}
+
+/// The fixture's text input, not its `<label for>`: both carry the same accessible name and the
+/// label comes first in pre-order, so `named` alone writes to the wrong element.
+fn text_input(tree: &AxTree) -> Option<&AxNode> {
+    find(tree, &|n| {
+        n.name.as_deref() == Some(INPUT) && n.states.editable
+    })
+}
+
+/// A node carrying `text` in either its name or its value. The result paragraph's text reaches
+/// `name` on an API that names a text element by its content and `value` on one that exposes a
+/// text interface — looking in only one field would read a working click as a failed one.
+fn carrying<'a>(tree: &'a AxTree, text: &str) -> Option<&'a AxNode> {
+    find(tree, &|n| {
+        n.name.as_deref() == Some(text) || n.value.as_deref() == Some(text)
+    })
+}
+
+/// Every node the reader put a `Document` control type on, whatever role it mapped to — the
+/// web-content boundary this probe reads. Matched on `raw_role` as well as `role` because the
+/// two need not agree, and which one holds the token is part of the reading.
+fn documents(tree: &AxTree) -> Vec<&AxNode> {
+    collect(tree, &|n| {
+        n.role == AxRole::Document || n.raw_role == "Document"
+    })
+}
+
+/// Re-snapshot until the page's own elements arrive or `budget` elapses. Returns the last tree
+/// read, how long it took, and whether the content arrived.
+///
+/// Arrival requires the fixture button to carry bounds, not merely to exist: an engine publishes
+/// the node before it has laid the page out, and a click on a node with no bounds is refused.
+/// The button, not the heading, is the trigger — a heading depends on a role mapping this
+/// backend may not have, and content that arrived must not read as content that did not.
+///
+/// Every error is retried until the deadline: a browser re-execs during startup and the reader
+/// has nothing to bind to until the second process owns the window. Each distinct error prints
+/// once.
+fn snapshot_until_page(glass: &mut Glass, budget: Duration) -> (Option<AxTree>, Duration, bool) {
+    let start = Instant::now();
+    let mut last = None;
+    let mut reported: Vec<String> = Vec::new();
+    loop {
+        match glass.a11y_snapshot(Some(0)) {
+            Ok(tree) => {
+                let arrived = named(&tree, BUTTON).is_some_and(|n| n.bounds.is_some());
+                last = Some(tree);
+                if arrived {
+                    return (last, start.elapsed(), true);
+                }
+            }
+            Err(GlassError::AccessibilityNotReady(_)) => {}
+            Err(e) => {
+                let text = e.to_string();
+                if !reported.contains(&text) {
+                    println!("snapshot error at {:?}: {text}", start.elapsed());
+                    reported.push(text);
+                }
+            }
+        }
+        if start.elapsed() > budget {
+            return (last, start.elapsed(), false);
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    }
+}
+
+fn report_tree(tree: &AxTree) {
+    for doc in documents(tree) {
+        println!(
+            "document: #{} role={:?} raw_role={:?} name={:?} children={} bounds={:?}",
+            doc.id.0,
+            doc.role,
+            doc.raw_role,
+            doc.name,
+            doc.children.len(),
+            doc.bounds
+        );
+    }
+    println!(
+        "heading {HEADING:?} present: {}",
+        find(tree, &|n| n.role == AxRole::Heading
+            && n.name.as_deref() == Some(HEADING))
+        .is_some()
+    );
+    println!("role histogram (role, count, native token):");
+    for tally in role_histogram(tree) {
+        println!("  {:?} {:>4}  {}", tally.role, tally.count, tally.raw_role);
+    }
+    for notice in [
+        tree.truncation_notice(),
+        tree.unreadable_notice(),
+        tree.subject_notice(),
+        tree.empty_guidance().map(str::to_string),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        println!("notice: {notice}");
+    }
+    println!("outline:\n{}", tree.to_outline());
+}
+
+/// How many times to re-snapshot-and-click. A browser's tree keeps changing while the page
+/// settles, and an id whose node has moved since the snapshot is rejected as changed.
+const CLICK_ATTEMPTS: usize = 4;
+
+/// The actuation readings. Each step re-snapshots first: `click_element` and `set_value` resolve
+/// ids against the session's most recent tree, so an id from an older one addresses nothing.
+/// Returns whether the click landed and whether the written value read back.
+fn exercise(glass: &mut Glass) -> (bool, bool) {
+    let mut clicked = false;
+    for attempt in 1..=CLICK_ATTEMPTS {
+        let before = match glass.a11y_snapshot(Some(0)) {
+            Ok(tree) => tree,
+            Err(e) => {
+                println!("snapshot before the click failed: {e} — no click reading");
+                return (false, false);
+            }
+        };
+        let Some(button) = named(&before, BUTTON) else {
+            println!("no node named {BUTTON:?} — no click reading");
+            return (false, false);
+        };
+        if attempt == 1 {
+            println!(
+                "button: #{} role={:?} raw_role={} bounds={:?}",
+                button.id.0, button.role, button.raw_role, button.bounds
+            );
+        }
+        match glass.click_element(button.id) {
+            Ok(method) => {
+                std::thread::sleep(Duration::from_millis(500));
+                match glass.a11y_snapshot(Some(0)) {
+                    Ok(after) => {
+                        clicked = carrying(&after, CLICKED).is_some();
+                        println!(
+                            "click_element (attempt {attempt}): {method:?} → result paragraph \
+                             reads {CLICKED:?}: {clicked}"
+                        );
+                    }
+                    Err(e) => println!("click_element: {method:?} → re-snapshot failed: {e}"),
+                }
+                break;
+            }
+            Err(e) => {
+                println!("click_element (attempt {attempt}) failed: {e}");
+                std::thread::sleep(Duration::from_millis(500));
+            }
+        }
+    }
+
+    let after = match glass.a11y_snapshot(Some(0)) {
+        Ok(tree) => tree,
+        Err(e) => {
+            println!("snapshot before set_value failed: {e} — no set_value reading");
+            return (clicked, false);
+        }
+    };
+    let Some(field) = text_input(&after) else {
+        println!("no editable node named {INPUT:?} — no set_value reading");
+        return (clicked, false);
+    };
+    println!(
+        "text input: #{} role={:?} raw_role={} value={:?}",
+        field.id.0, field.role, field.raw_role, field.value
+    );
+    let set = glass.set_value(field.id, TYPED);
+    std::thread::sleep(Duration::from_millis(500));
+    let after = match glass.a11y_snapshot(Some(0)) {
+        Ok(tree) => tree,
+        Err(e) => {
+            println!("set_value: {set:?} → re-snapshot failed: {e}");
+            return (clicked, false);
+        }
+    };
+    let read_back = text_input(&after).and_then(|n| n.value.clone());
+    let value_took = read_back.as_deref() == Some(TYPED);
+    println!("set_value: {set:?} → text input value={read_back:?}");
+
+    // The control for the line above. An empty read-back has two causes — the write never landed,
+    // or this engine never reports a web input's text — and only text that reached the field by
+    // another route tells them apart. Typed through the pointer and keyboard, which do not touch
+    // the accessibility write path.
+    if let Some(field) = text_input(&after) {
+        let focus = glass.click_element(field.id);
+        let raised = glass.window(&WindowOp::Focus);
+        let keyed = glass.key(&KeyEvent::Text(KEYED.to_string()));
+        std::thread::sleep(Duration::from_millis(500));
+        match glass.a11y_snapshot(Some(0)) {
+            Ok(after) => println!(
+                "control — click {focus:?}, focus {:?}, key {keyed:?} → text input value={:?}",
+                raised.is_ok(),
+                text_input(&after).and_then(|n| n.value.clone())
+            ),
+            Err(e) => println!("control — re-snapshot failed: {e}"),
+        }
+    }
+
+    match glass.a11y_snapshot(Some(0)) {
+        Ok(after) => {
+            println!("every editable node at the end:");
+            for node in collect(&after, &|n| n.states.editable) {
+                println!(
+                    "  #{} role={:?} raw_role={} name={:?} value={:?}",
+                    node.id.0, node.role, node.raw_role, node.name, node.value
+                );
+            }
+            println!("--- tree after actuation ---");
+            report_tree(&after);
+        }
+        Err(e) => println!("final snapshot failed: {e}"),
+    }
+    (clicked, value_took)
+}
+
+/// Every `Document` control type under `root`, with the `FrameworkId` that is the whole point of
+/// the reading. Returns the distinct framework ids seen, in the order first seen.
+fn documents_under(automation: &UIAutomation, root: UIElement, label: &str) -> Vec<String> {
+    let started = Instant::now();
+    let found = automation
+        .create_matcher()
+        .from(root)
+        .control_type(ControlType::Document)
+        .depth(DOC_DEPTH)
+        .find_all();
+    let mut frameworks: Vec<String> = Vec::new();
+    match found {
+        Ok(elements) => {
+            println!(
+                "{label}: {} Document element(s) in {:?}",
+                elements.len(),
+                started.elapsed()
+            );
+            for el in &elements {
+                let framework = el.get_framework_id().unwrap_or_default();
+                println!(
+                    "  Document: framework={framework:?} class={:?} name={:?} pid={:?}",
+                    el.get_classname(),
+                    el.get_name(),
+                    el.get_process_id()
+                );
+                if !framework.is_empty() && !frameworks.contains(&framework) {
+                    frameworks.push(framework);
+                }
+            }
+        }
+        // `find_all` reports "nothing matched" as an error, so this is the no-Document case too.
+        Err(e) => println!(
+            "{label}: no Document element after {:?} ({e})",
+            started.elapsed()
+        ),
+    }
+    frameworks
+}
+
+/// The app's top-level window as a UIA element, bound by handle exactly as the reader itself
+/// binds it — so the scoped walk sees the window glass drives, not a peer app's.
+fn app_window_element(glass: &mut Glass, automation: &UIAutomation) -> Option<UIElement> {
+    let windows = match glass.list_windows() {
+        Ok(w) => w,
+        Err(e) => {
+            println!("list_windows failed: {e}");
+            return None;
+        }
+    };
+    for w in &windows {
+        println!(
+            "window: handle=0x{:x} title={:?} class={:?} active={}",
+            w.id.0, w.title, w.class, w.active
+        );
+    }
+    let target = windows
+        .iter()
+        .find(|w| w.active)
+        .or_else(|| windows.first())?;
+    match automation.element_from_handle(Handle::from(target.id.0 as isize)) {
+        Ok(el) => {
+            println!(
+                "window element: framework={:?} class={:?} name={:?} pid={:?}",
+                el.get_framework_id(),
+                el.get_classname(),
+                el.get_name(),
+                el.get_process_id()
+            );
+            Some(el)
+        }
+        Err(e) => {
+            println!("element_from_handle failed: {e}");
+            None
+        }
+    }
+}
+
+/// The `FrameworkId` reading for a running app: scoped to its own window first (precise), then
+/// the whole-desktop walk the recipe calls for, which also shows what else on the box publishes
+/// a `Document`. Returns the framework ids seen under the app's own window.
+fn framework_reading(glass: &mut Glass, label: &str) -> Vec<String> {
+    let automation = match UIAutomation::new() {
+        Ok(a) => a,
+        Err(e) => {
+            println!("UIAutomation::new failed: {e}");
+            return Vec::new();
+        }
+    };
+    let scoped = match app_window_element(glass, &automation) {
+        Some(window) => documents_under(&automation, window, &format!("{label}, from its window")),
+        None => Vec::new(),
+    };
+    match automation.get_root_element() {
+        Ok(root) => {
+            documents_under(
+                &automation,
+                root,
+                &format!("{label}, from the desktop root"),
+            );
+        }
+        Err(e) => println!("get_root_element failed: {e}"),
+    }
+    scoped
+}
+
+/// Count processes named `exe` whose command line carries `marker` — our isolated profile — so
+/// the box's own browsers are not counted. `-1` means the query itself failed.
+fn our_process_count(exe: &str, marker: &str) -> i32 {
+    let ps = format!(
+        "@(Get-CimInstance Win32_Process -Filter \"Name='{exe}'\" | \
+         Where-Object {{ $_.CommandLine -like '*{marker}*' }}).Count"
+    );
+    match std::process::Command::new("powershell")
+        .args(["-NoProfile", "-Command", &ps])
+        .output()
+    {
+        Ok(o) => String::from_utf8_lossy(&o.stdout)
+            .trim()
+            .parse()
+            .unwrap_or(-1),
+        Err(_) => -1,
+    }
+}
+
+/// One engine's whole reading: launch on the fixture, wait for content, actuate, then read the
+/// `Document` control types. Never panics after `start` — `stop` has to run.
+fn probe_browser(engine: &'static str, exe: &str, marker: &str) -> Reading {
+    println!("\n=== {engine} — {exe} ===");
+    let profile = glass_windows::onbox_support::scratch_dir(marker);
+    let _ = std::fs::remove_dir_all(&profile);
+
+    let spec = browser_spec(exe, &profile);
+    println!("run: {:?}", spec.run);
+
+    let mut reading = Reading {
+        engine,
+        installed: true,
+        ..Reading::absent(engine)
+    };
+    let mut glass = glass_windows_with_a11y();
+    let started = Instant::now();
+    if let Err(e) = glass.start(&spec) {
+        println!("start failed after {:?}: {e}", started.elapsed());
+        let _ = std::fs::remove_dir_all(&profile);
+        return reading;
+    }
+    println!("window mapped after {:?}", started.elapsed());
+
+    let (tree, settle, arrived) = snapshot_until_page(&mut glass, SETTLE);
+    println!("page content arrived within {SETTLE:?}: {arrived} after {settle:?}");
+    let (tree, arrived) = if arrived {
+        (tree, true)
+    } else {
+        // A second, longer read so "slow" is not recorded as "never".
+        let (tree, settle, arrived) = snapshot_until_page(&mut glass, EXTENDED_SETTLE);
+        println!("extended read: arrived={arrived} after a further {settle:?}");
+        (tree, arrived)
+    };
+    reading.arrived = arrived;
+
+    match tree {
+        Some(tree) => {
+            report_tree(&tree);
+            if arrived {
+                let (clicked, value_took) = exercise(&mut glass);
+                reading.clicked = clicked;
+                reading.value_took = value_took;
+            } else if let Some(hint) = tree.document_guidance() {
+                println!("disclosure rendered:\n{hint}");
+            } else {
+                println!("NO DOCUMENT DISCLOSURE — content missing and nothing said so");
+            }
+        }
+        None => println!("no tree at all — nothing was published"),
+    }
+
+    reading.frameworks = framework_reading(&mut glass, engine);
+    println!("stop: {:?}", glass.stop());
+    let _ = std::fs::remove_dir_all(&profile);
+    reading
+}
+
+/// The text-editor half of the `FrameworkId` reading: a stock editor's `Document` is the thing a
+/// web document has to be told apart from.
+fn probe_notepad() -> Vec<String> {
+    println!("\n=== notepad ===");
+    let mut glass = glass_windows_with_a11y();
+    if let Err(e) = glass.start(&notepad_spec()) {
+        println!("start notepad failed: {e}");
+        return Vec::new();
+    }
+    let raised = glass.window(&WindowOp::Focus);
+    let typed = glass.key(&KeyEvent::Text(NOTEPAD_LINE.to_string()));
+    println!("focus {:?}, typed a line: {typed:?}", raised.is_ok());
+    std::thread::sleep(Duration::from_millis(800));
+    match glass.a11y_snapshot(Some(0)) {
+        Ok(tree) => report_tree(&tree),
+        Err(e) => println!("notepad snapshot failed: {e}"),
+    }
+    let frameworks = framework_reading(&mut glass, "notepad");
+    println!("stop: {:?}", glass.stop());
+    frameworks
+}
+
+#[test]
+#[ignore = "on-box only: needs the interactive desktop session and an installed browser"]
+fn web_probe() {
+    let mut readings = Vec::new();
+    let mut launched = Vec::new();
+    for (engine, relative) in BROWSERS {
+        let Some(exe) = locate(relative) else {
+            println!("\n=== {engine} — not installed at {relative}; skipped ===");
+            readings.push(Reading::absent(engine));
+            continue;
+        };
+        let stem = Path::new(&exe)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("browser")
+            .to_string();
+        let exe_name = Path::new(&exe)
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_string();
+        let marker = format!("glass-web-probe-{stem}");
+        readings.push(probe_browser(engine, &exe, &marker));
+        launched.push((exe_name, marker));
+    }
+    let notepad = probe_notepad();
+
+    println!("\n== aggregate: web-content probe ==");
+    for r in &readings {
+        if !r.installed {
+            println!("  {}: unread (not installed)", r.engine);
+            continue;
+        }
+        println!(
+            "  {}: arrived={} clicked={} set_value_took={} frameworks={:?}",
+            r.engine, r.arrived, r.clicked, r.value_took, r.frameworks
+        );
+    }
+    println!("  notepad: frameworks={notepad:?}");
+
+    // The only assertion: a browser this probe launched may not outlive it.
+    let survivors: Vec<(String, i32)> = launched
+        .iter()
+        .map(|(exe, marker)| (exe.clone(), our_process_count(exe, marker)))
+        .filter(|(_, n)| *n != 0)
+        .collect();
+    println!("  survivors after stop: {survivors:?}");
+    assert!(
+        survivors.is_empty(),
+        "processes carrying our profile marker survived stop: {survivors:?}"
+    );
+}

--- a/crates/glass-windows/tests/web_probe.rs
+++ b/crates/glass-windows/tests/web_probe.rs
@@ -60,6 +60,10 @@ const KEYED: &str = "keyed by glass";
 /// What the Notepad leg types, so its `Document` has content to expose.
 const NOTEPAD_LINE: &str = "glass web probe";
 
+/// The Notepad leg's scratch name: it names the directory holding the file Notepad opens, and so is
+/// the command-line marker [`our_pids`] matches on — the box's own Notepad is never touched.
+const NOTEPAD_MARKER: &str = "glass-web-probe-notepad";
+
 /// Each engine's per-machine install path, relative to a Program Files root, with the label the
 /// findings table uses. Gecko is listed so a box that has it reads it.
 const BROWSERS: [(&str, &str); 3] = [
@@ -247,12 +251,14 @@ fn browser_spec(exe: &str, profile: &str) -> AppSpec {
     }
 }
 
-/// Notepad, for the text-editor `Document` reading. No `window_hint`: its own process (or the
-/// descendant its launcher hands the UI to) is found by pid-set membership.
-fn notepad_spec() -> AppSpec {
+/// Notepad, for the text-editor `Document` reading, opened on `file` so the typed line belongs to
+/// a file this probe owns and deletes rather than to an unsaved tab the box would keep. No
+/// `window_hint`: its own process (or the descendant its launcher hands the UI to) is found by
+/// pid-set membership.
+fn notepad_spec(file: &str) -> AppSpec {
     AppSpec {
         build: None,
-        run: vec!["notepad.exe".to_string()],
+        run: vec!["notepad.exe".to_string(), file.to_string()],
         cwd: None,
         env: vec![],
         window_hint: None,
@@ -337,7 +343,6 @@ fn snapshot_until_page(
 ) -> (Option<AxTree>, Duration, bool) {
     let start = Instant::now();
     let mut last = None;
-    let mut reported: Vec<String> = Vec::new();
     loop {
         match glass.a11y_snapshot(Some(0)) {
             Ok(tree) => {
@@ -349,11 +354,12 @@ fn snapshot_until_page(
             }
             Err(GlassError::AccessibilityNotReady(_)) => {}
             Err(e) => {
-                let text = e.to_string();
-                if !reported.contains(&text) {
-                    say!("snapshot error at {:?}: {text}", start.elapsed());
-                    failures.push(format!("{label}: snapshot error: {text}"));
-                    reported.push(text);
+                // Deduped against `failures`, not a local set: this runs twice per browser (the
+                // initial pass, then the extended one), and one broken channel is one breakage.
+                let msg = format!("{label}: snapshot error: {e}");
+                if !failures.contains(&msg) {
+                    say!("snapshot error at {:?}: {e}", start.elapsed());
+                    failures.push(msg);
                 }
             }
         }
@@ -685,8 +691,8 @@ fn framework_reading(glass: &mut Glass, label: &str, failures: &mut Vec<String>)
     scoped
 }
 
-/// Pids of processes named `exe` whose command line carries `marker` — our isolated profile — so
-/// the box's own browsers are never matched. An empty vec also covers a failed query, which is
+/// Pids of processes named `exe` whose command line carries `marker` — our isolated profile, or
+/// the directory holding the file Notepad was opened on — so the box's own apps are never matched. An empty vec also covers a failed query, which is
 /// why the teardown check kills what this returns rather than trusting a count — and why a
 /// failed query is recorded into `failures` rather than trusted silently: a query that never
 /// works would otherwise report every survivor as "gone" for the rest of the run.
@@ -807,12 +813,35 @@ fn probe_browser(
     reading
 }
 
+/// The empty file Notepad opens, under a scratch directory named for [`NOTEPAD_MARKER`]. Notepad
+/// offers to create a path that does not exist instead of opening it, so the file is written
+/// first. `None` if either step fails.
+fn prepare_notepad_file() -> Option<String> {
+    let dir = glass_windows::onbox_support::scratch_dir(NOTEPAD_MARKER);
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        say!("could not create the notepad scratch dir {dir}: {e}");
+        return None;
+    }
+    let path = Path::new(&dir).join("notepad.txt");
+    if let Err(e) = std::fs::write(&path, "") {
+        say!("could not create the notepad file {}: {e}", path.display());
+        return None;
+    }
+    Some(path.display().to_string())
+}
+
 /// The text-editor half of the `FrameworkId` reading: a stock editor's `Document` is the thing a
-/// web document has to be told apart from.
+/// web document has to be told apart from. Launched on a file of its own so the line typed into it
+/// never becomes unsaved session state on the box; the caller survivor-checks and deletes both,
+/// the same way it does for a browser.
 fn probe_notepad(failures: &mut Vec<String>) -> Vec<String> {
     say!("\n=== notepad ===");
+    let Some(file) = prepare_notepad_file() else {
+        failures.push("notepad: could not create the file to open".to_string());
+        return Vec::new();
+    };
     let mut glass = glass_windows_with_a11y();
-    if let Err(e) = glass.start(&notepad_spec()) {
+    if let Err(e) = glass.start(&notepad_spec(&file)) {
         say!("start notepad failed: {e}");
         failures.push(format!("notepad: start failed: {e}"));
         return Vec::new();
@@ -863,6 +892,10 @@ fn web_probe() {
         launched.push((exe_name, marker));
     }
     let notepad = probe_notepad(&mut failures);
+    // The Notepad leg is launched like a browser, so it is torn down like one: the loop below
+    // reads whether its `stop` took, kills what is left by exact pid, and removes the scratch
+    // directory holding the file it opened.
+    launched.push(("notepad.exe".to_string(), NOTEPAD_MARKER.to_string()));
 
     say!("\n== aggregate: web-content probe ==");
     for r in &readings {
@@ -881,9 +914,10 @@ fn web_probe() {
     }
     say!("  notepad: frameworks={notepad:?}");
 
-    // Whether `stop` reached each browser is a reading, printed above the cleanup so a leak is
-    // visible even though the probe then repairs it. The probe owns every process carrying its
-    // own profile marker, so it kills those by exact pid rather than leaving them on the box.
+    // Whether `stop` reached each launched app is a reading, printed above the cleanup so a leak
+    // is visible even though the probe then repairs it. The probe owns every process carrying one
+    // of its own scratch markers, so it kills those by exact pid rather than leaving them on the
+    // box, and removes the scratch directory each marker names.
     let mut left_behind = Vec::new();
     for (exe, marker) in &launched {
         let survivors = wait_for_no_process(exe, marker, TEARDOWN_BUDGET, &mut failures);
@@ -909,8 +943,8 @@ fn web_probe() {
     // Nothing this probe launched may still be running on the box.
     assert!(
         left_behind.is_empty(),
-        "processes carrying our profile marker outlived both stop and the probe's own kill: \
-         {left_behind:?}"
+        "processes carrying one of our scratch markers outlived both stop and the probe's own \
+         kill: {left_behind:?}"
     );
     // Genuine breakage — a browser that never launched, or an accessibility channel that never
     // answered — collected while every browser still got its turn; asserted last, so the

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,3 +57,4 @@ way it does? The explanations.
 - [Containment and sandboxing](explanation/containment.md)
 - [The macOS permission model](explanation/macos-permissions.md)
 - [The Windows access model](explanation/windows-permissions.md)
+- [Web content](explanation/web-content.md)

--- a/docs/explanation/web-content.md
+++ b/docs/explanation/web-content.md
@@ -1,0 +1,66 @@
+# Web content
+
+A browser tab or an embedded web view is not like the rest of a native UI: the accessibility tree
+for it is built by a web engine (Chromium, WebKit, Gecko) sitting inside the app, on its own
+schedule, not by the toolkit glass reads everywhere else. That difference is why web content gets
+its own page rather than a line in the roles reference.
+
+## Publication is lazy, and conditional
+
+A web engine does not build its accessibility tree just because a page loaded. Most engines build
+it only once they believe an assistive technology is present — a signal that follows something
+other than the page load. Until an engine reaches that belief, the tree it hands to the OS's
+accessibility layer is empty or absent, no matter how populated the rendered page is. glass treats
+this as a mechanism to handle, not a guarantee: it discloses what it actually read rather than
+inferring what should be there from the DOM the agent can't see.
+
+## What glass does at launch
+
+Nothing extra, on every platform. glass never pokes a browser to turn its accessibility on. On
+Linux, the private AT-SPI bus that `glass_start` already spawns for every a11y-enabled session *is*
+the presence signal — a browser asking whether an AT is running finds one already there, so there
+is no separate step for web content. On Windows, macOS and Android the engines examined published
+at baseline against the readers glass already runs, with no extra lever pulled to get there.
+
+## What an agent sees
+
+Web content shows up in a `glass_a11y_snapshot` outline as one of three shapes, plus a fourth,
+older case that isn't specific to web content at all:
+
+- **A populated `Document`.** The engine has published its tree; the page's headings, links and
+  fields are the `Document`'s children, addressable by id like any other element.
+- **A childless `Document`, plus a notice.** The engine hasn't published yet, the page is genuinely
+  empty, or the walk was cut short before reaching the content — the outline alone can't tell those
+  apart. The notice names the element by id and bounds and asks for a fresh snapshot first; only if
+  the page is still empty on that re-read does it steer to pixels.
+- **A withheld placeholder, plus a different notice.** Some apps publish a stand-in element for a
+  web view whose accessibility is off entirely. Nothing behind a placeholder can ever be addressed
+  by id — a re-snapshot won't change that — so this notice goes straight to `glass_screenshot`, then
+  `glass_click` at x,y.
+- **No accessibility elements at all** (`empty_guidance`) is the pre-existing case for any app that
+  publishes no tree — canvas apps, toolkits that need a11y turned on. It is not web-specific, and a
+  page can also fall into it if the surrounding app itself exposes nothing.
+
+## Readings, by platform
+
+Every claim below is what a specific engine build did on the date read, not a fact about the
+engine — a later version, or the same engine under a different embedder, can differ.
+
+| Platform | Engines read (2026-08-24) | What was read |
+|---|---|---|
+| Linux (AT-SPI) | Firefox 153 | Publishes `document web` at baseline (0.3–0.9s) on both X11 and Wayland; a nested `<iframe>` is its own `Document`. |
+| Linux (AT-SPI) | Brave 151 (Chromium) | Publishes a null placeholder child while renderer accessibility is off — read as withheld content, not an empty page. |
+| Windows (UIA) | Edge 151, Brave 151, Firefox 154 | Publish at baseline (0.4–3.3s). A web page's `Document` and a text editor's edit surface report the same UIA control type; they're told apart per element by the `FrameworkId` each reports (`Chrome`/`Gecko` vs. `Win32`). Clicks and `set_value` land. |
+| macOS (AX) | Safari 26.5 (WebKit) | Publishes `AXWebArea` in the very first snapshot — reading the tree is itself what materializes the lazily built web area. `AXPress` clicks land; `set_value` on a web input is refused honestly (`AxValueNotApplied`) — type into it instead. |
+| Android | both readers | A WebView's page arrives as `Document` twice — the host view and the page root. The first snapshot right after launch can show a childless `Document`; the next one holds the page. |
+| iOS (idb) | WKWebView | No element at all — not the view, not the page, not an empty web area. See below. |
+
+## What stays open: iOS
+
+Every other platform's failure mode is a `Document` that arrived empty or as a placeholder — a
+node the agent can see and act on the disclosure for. On iOS, a `WKWebView`'s page contributes
+nothing to the tree `idb` hands back: no view, no content, no node to attach a notice to. The
+matrix records this as `unmarked` rather than `absent`, because the control is on screen and real —
+it just never surfaces through this reading path. Closing this gap needs a different signal than
+the childless-`Document` mechanism the other platforms use, since there is no element here for that
+mechanism to act on.

--- a/docs/explanation/web-content.md
+++ b/docs/explanation/web-content.md
@@ -19,10 +19,12 @@ actually read rather than what the DOM the agent can't see suggests should be th
 
 Nothing extra, on every platform. glass never pokes a browser to turn its accessibility on. On
 Linux, under the private AT-SPI bus `glass_start` already spawns for every a11y-enabled session,
-Firefox 153 published its page at baseline on both X11 and Wayland; Brave 151 did not, and neither
-of the two environment levers tried on it changed that (read 2026-08-24). On Windows, macOS and
-Android the engines examined published at baseline against the readers glass already runs, with no
-extra lever pulled to get there.
+Firefox 153 published its page at baseline on both X11 and Wayland; Brave 151 did not, and it
+stayed that way under both candidate levers tried on it: the `GNOME_ACCESSIBILITY=1` /
+`ACCESSIBILITY_ENABLED=1` environment pair, and the `--force-renderer-accessibility`
+command-line flag — which glass cannot inject into an arbitrary app it launches (read
+2026-08-24). On Windows, macOS and Android the engines examined published at baseline against
+the readers glass already runs, with no extra lever pulled to get there.
 
 ## What an agent sees
 

--- a/docs/explanation/web-content.md
+++ b/docs/explanation/web-content.md
@@ -54,7 +54,7 @@ engine — a later version, or the same engine under a different embedder, can d
 | Linux (AT-SPI) | Brave 151 (Chromium) | Publishes a null placeholder child while renderer accessibility is off — read as withheld content, not an empty page. |
 | Windows (UIA) | Edge 151, Brave 151, Firefox 154 | Publish at baseline (0.4–3.3s). A web page's `Document` and a text editor's edit surface report the same UIA control type; they're told apart per element by the `FrameworkId` each reports (`Chrome`/`Gecko` vs. `Win32`). Clicks and `set_value` land. |
 | macOS (AX) | Safari 26.5 (WebKit) | Publishes `AXWebArea` in the very first snapshot — reading the tree is itself what materializes the lazily built web area. `AXPress` clicks land; `set_value` on a web input is refused honestly (`AxValueNotApplied`) — type into it instead. |
-| Android | both readers | A WebView's page arrives as `Document` twice — the host view and the page root. The first snapshot right after launch can show a childless `Document`; the next one holds the page. |
+| Android | System WebView (version not read), on an API 34 emulator | Read through both readers — `uiautomator` and the on-device companion (v0.6.0). A WebView's page arrives as `Document` twice — the host view and the page root. The first snapshot right after launch can show a childless `Document`; the next one holds the page. |
 | iOS (idb) | WKWebView | No element at all — not the view, not the page, not an empty web area. See below. |
 
 ## What stays open: iOS

--- a/docs/explanation/web-content.md
+++ b/docs/explanation/web-content.md
@@ -5,22 +5,24 @@ for it is built by a web engine (Chromium, WebKit, Gecko) sitting inside the app
 schedule, not by the toolkit glass reads everywhere else. That difference is why web content gets
 its own page rather than a line in the roles reference.
 
-## Publication is lazy, and conditional
+## Publication is not tied to the page load
 
-A web engine does not build its accessibility tree just because a page loaded. Most engines build
-it only once they believe an assistive technology is present — a signal that follows something
-other than the page load. Until an engine reaches that belief, the tree it hands to the OS's
-accessibility layer is empty or absent, no matter how populated the rendered page is. glass treats
-this as a mechanism to handle, not a guarantee: it discloses what it actually read rather than
-inferring what should be there from the DOM the agent can't see.
+A web engine does not necessarily build its accessibility tree when the page loads. What was read
+here spans both outcomes: every engine read on Windows and macOS, and Firefox 153 on Linux,
+published within seconds of the page arriving, while Brave 151 on Linux published a placeholder and
+no tree at all inside the probe's 20 s wait (read 2026-08-24). Where an engine has not published,
+the tree it hands to the OS's accessibility layer is empty or absent no matter how populated the
+rendered page is. glass treats that as something to disclose, not to infer: it reports what it
+actually read rather than what the DOM the agent can't see suggests should be there.
 
 ## What glass does at launch
 
 Nothing extra, on every platform. glass never pokes a browser to turn its accessibility on. On
-Linux, the private AT-SPI bus that `glass_start` already spawns for every a11y-enabled session *is*
-the presence signal — a browser asking whether an AT is running finds one already there, so there
-is no separate step for web content. On Windows, macOS and Android the engines examined published
-at baseline against the readers glass already runs, with no extra lever pulled to get there.
+Linux, under the private AT-SPI bus `glass_start` already spawns for every a11y-enabled session,
+Firefox 153 published its page at baseline on both X11 and Wayland; Brave 151 did not, and neither
+of the two environment levers tried on it changed that (read 2026-08-24). On Windows, macOS and
+Android the engines examined published at baseline against the readers glass already runs, with no
+extra lever pulled to get there.
 
 ## What an agent sees
 

--- a/docs/reference/a11y-roles.md
+++ b/docs/reference/a11y-roles.md
@@ -64,16 +64,16 @@ now, and the outline only names the token of an element that has none.
 `Document` element with the page's elements as its children; an `<iframe>` is a `Document`
 inside it. On Windows a text editor's edit surface arrives under the same UIA control type, so
 the two are told apart per node by the framework the element reports — Chromium reported `Chrome`
-and Gecko `Gecko` against a stock text editor's `Win32` (read 2026-08-24). A web engine may
-publish its tree only after it detects an assistive technology, so a `Document` can arrive with
-no children at all. glass discloses that case in the snapshot rather
+and Gecko `Gecko` against a stock text editor's `Win32` (read 2026-08-24). A `Document` can arrive
+with no children — read on Android, where the first snapshot after a launch showed an empty
+WebView and the next held the page (2026-08-24). glass discloses that case in the snapshot rather
 than leaving an empty container to be read as an empty page, and where the walk completed the
 disclosure asks for a fresh snapshot before the pixel path: on an Android WebView the first
 snapshot after a launch was childless and the next held the whole page (read 2026-08-24). On iOS
 there is no such element to disclose — a `WKWebView` page contributed nothing to the tree through
 `idb`, neither the view nor its content (read on the iOS 26.5 Simulator, 2026-08-24), so a web
 page there is a pixel job: `glass_screenshot`, then `glass_click` at x,y. See
-[Web content](../explanation/web-content.md) for the mechanism and the per-platform readings.
+[Web content](../explanation/web-content.md) for the per-platform readings.
 
 <!-- BEGIN GENERATED: role-support -->
 | Role | Linux (AT-SPI) | Windows (UIA) | macOS (AX) | Android | iOS |

--- a/docs/reference/a11y-roles.md
+++ b/docs/reference/a11y-roles.md
@@ -72,7 +72,8 @@ disclosure asks for a fresh snapshot before the pixel path: on an Android WebVie
 snapshot after a launch was childless and the next held the whole page (read 2026-08-24). On iOS
 there is no such element to disclose — a `WKWebView` page contributed nothing to the tree through
 `idb`, neither the view nor its content (read on the iOS 26.5 Simulator, 2026-08-24), so a web
-page there is a pixel job: `glass_screenshot`, then `glass_click` at x,y.
+page there is a pixel job: `glass_screenshot`, then `glass_click` at x,y. See
+[Web content](../explanation/web-content.md) for the mechanism and the per-platform readings.
 
 <!-- BEGIN GENERATED: role-support -->
 | Role | Linux (AT-SPI) | Windows (UIA) | macOS (AX) | Android | iOS |

--- a/docs/reference/a11y-roles.md
+++ b/docs/reference/a11y-roles.md
@@ -62,8 +62,11 @@ now, and the outline only names the token of an element that has none.
 
 **A web document is a `Document`.** A browser page or an embedded web view arrives as one
 `Document` element with the page's elements as its children; an `<iframe>` is a `Document`
-inside it. A web engine may publish its tree only after it detects an assistive technology, so a
-`Document` can arrive with no children at all. glass discloses that case in the snapshot rather
+inside it. On Windows a text editor's edit surface arrives under the same UIA control type, so
+the two are told apart per node by the framework the element reports — Chromium reported `Chrome`
+and Gecko `Gecko` against a stock text editor's `Win32` (read 2026-08-24). A web engine may
+publish its tree only after it detects an assistive technology, so a `Document` can arrive with
+no children at all. glass discloses that case in the snapshot rather
 than leaving an empty container to be read as an empty page, and where the walk completed the
 disclosure asks for a fresh snapshot before the pixel path: on an Android WebView the first
 snapshot after a launch was childless and the next held the whole page (read 2026-08-24). On iOS
@@ -107,7 +110,7 @@ page there is a pixel job: `glass_screenshot`, then `glass_click` at x,y.
 | `Toolbar` | yes | yes | yes | unmarked | yes |
 | `StatusBar` | yes | yes | unmarked | elsewhere | elsewhere |
 | `Heading` | yes | gap | yes | gap | yes |
-| `Document` | yes | gap | yes | yes | unmarked |
+| `Document` | yes | yes | yes | yes | unmarked |
 
 ### Why a cell is not `yes`
 
@@ -158,6 +161,5 @@ page there is a pixel job: `glass_screenshot`, then `glass_click` at x,y.
 - `StatusBar` / iOS — elsewhere: the system status bar is outside the app tree
 - `Heading` / Windows (UIA) — gap: UIA marks a heading with the HeadingLevel property — an h1 arrives as Text carrying level 80051 — and the reader maps by control type alone, so it never sees it. Header and HeaderItem are a grid's column headers, a different concept the normalized set has no role for
 - `Heading` / Android — gap: AccessibilityNodeInfo's isHeading marks a heading, and neither reader carries it: the uiautomator dump has no such attribute and the service reader parses only class, text, description and bounds
-- `Document` / Windows (UIA) — gap: UIA's Document control type maps to TextArea, read from a text editor's edit surface; what a web document reports on this backend has not been read, so the cell waits on that reading
 - `Document` / iOS — unmarked: a WKWebView page exposes no element at all through idb — neither the view nor its content (read on the iOS 26.5 Simulator, companions 1.5.0b3 and 1.1.8)
 <!-- END GENERATED: role-support -->

--- a/docs/reference/a11y-roles.md
+++ b/docs/reference/a11y-roles.md
@@ -66,7 +66,10 @@ inside it. A web engine may publish its tree only after it detects an assistive 
 `Document` can arrive with no children at all. glass discloses that case in the snapshot rather
 than leaving an empty container to be read as an empty page, and where the walk completed the
 disclosure asks for a fresh snapshot before the pixel path: on an Android WebView the first
-snapshot after a launch was childless and the next held the whole page (read 2026-08-24).
+snapshot after a launch was childless and the next held the whole page (read 2026-08-24). On iOS
+there is no such element to disclose — a `WKWebView` page contributed nothing to the tree through
+`idb`, neither the view nor its content (read on the iOS 26.5 Simulator, 2026-08-24), so a web
+page there is a pixel job: `glass_screenshot`, then `glass_click` at x,y.
 
 <!-- BEGIN GENERATED: role-support -->
 | Role | Linux (AT-SPI) | Windows (UIA) | macOS (AX) | Android | iOS |
@@ -104,7 +107,7 @@ snapshot after a launch was childless and the next held the whole page (read 202
 | `Toolbar` | yes | yes | yes | unmarked | yes |
 | `StatusBar` | yes | yes | unmarked | elsewhere | elsewhere |
 | `Heading` | yes | gap | yes | gap | yes |
-| `Document` | yes | gap | yes | yes | yes |
+| `Document` | yes | gap | yes | yes | unmarked |
 
 ### Why a cell is not `yes`
 
@@ -156,4 +159,5 @@ snapshot after a launch was childless and the next held the whole page (read 202
 - `Heading` / Windows (UIA) — gap: UIA marks a heading with the HeadingLevel property — an h1 arrives as Text carrying level 80051 — and the reader maps by control type alone, so it never sees it. Header and HeaderItem are a grid's column headers, a different concept the normalized set has no role for
 - `Heading` / Android — gap: AccessibilityNodeInfo's isHeading marks a heading, and neither reader carries it: the uiautomator dump has no such attribute and the service reader parses only class, text, description and bounds
 - `Document` / Windows (UIA) — gap: UIA's Document control type maps to TextArea, read from a text editor's edit surface; what a web document reports on this backend has not been read, so the cell waits on that reading
+- `Document` / iOS — unmarked: a WKWebView page exposes no element at all through idb — neither the view nor its content (read on the iOS 26.5 Simulator, companions 1.5.0b3 and 1.1.8)
 <!-- END GENERATED: role-support -->

--- a/docs/reference/a11y-roles.md
+++ b/docs/reference/a11y-roles.md
@@ -61,19 +61,18 @@ window's own root node. The outline does not name that node's widget class — t
 now, and the outline only names the token of an element that has none.
 
 **A web document is a `Document`.** A browser page or an embedded web view arrives as one
-`Document` element with the page's elements as its children; an `<iframe>` is a `Document`
-inside it. On Windows a text editor's edit surface arrives under the same UIA control type, so
-the two are told apart per node by the framework the element reports — Chromium reported `Chrome`
-and Gecko `Gecko` against a stock text editor's `Win32` (read 2026-08-24). A `Document` can arrive
-with no children — read on Android, where the first snapshot after a launch showed an empty
-WebView and the next held the page (2026-08-24). glass discloses that case in the snapshot rather
-than leaving an empty container to be read as an empty page, and where the walk completed the
-disclosure asks for a fresh snapshot before the pixel path: on an Android WebView the first
-snapshot after a launch was childless and the next held the whole page (read 2026-08-24). On iOS
-there is no such element to disclose — a `WKWebView` page contributed nothing to the tree through
-`idb`, neither the view nor its content (read on the iOS 26.5 Simulator, 2026-08-24), so a web
-page there is a pixel job: `glass_screenshot`, then `glass_click` at x,y. See
-[Web content](../explanation/web-content.md) for the per-platform readings.
+`Document` element with the page's elements as its children; an `<iframe>` is a `Document` inside
+it. On Windows a text editor's edit surface arrives under the same UIA control type, so the two
+are told apart per node by the framework the element reports — Chromium reported `Chrome` and
+Gecko `Gecko` against a stock text editor's `Win32` (read 2026-08-24). A `Document` can arrive
+with no children. glass discloses that case in the snapshot rather than leaving an empty
+container to be read as an empty page, and where the walk completed the disclosure asks for a
+fresh snapshot before the pixel path: on an Android WebView the first snapshot after a launch was
+childless and the next held the whole page (read 2026-08-24). On iOS there is no such element to
+disclose — a `WKWebView` page contributed nothing to the tree through `idb`, neither the view nor
+its content (read on the iOS 26.5 Simulator, 2026-08-24), so a web page there is a pixel job:
+`glass_screenshot`, then `glass_click` at x,y. See [Web content](../explanation/web-content.md)
+for the per-platform readings.
 
 <!-- BEGIN GENERATED: role-support -->
 | Role | Linux (AT-SPI) | Windows (UIA) | macOS (AX) | Android | iOS |

--- a/docs/reference/a11y-roles.md
+++ b/docs/reference/a11y-roles.md
@@ -64,7 +64,9 @@ now, and the outline only names the token of an element that has none.
 `Document` element with the page's elements as its children; an `<iframe>` is a `Document`
 inside it. A web engine may publish its tree only after it detects an assistive technology, so a
 `Document` can arrive with no children at all. glass discloses that case in the snapshot rather
-than leaving an empty container to be read as an empty page.
+than leaving an empty container to be read as an empty page, and where the walk completed the
+disclosure asks for a fresh snapshot before the pixel path: on an Android WebView the first
+snapshot after a launch was childless and the next held the whole page (read 2026-08-24).
 
 <!-- BEGIN GENERATED: role-support -->
 | Role | Linux (AT-SPI) | Windows (UIA) | macOS (AX) | Android | iOS |

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -534,7 +534,9 @@ to the pixel path only if the page stays empty: on an Android WebView the first 
 launch was childless and the next held the whole page (read 2026-08-24). An app can also publish a
 *placeholder* where the content would be — an element standing in for a web view whose
 accessibility is off — and that gets its own notice: nothing behind it can be addressed by id and a
-re-snapshot will not change that, so it steers straight to the pixel path.
+re-snapshot will not change that, so it steers straight to the pixel path. See
+[Web content](../explanation/web-content.md) for why publication is lazy and what each platform's
+readings say.
 
 - `max_nodes` (integer) — raise the element cap above the default (which protects the token
   budget), or `0` to remove the element-count limit. Omit for the default cap. (Structural

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -522,7 +522,9 @@ An element whose platform role glass has no mapping for renders as `Other(<nativ
 visible; a bare `Other` means the platform named no token at all.
 
 Web content — a browser's page, a WebView's content — arrives under a `Document` element whose
-children are the page's own elements (headings, links, fields), addressable like any other. A
+children are the page's own elements (headings, links, fields), addressable like any other. On
+Windows a text editor's edit surface uses the same underlying control type and stays a
+`TextArea`; the two are told apart by the framework each element reports (read 2026-08-24). A
 `Document` with **no** children has nothing inside to address: the web engine has not published
 its accessibility tree yet, the page is empty, or the walk did not complete — whether a bound cut
 it short or it dropped a subtree it could not read — before reaching its content. The snapshot

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -535,8 +535,7 @@ launch was childless and the next held the whole page (read 2026-08-24). An app 
 *placeholder* where the content would be — an element standing in for a web view whose
 accessibility is off — and that gets its own notice: nothing behind it can be addressed by id and a
 re-snapshot will not change that, so it steers straight to the pixel path. See
-[Web content](../explanation/web-content.md) for why publication is lazy and what each platform's
-readings say.
+[Web content](../explanation/web-content.md) for what each platform's readings say.
 
 - `max_nodes` (integer) — raise the element cap above the default (which protects the token
   budget), or `0` to remove the element-count limit. Omit for the default cap. (Structural

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -531,7 +531,10 @@ it short or it dropped a subtree it could not read — before reaching its conte
 says so in a separate notice naming the element's id and bounds, the same way a truncated tree is
 disclosed. Where the walk completed, that notice steers to a fresh `glass_a11y_snapshot` first and
 to the pixel path only if the page stays empty: on an Android WebView the first snapshot after a
-launch was childless and the next held the whole page (read 2026-08-24).
+launch was childless and the next held the whole page (read 2026-08-24). An app can also publish a
+*placeholder* where the content would be — an element standing in for a web view whose
+accessibility is off — and that gets its own notice: nothing behind it can be addressed by id and a
+re-snapshot will not change that, so it steers straight to the pixel path.
 
 - `max_nodes` (integer) — raise the element cap above the default (which protects the token
   budget), or `0` to remove the element-count limit. Omit for the default cap. (Structural

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -524,10 +524,12 @@ visible; a bare `Other` means the platform named no token at all.
 Web content — a browser's page, a WebView's content — arrives under a `Document` element whose
 children are the page's own elements (headings, links, fields), addressable like any other. A
 `Document` with **no** children has nothing inside to address: the web engine has not published
-its accessibility tree, the page is empty, or the walk did not complete — whether a bound cut it
-short or it dropped a subtree it could not read — before reaching its content. The snapshot says
-so in a separate notice naming the element's id, bounds and the pixel path, the same way a
-truncated tree is disclosed.
+its accessibility tree yet, the page is empty, or the walk did not complete — whether a bound cut
+it short or it dropped a subtree it could not read — before reaching its content. The snapshot
+says so in a separate notice naming the element's id and bounds, the same way a truncated tree is
+disclosed. Where the walk completed, that notice steers to a fresh `glass_a11y_snapshot` first and
+to the pixel path only if the page stays empty: on an Android WebView the first snapshot after a
+launch was childless and the next held the whole page (read 2026-08-24).
 
 - `max_nodes` (integer) — raise the element cap above the default (which protects the token
   budget), or `0` to remove the element-count limit. Omit for the default cap. (Structural

--- a/examples/android-role-fixture/AndroidManifest.xml
+++ b/examples/android-role-fixture/AndroidManifest.xml
@@ -8,5 +8,6 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".WebActivity" android:exported="true" />
     </application>
 </manifest>

--- a/examples/android-role-fixture/README.md
+++ b/examples/android-role-fixture/README.md
@@ -43,6 +43,21 @@ adb install -r build/role-fixture.apk
 adb shell am start -n tech.fixedwidth.glassrolefixture/.MainActivity
 ```
 
+## Web view
+
+A second screen holds a stock `WebView` on the shared page in
+[../web-role-fixture](../web-role-fixture), copied into the APK's assets at build time and loaded
+over `file:///android_asset/index.html`. It is a separate activity so the readings above do not
+move:
+
+```bash
+adb shell am start -n tech.fixedwidth.glassrolefixture/.WebActivity
+```
+
+Its reading answers the `Document` row of
+[docs/reference/a11y-roles.md](../../docs/reference/a11y-roles.md): whether the page's own
+elements reach either reader, and under which widget classes they arrive.
+
 ## Read the tree
 
 Either reader answers the same question — the widget class is the token both key off.

--- a/examples/android-role-fixture/build.sh
+++ b/examples/android-role-fixture/build.sh
@@ -64,12 +64,16 @@ rm -rf "$out"
 mkdir -p "$out/classes"
 
 javac --release 17 -classpath "$android_jar" -d "$out/classes" \
-  "$here/src/tech/fixedwidth/glassrolefixture/MainActivity.java"
+  "$here"/src/tech/fixedwidth/glassrolefixture/*.java
 # -exec rather than $(find ...): the class list must survive a path containing spaces.
 find "$out/classes" -name '*.class' -exec "$tools/d8" --lib "$android_jar" --output "$out" {} +
 [ -f "$out/classes.dex" ] || { echo "d8 produced no dex" >&2; exit 1; }
 
-"$tools/aapt2" link -o "$out/unsigned.apk" -I "$android_jar" \
+# The shared page travels as an asset, copied at build time so there is one copy to edit.
+mkdir -p "$out/assets"
+cp "$here/../web-role-fixture/index.html" "$out/assets/index.html"
+
+"$tools/aapt2" link -o "$out/unsigned.apk" -I "$android_jar" -A "$out/assets" \
   --manifest "$here/AndroidManifest.xml" --min-sdk-version 24 --target-sdk-version 34
 # classes*.dex, not classes.dex: d8 splits past the method limit, and a silently half-packaged
 # APK still installs and runs — until it reaches the missing code.

--- a/examples/android-role-fixture/src/tech/fixedwidth/glassrolefixture/WebActivity.java
+++ b/examples/android-role-fixture/src/tech/fixedwidth/glassrolefixture/WebActivity.java
@@ -1,0 +1,26 @@
+package tech.fixedwidth.glassrolefixture;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.webkit.WebView;
+
+/**
+ * One screen holding a stock {@link WebView} on the shared fixture page, for reading what the
+ * two Android readers publish for web content: whether the page's elements arrive at all, and
+ * under which class names. Launched on its own so the main screen's readings do not move:
+ * {@code adb shell am start -n tech.fixedwidth.glassrolefixture/.WebActivity}.
+ *
+ * <p>JavaScript is on because the page's button writes its result with it; nothing else is
+ * configured, so what is read is the platform's default.
+ */
+public class WebActivity extends Activity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        WebView web = new WebView(this);
+        web.getSettings().setJavaScriptEnabled(true);
+        web.setContentDescription("the web view");
+        web.loadUrl("file:///android_asset/index.html");
+        setContentView(web);
+    }
+}

--- a/examples/ios-role-fixture/README.md
+++ b/examples/ios-role-fixture/README.md
@@ -26,6 +26,7 @@ accessibility tree exposes, which may be narrower than what UIKit publishes to V
 | SwiftUI `Picker`, `.menu` | `AXPopUpButton` — a token glass does not map yet |
 | `UIButton` with an `accessibilityHint` | `help` carries the hint verbatim: `"Saves and closes the sheet"` |
 | `UITextField` with an identifier and a label | `AXTextField`; the label sits in `AXLabel` beside the id |
+| `WKWebView` on the shared web page (the `web` tab) | nothing at all — neither the page's elements nor the web view itself appears |
 
 ## Build and install
 
@@ -43,7 +44,7 @@ is chosen at launch instead, by environment variable or by launch argument. Both
 through glass (`AppSpec::env` and `AppSpec::run`'s tail) as well as through `simctl` by hand:
 
 ```bash
-xcrun simctl launch booted tech.fixedwidth.glassrolefixture --tab=collection    # or: swiftui
+xcrun simctl launch booted tech.fixedwidth.glassrolefixture --tab=collection    # or: swiftui, web
 SIMCTL_CHILD_ROLE_FIXTURE_TAB=swiftui xcrun simctl launch booted tech.fixedwidth.glassrolefixture
 ```
 
@@ -52,6 +53,28 @@ works as well as `--tab=swiftui`. A `--tab` with no value, or an unrecognized na
 than a quiet fall back to the first screen. The collection and SwiftUI screens also name themselves
 in the tree — `screen-collection` and `screen-swiftui` appear as element identifiers — and the
 Controls screen is headed `Controls`.
+
+## The `web` tab
+
+A stock `WKWebView` on `examples/web-role-fixture/index.html` — the same page every platform's web
+reading uses. `build.sh` copies it into the bundle, and the view loads it with `loadFileURL`.
+
+```bash
+xcrun simctl launch booted tech.fixedwidth.glassrolefixture --tab web
+xcrun simctl io booted screenshot /tmp/web-tab.png     # the page renders in full
+```
+
+Read back through idb on an iOS 26.5 Simulator (2026-08-24), the whole screen is two nodes:
+`AXApplication "Glass Role Fixture"` holding one `AXGroup "Tab Bar"`. The page's heading, button,
+inputs, table and nested frame are absent, and so is the `WKWebView` itself — there is no
+`AXWebArea`, and no empty container standing in for one. It stays that way for at least 30 seconds
+and across taps inside the page. Apple's own Simulator Safari reads the same way: its chrome
+(`Back`, `Page Menu`, `Address`, `refresh`, `More`) is exposed and the rendered page is not, so the
+absence is in what idb reported here, not in this fixture.
+
+Driving the page through glass is therefore a pixel job on this platform. The reading is
+re-taken by `crates/glass-ios/tests/drive_integration.rs`'s
+`web_fixture_button_and_field_respond`.
 
 ## Read the tree
 

--- a/examples/ios-role-fixture/RoleFixture.swift
+++ b/examples/ios-role-fixture/RoleFixture.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import UIKit
+import WebKit
 
 /// The controls whose accessibility vocabulary decides a cell in glass's role matrix
 /// (`glass_core::role_support::ROLE_SUPPORT`), built from stock UIKit classes. Reading this app
@@ -207,13 +208,38 @@ struct SwiftUIScreen: View {
     }
 }
 
+/// A stock `WKWebView` on the shared `examples/web-role-fixture` page, for reading what idb
+/// exposes of web content: whether the page's elements arrive at all, under which role strings,
+/// and whether the web area itself is a boundary the reader can enter.
+///
+/// The page is the same file every platform's web reading uses, so a row in one platform's table
+/// is comparable with the next; `build.sh` copies it into the bundle.
+final class WebViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Web"
+        view.backgroundColor = .systemBackground
+        let web = WKWebView(frame: view.bounds)
+        web.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        web.accessibilityIdentifier = "the-web-view"
+        view.addSubview(web)
+        // Fatal rather than a blank screen: a missing page would read as "the web view exposes
+        // nothing", which is the finding this screen exists to make, arrived at for the wrong
+        // reason.
+        guard let url = Bundle.main.url(forResource: "index", withExtension: "html") else {
+            fatalError("index.html is not in the bundle — build.sh copies it")
+        }
+        web.loadFileURL(url, allowingReadAccessTo: url.deletingLastPathComponent())
+    }
+}
+
 @main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     /// The screen to show, as an index into the tab controller.
     ///
-    /// Named by `ROLE_FIXTURE_TAB=controls|collection|swiftui` in the environment, or by a
+    /// Named by `ROLE_FIXTURE_TAB=controls|collection|swiftui|web` in the environment, or by a
     /// `--tab=<name>` launch argument. Either reaches the app through glass — `AppSpec::env`
     /// arrives as `SIMCTL_CHILD_*`, and `AppSpec::run`'s tail is forwarded to `simctl launch` —
     /// or through `simctl` driven by hand.
@@ -231,7 +257,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
             requested = String(inline.dropFirst("--tab=".count))
         } else if let flag = arguments.firstIndex(of: "--tab") {
             guard flag + 1 < arguments.count else {
-                fatalError("--tab needs a value: controls, collection or swiftui")
+                fatalError("--tab needs a value: controls, collection, swiftui or web")
             }
             requested = arguments[flag + 1]
         }
@@ -240,8 +266,9 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         case "controls": return 0
         case "collection": return 1
         case "swiftui": return 2
+        case "web": return 3
         default:
-            fatalError("unknown tab '\(name)' — use controls, collection or swiftui")
+            fatalError("unknown tab '\(name)' — use controls, collection, swiftui or web")
         }
     }
 
@@ -255,12 +282,14 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         collection.tabBarItem = UITabBarItem(title: "Collection", image: nil, tag: 1)
         let swiftui = UIHostingController(rootView: SwiftUIScreen())
         swiftui.tabBarItem = UITabBarItem(title: "SwiftUI", image: nil, tag: 2)
+        let web = WebViewController()
+        web.tabBarItem = UITabBarItem(title: "Web", image: nil, tag: 3)
 
         // The tab bar's items are not exposed as accessibility elements and a synthetic tap on
         // one does not switch tabs, so the screen to show is chosen at launch instead:
         // `simctl launch booted tech.fixedwidth.glassrolefixture --tab collection`.
         let tabs = UITabBarController()
-        tabs.viewControllers = [controls, collection, swiftui]
+        tabs.viewControllers = [controls, collection, swiftui, web]
         tabs.selectedIndex = Self.requestedTab()
 
         let window = UIWindow(frame: UIScreen.main.bounds)

--- a/examples/ios-role-fixture/build.sh
+++ b/examples/ios-role-fixture/build.sh
@@ -28,4 +28,8 @@ executable="$(plutil -extract CFBundleExecutable raw -o - "$here/Info.plist")"
 }
 cp "$here/Info.plist" "$app/Info.plist"
 
+# The web tab loads this page out of the bundle, and shares it with every other platform's web
+# reading, so it is copied rather than duplicated.
+cp "$here/../web-role-fixture/index.html" "$app/index.html"
+
 echo "built: $app ($arch, $(xcrun --sdk iphonesimulator --show-sdk-version) SDK)"

--- a/examples/web-role-fixture/README.md
+++ b/examples/web-role-fixture/README.md
@@ -1,0 +1,36 @@
+# web-role-fixture
+
+One page of plain HTML controls, for deciding what the web accessibility vocabulary can
+express on each platform. Each control answers one question: what role does each platform's
+accessibility API report for it? That answer is what a cell in
+[docs/reference/a11y-roles.md](../../docs/reference/a11y-roles.md) records.
+
+The controls below are what each platform reads when glass probes the page — a reading,
+not a guarantee. Re-run it rather than trusting it; the probe step prints the platform
+and browser it saw.
+
+| Control | Purpose |
+|---|---|
+| link | Hyperlink navigation |
+| button | Interactive control (click me) |
+| text input | Text field with label |
+| text area | Multi-line text field with label |
+| checkbox | Toggle control with label |
+| select | Dropdown list with options |
+| table | Data grid with headers and cells |
+| iframe | Nested document |
+
+## How each platform loads it
+
+- **Linux, macOS, Windows browsers**: `file://` URL pointing to this directory's `index.html`
+- **Android fixture**: Copied into the fixture's assets at build time; fixture loads it via WebView
+- **iOS fixture**: Copied into the fixture's assets at build time; fixture loads it via WKWebView
+
+Never use a top-level `data:` URL — browsers load it synchronously and fixtures need a stable
+`file://` baseline; the platform probe reads it over that URL, so all runs see the same content.
+
+## Verify it works
+
+Open `index.html` in a browser by hand (`firefox file://$PWD/index.html`), then click the button.
+The `"not clicked"` text should change to `"clicked"`. A fixture that doesn't work is evidence
+of nothing.

--- a/examples/web-role-fixture/README.md
+++ b/examples/web-role-fixture/README.md
@@ -5,9 +5,10 @@ express on each platform. Each control answers one question: what role does each
 accessibility API report for it? That answer is what a cell in
 [docs/reference/a11y-roles.md](../../docs/reference/a11y-roles.md) records.
 
-The table below lists what each control is for — not what any platform reported. For the
-readings themselves, dated per platform and browser, see
-[docs/reference/a11y-roles.md](../../docs/reference/a11y-roles.md).
+The table below lists what each control is for — not what any platform reported. For the readings
+themselves, dated per platform and browser, see
+[docs/explanation/web-content.md](../../docs/explanation/web-content.md); `a11y-roles.md` holds the
+matrix cell each one settles.
 
 | Control | Purpose |
 |---|---|
@@ -26,8 +27,11 @@ readings themselves, dated per platform and browser, see
 - **Android fixture**: Copied into the fixture's assets at build time; fixture loads it via WebView
 - **iOS fixture**: Copied into the fixture's assets at build time; fixture loads it via WKWebView
 
-Never use a top-level `data:` URL — browsers load it synchronously and fixtures need a stable
-`file://` baseline; the platform probe reads it over that URL, so all runs see the same content.
+Never use a top-level `data:` URL. Firefox refused a top-level `data:` navigation
+(`security.data_uri.block_toplevel_data_uri_navigation`) and the page stayed blank while every
+other signal looked healthy, so the run read as an engine publishing nothing (read 2026-07 on
+Firefox). Keeping the fixture a file gives every platform the same stable baseline: the desktop
+probes read it over `file://`, the mobile fixtures from the app's own assets.
 
 ## Verify it works
 

--- a/examples/web-role-fixture/README.md
+++ b/examples/web-role-fixture/README.md
@@ -5,9 +5,9 @@ express on each platform. Each control answers one question: what role does each
 accessibility API report for it? That answer is what a cell in
 [docs/reference/a11y-roles.md](../../docs/reference/a11y-roles.md) records.
 
-The controls below are what each platform reads when glass probes the page — a reading,
-not a guarantee. Re-run it rather than trusting it; the probe step prints the platform
-and browser it saw.
+The table below lists what each control is for — not what any platform reported. For the
+readings themselves, dated per platform and browser, see
+[docs/reference/a11y-roles.md](../../docs/reference/a11y-roles.md).
 
 | Control | Purpose |
 |---|---|

--- a/examples/web-role-fixture/README.md
+++ b/examples/web-role-fixture/README.md
@@ -29,9 +29,9 @@ matrix cell each one settles.
 
 Never use a top-level `data:` URL. Firefox refused a top-level `data:` navigation
 (`security.data_uri.block_toplevel_data_uri_navigation`) and the page stayed blank while every
-other signal looked healthy, so the run read as an engine publishing nothing (read 2026-07 on
-Firefox). Keeping the fixture a file gives every platform the same stable baseline: the desktop
-probes read it over `file://`, the mobile fixtures from the app's own assets.
+other signal looked healthy, so the run read as an engine publishing nothing (read on Firefox in
+June 2026). Keeping the fixture a file gives every platform the same stable baseline: the
+desktop probes read it over `file://`, the mobile fixtures from the app's own assets.
 
 ## Verify it works
 

--- a/examples/web-role-fixture/index.html
+++ b/examples/web-role-fixture/index.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Glass web fixture</title>
+<style>body{font:16px sans-serif;margin:24px} section{margin-bottom:16px} iframe{width:320px;height:120px}</style>
+</head>
+<body>
+<h1>Glass web fixture</h1>
+<p id="intro">One page of plain HTML controls, read back through each platform's accessibility API.</p>
+<section>
+  <a id="link" href="#intro">a link</a>
+</section>
+<section>
+  <button id="button" type="button">click me</button>
+  <p id="result">not clicked</p>
+</section>
+<section>
+  <label for="text">text input</label>
+  <input id="text" type="text" value="">
+</section>
+<section>
+  <label for="area">text area</label>
+  <textarea id="area" rows="2"></textarea>
+</section>
+<section>
+  <input id="check" type="checkbox"> <label for="check">a checkbox</label>
+</section>
+<section>
+  <label for="select">a select</label>
+  <select id="select"><option>alpha</option><option>beta</option></select>
+</section>
+<section>
+  <table id="table">
+    <tr><th>header one</th><th>header two</th></tr>
+    <tr><td>cell one</td><td>cell two</td></tr>
+  </table>
+</section>
+<section>
+  <iframe id="frame" title="nested document" srcdoc="<h2>inside the frame</h2><button type='button'>frame button</button>"></iframe>
+</section>
+<script>
+document.getElementById('button').addEventListener('click', function () {
+  document.getElementById('result').textContent = 'clicked';
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
Web content read back on every backend, and glass changed where the readings said so.

- **Linux (AT-SPI):** Firefox 153 publishes `document web` at baseline on X11 and Wayland — no launch-time step. Brave 151 publishes a null placeholder child while renderer accessibility is off; the reader now counts that as content the app has not exposed and the snapshot says so (pixels), instead of "went away mid-walk". `set_value` on an AT-SPI text field now confirms the write by read-back and returns `AxValueNotApplied` when it did not take (Gecko's `<input>` acknowledged writes it never applied).
- **Windows (UIA):** Edge, Brave and Firefox publish at baseline; a web page's `Document` is told from a text editor's by the `FrameworkId` it reports (`Chrome`/`Gecko` vs `Win32`), so it reads as `Document` while Notepad keeps `TextArea`.
- **macOS (AX):** Safari 26.5 publishes `AXWebArea` in the first snapshot; nothing to enable.
- **Android:** both readers publish a WebView's page; the first snapshot after launch can show a childless `Document` and the next holds the page — the notice now steers to a re-snapshot before pixels.
- **iOS:** idb exposes no element at all for a WKWebView; the matrix records the reading and the unread `AXWebArea` mapping is dropped.
- A withheld subtree no longer counts as proof that an element is gone (`can_prove_absence`).
- Probes: `#[ignore]` web-content probes for Linux, macOS, Windows, Android and iOS, a shared fixture page, and WebView/WKWebView screens in the role fixtures. `docs/explanation/web-content.md` explains what an agent sees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
