### PR TITLE
fix(a11y-linux): an <iframe> is a Group, not a Window (fixes #520)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ internal refactors, CI, or test-only changes.
 ### Fixed
 - A web view whose content the platform has not published is disclosed in the snapshot instead of arriving as an indistinguishable empty group: a childless `Document` is named by id and bounds and steers to a re-snapshot before pixels, while a placeholder the app published for content it withheld steers straight to pixels.
 - On Linux, `glass_set_value` now confirms a write actually landed instead of trusting the AT-SPI toolkit's own acknowledgment of it, the way the Windows and macOS readers already did: it reads the element back (polling briefly, since the toolkit applies the write on a later main-loop pass), and an element that acknowledges a write without applying it — as web content can — now reports that instead of a silent false success.
+- On Linux, the container of an `<iframe>` inside a browser page no longer reads as a `Window`: AT-SPI's `internal frame`, which the web engines publish for an embedded frame and no desktop toolkit uses, now maps to `Group`, so a `role:"Window"` selector matches the app's real windows again instead of frames inside a page. The nested `Document` inside such a frame is unchanged.
 
 ## [1.5.0] - 2026-08-22
 

--- a/crates/glass-a11y-linux/src/mapping.rs
+++ b/crates/glass-a11y-linux/src/mapping.rs
@@ -9,11 +9,14 @@ use glass_core::{AxRole, AxStates};
 pub(crate) fn map_role(role: Role) -> AxRole {
     match role {
         Role::Application => AxRole::Application,
-        Role::Frame | Role::Window | Role::InternalFrame => AxRole::Window,
+        Role::Frame | Role::Window => AxRole::Window,
         Role::Dialog | Role::Alert | Role::FileChooser | Role::ColorChooser | Role::FontChooser => {
             AxRole::Dialog
         }
         Role::Panel
+        // `InternalFrame` is a web engine's `<iframe>`, not a desktop window — see
+        // `a_web_frame_is_a_group_not_a_window`.
+        | Role::InternalFrame
         | Role::Filler
         | Role::Viewport
         | Role::SplitPane
@@ -102,6 +105,18 @@ mod tests {
         assert_eq!(map_role(Role::MenuItem), AxRole::MenuItem);
         assert_eq!(map_role(Role::PageTabList), AxRole::TabList);
         assert_eq!(map_role(Role::Application), AxRole::Application);
+    }
+
+    #[test]
+    fn a_web_frame_is_a_group_not_a_window() {
+        // Measured 2026-08-25 (#520): Firefox 153 publishes `internal frame` for an `<iframe>`
+        // and for each of its own browser docshells, and Chromium maps `kIframe` to the same
+        // token. Mapping it to `Window` put windows inside a page and made a `role:"Window"`
+        // selector match iframes. No desktop toolkit publishes the role: GTK 3.24.41 and 4.14.5
+        // never return it, and Qt's 82-role table has no entry for it.
+        assert_eq!(map_role(Role::InternalFrame), AxRole::Group);
+        assert_eq!(map_role(Role::Frame), AxRole::Window);
+        assert_eq!(map_role(Role::Window), AxRole::Window);
     }
 
     #[test]


### PR DESCRIPTION
AT-SPI's `internal frame` mapped to `AxRole::Window`, so a page's iframes arrived as windows inside the page and a `role:"Window"` selector matched them. No desktop toolkit publishes the role — GTK 3.24.41, GTK 4.14.5 and Qt never return it, and only Firefox and Chromium emit it, for embedded frames — so it maps to `Group`. The reading behind that is in #520.