### PR TITLE
Fix accessibility blank names and Windows console flashes

### DIFF
--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -11,7 +11,7 @@ use atspi::proxy::component::ComponentProxy;
 use atspi_common::{CoordType, ObjectRefOwned};
 use glass_core::{
     A11yThread, Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxTarget, AxTree, Deadline,
-    GlassError, Result, WalkBudget, normalize_description, read_back_confirms,
+    GlassError, Result, WalkBudget, normalize_description, normalize_name, read_back_confirms,
     write_took_no_effect,
 };
 
@@ -837,7 +837,7 @@ async fn read_number(proxy: &AccessibleProxy<'_>, conn: &zbus::Connection) -> Op
 }
 
 fn nonempty(s: String) -> Option<String> {
-    (!s.is_empty()).then_some(s)
+    normalize_name(&s)
 }
 
 /// Records a null `child_ref` on `budget` as content the app has not exposed, and says whether it

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -20,7 +20,7 @@ use glass_core::coords::pixel_geometry_from_content_rect;
 use glass_core::platform::WindowGeometry;
 use glass_core::{
     Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxTarget, AxTree, GlassError,
-    Result, WalkBudget, read_back_confirms, write_took_no_effect,
+    Result, WalkBudget, normalize_name, read_back_confirms, write_took_no_effect,
 };
 use objc2_application_services::AXUIElement;
 use objc2_core_foundation::CFRetained;
@@ -374,7 +374,7 @@ fn select_window(
 /// describe the node.
 fn read_label(el: &AXUIElement, attr_name: &str) -> Option<String> {
     match ffi::attribute_string_checked(el, attr_name) {
-        Ok(text) => text.filter(|t| !t.is_empty()),
+        Ok(text) => text.and_then(|text| normalize_name(&text)),
         Err(err) => {
             eprintln!(
                 "glass-a11y-macos: {attr_name} read failed: {err}; treating the element as \

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 
 use glass_core::{
     A11yThread, Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxTarget, AxTree, ChangeSignal,
-    GlassError, Result, WalkBudget, normalize_description, read_back_confirms,
+    GlassError, Result, WalkBudget, normalize_description, normalize_name, read_back_confirms,
     write_took_no_effect,
 };
 use uiautomation::patterns::{
@@ -341,7 +341,7 @@ fn window_relative_bounds(el: &UIElement, origin: (i32, i32)) -> Option<AxRect> 
 }
 
 fn nonempty(s: String) -> Option<String> {
-    (!s.is_empty()).then_some(s)
+    normalize_name(&s)
 }
 
 /// The element's UIA `FrameworkId`, which `map_role_with_framework` decides a `Document` on.

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -356,6 +356,13 @@ pub struct AxNode {
     pub children: Vec<AxNode>,
 }
 
+/// A node name, or `None` when the platform supplied no non-whitespace content.
+/// The original string is preserved so meaningful leading, trailing, and interior spacing
+/// remains available to selectors and target fingerprints.
+pub fn normalize_name(raw: &str) -> Option<String> {
+    (!raw.trim().is_empty()).then(|| raw.to_string())
+}
+
 /// A node's description, or `None` when it would add nothing: empty, whitespace-only, or the
 /// same string as `name` (platforms routinely report both fields with one label in them).
 /// Every backend normalizes through this so the rule cannot drift per-platform.
@@ -3679,10 +3686,16 @@ mod tests {
         assert_eq!(normalize_description("   ", None), None);
         // A description identical to the name would print the same label twice per line.
         assert_eq!(normalize_description("Save", Some("Save")), None);
-        // Both sides are trimmed, and the name side is reachable: the readers' `nonempty`
-        // helper does not trim, so a name can arrive as `Some("Save ")`.
+        // Both sides are trimmed while meaningful spacing remains stored verbatim.
         assert_eq!(normalize_description("  Save  ", Some("Save")), None);
         assert_eq!(normalize_description("Save", Some("  Save  ")), None);
+    }
+
+    #[test]
+    fn normalize_name_drops_only_names_without_content() {
+        assert_eq!(normalize_name(""), None);
+        assert_eq!(normalize_name("   \t"), None);
+        assert_eq!(normalize_name("  Save  "), Some("  Save  ".into()));
     }
 
     #[test]

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -94,7 +94,7 @@ pub use accessibility::{
     Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget, AxTree,
     ChangeSignal, ChangeWait, ClickMethod, ElementCondition, ElementInfo, ElementMatch, MAX_DEPTH,
     MAX_NODES, MAX_SIBLINGS, Subject, Truncation, TruncationLimit, WalkBudget, WalkLimits,
-    element_match, normalize_description,
+    element_match, normalize_description, normalize_name,
 };
 
 pub mod marks;

--- a/crates/glass-ios/src/axmap.rs
+++ b/crates/glass-ios/src/axmap.rs
@@ -21,7 +21,7 @@
 //! backend — a known limitation.
 use glass_core::accessibility::{
     AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTree, WalkBudget, WalkLimits,
-    normalize_description,
+    normalize_description, normalize_name,
 };
 use glass_core::{GlassError, Result, WindowGeometry};
 use serde_json::Value;
@@ -180,8 +180,8 @@ fn map_node(n: &Value, scale: f64, depth: usize, budget: &mut WalkBudget) -> AxN
     // none — so this is a plain field read, not an extra round-trip.
     let role = ax_role_with_subrole(&ax_type, s("subrole").as_deref());
     let editable = matches!(role, AxRole::TextField | AxRole::TextArea);
-    let uid = s("AXUniqueId");
-    let label = s("AXLabel");
+    let uid = s("AXUniqueId").and_then(|value| normalize_name(&value));
+    let label = s("AXLabel").and_then(|value| normalize_name(&value));
     // Prefer the stable identifier for semantic addressing; fall back to the label.
     let name = uid.clone().or_else(|| label.clone());
     // Editable → value is `AXValue`; non-editable with a uid → the uid already displaced the

--- a/crates/glass-windows/src/process.rs
+++ b/crates/glass-windows/src/process.rs
@@ -1,4 +1,5 @@
-//! Process lifecycle for the Windows backend: spawn the app **CREATE_SUSPENDED**,
+//! Process lifecycle for the Windows backend: spawn the app **CREATE_SUSPENDED** without a
+//! launcher console window,
 //! assign it to a `KILL_ON_JOB_CLOSE` Job before it can fork any children, wire
 //! up log readers, then resume — so a launcher that exits and hands off
 //! (Chromium/Electron) cannot escape the Job. Teardown asks the app's windows to close and
@@ -36,8 +37,8 @@ use windows::Win32::System::JobObjects::{
     SetInformationJobObject,
 };
 use windows::Win32::System::Threading::{
-    CREATE_SUSPENDED, OpenProcess, OpenThread, PROCESS_QUERY_INFORMATION, PROCESS_SET_QUOTA,
-    PROCESS_TERMINATE, ResumeThread, THREAD_SUSPEND_RESUME,
+    CREATE_NO_WINDOW, CREATE_SUSPENDED, OpenProcess, OpenThread, PROCESS_QUERY_INFORMATION,
+    PROCESS_SET_QUOTA, PROCESS_TERMINATE, ResumeThread, THREAD_SUSPEND_RESUME,
 };
 use windows::Win32::UI::WindowsAndMessaging::{PostMessageW, WM_CLOSE};
 
@@ -52,6 +53,8 @@ use windows::Win32::UI::WindowsAndMessaging::{PostMessageW, WM_CLOSE};
 /// here — the tree would instead be terminated as a side effect of the handle closing at process
 /// exit, which is the ungraceful teardown this whole path exists to avoid, arrived at slowly.
 const CLOSE_GRACE: Duration = Duration::from_millis(1500);
+
+const APP_CREATION_FLAGS: u32 = CREATE_SUSPENDED.0 | CREATE_NO_WINDOW.0;
 
 // Teardown must finish inside the budget it is given, or `glass-mcp` walks away mid-close. This
 // is the only thing keeping the two numbers — in different crates — honest about each other.
@@ -333,7 +336,8 @@ fn request_close(pids: &[u32]) -> Asked {
     }
 }
 
-/// Spawn `cmd` CREATE_SUSPENDED with piped stdout/stderr, create a KILL_ON_JOB_CLOSE Job,
+/// Spawn `cmd` CREATE_SUSPENDED and CREATE_NO_WINDOW with piped stdout/stderr, create a
+/// KILL_ON_JOB_CLOSE Job,
 /// assign the (still-suspended, child-less) process to it, and return the LaunchedApp
 /// WITHOUT resuming (so the caller can wire log readers before output starts).
 ///
@@ -346,7 +350,7 @@ pub(crate) fn spawn_suspended_in_job(
     level: SandboxLevel,
 ) -> Result<LaunchedApp> {
     let mut child = cmd
-        .creation_flags(CREATE_SUSPENDED.0)
+        .creation_flags(APP_CREATION_FLAGS)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
@@ -561,5 +565,16 @@ fn resume_process(pid: u32) {
             }
         }
         let _ = CloseHandle(snap);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn app_spawn_is_suspended_without_a_console_window() {
+        assert_ne!(APP_CREATION_FLAGS & CREATE_SUSPENDED.0, 0);
+        assert_ne!(APP_CREATION_FLAGS & CREATE_NO_WINDOW.0, 0);
     }
 }


### PR DESCRIPTION
## Summary

- treat whitespace-only accessibility names as absent across Linux, Windows, macOS, and iOS while preserving meaningful spacing
- launch Windows apps with `CREATE_NO_WINDOW` in addition to `CREATE_SUSPENDED`, preserving piped logs and Job assignment

Fixes #500.
Fixes #505.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- Windows GNU cross-target Clippy for `glass-windows` and `glass-a11y-windows`
- macOS cross-target Clippy for `glass-a11y-macos`

--- *— Jcode agent (automated triage), on behalf of @fixed-width*