### PR TITLE
android a11y: distinguish displayed hints from entered values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ internal refactors, CI, or test-only changes.
 - MCP descriptions and the tool reference now distinguish current semantic state, current visual evidence, transition completion and visual quiescence, including `glass_wait_for_element` exact-value matching and direct routes for dialog dismissal, canvas changes and animation completion.
 
 ### Fixed
+- On Android, the accessibility-service reader no longer reports an untouched editable field's displayed hint as entered content: the hint remains its `description`, its `value` is absent while Android says the hint is showing, and entered text becomes the value once the hint stops showing. Older companion APKs that do not publish that state keep the previous value mapping.
 - Compact accessibility snapshots now include bounded current values for editable controls, while distinguishing empty, unavailable, redacted, and truncated values and never disclosing secure-field contents.
 - `glass_wait_for_element` and `glass_scroll_to_element` can now select by accessible `description`, using the same case-sensitive substring semantics as `name`. This lets role-plus-description reveal unnamed controls such as Android fields labelled only by a hint, and returns the realized element id as usual.
 - `glass_set_value` no longer reports that a desktop accessibility write "did not take" when the element exposes a writable value but no readable value for confirmation. Linux, macOS and Windows now report the write as unconfirmed and steer the caller to re-snapshot instead of retrying a write that may already have landed.

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -64,8 +64,8 @@ fn json_to_node(v: &Value, win: &WindowGeometry, depth: usize, walk: &mut Walk) 
         .get("text")
         .and_then(Value::as_str)
         .or_else(|| editable.then_some(""));
-    // Android also publishes a displayed hint through `text`. The additive flag is absent on
-    // older companions, where `flag` deliberately defaults to false and preserves legacy mapping.
+    // Android can publish its displayed hint through `text`.
+    // Older companions omit the flag, preserving their legacy text mapping.
     let text = if flag("showing_hint_text") {
         None
     } else {

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -58,11 +58,19 @@ fn json_to_node(v: &Value, win: &WindowGeometry, depth: usize, walk: &mut Walk) 
     walk.refs.push(device_ref);
     let cls = v.get("class").and_then(Value::as_str).unwrap_or("");
     let flag = |k: &str| v.get(k).and_then(Value::as_bool).unwrap_or(false);
+    let editable = flag("editable");
     // The device omits empty text; preserve it as empty for editable nodes.
     let text = v
         .get("text")
         .and_then(Value::as_str)
-        .or_else(|| flag("editable").then_some(""));
+        .or_else(|| editable.then_some(""));
+    // Android also publishes a displayed hint through `text`. The additive flag is absent on
+    // older companions, where `flag` deliberately defaults to false and preserves legacy mapping.
+    let text = if flag("showing_hint_text") {
+        None
+    } else {
+        text
+    };
     let desc = v.get("desc").and_then(Value::as_str);
     // Both keys are absent (not null) on an older companion; `get` returns `None` either way, so
     // no version check is needed to stay compatible with it.
@@ -73,7 +81,7 @@ fn json_to_node(v: &Value, win: &WindowGeometry, depth: usize, walk: &mut Walk) 
         desc,
         resource_id,
         hint,
-        editable: flag("editable"),
+        editable,
     });
     let b = v
         .get("bounds")
@@ -1984,6 +1992,14 @@ mod tests {
         mapped_node(&v)
     }
 
+    fn mapped_hint_state(text: &str, showing_hint_text: bool) -> AxNode {
+        let mut v = node_json(Some(text), None, None, Some("Search settings"));
+        v["class"] = json!("android.widget.EditText");
+        v["editable"] = json!(true);
+        v["showing_hint_text"] = json!(showing_hint_text);
+        mapped_node(&v)
+    }
+
     #[test]
     fn the_content_description_a_text_displaced_becomes_the_description() {
         let node = mapped(Some("Save"), Some("Save changes"));
@@ -2081,6 +2097,34 @@ mod tests {
         );
         assert_eq!(node.name.as_deref(), Some("q"));
         assert_eq!(node.description.as_deref(), Some("Search settings"));
+    }
+
+    #[test]
+    fn a_displayed_hint_is_not_claimed_as_the_editable_value() {
+        let node = mapped_hint_state("Search settings", true);
+        assert_eq!(node.name, None);
+        assert_eq!(node.description.as_deref(), Some("Search settings"));
+        assert_eq!(node.value, None);
+    }
+
+    #[test]
+    fn entered_text_remains_the_value_after_the_hint_stops_showing() {
+        let node = mapped_hint_state("head-to-head", false);
+        assert_eq!(node.description.as_deref(), Some("Search settings"));
+        assert_eq!(node.value.as_deref(), Some("head-to-head"));
+    }
+
+    #[test]
+    fn an_older_companion_without_hint_state_keeps_the_legacy_value_mapping() {
+        let node = mapped_full(
+            Some("Search settings"),
+            None,
+            None,
+            Some("Search settings"),
+            true,
+        );
+        assert_eq!(node.description.as_deref(), Some("Search settings"));
+        assert_eq!(node.value.as_deref(), Some("Search settings"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- suppress Android node `text` as an entered value while the accessibility companion reports that the hint is showing
- keep the hint in `description` and restore ordinary value mapping after entered text replaces it
- preserve legacy behavior when an older companion omits the additive hint-state field
- add regression coverage for displayed, entered, and older-companion states

## Testing

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- API 34 `glass` AVD using this branch's `glass-mcp` and the companion branch APK
- untouched role fixture snapshot: `#35 TextField desc="Search settings"` with no value
- after `glass_set_value` to `head-to-head`: `#35 TextField desc="Search settings" value="head-to-head"`
- exact semantic wait matched `description="Search settings"`, `role="TextField"`, and `value="head-to-head"`
- `./scripts/test-android.sh`: 15 device tests passed and residue was clean

Depends on fixed-width/glass-android-agent#10

Fixes #547