### PR TITLE
fix(doctor): scope macOS a11y checks to macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ internal refactors, CI, or test-only changes.
 - MCP descriptions and the tool reference now distinguish current semantic state, current visual evidence, transition completion and visual quiescence, including `glass_wait_for_element` exact-value matching and direct routes for dialog dismissal, canvas changes and animation completion.
 
 ### Fixed
+- On macOS, `glass doctor` no longer fails an otherwise healthy iOS backend because the separate macOS accessibility reader cannot answer its system-wide probe. The macOS reader check remains a hard failure when `macos` is selected, and is now an advisory warning when `ios` is selected, like the other inactive-backend checks.
 - On Android, the accessibility-service reader no longer reports an untouched editable field's displayed hint as entered content: the hint remains its `description`, its `value` is absent while Android says the hint is showing, and entered text becomes the value once the hint stops showing. Older companion APKs that do not publish that state keep the previous value mapping.
 - Compact accessibility snapshots now include bounded current values for editable controls, while distinguishing empty, unavailable, redacted, and truncated values and never disclosing secure-field contents.
 - `glass_wait_for_element` and `glass_scroll_to_element` can now select by accessible `description`, using the same case-sensitive substring semantics as `name`. This lets role-plus-description reveal unnamed controls such as Android fields labelled only by a hint, and returns the realized element id as usual.

--- a/crates/glass-mcp/src/doctor.rs
+++ b/crates/glass-mcp/src/doctor.rs
@@ -206,7 +206,7 @@ fn diagnose_inner(deep: bool, audit: Option<&crate::audit::AuditReport>) -> Diag
         // `glass_macos::accessibility_granted()` fact and remedy string.
         sections.push(Section::new(
             "accessibility (macos)",
-            None,
+            Some("macos".into()),
             macos_a11y_checks(
                 glass_a11y_macos::doctor::probe(),
                 glass_macos::accessibility_granted(),
@@ -810,6 +810,13 @@ mod tests {
         // iOS's section follows the same non-empty shape, but only exists on macOS.
         #[cfg(target_os = "macos")]
         {
+            let macos_a11y = d
+                .sections
+                .iter()
+                .find(|s| s.title == "accessibility (macos)")
+                .expect("macos accessibility section");
+            assert_eq!(macos_a11y.backend.as_deref(), Some("macos"));
+
             let ios = d
                 .sections
                 .iter()


### PR DESCRIPTION
## Summary

- mark the dedicated macOS accessibility-reader doctor section as `backend=macos`
- keep its failures hard when `macos` is active, but downgrade them to warnings when `ios` is active through the existing diagnosis criticality model
- document the user-visible correction in the changelog

## Why

The v1.6.0 six-backend release gate reproduced `AXError -25204` in the macOS system-wide accessibility probe while the iOS backend itself was healthy: its device, `idb_companion`, screenshot, accessibility snapshot, interaction, logs and teardown all passed. Because the reader section had no backend metadata, that unrelated check made `glass_doctor` and the iOS release smoke report FAIL.

The reproduction ran as a LaunchAgent in the unlocked interactive `gui/501` domain, not in an SSH session, so this is not an SSH/headless artifact.

## Verification

- TDD on macOS: the section-metadata regression test failed with `left: None`, then passed with `Some("macos")`
- `cargo fmt --check`
- `cargo test -p glass-core doctor::tests --lib` (29 passed)
- `cargo test -p glass-mcp doctor::tests --lib` (17 passed locally; macOS-specific assertion passed on macOS)
- `cargo clippy -p glass-mcp --all-targets -- -D warnings`
- live iOS Simulator MCP smoke in the TCC-granted GUI LaunchAgent: 8/8, doctor now WARN rather than FAIL
