### PR TITLE
chore(release): v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ internal refactors, CI, or test-only changes.
 - MCP descriptions and the tool reference now distinguish current semantic state, current visual evidence, transition completion and visual quiescence, including `glass_wait_for_element` exact-value matching and direct routes for dialog dismissal, canvas changes and animation completion.
 
 ### Changed
-- The MCP schema and tool reference now describe Android `glass_start.run` as its actual APK/component tuple instead of as desktop argv: `[path/to/app.apk, package/activity]`, with the APK optional when the app is already installed.
+- The MCP schema and tool reference now describe Android `glass_start.run` as its actual APK/component tuple instead of as desktop argv: `[apk?, package/.Activity]` in either order, with the APK optional when the app is already installed.
 
 ### Fixed
 - On macOS, `glass doctor` no longer fails an otherwise healthy iOS backend because the separate macOS accessibility reader cannot answer its system-wide probe. The macOS reader check remains a hard failure when `macos` is selected, and is now an advisory warning when `ios` is selected, like the other inactive-backend checks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,16 +19,25 @@ internal refactors, CI, or test-only changes.
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-08-27
+
 ### Added
 - `Document` accessibility role: a browser page or embedded web view (AT-SPI `document web`/`document frame`, `AXWebArea`, Android `WebView`, UIA `Document` from a web engine) now reads as a `Document` whose children are the page's elements, on Linux, Windows, macOS and Android.
 - MCP descriptions and the tool reference now distinguish current semantic state, current visual evidence, transition completion and visual quiescence, including `glass_wait_for_element` exact-value matching and direct routes for dialog dismissal, canvas changes and animation completion.
 
+### Changed
+- The MCP schema and tool reference now describe Android `glass_start.run` as its actual APK/component tuple instead of as desktop argv: `[path/to/app.apk, package/activity]`, with the APK optional when the app is already installed.
+
 ### Fixed
 - On macOS, `glass doctor` no longer fails an otherwise healthy iOS backend because the separate macOS accessibility reader cannot answer its system-wide probe. The macOS reader check remains a hard failure when `macos` is selected, and is now an advisory warning when `ios` is selected, like the other inactive-backend checks.
 - On Android, the accessibility-service reader no longer reports an untouched editable field's displayed hint as entered content: the hint remains its `description`, its `value` is absent while Android says the hint is showing, and entered text becomes the value once the hint stops showing. Older companion APKs that do not publish that state keep the previous value mapping.
+- On Android, `glass_set_value` now re-finds an editable field after the IME replaces or moves its accessibility node, including when the original hint-derived name disappears, and confirms the write only against one focused, enabled field with the exact requested value.
 - Compact accessibility snapshots now include bounded current values for editable controls, while distinguishing empty, unavailable, redacted, and truncated values and never disclosing secure-field contents.
 - `glass_wait_for_element` and `glass_scroll_to_element` can now select by accessible `description`, using the same case-sensitive substring semantics as `name`. This lets role-plus-description reveal unnamed controls such as Android fields labelled only by a hint, and returns the realized element id as usual.
 - `glass_set_value` no longer reports that a desktop accessibility write "did not take" when the element exposes a writable value but no readable value for confirmation. Linux, macOS and Windows now report the write as unconfirmed and steer the caller to re-snapshot instead of retrying a write that may already have landed.
+- Accessibility nodes whose platform name is only whitespace now fall through to useful labels, descriptions or ids instead of rendering as blank-named controls on Linux, Windows, macOS and iOS.
+- On Windows, launching a console-subsystem app no longer flashes a launcher console or lets it take foreground; stdout and stderr still flow to `glass_logs`.
+- On Wayland, an unreadable process table or unreadable session Xwayland metadata no longer masquerades as "no Xwayland": lost-window recovery and leak accounting report the failed cross-check instead of silently disabling recovery or deleting a runtime directory whose survivors could not be counted.
 - A web view whose content the platform has not published is disclosed in the snapshot instead of arriving as an indistinguishable empty group: a childless `Document` is named by id and bounds and steers to a re-snapshot before pixels, while a placeholder the app published for content it withheld steers straight to pixels.
 - On Linux, `glass_set_value` now confirms a write actually landed instead of trusting the AT-SPI toolkit's own acknowledgment of it, the way the Windows and macOS readers already did: it reads the element back (polling briefly, since the toolkit applies the write on a later main-loop pass), and an element that acknowledges a write without applying it — as web content can — now reports that instead of a silent false success.
 - On Linux, the container of an `<iframe>` inside a browser page no longer reads as a `Window`: AT-SPI's `internal frame`, which the web engines publish for an embedded frame and no desktop toolkit uses, now maps to `Group`, so a `role:"Window"` selector matches the app's real windows again instead of frames inside a page. The nested `Document` inside such a frame is unchanged.
@@ -1209,7 +1218,8 @@ First public release — open core, Apache-2.0.
 - Core tools: `glass_start`, `glass_stop`, `glass_screenshot`, `glass_click`,
   `glass_list_windows`, `glass_select_window`, and `glass_doctor`.
 
-[Unreleased]: https://github.com/fixed-width/glass/compare/v1.5.0...HEAD
+[Unreleased]: https://github.com/fixed-width/glass/compare/v1.6.0...HEAD
+[1.6.0]: https://github.com/fixed-width/glass/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/fixed-width/glass/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/fixed-width/glass/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/fixed-width/glass/compare/v1.2.0...v1.3.0


### PR DESCRIPTION
## Summary

- close `[Unreleased]` as `[1.6.0] - 2026-08-27` and open a fresh empty section
- update the v1.6.0 and Unreleased compare links
- backfill user-facing entries for Wayland process-table honesty, whitespace-only accessibility names, Windows console suppression, Android IME relayout write confirmation, and the Android launch tuple metadata

## Release gate

Pre-release source smoke on merged master `c5d75d2` passed 8/8 on all six backends:

- X11: xed, 401 accessibility nodes
- Wayland: xed, 402 nodes
- Android: Contacts with published companion v0.7.0, 26 nodes
- macOS: Font Book, 231 nodes
- iOS: RoleFixture, 16 nodes
- Windows: Notepad, 30 nodes, repeated 8/8

The gate found and fixed one release blocker before this PR: #549 corrected `glass_doctor` so an inactive macOS accessibility-reader failure no longer fails an otherwise healthy iOS backend. Its full CI matrix and live iOS rerun passed.
