### PR TITLE
fix(a11y): render bounded editable values in compact snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ internal refactors, CI, or test-only changes.
 - `Document` accessibility role: a browser page or embedded web view (AT-SPI `document web`/`document frame`, `AXWebArea`, Android `WebView`, UIA `Document` from a web engine) now reads as a `Document` whose children are the page's elements, on Linux, Windows, macOS and Android.
 
 ### Fixed
+- Compact accessibility snapshots now include bounded current values for editable controls, while distinguishing empty, unavailable, redacted, and truncated values and never disclosing secure-field contents.
 - `glass_wait_for_element` and `glass_scroll_to_element` can now select by accessible `description`, using the same case-sensitive substring semantics as `name`. This lets role-plus-description reveal unnamed controls such as Android fields labelled only by a hint, and returns the realized element id as usual.
 - `glass_set_value` no longer reports that a desktop accessibility write "did not take" when the element exposes a writable value but no readable value for confirmation. Linux, macOS and Windows now report the write as unconfirmed and steer the caller to re-snapshot instead of retrying a write that may already have landed.
 - A web view whose content the platform has not published is disclosed in the snapshot instead of arriving as an indistinguishable empty group: a childless `Document` is named by id and bounds and steers to a re-snapshot before pixels, while a placeholder the app published for content it withheld steers straight to pixels.

--- a/crates/glass-a11y-linux/src/mapping.rs
+++ b/crates/glass-a11y-linux/src/mapping.rs
@@ -70,6 +70,7 @@ pub(crate) fn map_states(states: &StateSet) -> AxStates {
         checkable: states.contains(State::Checkable),
         expanded: states.contains(State::Expanded),
         editable: states.contains(State::Editable),
+        secure: false,
     }
 }
 

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -483,7 +483,8 @@ async fn walk(
     let raw_role = raw_role_res.unwrap_or_default();
     let name = nonempty(name_res.unwrap_or_default());
     let description = normalize_description(&description_res.unwrap_or_default(), name.as_deref());
-    let states = map_states(&state_res.map_err(bus_err)?);
+    let mut states = map_states(&state_res.map_err(bus_err)?);
+    states.secure = role == atspi::Role::PasswordText;
 
     let mut children = Vec::new();
     // Resolved before the gate: a childless node must never be reported truncated for
@@ -800,7 +801,7 @@ async fn read_value(
 ) -> Option<String> {
     use glass_core::AxRole::*;
     match role {
-        TextField | TextArea | ComboBox => read_text(proxy, conn).await.and_then(nonempty),
+        TextField | TextArea | ComboBox => read_text(proxy, conn).await,
         Slider | SpinButton | ProgressBar => read_number(proxy, conn).await,
         _ => None,
     }

--- a/crates/glass-a11y-macos/src/mapping.rs
+++ b/crates/glass-a11y-macos/src/mapping.rs
@@ -115,6 +115,7 @@ pub struct AxStateFacts {
     pub checkable: bool,
     pub expanded: bool,
     pub editable: bool,
+    pub secure: bool,
     pub visible: bool,
 }
 
@@ -130,6 +131,7 @@ pub fn map_states(f: &AxStateFacts) -> AxStates {
         checkable: f.checkable,
         expanded: f.expanded,
         editable: f.editable,
+        secure: f.secure,
     }
 }
 

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -487,7 +487,11 @@ fn walk(
     );
     let value = ffi::attribute_string(el, attr::VALUE);
     let bounds = window_relative_rect(el, scale, win);
-    let states = mapping::map_states(&gather_states(el, role));
+    let states = mapping::map_states(&gather_states(
+        el,
+        role,
+        subrole.as_deref() == Some("AXSecureTextField"),
+    ));
 
     let mut children = Vec::new();
     // `ffi::children` returns `Ok(vec![])` for a legitimately-childless (or absent-
@@ -625,7 +629,7 @@ fn window_relative_rect(el: &AXUIElement, scale: f64, win: &WindowGeometry) -> O
 /// unreadable value claims neither). The remaining facts stay at their defaults — macOS doesn't
 /// expose them as simple universal attributes, and the reader never over-claims a state it
 /// didn't read.
-fn gather_states(el: &AXUIElement, role: AxRole) -> AxStateFacts {
+fn gather_states(el: &AXUIElement, role: AxRole, secure: bool) -> AxStateFacts {
     // Only a checkbox/radio/switch carries a checked state, so read the numeric `AXValue` (an
     // extra AX IPC round-trip) only for those roles — every other node skips it. `ToggleButton`
     // is where a switch lands, whichever base role its toolkit gave it.
@@ -650,7 +654,7 @@ fn gather_states(el: &AXUIElement, role: AxRole) -> AxStateFacts {
         focused: ffi::attribute_bool(el, attr::FOCUSED).unwrap_or(false),
         focusable: ffi::is_settable(el, attr::FOCUSED),
         editable: ffi::is_settable(el, attr::VALUE),
-        secure: subrole.as_deref() == Some("AXSecureTextField"),
+        secure,
         checkable,
         checked,
         ..Default::default()

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -445,7 +445,11 @@ fn walk(
     budget.visit();
 
     let ax_role = ffi::attribute_string(el, attr::ROLE).unwrap_or_default();
-    let subrole = read_subrole(el, &ax_role);
+    let subrole = if ax_role == "AXTextField" {
+        ffi::attribute_string(el, attr::SUBROLE)
+    } else {
+        read_subrole(el, &ax_role)
+    };
     let role = mapping::map_role(&ax_role, subrole.as_deref());
     // `raw_role` is normally the same AX role string `map_role` matched on — the token, not
     // `AXRoleDescription`'s localized human phrase ("button" / "bouton"), which is useless as a
@@ -646,6 +650,7 @@ fn gather_states(el: &AXUIElement, role: AxRole) -> AxStateFacts {
         focused: ffi::attribute_bool(el, attr::FOCUSED).unwrap_or(false),
         focusable: ffi::is_settable(el, attr::FOCUSED),
         editable: ffi::is_settable(el, attr::VALUE),
+        secure: subrole.as_deref() == Some("AXSecureTextField"),
         checkable,
         checked,
         ..Default::default()

--- a/crates/glass-a11y-windows/src/mapping.rs
+++ b/crates/glass-a11y-windows/src/mapping.rs
@@ -143,6 +143,7 @@ pub struct StateFacts {
     pub toggled_on: bool,
     pub expanded: bool,
     pub editable: bool,
+    pub secure: bool,
     pub checkable: bool,
 }
 
@@ -158,6 +159,7 @@ pub fn map_states(f: &StateFacts) -> AxStates {
         checkable: f.checkable,
         expanded: f.expanded,
         editable: f.editable,
+        secure: f.secure,
     }
 }
 

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -262,7 +262,7 @@ fn gather(el: &UIElement, ct_id: u32) -> (crate::mapping::StateFacts, Option<Str
     // Value pattern: one fetch for both the value string and read-only (Edit/ComboBox/Document)
     let (value_text, readonly) = if matches!(ct_id, 50003 | 50004 | 50030) {
         match el.get_pattern::<UIValuePattern>() {
-            Ok(p) => (p.get_value().ok().and_then(nonempty), p.is_readonly().ok()),
+            Ok(p) => (p.get_value().ok(), p.is_readonly().ok()),
             Err(_) => (None, None),
         }
     } else {
@@ -297,6 +297,7 @@ fn gather(el: &UIElement, ct_id: u32) -> (crate::mapping::StateFacts, Option<Str
         toggled_on,
         expanded,
         editable,
+        secure: el.is_password().unwrap_or(false),
         checkable,
     };
     (facts, value)

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -60,7 +60,10 @@ fn json_to_node(v: &Value, win: &WindowGeometry, depth: usize, walk: &mut Walk) 
     let flag = |k: &str| v.get(k).and_then(Value::as_bool).unwrap_or(false);
     // The device agent omits an empty text/desc rather than sending `""`, so both arrive as
     // `None` here; `labels` judges a blank one absent either way.
-    let text = v.get("text").and_then(Value::as_str);
+    let text = v
+        .get("text")
+        .and_then(Value::as_str)
+        .or_else(|| flag("editable").then_some(""));
     let desc = v.get("desc").and_then(Value::as_str);
     // Both keys are absent (not null) on an older companion; `get` returns `None` either way, so
     // no version check is needed to stay compatible with it.
@@ -122,6 +125,7 @@ fn json_to_node(v: &Value, win: &WindowGeometry, depth: usize, walk: &mut Walk) 
         states: AxStates {
             enabled: flag("enabled"),
             editable: flag("editable"),
+            secure: flag("password"),
             // Android "focusable" is keyboard-only; map isClickable -> focusable as the actability proxy.
             focusable: flag("clickable"),
             visible: true,

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -1919,6 +1919,17 @@ mod tests {
     }
 
     #[test]
+    fn a_password_field_is_secure() {
+        let mut password = node_json(Some("secret"), Some("Password"), None, None);
+        password["class"] = json!("android.widget.EditText");
+        password["editable"] = json!(true);
+        password["password"] = json!(true);
+
+        assert!(mapped_node(&password).states.secure);
+        assert!(!mapped_editable(Some("visible"), Some("Name")).states.secure);
+    }
+
+    #[test]
     fn an_editable_node_with_no_desc_and_no_id_is_unnamed_not_named_by_its_contents() {
         // The device omits the key entirely for a field with no content description, and
         // `mapped_editable` omits `resource_id` too, so nothing is left to fall back to. Naming it

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -58,8 +58,7 @@ fn json_to_node(v: &Value, win: &WindowGeometry, depth: usize, walk: &mut Walk) 
     walk.refs.push(device_ref);
     let cls = v.get("class").and_then(Value::as_str).unwrap_or("");
     let flag = |k: &str| v.get(k).and_then(Value::as_bool).unwrap_or(false);
-    // The device agent omits an empty text/desc rather than sending `""`, so both arrive as
-    // `None` here; `labels` judges a blank one absent either way.
+    // The device omits empty text; preserve it as empty for editable nodes.
     let text = v
         .get("text")
         .and_then(Value::as_str)

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -330,9 +330,7 @@ pub(crate) fn labels(inputs: LabelInputs<'_>) -> (Option<String>, Option<String>
     )
 }
 
-/// Absent attribute and empty attribute are the same thing to `uiautomator`, which emits
-/// `text=""` on every node that has none. Kept even though [`labels`] judges the *name* itself,
-/// because non-editable nodes still use it to avoid manufacturing values from empty attributes.
+/// Treat `uiautomator`'s empty attributes as absent on non-editable nodes.
 fn non_empty(s: &str) -> Option<String> {
     if s.is_empty() {
         None
@@ -810,9 +808,6 @@ mod tests {
 
     #[test]
     fn an_empty_editable_node_reports_an_empty_value() {
-        // Compact snapshots distinguish an empty value from a value the backend could not read.
-        // `typed_clear_landed` accepts both shapes, so preserving the distinction is compatible
-        // with clear verification.
         let xml = edit_text_xml("", "Email");
         let tree = build_tree(&xml, &win(), WalkLimits::DEFAULT).unwrap();
         let field = &tree.root.children[0];

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -181,7 +181,11 @@ fn map_node(
     let role = class_to_role(class);
     let editable = role == AxRole::TextField || boolean("password");
     let content_desc = non_empty(attr("content-desc"));
-    let text = non_empty(attr("text"));
+    let text = if editable {
+        Some(attr("text").to_string())
+    } else {
+        non_empty(attr("text"))
+    };
     let resource_id = non_empty(attr("resource-id"));
     let (name, value, description) = labels(LabelInputs {
         text: text.as_deref(),
@@ -206,6 +210,7 @@ fn map_node(
         checkable: boolean("checkable") || boolean("checked"),
         expanded: false,
         editable,
+        secure: boolean("password"),
     };
     // Recursion is bounded by `budget` (depth, node count, siblings per level), so a
     // pathologically deep or wide device tree cannot blow the stack or the token budget.
@@ -327,8 +332,7 @@ pub(crate) fn labels(inputs: LabelInputs<'_>) -> (Option<String>, Option<String>
 
 /// Absent attribute and empty attribute are the same thing to `uiautomator`, which emits
 /// `text=""` on every node that has none. Kept even though [`labels`] judges the *name* itself,
-/// because it is also what keeps an empty field's `value` `None` rather than `Some("")` — the
-/// shape `typed_clear_landed` and a `value_contains` filter both read.
+/// because non-editable nodes still use it to avoid manufacturing values from empty attributes.
 fn non_empty(s: &str) -> Option<String> {
     if s.is_empty() {
         None
@@ -805,14 +809,15 @@ mod tests {
     }
 
     #[test]
-    fn an_empty_editable_node_reports_no_value_rather_than_an_empty_one() {
-        // `typed_clear_landed` and a `value_contains` filter both read "empty" as no value at
-        // all, so `text=""` must not surface as `Some("")`.
+    fn an_empty_editable_node_reports_an_empty_value() {
+        // Compact snapshots distinguish an empty value from a value the backend could not read.
+        // `typed_clear_landed` accepts both shapes, so preserving the distinction is compatible
+        // with clear verification.
         let xml = edit_text_xml("", "Email");
         let tree = build_tree(&xml, &win(), WalkLimits::DEFAULT).unwrap();
         let field = &tree.root.children[0];
         assert_eq!(field.name.as_deref(), Some("Email"));
-        assert_eq!(field.value, None);
+        assert_eq!(field.value.as_deref(), Some(""));
     }
 
     #[test]

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -178,7 +178,7 @@ pub struct AxStates {
     pub checkable: bool,
     pub expanded: bool,
     pub editable: bool,
-    /// The element is a password or otherwise protected text field. Its value must never render.
+    /// Password or protected field; its value must never render.
     pub secure: bool,
 }
 

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -770,7 +770,7 @@ impl AxTree {
     /// this text in at the MCP boundary. See [`Self::truncation_notice`].
     pub fn to_outline(&self) -> String {
         fn walk(node: &AxNode, depth: usize, out: &mut String) {
-            crate::outline::write_line(node, depth, out);
+            crate::outline::write_line(node, depth, out, false);
             for child in &node.children {
                 walk(child, depth + 1, out);
             }

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -178,6 +178,8 @@ pub struct AxStates {
     pub checkable: bool,
     pub expanded: bool,
     pub editable: bool,
+    /// The element is a password or otherwise protected text field. Its value must never render.
+    pub secure: bool,
 }
 
 impl AxStates {
@@ -207,6 +209,9 @@ impl AxStates {
         }
         if self.editable {
             v.push("editable");
+        }
+        if self.secure {
+            v.push("secure");
         }
         v
     }
@@ -1689,6 +1694,7 @@ mod tests {
             checked: true,
             expanded: true,
             editable: true,
+            secure: true,
         };
         let off = AxStates::default();
 

--- a/crates/glass-core/src/outline.rs
+++ b/crates/glass-core/src/outline.rs
@@ -75,9 +75,10 @@ fn is_scaffolding(node: &AxNode) -> bool {
 /// reported. A bare `Other` therefore means the backend named no token at all, not that glass
 /// dropped one. `role:` selectors still will not match either.
 ///
-/// Shared by [`AxTree::to_outline`] and [`render_compact`] so the two renders cannot drift —
-/// a test asserts they are identical for a tree with nothing to elide.
-pub(crate) fn write_line(node: &AxNode, depth: usize, out: &mut String) {
+/// Shared by [`AxTree::to_outline`] and [`render_compact`] so their common fields cannot drift.
+/// `editable_values` is enabled only for the compact, agent-facing snapshot contract; the full
+/// outline remains the structural representation used by scroll-saturation detection.
+pub(crate) fn write_line(node: &AxNode, depth: usize, out: &mut String, editable_values: bool) {
     let indent = "  ".repeat(depth);
     let _ = write!(out, "{indent}#{}", node.id.0);
     if node.role == AxRole::Other && !node.raw_role.is_empty() {
@@ -91,7 +92,9 @@ pub(crate) fn write_line(node: &AxNode, depth: usize, out: &mut String) {
     if let Some(description) = &node.description {
         let _ = write!(out, " desc={description:?}");
     }
-    write_editable_value(node, out);
+    if editable_values {
+        write_editable_value(node, out);
+    }
     if let Some(b) = &node.bounds {
         let _ = write!(out, " {b}");
     }
@@ -113,7 +116,7 @@ pub fn render_compact(tree: &AxTree) -> String {
     let mut out = String::new();
     // The root anchors the outline and is rendered unconditionally, even when it is itself
     // an unnamed single-child container.
-    write_line(&tree.root, 0, &mut out);
+    write_line(&tree.root, 0, &mut out, true);
     write_children(&tree.root, 1, &mut out);
     out
 }
@@ -132,7 +135,7 @@ fn write_children(parent: &AxNode, depth: usize, out: &mut String) {
             };
             node = only;
         }
-        write_line(node, depth, out);
+        write_line(node, depth, out, true);
         write_children(node, depth + 1, out);
     }
 }
@@ -485,5 +488,15 @@ mod tests {
         n.value = Some("same".into());
         n.states.editable = true;
         assert!(!render_compact(&tree_of(n)).contains("value="));
+    }
+
+    #[test]
+    fn editable_values_are_compact_only() {
+        let mut n = node(AxRole::TextField, Some("Email"));
+        n.value = Some("alice@example.com".into());
+        n.states.editable = true;
+        let tree = tree_of(n);
+        assert!(render_compact(&tree).contains("value=\"alice@example.com\""));
+        assert!(!tree.to_outline().contains("value="));
     }
 }

--- a/crates/glass-core/src/outline.rs
+++ b/crates/glass-core/src/outline.rs
@@ -19,6 +19,32 @@ use std::fmt::Write as _;
 
 use crate::accessibility::{AxNode, AxRole, AxTree};
 
+/// Maximum number of Unicode scalar values rendered from an editable value.
+const EDITABLE_VALUE_CHARS: usize = 80;
+
+fn write_editable_value(node: &AxNode, out: &mut String) {
+    if !node.states.editable {
+        return;
+    }
+    if node.states.secure {
+        let _ = write!(out, " value=<redacted>");
+        return;
+    }
+    if node.value.as_deref() == node.name.as_deref() {
+        return;
+    }
+    let Some(value) = &node.value else {
+        let _ = write!(out, " value=<unavailable>");
+        return;
+    };
+    let mut chars = value.chars();
+    let prefix: String = chars.by_ref().take(EDITABLE_VALUE_CHARS).collect();
+    let _ = write!(out, " value={prefix:?}");
+    if chars.next().is_some() {
+        out.push('…');
+    }
+}
+
 /// Whether `node` is pure structural scaffolding — a container that conveys nothing its
 /// single child does not already convey.
 ///
@@ -65,6 +91,7 @@ pub(crate) fn write_line(node: &AxNode, depth: usize, out: &mut String) {
     if let Some(description) = &node.description {
         let _ = write!(out, " desc={description:?}");
     }
+    write_editable_value(node, out);
     if let Some(b) = &node.bounds {
         let _ = write!(out, " {b}");
     }
@@ -431,5 +458,32 @@ mod tests {
             ..AxStates::default()
         };
         assert!(render_compact(&tree_of(wrap(b, 3))).contains("(12,40 80x24) [enabled]"));
+    }
+
+    #[test]
+    fn editable_values_distinguish_short_empty_unavailable_redacted_and_truncated() {
+        let render = |value: Option<&str>, secure: bool| {
+            let mut n = node(AxRole::TextField, Some("Email"));
+            n.value = value.map(Into::into);
+            n.states.editable = true;
+            n.states.secure = secure;
+            render_compact(&tree_of(n))
+        };
+        assert!(render(Some("alice@example.com"), false).contains("value=\"alice@example.com\""));
+        assert!(render(Some(""), false).contains("value=\"\""));
+        assert!(render(None, false).contains("value=<unavailable>"));
+        assert!(render(Some("secret"), true).contains("value=<redacted>"));
+        let long = "x".repeat(EDITABLE_VALUE_CHARS + 1);
+        let out = render(Some(&long), false);
+        assert!(out.contains(&format!("value=\"{}\"…", "x".repeat(EDITABLE_VALUE_CHARS))));
+        assert!(!out.contains(&long));
+    }
+
+    #[test]
+    fn editable_value_is_not_repeated_when_it_is_already_the_name() {
+        let mut n = node(AxRole::TextField, Some("same"));
+        n.value = Some("same".into());
+        n.states.editable = true;
+        assert!(!render_compact(&tree_of(n)).contains("value="));
     }
 }

--- a/crates/glass-core/src/outline.rs
+++ b/crates/glass-core/src/outline.rs
@@ -75,9 +75,7 @@ fn is_scaffolding(node: &AxNode) -> bool {
 /// reported. A bare `Other` therefore means the backend named no token at all, not that glass
 /// dropped one. `role:` selectors still will not match either.
 ///
-/// Shared by [`AxTree::to_outline`] and [`render_compact`] so their common fields cannot drift.
-/// `editable_values` is enabled only for the compact, agent-facing snapshot contract; the full
-/// outline remains the structural representation used by scroll-saturation detection.
+/// Shared line format. Editable values are compact-only. Full outlines drive scroll detection.
 pub(crate) fn write_line(node: &AxNode, depth: usize, out: &mut String, editable_values: bool) {
     let indent = "  ".repeat(depth);
     let _ = write!(out, "{indent}#{}", node.id.0);

--- a/crates/glass-ios/src/axmap.rs
+++ b/crates/glass-ios/src/axmap.rs
@@ -180,6 +180,8 @@ fn map_node(n: &Value, scale: f64, depth: usize, budget: &mut WalkBudget) -> AxN
     // none — so this is a plain field read, not an extra round-trip.
     let role = ax_role_with_subrole(&ax_type, s("subrole").as_deref());
     let editable = matches!(role, AxRole::TextField | AxRole::TextArea);
+    let secure =
+        s("subrole").as_deref() == Some("AXSecureTextField") || ax_type == "AXSecureTextField";
     let uid = s("AXUniqueId").and_then(|value| normalize_name(&value));
     let label = s("AXLabel").and_then(|value| normalize_name(&value));
     // Prefer the stable identifier for semantic addressing; fall back to the label.
@@ -191,8 +193,14 @@ fn map_node(n: &Value, scale: f64, depth: usize, budget: &mut WalkBudget) -> AxN
     // two sequential `if`s, so the compiler sees the label-moving arms are disjoint and skips
     // a clone.
     let (value, orphan_label) = match (editable, uid.is_some()) {
-        (true, true) => (s("AXValue"), label),
-        (true, false) => (s("AXValue"), None),
+        (true, true) => (
+            n.get("AXValue").and_then(Value::as_str).map(str::to_string),
+            label,
+        ),
+        (true, false) => (
+            n.get("AXValue").and_then(Value::as_str).map(str::to_string),
+            None,
+        ),
         (false, true) => (label, None),
         (false, false) => (None, None),
     };
@@ -210,6 +218,7 @@ fn map_node(n: &Value, scale: f64, depth: usize, budget: &mut WalkBudget) -> AxN
         visible: true,
         focused: false,
         editable,
+        secure,
         checkable,
         checked,
         ..AxStates::default()


### PR DESCRIPTION
## Summary

- render current editable values in compact accessibility snapshots
- distinguish empty, unavailable, redacted, and truncated values while avoiding duplicate names
- detect secure fields across Linux, macOS, Windows, Android, and iOS
- keep full outlines unchanged for scroll-saturation detection

## Verification

- `cargo test --workspace --locked --no-fail-fast`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo check --target x86_64-apple-darwin -p glass-a11y-macos --lib --locked`
- `cargo check --target x86_64-pc-windows-gnu -p glass-a11y-windows --lib --locked`

Closes #534
