### PR TITLE
fix(wayland): a process table glass cannot read is not an absent Xwayland

### DIFF
--- a/crates/glass-wayland/src/doctor.rs
+++ b/crates/glass-wayland/src/doctor.rs
@@ -57,7 +57,7 @@ enum CameUp {
 }
 
 /// What the probe started and did not stop. Something to report by construction — the absence is
-/// `None` — though not always something it can name: see `unknown`.
+/// `None`.
 #[derive(Debug)]
 struct Leaked {
     /// Processes of the probe's own session still running.
@@ -86,7 +86,6 @@ impl Leaked {
 #[derive(Debug)]
 struct LeftRunning {
     pids: Vec<u32>,
-    /// Why the session scan could not be run, when it could not.
     unknown: Option<String>,
 }
 
@@ -217,8 +216,7 @@ struct Survivors {
     remedy: String,
 }
 
-/// Describe what was left running, and what could not be established — a survivor the notice
-/// cannot name.
+/// Describe what was left running, and what could not be established.
 fn leak_notice(leaked: &Leaked) -> Survivors {
     let dir = leaked.runtime_dir.display();
     let mut details = Vec::new();

--- a/crates/glass-wayland/src/doctor.rs
+++ b/crates/glass-wayland/src/doctor.rs
@@ -1190,6 +1190,8 @@ mod tests {
         assert!(deep.detail.contains("could not tell"), "{deep:?}");
         // The cause, so an operator can act on it rather than re-run and hope.
         assert!(deep.detail.contains(SCAN_FAILED), "{deep:?}");
+        // And nothing about survivors it never saw.
+        assert!(!deep.detail.contains("still running"), "{deep:?}");
         assert!(
             deep.detail.contains("/tmp/glass-doctor-wl.abc123"),
             "{deep:?}"

--- a/crates/glass-wayland/src/doctor.rs
+++ b/crates/glass-wayland/src/doctor.rs
@@ -56,23 +56,45 @@ enum CameUp {
     Unknown(String),
 }
 
-/// What the probe started and did not stop. Non-empty by construction — the absence is `None`.
+/// What the probe started and did not stop. Something to report by construction — the absence is
+/// `None` — though not always something it can name: see `unknown`.
 #[derive(Debug)]
 struct Leaked {
     /// Processes of the probe's own session still running.
     pids: Vec<u32>,
+    /// Why the session scan could not be run, when it could not. A survivor glass cannot name is
+    /// still a survivor (glass#381).
+    unknown: Option<String>,
     /// The probe's runtime dir, kept because those processes still have sockets in it.
     runtime_dir: PathBuf,
 }
 
 impl Leaked {
-    /// `rt` is consumed either way: deleted when nothing survived, kept when something did,
-    /// because deleting it would take that process's sockets with it.
-    fn after_reap(pids: Vec<u32>, rt: tempfile::TempDir) -> Option<Leaked> {
-        (!pids.is_empty()).then(|| Leaked {
-            pids,
+    /// `rt` is consumed either way: deleted when nothing survived, kept when something did — or
+    /// when glass could not establish that nothing did — because deleting it would take that
+    /// process's sockets with it.
+    fn after_reap(left: LeftRunning, rt: tempfile::TempDir) -> Option<Leaked> {
+        (!left.is_clean()).then(|| Leaked {
+            pids: left.pids,
+            unknown: left.unknown,
             runtime_dir: rt.keep(),
         })
+    }
+}
+
+/// What the probe left running, and whether that is the whole answer.
+#[derive(Debug)]
+struct LeftRunning {
+    pids: Vec<u32>,
+    /// Why the session scan could not be run, when it could not.
+    unknown: Option<String>,
+}
+
+impl LeftRunning {
+    /// Whether the probe is established to have left nothing behind — a scan that could not run
+    /// establishes nothing.
+    fn is_clean(&self) -> bool {
+        self.pids.is_empty() && self.unknown.is_none()
     }
 }
 
@@ -195,29 +217,49 @@ struct Survivors {
     remedy: String,
 }
 
-/// Describe what was left running.
+/// Describe what was left running, and what could not be established — a survivor the notice
+/// cannot name.
 fn leak_notice(leaked: &Leaked) -> Survivors {
-    let pids: Vec<String> = leaked.pids.iter().map(u32::to_string).collect();
-    let (count, label) = match pids.len() {
-        1 => ("1 process".to_string(), "pid"),
-        n => (format!("{n} processes"), "pids"),
-    };
     let dir = leaked.runtime_dir.display();
-    Survivors {
-        detail: format!(
+    let mut details = Vec::new();
+    let mut remedies = Vec::new();
+    if !leaked.pids.is_empty() {
+        let pids: Vec<String> = leaked.pids.iter().map(u32::to_string).collect();
+        let (count, label) = match pids.len() {
+            1 => ("1 process".to_string(), "pid"),
+            n => (format!("{n} processes"), "pids"),
+        };
+        details.push(format!(
             "{count} it started was still running {LEAK_GRACE:?} after the probe signalled it \
-             ({label} {}); the probe's runtime dir is kept at {dir} rather than deleted, so \
-             whatever is still using it keeps its sockets",
+             ({label} {})",
             pids.join(", ")
-        ),
+        ));
         // No cause is named: the same observation is produced by a process on its way out, one
         // the kernel cannot kill, and a pid that has been reused since.
-        remedy: format!(
+        remedies.push(format!(
             "look first — `ps -p {} -o pid,stat,args` says whether they are still the probe's \
              sway; if they are, `kill -9 {}` and remove {dir}",
             pids.join(","),
             pids.join(" ")
+        ));
+    }
+    if let Some(why) = &leaked.unknown {
+        let rest = if leaked.pids.is_empty() { "" } else { " else" };
+        details.push(format!(
+            "glass could not tell what{rest} it left running ({why})"
+        ));
+        remedies.push(format!(
+            "look for the probe's own session by hand — `ls {dir}` says whether anything still \
+             has sockets there; remove it once nothing does"
+        ));
+    }
+    Survivors {
+        detail: format!(
+            "{}; the probe's runtime dir is kept at {dir} rather than deleted, so whatever is \
+             still using it keeps its sockets",
+            details.join(", and ")
         ),
+        remedy: remedies.join(". "),
     }
 }
 
@@ -442,15 +484,25 @@ fn reap_and_account(child: &mut Child, rt: tempfile::TempDir) -> Option<Leaked> 
 ///
 /// `after_reap` is what the reaper could still see of the tree it signalled; only
 /// [`session_processes`] finds a compositor's Xwayland or the app it `exec`s (glass#380).
-fn left_running(runtime_dir: &Path, after_reap: &[u32], grace: Duration) -> Vec<u32> {
+fn left_running(runtime_dir: &Path, after_reap: &[u32], grace: Duration) -> LeftRunning {
     let look = || {
-        let mut left = crate::xwayland::session_processes(runtime_dir);
+        // A scan that could not run leaves the pids it would have found unknown rather than
+        // absent; the reaper's own answer still stands (glass#381).
+        let (mut left, unknown) = match crate::xwayland::session_processes(runtime_dir) {
+            Ok(pids) => (pids, None),
+            Err(e) => (Vec::new(), Some(e.to_string())),
+        };
         left.extend(glass_proc_linux::live_pids(after_reap));
         left.sort_unstable();
         left.dedup();
-        left
+        LeftRunning {
+            pids: left,
+            unknown,
+        }
     };
-    glass_proc_linux::await_condition(grace, || look().is_empty());
+    // Retried for the grace too: what stops it — a host out of file descriptors — is the
+    // transient the wait is there for.
+    glass_proc_linux::await_condition(grace, || look().is_clean());
     look()
 }
 
@@ -1083,8 +1135,88 @@ mod tests {
     fn leaked(pids: Vec<u32>) -> Option<Leaked> {
         Some(Leaked {
             pids,
+            unknown: None,
             runtime_dir: PathBuf::from("/tmp/glass-doctor-wl.abc123"),
         })
+    }
+
+    /// Why a session scan could not be run, in the words the caller would see.
+    const SCAN_FAILED: &str = "read /proc: Too many open files (os error 24)";
+
+    /// glass#381: the session scan returned an empty list on an unreadable `/proc`, which reads
+    /// as "the probe left nothing running" — and the runtime dir is deleted on the strength of
+    /// it, taking the sockets of whatever is still in there with it.
+    #[test]
+    fn a_session_scan_that_could_not_run_is_not_a_probe_that_left_nothing() {
+        let rt = tempfile::tempdir().expect("tempdir");
+        let kept = rt.path().to_path_buf();
+        let leaked = Leaked::after_reap(
+            LeftRunning {
+                pids: Vec::new(),
+                unknown: Some(SCAN_FAILED.into()),
+            },
+            rt,
+        );
+        assert!(
+            leaked.is_some(),
+            "a scan that could not run is not an answer of none"
+        );
+        assert!(
+            kept.exists(),
+            "the runtime dir is kept: something may still hold sockets in it"
+        );
+    }
+
+    /// And the check says which it is. A probe that could not look reported the green line of one
+    /// that tore everything down.
+    #[test]
+    fn a_probe_whose_session_scan_failed_reports_that_it_could_not_tell() {
+        let cs = wayland_checks(
+            &answered("1.12"),
+            true,
+            Some(SwaySpawn {
+                came_up: CameUp::Yes,
+                last_ipc: None,
+                said: None,
+                leaked: Some(Leaked {
+                    pids: Vec::new(),
+                    unknown: Some(SCAN_FAILED.into()),
+                    runtime_dir: PathBuf::from("/tmp/glass-doctor-wl.abc123"),
+                }),
+            }),
+        );
+        let deep = cs.iter().find(|c| c.name == "sway spawn (deep)").unwrap();
+        assert_eq!(deep.status, CheckStatus::Warn, "{deep:?}");
+        assert!(deep.detail.contains("could not tell"), "{deep:?}");
+        // The cause, so an operator can act on it rather than re-run and hope.
+        assert!(deep.detail.contains(SCAN_FAILED), "{deep:?}");
+        assert!(
+            deep.detail.contains("/tmp/glass-doctor-wl.abc123"),
+            "{deep:?}"
+        );
+    }
+
+    /// Both halves ride together: naming the survivors the scan did see must not imply they are
+    /// all of them.
+    #[test]
+    fn survivors_and_a_scan_that_could_not_finish_are_both_reported() {
+        let cs = wayland_checks(
+            &answered("1.12"),
+            true,
+            Some(SwaySpawn {
+                came_up: CameUp::Yes,
+                last_ipc: None,
+                said: None,
+                leaked: Some(Leaked {
+                    pids: vec![4242],
+                    unknown: Some(SCAN_FAILED.into()),
+                    runtime_dir: PathBuf::from("/tmp/glass-doctor-wl.abc123"),
+                }),
+            }),
+        );
+        let deep = cs.iter().find(|c| c.name == "sway spawn (deep)").unwrap();
+        assert!(deep.detail.contains("pid 4242"), "{deep:?}");
+        assert!(deep.detail.contains("could not tell"), "{deep:?}");
     }
 
     /// glass#380: the detail said "started and stopped" on the strength of the start alone, so a

--- a/crates/glass-wayland/src/xwayland.rs
+++ b/crates/glass-wayland/src/xwayland.rs
@@ -46,6 +46,18 @@ pub const CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_millis
 /// recovery runs at all, and neither can be arranged in the real one.
 const PROC: &str = "/proc";
 
+/// Which step of a cross-check failed. Kept so a session reports each kind once rather than
+/// reporting only whichever failed first.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Failed {
+    /// Finding the session's Xwayland at all — the process table, or the entry it matched.
+    Discovery,
+    /// Connecting to the display it found.
+    Connect,
+    /// Reading the windows from a connection that was established.
+    Read,
+}
+
 /// A session's state for recovering lost toplevels: which session it is, the X connection once
 /// one exists, what has been tried, what was missing last time, and when the last check ran.
 pub struct Recovery {
@@ -66,11 +78,11 @@ pub struct Recovery {
     /// bare timeout for an app whose window glass could see all along.
     unrecovered: usize,
     last_checked: Option<std::time::Instant>,
-    /// Whether a failure to reach the X side has already been reported. Checks repeat for the
-    /// life of the session, and one unreachable X server should read as one warning, not as a
-    /// line every interval. Cleared with the connection, so a later failure of a different kind
-    /// still gets said once.
-    warned: bool,
+    /// What the last reported failure to reach the X side was, or `None` while there has been
+    /// none. Checks repeat for the life of the session, and one unreachable X server should read
+    /// as one warning, not as a line every interval — but a failure of a *different* kind is
+    /// news, so the kind is kept rather than a flag (glass#381).
+    warned: Option<Failed>,
 }
 
 impl Recovery {
@@ -82,7 +94,7 @@ impl Recovery {
             missing_before: HashSet::new(),
             unrecovered: 0,
             last_checked: None,
-            warned: false,
+            warned: None,
         }
     }
 
@@ -107,12 +119,12 @@ impl Recovery {
             .is_none_or(|last| now.duration_since(last) >= CHECK_INTERVAL)
     }
 
-    /// Report a failure to reach the session's X side once. The cross-check repeats for the life
-    /// of the session, so an X server that stays unreachable would otherwise repeat its warning
-    /// every interval — drowning out whatever the app itself is saying.
-    fn warn_once(&mut self, message: String) {
-        if !self.warned {
-            self.warned = true;
+    /// Report a failure to reach the session's X side once per kind. The cross-check repeats for
+    /// the life of the session, so an X server that stays unreachable would otherwise repeat its
+    /// warning every interval — drowning out whatever the app itself is saying.
+    fn warn_once(&mut self, failed: Failed, message: String) {
+        if self.warned != Some(failed) {
+            self.warned = Some(failed);
             eprintln!("{message}");
         }
     }
@@ -157,19 +169,23 @@ impl Recovery {
                     // Not that: glass could not look. Recovery is off for the session either
                     // way, so it is said like a failed connect (glass#381).
                     Err(e) => {
-                        self.warn_once(format!(
-                            "glass: could not find the session's Xwayland: {e}. Windows the \
-                             compositor loses will not be recovered."
-                        ));
+                        self.warn_once(
+                            Failed::Discovery,
+                            format!(
+                                "glass: could not find the session's Xwayland: {e}. Windows the \
+                                 compositor loses will not be recovered."
+                            ),
+                        );
                         return 0;
                     }
                 };
                 match XProbe::connect(&display) {
                     Ok(p) => p,
                     Err(e) => {
-                        self.warn_once(format!(
-                            "glass: could not inspect the session's Xwayland display: {e}"
-                        ));
+                        self.warn_once(
+                            Failed::Connect,
+                            format!("glass: could not inspect the session's Xwayland display: {e}"),
+                        );
                         return 0;
                     }
                 }
@@ -181,11 +197,12 @@ impl Recovery {
                 // The connection is dropped rather than kept (it was taken out of `self` above):
                 // an Xwayland that went away leaves a socket that answers nothing, and keeping it
                 // would turn one dead connection into recovery being off for the rest of the
-                // session. The warning is re-armed with it, so the next failure still gets said.
-                self.warned = false;
-                self.warn_once(format!(
-                    "glass: could not read the session's Xwayland windows: {e}"
-                ));
+                // session. Whatever the reconnect then fails at is a different kind, so it is
+                // still said once.
+                self.warn_once(
+                    Failed::Read,
+                    format!("glass: could not read the session's Xwayland windows: {e}"),
+                );
                 return 0;
             }
         };
@@ -361,7 +378,7 @@ fn session_display(proc_root: &Path, runtime_dir: &Path) -> Result<Option<String
         })?;
         return display_from_cmdline(&cmdline).map(Some).ok_or_else(|| {
             GlassError::Backend(format!(
-                "the session's Xwayland (pid {pid}) was started with no display argument"
+                "no bare `:N` display argument in the session's Xwayland cmdline (pid {pid})"
             ))
         });
     }
@@ -403,6 +420,8 @@ pub(crate) fn session_processes(runtime_dir: &Path) -> Result<Vec<u32>> {
 fn session_processes_in(proc_root: &Path, runtime_dir: &Path) -> Result<Vec<u32>> {
     Ok(proc_pids(proc_root)?
         .into_iter()
+        // A process whose environ cannot be read is another user's or already gone; the
+        // session's own are this process's children and readable by it.
         .filter(|pid| {
             std::fs::read(proc_root.join(pid.to_string()).join("environ"))
                 .is_ok_and(|environ| serves_session(&environ, runtime_dir))
@@ -433,6 +452,9 @@ fn display_from_cmdline(cmdline: &[u8]) -> Option<String> {
 
 /// Whether `pid` is an Xwayland process, read from `/proc/<pid>/comm`. Also used by teardown,
 /// which must not wait on the compositor's own plumbing the way it waits on the app.
+///
+/// A `comm` that cannot be read answers `false`: it is world-readable, so the process is one that
+/// exited mid-scan.
 pub fn is_xwayland(pid: u32) -> bool {
     is_xwayland_in(Path::new(PROC), pid)
 }
@@ -828,20 +850,26 @@ mod session_tests {
     /// The failures glass#381 is about — a `/proc` that cannot be read at all, an entry whose
     /// files cannot be — do not happen on demand in the real one, and each of them decides
     /// whether recovery runs for the session.
-    struct FakeProc(tempfile::TempDir);
+    pub(super) struct FakeProc(tempfile::TempDir);
 
     impl FakeProc {
-        fn new() -> FakeProc {
+        pub(super) fn new() -> FakeProc {
             FakeProc(tempfile::tempdir().expect("tempdir"))
         }
 
-        fn path(&self) -> &Path {
+        pub(super) fn path(&self) -> &Path {
             self.0.path()
         }
 
         /// A process whose `comm` is `comm`, whose environment says it belongs to `runtime_dir`,
         /// and whose `cmdline` is `argv`.
-        fn process(&self, pid: u32, comm: &str, runtime_dir: &Path, argv: &[&str]) -> PathBuf {
+        pub(super) fn process(
+            &self,
+            pid: u32,
+            comm: &str,
+            runtime_dir: &Path,
+            argv: &[&str],
+        ) -> PathBuf {
             let dir = self.path().join(pid.to_string());
             std::fs::create_dir(&dir).expect("pid dir");
             std::fs::write(dir.join("comm"), format!("{comm}\n")).expect("comm");
@@ -856,7 +884,7 @@ mod session_tests {
     }
 
     /// Put something in place of `file` that no read can succeed on whatever the caller's
-    /// privileges — a mode-0 file still opens as root, which is how CI runs.
+    /// privileges — a mode-0 file still opens as root.
     fn make_unreadable(file: &Path) {
         std::fs::remove_file(file).expect("remove the file");
         std::fs::create_dir(file).expect("a directory in its place");
@@ -924,7 +952,11 @@ mod session_tests {
     }
 
     /// Before the match a read failure is routine: another user's Xwayland is unreadable by
-    /// design, and one that exits mid-scan is gone. Neither may hide the session's own.
+    /// design, and one that exits mid-scan is gone. Neither is this session's to report.
+    ///
+    /// The only Xwayland in the table is the unreadable one, so the answer cannot come from
+    /// somewhere else — a second, readable entry would let the scan return before ever reading
+    /// this one, whatever it does with a read it cannot make.
     #[test]
     fn an_xwayland_whose_environ_cannot_be_read_is_skipped_not_reported() {
         let proc = FakeProc::new();
@@ -932,10 +964,9 @@ mod session_tests {
         let theirs = tempfile::tempdir().expect("tempdir");
         let unreadable = proc.process(41, "Xwayland", theirs.path(), &["Xwayland", ":1"]);
         make_unreadable(&unreadable.join("environ"));
-        proc.process(42, "Xwayland", mine.path(), &["Xwayland", ":7"]);
         assert_eq!(
             session_display(proc.path(), mine.path()).expect("scan"),
-            Some(":7".to_string())
+            None
         );
     }
 
@@ -1019,11 +1050,12 @@ mod tests {
     #[test]
     fn the_first_warning_is_said_and_arms_the_silence() {
         let mut r = Recovery::new(std::path::Path::new("/nonexistent"));
-        assert!(!r.warned);
-        r.warn_once("glass: test warning".into());
-        assert!(
+        assert!(r.warned.is_none());
+        r.warn_once(Failed::Connect, "glass: test warning".into());
+        assert_eq!(
             r.warned,
-            "a warning that never arms the flag repeats forever"
+            Some(Failed::Connect),
+            "a warning that never records its kind repeats forever"
         );
     }
 
@@ -1133,7 +1165,29 @@ mod tests {
             r.recover_if_due_in(Path::new("/nonexistent/glass-381/proc"), now, &[]),
             0
         );
-        assert!(r.warned, "recovery off for the session, said out loud");
+        assert_eq!(
+            r.warned,
+            Some(Failed::Discovery),
+            "recovery off for the session, said out loud"
+        );
+    }
+
+    /// One line per failure, not per session: the discovery failure above must not consume the
+    /// line a failed connect would have said, which is the asymmetry glass#381 is about.
+    #[test]
+    fn a_connect_failure_after_a_table_failure_is_still_said() {
+        let rt = tempfile::tempdir().expect("tempdir");
+        let mut r = Recovery::new(rt.path());
+        let now = std::time::Instant::now();
+        r.recover_if_due_in(Path::new("/nonexistent/glass-381/proc"), now, &[]);
+        // A display no X server serves: discovery answers, and the connect behind it cannot.
+        let proc = super::session_tests::FakeProc::new();
+        proc.process(41, "Xwayland", rt.path(), &["Xwayland", ":999"]);
+        assert_eq!(
+            r.recover_if_due_in(proc.path(), now + CHECK_INTERVAL, &[]),
+            0
+        );
+        assert_eq!(r.warned, Some(Failed::Connect));
     }
 
     /// A session whose runtime directory no Xwayland holds is a native Wayland app: no work, no
@@ -1142,7 +1196,10 @@ mod tests {
     fn a_session_with_no_xwayland_recovers_nothing_and_says_nothing() {
         let mut r = Recovery::new(Path::new("/tmp/glass-wl.no-such-session"));
         assert_eq!(r.recover_if_due(std::time::Instant::now(), &[]), 0);
-        assert!(!r.warned, "a session with no X11 side is not a failure");
+        assert!(
+            r.warned.is_none(),
+            "a session with no X11 side is not a failure"
+        );
         assert_eq!(r.unrecovered(), 0);
     }
 

--- a/crates/glass-wayland/src/xwayland.rs
+++ b/crates/glass-wayland/src/xwayland.rs
@@ -770,8 +770,7 @@ mod x_tests {
 #[cfg(test)]
 mod session_tests {
     //! Finding the session's own Xwayland. Only a real session shows the match is by runtime
-    //! directory rather than by whatever `DISPLAY` is set to; the process table a scan reads is a
-    //! parameter, so what it does with one it cannot read is shown against a built table.
+    //! directory rather than by whatever `DISPLAY` is set to.
     use super::*;
     use crate::testw::Launch;
 
@@ -845,10 +844,6 @@ mod session_tests {
     }
 
     /// A process table built for a test: pid directories holding the files the scans read.
-    ///
-    /// The failures glass#381 is about — a `/proc` that cannot be read at all, an entry whose
-    /// files cannot be — do not happen on demand in the real one, and each of them decides
-    /// whether recovery runs for the session.
     pub(super) struct FakeProc(tempfile::TempDir);
 
     impl FakeProc {
@@ -926,8 +921,8 @@ mod session_tests {
         );
     }
 
-    /// Past the runtime-dir match the process is this session's own, so a file that cannot be read
-    /// is glass unable to read its own Xwayland — not another session's, which it may skip.
+    /// The other half of the split: past the match, a file that cannot be read is glass unable to
+    /// read its own Xwayland.
     #[test]
     fn the_sessions_own_xwayland_with_an_unreadable_cmdline_is_reported() {
         let proc = FakeProc::new();
@@ -939,8 +934,8 @@ mod session_tests {
         assert!(e.to_string().contains("cmdline"), "{e}");
     }
 
-    /// Its display is what the probe connects to. Not finding one leaves recovery off just as an
-    /// unreadable table does, so it is reported the same way rather than read as no X11 side.
+    /// Its display is what the probe connects to; not finding one leaves recovery off just as an
+    /// unreadable table does.
     #[test]
     fn the_sessions_own_xwayland_with_no_display_argument_is_reported() {
         let proc = FakeProc::new();
@@ -950,9 +945,6 @@ mod session_tests {
             .expect_err("an Xwayland with no display is not one this session can be probed on");
     }
 
-    /// Before the match a read failure is routine: another user's Xwayland is unreadable by
-    /// design, and one that exits mid-scan is gone. Neither is this session's to report.
-    ///
     /// The only Xwayland in the table is the unreadable one: a second, readable entry would let
     /// the scan return before ever reading this one.
     #[test]
@@ -968,8 +960,8 @@ mod session_tests {
         );
     }
 
-    /// glass#381: doctor reads an empty list as "the probe left nothing running" and deletes the
-    /// session's runtime dir on the strength of it. A table that could not be read is not that.
+    /// glass#381: doctor reads an empty list as "the probe left nothing running"; a table that
+    /// could not be read is not that.
     #[test]
     fn a_process_table_that_cannot_be_read_is_not_an_empty_session() {
         session_processes_in(no_process_table(), Path::new("/tmp/glass-wl.ab"))
@@ -1152,9 +1144,8 @@ mod tests {
         assert!(r.due(now));
     }
 
-    /// glass#381: a process table glass cannot read leaves recovery off for the whole session.
-    /// That is a failure of glass's own machinery and has to read like one, not like the native
-    /// Wayland session that legitimately has no display to find.
+    /// glass#381: recovery off for the session reads as a failure of glass's own machinery, not
+    /// as the native Wayland session that legitimately has no display to find.
     #[test]
     fn a_process_table_that_cannot_be_read_is_reported_and_recovers_nothing() {
         let mut r = Recovery::new(Path::new("/tmp/glass-wl.ab"));

--- a/crates/glass-wayland/src/xwayland.rs
+++ b/crates/glass-wayland/src/xwayland.rs
@@ -41,6 +41,11 @@ pub const REMAP_SETTLE: std::time::Duration = std::time::Duration::from_millis(2
 /// otherwise pay on every window enumeration. Afterwards each check is a round trip per X window.
 pub const CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_millis(750);
 
+/// The process table every scan here reads. Passed to the scans as a parameter so a test can
+/// build one: an unreadable `/proc`, or an entry whose files cannot be read, decides whether
+/// recovery runs at all, and neither can be arranged in the real one.
+const PROC: &str = "/proc";
+
 /// A session's state for recovering lost toplevels: which session it is, the X connection once
 /// one exists, what has been tried, what was missing last time, and when the last check ran.
 pub struct Recovery {
@@ -117,13 +122,25 @@ impl Recovery {
     /// costs a `/proc` walk and this sits on the window-enumeration path.
     ///
     /// Best effort: a session with no Xwayland (a native Wayland app), an X server that will not
-    /// answer, or a check that is not due yet all leave the caller exactly as it was. The
-    /// throttle lives here rather than at the call sites so a caller cannot spend the walk by
-    /// forgetting to ask first.
+    /// answer, a process table that cannot be read, or a check that is not due yet all leave the
+    /// caller exactly as it was. Only the first is silent; the rest are glass failing to look and
+    /// say so (glass#381). The throttle lives here rather than at the call sites so a caller
+    /// cannot spend the walk by forgetting to ask first.
     ///
     /// `in_compositor` is the X11 window id of each window sway currently reports (native
     /// Wayland views have none and are simply absent from it).
     pub fn recover_if_due(&mut self, now: std::time::Instant, in_compositor: &[u32]) -> usize {
+        self.recover_if_due_in(Path::new(PROC), now, in_compositor)
+    }
+
+    /// [`Self::recover_if_due`] with the process table to scan passed in, so the outcomes of a
+    /// table that cannot be read are reachable without one.
+    fn recover_if_due_in(
+        &mut self,
+        proc_root: &Path,
+        now: std::time::Instant,
+        in_compositor: &[u32],
+    ) -> usize {
         if !self.due(now) {
             return 0;
         }
@@ -131,10 +148,21 @@ impl Recovery {
         let probe = match self.probe.take() {
             Some(p) => p,
             None => {
-                // No Xwayland holding this session's runtime directory: a native Wayland app,
-                // which never takes the path this recovers. Nothing to do, nothing to warn about.
-                let Some(display) = session_display(&self.runtime_dir) else {
-                    return 0;
+                let display = match session_display(proc_root, &self.runtime_dir) {
+                    Ok(Some(d)) => d,
+                    // No Xwayland holds this session's runtime directory: a native Wayland app,
+                    // which never takes the path this recovers. Nothing to do, nothing to warn
+                    // about.
+                    Ok(None) => return 0,
+                    // Not that: glass could not look. Recovery is off for the session either
+                    // way, so it is said like a failed connect (glass#381).
+                    Err(e) => {
+                        self.warn_once(format!(
+                            "glass: could not find the session's Xwayland: {e}. Windows the \
+                             compositor loses will not be recovered."
+                        ));
+                        return 0;
+                    }
                 };
                 match XProbe::connect(&display) {
                     Ok(p) => p,
@@ -297,8 +325,8 @@ fn window_is_gone(e: &ReplyError) -> bool {
     matches!(e, ReplyError::X11Error(x) if x.error_kind == ErrorKind::Window)
 }
 
-/// The display served by *this session's* Xwayland, or `None` when the session has no X11 side
-/// (a native Wayland app — sway only starts Xwayland once an X11 client connects).
+/// The display served by *this session's* Xwayland, or `Ok(None)` when the session has no X11
+/// side (a native Wayland app — sway only starts Xwayland once an X11 client connects).
 ///
 /// The session's Xwayland is found by its private runtime directory rather than by reading
 /// `DISPLAY` out of the app's environment, and that difference is a safety property, not a
@@ -310,28 +338,56 @@ fn window_is_gone(e: &ReplyError) -> bool {
 ///
 /// The process itself has to be found by scanning: sway reparents Xwayland out of its own
 /// process tree (its parent becomes init), so walking sway's descendants never finds it.
-fn session_display(runtime_dir: &Path) -> Option<String> {
-    xwayland_pids().into_iter().find_map(|pid| {
-        let environ = std::fs::read(format!("/proc/{pid}/environ")).ok()?;
+///
+/// The no-X11-side answer is `Ok(None)` and nothing else; a scan that could not be run is an
+/// `Err`, because both leave recovery off and only one of them is expected (glass#381).
+fn session_display(proc_root: &Path, runtime_dir: &Path) -> Result<Option<String>> {
+    for pid in xwayland_pids(proc_root)? {
+        let dir = proc_root.join(pid.to_string());
+        // Before the match a read failure is routine: another user's Xwayland is unreadable by
+        // design, one that exited mid-scan is gone.
+        let Ok(environ) = std::fs::read(dir.join("environ")) else {
+            continue;
+        };
         if !serves_session(&environ, runtime_dir) {
-            return None;
+            continue;
         }
-        let cmdline = std::fs::read(format!("/proc/{pid}/cmdline")).ok()?;
-        display_from_cmdline(&cmdline)
-    })
+        // Past it the process is this session's own, so a failed read is glass failing to
+        // inspect what it started.
+        let cmdline = std::fs::read(dir.join("cmdline")).map_err(|e| {
+            GlassError::Backend(format!(
+                "read the session's Xwayland cmdline (pid {pid}): {e}"
+            ))
+        })?;
+        return display_from_cmdline(&cmdline).map(Some).ok_or_else(|| {
+            GlassError::Backend(format!(
+                "the session's Xwayland (pid {pid}) was started with no display argument"
+            ))
+        });
+    }
+    Ok(None)
 }
 
-/// Every Xwayland process on the machine. The session's own is picked out of these by its
+/// Every Xwayland process in a process table. The session's own is picked out of these by its
 /// runtime directory; a host with none simply has no X11 side to recover.
-fn xwayland_pids() -> Vec<u32> {
-    let Ok(entries) = std::fs::read_dir("/proc") else {
-        return Vec::new();
-    };
-    entries
+fn xwayland_pids(proc_root: &Path) -> Result<Vec<u32>> {
+    Ok(proc_pids(proc_root)?
+        .into_iter()
+        .filter(|pid| is_xwayland_in(proc_root, *pid))
+        .collect())
+}
+
+/// Every process id in a process table, or why it could not be read.
+///
+/// The failure is returned rather than swallowed as an empty list: callers act on "nothing there",
+/// and a table that could not be read is not that (glass#381).
+fn proc_pids(proc_root: &Path) -> Result<Vec<u32>> {
+    let entries = std::fs::read_dir(proc_root)
+        .map_err(|e| GlassError::Backend(format!("read {}: {e}", proc_root.display())))?;
+    Ok(entries
         .flatten()
         .filter_map(|e| e.file_name().to_str()?.parse::<u32>().ok())
-        .filter(|pid| is_xwayland(*pid))
-        .collect()
+        .collect())
 }
 
 /// Every process on the machine that belongs to the session `runtime_dir` was created for.
@@ -339,18 +395,19 @@ fn xwayland_pids() -> Vec<u32> {
 /// By what a process inherited, not by parentage: sway reparents Xwayland out of its own tree and
 /// `setsid`s every app it `exec`s, so a walk of sway's descendants finds neither. This is what
 /// answers whether a launch is really gone (glass#380).
-pub(crate) fn session_processes(runtime_dir: &Path) -> Vec<u32> {
-    let Ok(entries) = std::fs::read_dir("/proc") else {
-        return Vec::new();
-    };
-    entries
-        .flatten()
-        .filter_map(|e| e.file_name().to_str()?.parse::<u32>().ok())
+pub(crate) fn session_processes(runtime_dir: &Path) -> Result<Vec<u32>> {
+    session_processes_in(Path::new(PROC), runtime_dir)
+}
+
+/// [`session_processes`] over a given process table.
+fn session_processes_in(proc_root: &Path, runtime_dir: &Path) -> Result<Vec<u32>> {
+    Ok(proc_pids(proc_root)?
+        .into_iter()
         .filter(|pid| {
-            std::fs::read(format!("/proc/{pid}/environ"))
+            std::fs::read(proc_root.join(pid.to_string()).join("environ"))
                 .is_ok_and(|environ| serves_session(&environ, runtime_dir))
         })
-        .collect()
+        .collect())
 }
 
 /// Whether a process's environment (`/proc/<pid>/environ`: NUL-separated `KEY=VALUE`) says it
@@ -377,7 +434,13 @@ fn display_from_cmdline(cmdline: &[u8]) -> Option<String> {
 /// Whether `pid` is an Xwayland process, read from `/proc/<pid>/comm`. Also used by teardown,
 /// which must not wait on the compositor's own plumbing the way it waits on the app.
 pub fn is_xwayland(pid: u32) -> bool {
-    std::fs::read_to_string(format!("/proc/{pid}/comm")).is_ok_and(|comm| comm.trim() == "Xwayland")
+    is_xwayland_in(Path::new(PROC), pid)
+}
+
+/// [`is_xwayland`] over a given process table.
+fn is_xwayland_in(proc_root: &Path, pid: u32) -> bool {
+    std::fs::read_to_string(proc_root.join(pid.to_string()).join("comm"))
+        .is_ok_and(|comm| comm.trim() == "Xwayland")
 }
 
 /// `:0`, `:1`, … — a bare display token. Rejects a screen-qualified (`:0.0`) or host-qualified
@@ -685,8 +748,9 @@ mod x_tests {
 
 #[cfg(test)]
 mod session_tests {
-    //! Finding the session's own Xwayland. The scan reads `/proc`, so only a real session shows
-    //! the match is by runtime directory rather than by whatever `DISPLAY` is set to.
+    //! Finding the session's own Xwayland. Only a real session shows the match is by runtime
+    //! directory rather than by whatever `DISPLAY` is set to; the process table a scan reads is a
+    //! parameter, so what it does with one it cannot read is shown against a built table.
     use super::*;
     use crate::testw::Launch;
 
@@ -698,7 +762,8 @@ mod session_tests {
         // Computed here rather than trusted from the lookup: sibling tests run their own sessions
         // in parallel, so a lookup that ignored the runtime dir would still find one of theirs and
         // answer with a perfectly plausible display.
-        let mine: Vec<String> = xwayland_pids()
+        let mine: Vec<String> = xwayland_pids(Path::new(PROC))
+            .expect("scan /proc")
             .into_iter()
             .filter(|pid| {
                 std::fs::read(format!("/proc/{pid}/environ"))
@@ -710,7 +775,9 @@ mod session_tests {
             .collect();
         assert_eq!(mine.len(), 1, "one Xwayland serves this session: {mine:?}");
         assert_eq!(
-            session_display(&dir).as_deref(),
+            session_display(Path::new(PROC), &dir)
+                .expect("scan /proc")
+                .as_deref(),
             Some(mine[0].as_str()),
             "the lookup answered with an X server this session does not own"
         );
@@ -721,7 +788,10 @@ mod session_tests {
     #[test]
     fn a_runtime_dir_no_xwayland_holds_has_no_display() {
         let dir = tempfile::tempdir().expect("tempdir");
-        assert_eq!(session_display(dir.path()), None);
+        assert_eq!(
+            session_display(Path::new(PROC), dir.path()).expect("scan /proc"),
+            None
+        );
     }
 
     /// The scan has to find the session's *own* Xwayland. An empty list reads as "no X11 side",
@@ -735,7 +805,8 @@ mod session_tests {
     fn the_scan_finds_this_sessions_own_xwayland() {
         let s = Launch::new().through_xwayland().start();
         let dir = s.runtime_dir();
-        let mine: Vec<u32> = xwayland_pids()
+        let mine: Vec<u32> = xwayland_pids(Path::new(PROC))
+            .expect("scan /proc")
             .into_iter()
             .filter(|pid| {
                 std::fs::read(format!("/proc/{pid}/environ"))
@@ -750,6 +821,130 @@ mod session_tests {
     #[test]
     fn this_test_process_is_not_an_xwayland() {
         assert!(!is_xwayland(std::process::id()));
+    }
+
+    /// A process table built for a test: pid directories holding the files the scans read.
+    ///
+    /// The failures glass#381 is about — a `/proc` that cannot be read at all, an entry whose
+    /// files cannot be — do not happen on demand in the real one, and each of them decides
+    /// whether recovery runs for the session.
+    struct FakeProc(tempfile::TempDir);
+
+    impl FakeProc {
+        fn new() -> FakeProc {
+            FakeProc(tempfile::tempdir().expect("tempdir"))
+        }
+
+        fn path(&self) -> &Path {
+            self.0.path()
+        }
+
+        /// A process whose `comm` is `comm`, whose environment says it belongs to `runtime_dir`,
+        /// and whose `cmdline` is `argv`.
+        fn process(&self, pid: u32, comm: &str, runtime_dir: &Path, argv: &[&str]) -> PathBuf {
+            let dir = self.path().join(pid.to_string());
+            std::fs::create_dir(&dir).expect("pid dir");
+            std::fs::write(dir.join("comm"), format!("{comm}\n")).expect("comm");
+            std::fs::write(
+                dir.join("environ"),
+                format!("HOME=/tmp\0XDG_RUNTIME_DIR={}\0", runtime_dir.display()),
+            )
+            .expect("environ");
+            std::fs::write(dir.join("cmdline"), argv.join("\0")).expect("cmdline");
+            dir
+        }
+    }
+
+    /// Put something in place of `file` that no read can succeed on whatever the caller's
+    /// privileges — a mode-0 file still opens as root, which is how CI runs.
+    fn make_unreadable(file: &Path) {
+        std::fs::remove_file(file).expect("remove the file");
+        std::fs::create_dir(file).expect("a directory in its place");
+    }
+
+    /// A path no process table is at, for the scans that must report rather than answer.
+    fn no_process_table() -> &'static Path {
+        Path::new("/nonexistent/glass-381/proc")
+    }
+
+    /// glass#381: an unreadable process table is not "this session has no X11 side". Read as one,
+    /// it switches lost-window recovery off for the session with nothing said.
+    #[test]
+    fn a_process_table_that_cannot_be_read_is_not_an_absent_xwayland() {
+        session_display(no_process_table(), Path::new("/tmp/glass-wl.ab"))
+            .expect_err("a process table that cannot be read says nothing about Xwayland");
+    }
+
+    #[test]
+    fn the_sessions_xwayland_is_found_in_the_scanned_table() {
+        let proc = FakeProc::new();
+        let rt = tempfile::tempdir().expect("tempdir");
+        proc.process(41, "Xwayland", rt.path(), &["Xwayland", ":7", "-rootless"]);
+        assert_eq!(
+            session_display(proc.path(), rt.path()).expect("scan"),
+            Some(":7".to_string())
+        );
+    }
+
+    /// The silent case, and the only one: sway starts no Xwayland until an X11 client connects.
+    #[test]
+    fn an_xwayland_serving_another_session_leaves_this_one_with_no_display() {
+        let proc = FakeProc::new();
+        let theirs = tempfile::tempdir().expect("tempdir");
+        let mine = tempfile::tempdir().expect("tempdir");
+        proc.process(41, "Xwayland", theirs.path(), &["Xwayland", ":7"]);
+        assert_eq!(
+            session_display(proc.path(), mine.path()).expect("scan"),
+            None
+        );
+    }
+
+    /// Past the runtime-dir match the process is this session's own, so a file that cannot be read
+    /// is glass unable to read its own Xwayland — not another session's, which it may skip.
+    #[test]
+    fn the_sessions_own_xwayland_with_an_unreadable_cmdline_is_reported() {
+        let proc = FakeProc::new();
+        let rt = tempfile::tempdir().expect("tempdir");
+        let dir = proc.process(41, "Xwayland", rt.path(), &["Xwayland", ":7"]);
+        make_unreadable(&dir.join("cmdline"));
+        let e = session_display(proc.path(), rt.path())
+            .expect_err("the session's own Xwayland could not be read");
+        assert!(e.to_string().contains("cmdline"), "{e}");
+    }
+
+    /// Its display is what the probe connects to. Not finding one leaves recovery off just as an
+    /// unreadable table does, so it is reported the same way rather than read as no X11 side.
+    #[test]
+    fn the_sessions_own_xwayland_with_no_display_argument_is_reported() {
+        let proc = FakeProc::new();
+        let rt = tempfile::tempdir().expect("tempdir");
+        proc.process(41, "Xwayland", rt.path(), &["Xwayland", "-rootless"]);
+        session_display(proc.path(), rt.path())
+            .expect_err("an Xwayland with no display is not one this session can be probed on");
+    }
+
+    /// Before the match a read failure is routine: another user's Xwayland is unreadable by
+    /// design, and one that exits mid-scan is gone. Neither may hide the session's own.
+    #[test]
+    fn an_xwayland_whose_environ_cannot_be_read_is_skipped_not_reported() {
+        let proc = FakeProc::new();
+        let mine = tempfile::tempdir().expect("tempdir");
+        let theirs = tempfile::tempdir().expect("tempdir");
+        let unreadable = proc.process(41, "Xwayland", theirs.path(), &["Xwayland", ":1"]);
+        make_unreadable(&unreadable.join("environ"));
+        proc.process(42, "Xwayland", mine.path(), &["Xwayland", ":7"]);
+        assert_eq!(
+            session_display(proc.path(), mine.path()).expect("scan"),
+            Some(":7".to_string())
+        );
+    }
+
+    /// glass#381: doctor reads an empty list as "the probe left nothing running" and deletes the
+    /// session's runtime dir on the strength of it. A table that could not be read is not that.
+    #[test]
+    fn a_process_table_that_cannot_be_read_is_not_an_empty_session() {
+        session_processes_in(no_process_table(), Path::new("/tmp/glass-wl.ab"))
+            .expect_err("a process table that cannot be read says nothing about the session");
     }
 }
 
@@ -771,15 +966,25 @@ mod tests {
             .expect("spawn sleep");
         let pid = child.id();
         assert!(
-            session_processes(rt.path()).contains(&pid),
+            session_processes(rt.path())
+                .expect("scan /proc")
+                .contains(&pid),
             "a process carrying the session's runtime dir belongs to it"
         );
         // Another session's dir must not match it — the whole point is telling them apart.
         let other = tempfile::tempdir().expect("tempdir");
-        assert!(!session_processes(other.path()).contains(&pid));
+        assert!(
+            !session_processes(other.path())
+                .expect("scan /proc")
+                .contains(&pid)
+        );
         child.kill().expect("kill");
         child.wait().expect("reap");
-        assert!(!session_processes(rt.path()).contains(&pid));
+        assert!(
+            !session_processes(rt.path())
+                .expect("scan /proc")
+                .contains(&pid)
+        );
     }
 
     fn toplevel() -> WindowFacts {
@@ -915,6 +1120,20 @@ mod tests {
         assert!(!r.due(now));
         r.rearm();
         assert!(r.due(now));
+    }
+
+    /// glass#381: a process table glass cannot read leaves recovery off for the whole session.
+    /// That is a failure of glass's own machinery and has to read like one, not like the native
+    /// Wayland session that legitimately has no display to find.
+    #[test]
+    fn a_process_table_that_cannot_be_read_is_reported_and_recovers_nothing() {
+        let mut r = Recovery::new(Path::new("/tmp/glass-wl.ab"));
+        let now = std::time::Instant::now();
+        assert_eq!(
+            r.recover_if_due_in(Path::new("/nonexistent/glass-381/proc"), now, &[]),
+            0
+        );
+        assert!(r.warned, "recovery off for the session, said out loud");
     }
 
     /// A session whose runtime directory no Xwayland holds is a native Wayland app: no work, no

--- a/crates/glass-wayland/src/xwayland.rs
+++ b/crates/glass-wayland/src/xwayland.rs
@@ -46,8 +46,8 @@ pub const CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_millis
 /// recovery runs at all, and neither can be arranged in the real one.
 const PROC: &str = "/proc";
 
-/// Which step of a cross-check failed. Kept so a session reports each kind once rather than
-/// reporting only whichever failed first.
+/// Which step of a cross-check failed — kept so a session reports each kind once, not only
+/// whichever failed first.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Failed {
     /// Finding the session's Xwayland at all — the process table, or the entry it matched.
@@ -79,9 +79,8 @@ pub struct Recovery {
     unrecovered: usize,
     last_checked: Option<std::time::Instant>,
     /// What the last reported failure to reach the X side was, or `None` while there has been
-    /// none. Checks repeat for the life of the session, and one unreachable X server should read
-    /// as one warning, not as a line every interval — but a failure of a *different* kind is
-    /// news, so the kind is kept rather than a flag (glass#381).
+    /// none. One unreachable X server reads as one warning rather than a line every interval; a
+    /// failure of a *different* kind is news (glass#381).
     warned: Option<Failed>,
 }
 
@@ -119,9 +118,9 @@ impl Recovery {
             .is_none_or(|last| now.duration_since(last) >= CHECK_INTERVAL)
     }
 
-    /// Report a failure to reach the session's X side once per kind. The cross-check repeats for
-    /// the life of the session, so an X server that stays unreachable would otherwise repeat its
-    /// warning every interval — drowning out whatever the app itself is saying.
+    /// Report a failure to reach the session's X side once per kind. An X server that stays
+    /// unreachable would otherwise repeat its warning every interval, drowning out the app's own
+    /// output.
     fn warn_once(&mut self, failed: Failed, message: String) {
         if self.warned != Some(failed) {
             self.warned = Some(failed);
@@ -954,9 +953,8 @@ mod session_tests {
     /// Before the match a read failure is routine: another user's Xwayland is unreadable by
     /// design, and one that exits mid-scan is gone. Neither is this session's to report.
     ///
-    /// The only Xwayland in the table is the unreadable one, so the answer cannot come from
-    /// somewhere else — a second, readable entry would let the scan return before ever reading
-    /// this one, whatever it does with a read it cannot make.
+    /// The only Xwayland in the table is the unreadable one: a second, readable entry would let
+    /// the scan return before ever reading this one.
     #[test]
     fn an_xwayland_whose_environ_cannot_be_read_is_skipped_not_reported() {
         let proc = FakeProc::new();
@@ -1172,8 +1170,8 @@ mod tests {
         );
     }
 
-    /// One line per failure, not per session: the discovery failure above must not consume the
-    /// line a failed connect would have said, which is the asymmetry glass#381 is about.
+    /// One line per failure kind, not per session: the discovery failure must not consume the
+    /// line a failed connect would have said (glass#381).
     #[test]
     fn a_connect_failure_after_a_table_failure_is_still_said() {
         let rt = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
Fixes #381.

`session_display` returned `None` for four different reasons and `recover_if_due` read all of them as the one that is expected — a native Wayland app with no X11 side. An unreadable `/proc`, or an unreadable `environ`/`cmdline` on the session's own Xwayland, switched lost-window recovery off for the life of the session with nothing said, after which `list_windows` reported the compositor's shorter list as fact.

The scans now separate "looked and found nothing" from "could not look". `Ok(None)` is the native Wayland session and nothing else; an `Err` is reported like a failed `XProbe::connect`. A read failure *before* the runtime-dir match stays a silent skip — that is what another user's Xwayland, or one that exited mid-scan, correctly looks like.

`Recovery::warned` records which step failed rather than that something did, so a `/proc` failure no longer consumes the line a later connect failure would have said (the same asymmetry, one branch over).

`session_processes` swallowed the same `read_dir("/proc")` failure, and doctor's leak accounting read the empty list as "the probe left nothing running" — deleting the probe's runtime dir out from under whatever still held sockets in it. It now reports that it could not tell, and keeps the dir. A failed scan is retried within the existing 500 ms `LEAK_GRACE`, since a host out of file descriptors is the transient that wait is there for.

## Verification

- 189 `glass-wayland` unit tests; 93 workspace test binaries; 0 failures.
- `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --check` clean.
- The `#[ignore]`d real-session tests pass against a live sway/Xwayland (`--include-ignored`).
- The process table is a parameter to the scans, so the branches that decide whether recovery runs are covered against a built one: no `/proc`, an entry whose files cannot be read, an Xwayland with no `:N` argument, one serving another session, and a table whose only entry is unreadable.
- Each new test was shown to fail by reinstating the swallow it guards (5 ablations).