### PR TITLE
feat: add targeted semantic element discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ internal refactors, CI, or test-only changes.
 
 ## [Unreleased]
 
+### Added
+- `glass_find_elements` performs a fresh bounded accessibility search across native and published web content, returning up to 20 ranked actionable matches with semantic scope, optional publication waiting, compact context, explicit incompleteness, secure-value exclusion, and an 8 KiB total response ceiling.
+
 ## [1.7.0] - 2026-08-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -53,13 +53,18 @@ tree, the agent drives it semantically — addressing widgets by `#id` and confi
 text, no per-step screenshot:
 
 ```jsonc
-glass_start            { "run": ["python3", "app.py"] }   // launch (accessibility on by default)
-glass_a11y_snapshot                        // the tree: role, name, #id, bounds — as text
-glass_click_element    { "id": 5 }         // click by #id, not pixels
-glass_wait_for_element { "name": "Save", "condition": "enabled" }       // wait on state — no polling
-glass_set_value        { "id": 4, "value": "hello" }   // set a field / toggle / dropdown
-glass_logs                                 // read the app's stderr
+glass_start         { "run": ["python3", "app.py"] }
+glass_find_elements { "query": "account", "states": ["visible"] } // returns field #4 and Save #5
+glass_do            { "actions": [
+  { "action": "set_value", "id": 4, "text": "hello" },
+  { "action": "click_element", "id": 5 },
+  { "action": "wait_for_element", "name": "Saved" }
+] }
+glass_logs
 ```
+
+Use `glass_a11y_snapshot` when the agent needs broad structural inspection rather than a small set
+of likely targets.
 
 For a canvas or custom-rendered app with no accessibility tree, drive it by pixels instead —
 `glass_screenshot`, `glass_click {x,y}`, and `glass_diff`, which returns `changed_pct` + a `bbox` as

--- a/crates/glass-a11y-linux/tests/integration.rs
+++ b/crates/glass-a11y-linux/tests/integration.rs
@@ -1183,6 +1183,41 @@ fn raised_cap_snapshot_stops_at_the_requested_count() {
     );
 }
 
+/// Targeted discovery finds an early button in the real over-cap AT-SPI tree while preserving
+/// explicit metadata that the default-bounded search could not prove absence elsewhere.
+#[test]
+#[ignore = "needs session bus + AT-SPI registry + GTK4 fixture; run via scripts/test-a11y.sh"]
+fn targeted_discovery_finds_a_button_in_a_truncated_large_native_tree() {
+    let mut glass = launch_bench();
+    let query = glass_core::SemanticQuery::new(
+        glass_core::SemanticSelector::new(
+            Some("btn 00-00".into()),
+            Some(glass_core::AxRole::Button),
+            vec![glass_core::SemanticState::Visible],
+        )
+        .unwrap(),
+        None,
+        10,
+    )
+    .unwrap();
+    let out = glass
+        .find_elements(&glass_core::FindElementsParams {
+            query,
+            max_nodes: None,
+            timeout_ms: 0,
+        })
+        .expect("targeted discovery");
+    glass.stop().expect("stop");
+    assert!(out.matched);
+    assert_eq!(out.result.matches.len(), 1);
+    assert_eq!(
+        out.result.matches[0].element.name.as_deref(),
+        Some("Btn 00-00")
+    );
+    assert!(!out.result.search_complete);
+    assert!(out.result.tree_truncated.is_some());
+}
+
 /// Lockstep across a raised cap: an id assigned PAST the old cap by an unbounded snapshot is still
 /// resolvable by set_value — find_nth re-walks with the session's stored (unbounded) limits. If
 /// the limits weren't reused, find_nth would truncate at the default cap and fail to resolve the id

--- a/crates/glass-a11y-linux/tests/web_probe.rs
+++ b/crates/glass-a11y-linux/tests/web_probe.rs
@@ -32,8 +32,9 @@ use std::process::Command;
 use std::time::{Duration, Instant};
 
 use glass_core::{
-    AppSpec, AxNode, AxRole, AxTree, Backend, BaselineStore, Glass, GlassError, KeyEvent,
-    PlatformFactory, SandboxLevel, WindowHint, read_back_confirms, role_histogram,
+    AppSpec, AxNode, AxRole, AxTree, Backend, BaselineStore, FindElementsParams, Glass, GlassError,
+    KeyEvent, PlatformFactory, SandboxLevel, ScopeResolution, SemanticQuery, SemanticSelector,
+    SemanticState, WindowHint, read_back_confirms, role_histogram,
 };
 
 const BROWSERS_VAR: &str = "GLASS_WEB_PROBE_BROWSERS";
@@ -514,6 +515,160 @@ fn exercise(glass: &mut Glass, label: &str, failures: &mut Vec<String>) {
     }
 }
 
+/// Discover the large fixture's account controls before any explicit unbounded diagnostic
+/// snapshot. Browser non-publication remains evidence-only, while malformed published content is
+/// recorded as a probe failure.
+fn discover_account_controls(glass: &mut Glass, label: &str, failures: &mut Vec<String>) {
+    let within = SemanticSelector::new(
+        Some("Glass web fixture".into()),
+        Some(AxRole::Document),
+        vec![SemanticState::Visible],
+    )
+    .expect("document scope");
+    let account = SemanticQuery::new(
+        SemanticSelector::new(
+            Some("account name".into()),
+            Some(AxRole::TextField),
+            vec![SemanticState::Visible],
+        )
+        .expect("account selector"),
+        Some(within.clone()),
+        10,
+    )
+    .expect("account query");
+    let found = glass.find_elements(&FindElementsParams {
+        query: account,
+        max_nodes: None,
+        timeout_ms: SETTLE.as_millis() as u64,
+    });
+
+    let account = match found {
+        Err(GlassError::AccessibilityNotReady(message)) => {
+            println!(
+                "targeted discovery: page accessibility remained not ready for {SETTLE:?}: \
+                 {message}"
+            );
+            return;
+        }
+        Err(e) => {
+            failures.push(format!(
+                "{label}: targeted Account name discovery failed: {e}"
+            ));
+            return;
+        }
+        Ok(out) => out,
+    };
+
+    if let ScopeResolution::Ambiguous { observed } = account.result.scope {
+        failures.push(format!(
+            "{label}: targeted Account name discovery found {observed} visible Documents named \
+             \"Glass web fixture\""
+        ));
+        return;
+    }
+    if !account.matched && account.result.unexposed_placeholders > 0 {
+        println!(
+            "targeted discovery: browser withheld {} placeholder(s); preserving evidence-only \
+             behavior",
+            account.result.unexposed_placeholders
+        );
+        return;
+    }
+    if !matches!(account.result.scope, ScopeResolution::Resolved(_)) {
+        failures.push(format!(
+            "{label}: targeted Account name discovery did not uniquely resolve the visible \
+             Document scope: {:?}",
+            account.result.scope
+        ));
+        return;
+    }
+    if account.timed_out || account.result.matches.len() != 1 {
+        failures.push(format!(
+            "{label}: targeted Account name discovery expected one match before any unbounded \
+             diagnostic snapshot, got matched={} timed_out={} matches={}",
+            account.matched,
+            account.timed_out,
+            account.result.matches.len()
+        ));
+        return;
+    }
+    let field = &account.result.matches[0].element;
+    if field.name.as_deref() != Some("Account name")
+        || field.role != AxRole::TextField
+        || field.states.secure
+    {
+        failures.push(format!(
+            "{label}: targeted Account name discovery returned the wrong or secure element: \
+             name={:?} role={:?} secure={} value={:?}",
+            field.name, field.role, field.states.secure, field.value
+        ));
+        return;
+    }
+    println!(
+        "targeted discovery before any unbounded diagnostic snapshot: Account name → #{} \
+         {:?}",
+        field.id.0, field.role
+    );
+
+    let save = SemanticQuery::new(
+        SemanticSelector::new(
+            Some("save account".into()),
+            Some(AxRole::Button),
+            vec![SemanticState::Visible],
+        )
+        .expect("save selector"),
+        Some(within),
+        10,
+    )
+    .expect("save query");
+    let save = match glass.find_elements(&FindElementsParams {
+        query: save,
+        max_nodes: None,
+        timeout_ms: 0,
+    }) {
+        Ok(out) => out,
+        Err(e) => {
+            failures.push(format!(
+                "{label}: targeted Save account discovery failed: {e}"
+            ));
+            return;
+        }
+    };
+    if let ScopeResolution::Ambiguous { observed } = save.result.scope {
+        failures.push(format!(
+            "{label}: zero-timeout Save account discovery found {observed} visible Documents named \
+             \"Glass web fixture\""
+        ));
+        return;
+    }
+    if !matches!(save.result.scope, ScopeResolution::Resolved(_)) || save.result.matches.len() != 1
+    {
+        failures.push(format!(
+            "{label}: zero-timeout Save account discovery expected one match in the resolved \
+             Document scope, got scope={:?} matches={}",
+            save.result.scope,
+            save.result.matches.len()
+        ));
+        return;
+    }
+    let button = &save.result.matches[0].element;
+    if button.name.as_deref() != Some("Save account")
+        || button.role != AxRole::Button
+        || button.states.secure
+    {
+        failures.push(format!(
+            "{label}: zero-timeout Save account discovery returned the wrong or secure element: \
+             name={:?} role={:?} secure={} value={:?}",
+            button.name, button.role, button.states.secure, button.value
+        ));
+        return;
+    }
+    println!(
+        "zero-timeout targeted discovery: Save account → #{} {:?}",
+        button.id.0, button.role
+    );
+}
+
 /// One backend/browser/lever combination. Failures that mean the a11y bus itself broke — a
 /// launch that never happened, or a snapshot channel that never answered — are appended to
 /// `failures` rather than panicking, so the rest of the requested browsers still get their turn
@@ -541,6 +696,7 @@ fn probe(backend: &str, browser: &str, lever: Lever, failures: &mut Vec<String>)
     }
     println!("window mapped after {:?}", started.elapsed());
 
+    discover_account_controls(&mut glass, &label, failures);
     let (tree, settle, arrived) = snapshot_until_page(&mut glass, &label, failures);
     println!("page content arrived: {arrived} after {settle:?}");
     match tree {

--- a/crates/glass-a11y-linux/tests/web_probe.rs
+++ b/crates/glass-a11y-linux/tests/web_probe.rs
@@ -595,12 +595,13 @@ fn discover_account_controls(glass: &mut Glass, label: &str, failures: &mut Vec<
     let field = &account.result.matches[0].element;
     if field.name.as_deref() != Some("Account name")
         || field.role != AxRole::TextField
+        || !field.states.visible
         || field.states.secure
     {
         failures.push(format!(
-            "{label}: targeted Account name discovery returned the wrong or secure element: \
-             name={:?} role={:?} secure={} value={:?}",
-            field.name, field.role, field.states.secure, field.value
+            "{label}: targeted Account name discovery returned the wrong, hidden, or secure element: \
+             name={:?} role={:?} visible={} secure={} value={:?}",
+            field.name, field.role, field.states.visible, field.states.secure, field.value
         ));
         return;
     }
@@ -654,12 +655,13 @@ fn discover_account_controls(glass: &mut Glass, label: &str, failures: &mut Vec<
     let button = &save.result.matches[0].element;
     if button.name.as_deref() != Some("Save account")
         || button.role != AxRole::Button
+        || !button.states.visible
         || button.states.secure
     {
         failures.push(format!(
-            "{label}: zero-timeout Save account discovery returned the wrong or secure element: \
-             name={:?} role={:?} secure={} value={:?}",
-            button.name, button.role, button.states.secure, button.value
+            "{label}: zero-timeout Save account discovery returned the wrong, hidden, or secure \
+             element: name={:?} role={:?} visible={} secure={} value={:?}",
+            button.name, button.role, button.states.visible, button.states.secure, button.value
         ));
         return;
     }

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -10,6 +10,12 @@ use crate::deadline::Deadline;
 use crate::error::{GlassError, Result};
 use crate::platform::{Segment, WindowGeometry};
 
+mod query;
+pub use query::{
+    MatchField, MatchTier, ScopeResolution, SemanticMatch, SemanticQuery, SemanticQueryError,
+    SemanticQueryResult, SemanticSelector, SemanticState,
+};
+
 /// Normalized accessibility role — the union of the AT-SPI / AX / UIA
 /// vocabularies. A backend maps its native role in; anything unmapped becomes
 /// [`AxRole::Other`] with the native string preserved in [`AxNode::raw_role`].

--- a/crates/glass-core/src/accessibility/query.rs
+++ b/crates/glass-core/src/accessibility/query.rs
@@ -483,6 +483,86 @@ mod tests {
     }
 
     #[test]
+    fn every_semantic_state_parses_renders_and_matches_its_predicate() {
+        let cases = [
+            (
+                "enabled",
+                SemanticState::Enabled,
+                AxStates {
+                    enabled: true,
+                    ..Default::default()
+                },
+            ),
+            ("disabled", SemanticState::Disabled, AxStates::default()),
+            (
+                "checked",
+                SemanticState::Checked,
+                AxStates {
+                    checked: true,
+                    checkable: true,
+                    ..Default::default()
+                },
+            ),
+            (
+                "unchecked",
+                SemanticState::Unchecked,
+                AxStates {
+                    checkable: true,
+                    ..Default::default()
+                },
+            ),
+            (
+                "selected",
+                SemanticState::Selected,
+                AxStates {
+                    selected: true,
+                    ..Default::default()
+                },
+            ),
+            ("unselected", SemanticState::Unselected, AxStates::default()),
+            (
+                "expanded",
+                SemanticState::Expanded,
+                AxStates {
+                    expanded: true,
+                    ..Default::default()
+                },
+            ),
+            ("collapsed", SemanticState::Collapsed, AxStates::default()),
+            (
+                "focused",
+                SemanticState::Focused,
+                AxStates {
+                    focused: true,
+                    ..Default::default()
+                },
+            ),
+            (
+                "visible",
+                SemanticState::Visible,
+                AxStates {
+                    visible: true,
+                    ..Default::default()
+                },
+            ),
+            ("hidden", SemanticState::Hidden, AxStates::default()),
+        ];
+
+        for (name, expected, states) in cases {
+            let parsed = SemanticState::from_name(&name.to_ascii_uppercase());
+            assert_eq!(parsed, Some(expected), "failed to parse {name}");
+            assert_eq!(expected.as_str(), name);
+            assert!(expected.matches(&states), "failed to match {name}");
+        }
+        assert_eq!(SemanticState::from_name("unknown"), None);
+        assert!(!SemanticState::Enabled.matches(&AxStates::default()));
+        assert!(!SemanticState::Disabled.matches(&AxStates {
+            enabled: true,
+            ..Default::default()
+        }));
+    }
+
+    #[test]
     fn semantic_query_ranks_exact_name_before_other_substrings() {
         let exact = node(AxRole::Button, Some("save"));
         let name = node(AxRole::Button, Some("Save account"));
@@ -696,5 +776,42 @@ mod tests {
             assert!(context.contains(name));
         }
         assert!(!context.contains("child 4"));
+    }
+
+    #[test]
+    fn scoped_context_starts_at_the_scope_and_keeps_exactly_four_ancestors_without_omission() {
+        let target = node(AxRole::Button, Some("Save target"));
+        let nested = (1..=3).rev().fold(target, |child, index| {
+            let mut parent = node(AxRole::Group, Some(&format!("inside {index}")));
+            parent.children.push(child);
+            parent
+        });
+        let mut scope = node(AxRole::Document, Some("Chosen scope"));
+        scope.children.push(nested);
+        let mut outside = node(AxRole::Group, Some("outside scope"));
+        outside.children.push(scope);
+        let tree = tree(vec![outside]);
+        let query = SemanticQuery::new(
+            SemanticSelector::new(Some("save target".into()), Some(AxRole::Button), Vec::new())
+                .unwrap(),
+            Some(
+                SemanticSelector::new(
+                    Some("chosen scope".into()),
+                    Some(AxRole::Document),
+                    Vec::new(),
+                )
+                .unwrap(),
+            ),
+            10,
+        )
+        .unwrap();
+
+        let context = &tree.semantic_query(&query).matches[0].context;
+        assert!(context.contains("Chosen scope"));
+        for name in ["inside 1", "inside 2", "inside 3"] {
+            assert!(context.contains(name));
+        }
+        assert!(!context.contains("outside scope"));
+        assert!(!context.contains("higher ancestors omitted"));
     }
 }

--- a/crates/glass-core/src/accessibility/query.rs
+++ b/crates/glass-core/src/accessibility/query.rs
@@ -1,0 +1,652 @@
+use crate::accessibility::{
+    AxNode, AxNodeId, AxRole, AxStates, AxTree, ElementCondition, ElementInfo,
+};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum SemanticState {
+    Enabled,
+    Disabled,
+    Checked,
+    Unchecked,
+    Selected,
+    Unselected,
+    Expanded,
+    Collapsed,
+    Focused,
+    Visible,
+    Hidden,
+}
+
+impl SemanticState {
+    pub fn from_name(name: &str) -> Option<Self> {
+        Some(match name.to_ascii_lowercase().as_str() {
+            "enabled" => Self::Enabled,
+            "disabled" => Self::Disabled,
+            "checked" => Self::Checked,
+            "unchecked" => Self::Unchecked,
+            "selected" => Self::Selected,
+            "unselected" => Self::Unselected,
+            "expanded" => Self::Expanded,
+            "collapsed" => Self::Collapsed,
+            "focused" => Self::Focused,
+            "visible" => Self::Visible,
+            "hidden" => Self::Hidden,
+            _ => return None,
+        })
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Enabled => "enabled",
+            Self::Disabled => "disabled",
+            Self::Checked => "checked",
+            Self::Unchecked => "unchecked",
+            Self::Selected => "selected",
+            Self::Unselected => "unselected",
+            Self::Expanded => "expanded",
+            Self::Collapsed => "collapsed",
+            Self::Focused => "focused",
+            Self::Visible => "visible",
+            Self::Hidden => "hidden",
+        }
+    }
+
+    pub fn matches(self, states: &AxStates) -> bool {
+        let condition = match self {
+            Self::Enabled => ElementCondition::Enabled,
+            Self::Disabled => ElementCondition::Disabled,
+            Self::Checked => ElementCondition::Checked,
+            Self::Unchecked => ElementCondition::Unchecked,
+            Self::Selected => ElementCondition::Selected,
+            Self::Unselected => ElementCondition::Unselected,
+            Self::Expanded => ElementCondition::Expanded,
+            Self::Collapsed => ElementCondition::Collapsed,
+            Self::Focused => ElementCondition::Focused,
+            Self::Visible => ElementCondition::Visible,
+            Self::Hidden => ElementCondition::Hidden,
+        };
+        (condition.state_pred())(states)
+    }
+
+    fn opposite(self) -> Option<Self> {
+        Some(match self {
+            Self::Enabled => Self::Disabled,
+            Self::Disabled => Self::Enabled,
+            Self::Checked => Self::Unchecked,
+            Self::Unchecked => Self::Checked,
+            Self::Selected => Self::Unselected,
+            Self::Unselected => Self::Selected,
+            Self::Expanded => Self::Collapsed,
+            Self::Collapsed => Self::Expanded,
+            Self::Visible => Self::Hidden,
+            Self::Hidden => Self::Visible,
+            Self::Focused => return None,
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum SemanticQueryError {
+    #[error("specify query, role, and/or states")]
+    EmptySelector,
+    #[error("query must not be empty")]
+    EmptyQuery,
+    #[error("contradictory states: {first} and {second}")]
+    ContradictoryStates {
+        first: &'static str,
+        second: &'static str,
+    },
+    #[error("max_results must be between 1 and 20")]
+    InvalidMaxResults,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SemanticSelector {
+    query: Option<String>,
+    folded_query: Option<String>,
+    role: Option<AxRole>,
+    states: Vec<SemanticState>,
+}
+
+impl SemanticSelector {
+    pub fn new(
+        query: Option<String>,
+        role: Option<AxRole>,
+        states: Vec<SemanticState>,
+    ) -> Result<Self, SemanticQueryError> {
+        let query = match query {
+            Some(query) if query.is_empty() => return Err(SemanticQueryError::EmptyQuery),
+            value => value,
+        };
+        if query.is_none() && role.is_none() && states.is_empty() {
+            return Err(SemanticQueryError::EmptySelector);
+        }
+
+        let mut deduplicated = Vec::with_capacity(states.len());
+        for state in states {
+            if deduplicated.contains(&state) {
+                continue;
+            }
+            if let Some(opposite) = state.opposite()
+                && deduplicated.contains(&opposite)
+            {
+                return Err(SemanticQueryError::ContradictoryStates {
+                    first: opposite.as_str(),
+                    second: state.as_str(),
+                });
+            }
+            deduplicated.push(state);
+        }
+
+        let folded_query = query.as_deref().map(str::to_lowercase);
+        Ok(Self {
+            query,
+            folded_query,
+            role,
+            states: deduplicated,
+        })
+    }
+
+    pub fn query(&self) -> Option<&str> {
+        self.query.as_deref()
+    }
+
+    pub fn role(&self) -> Option<AxRole> {
+        self.role
+    }
+
+    pub fn states(&self) -> &[SemanticState] {
+        &self.states
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SemanticQuery {
+    pub target: SemanticSelector,
+    pub within: Option<SemanticSelector>,
+    pub max_results: usize,
+}
+
+impl SemanticQuery {
+    pub fn new(
+        target: SemanticSelector,
+        within: Option<SemanticSelector>,
+        max_results: usize,
+    ) -> Result<Self, SemanticQueryError> {
+        if !(1..=20).contains(&max_results) {
+            return Err(SemanticQueryError::InvalidMaxResults);
+        }
+        Ok(Self {
+            target,
+            within,
+            max_results,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ScopeResolution {
+    Unscoped,
+    NotFound,
+    Resolved(AxNodeId),
+    Ambiguous { observed: usize },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MatchField {
+    Name,
+    Description,
+    Value,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum MatchTier {
+    ExactName,
+    NameSubstring,
+    DescriptionSubstring,
+    ValueSubstring,
+    FilterOnly,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SemanticMatch {
+    pub element: ElementInfo,
+    pub field: Option<MatchField>,
+    pub tier: MatchTier,
+    pub context: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SemanticQueryResult {
+    pub scope: ScopeResolution,
+    pub matches_in_walk: usize,
+    pub matches: Vec<SemanticMatch>,
+    pub omitted_by_max_results: usize,
+    pub search_complete: bool,
+    pub tree_truncated: Option<crate::Truncation>,
+    pub unreadable_subtrees: usize,
+    pub unexposed_placeholders: usize,
+}
+
+impl AxTree {
+    pub fn semantic_query(&self, query: &SemanticQuery) -> SemanticQueryResult {
+        query_tree(self, query)
+    }
+}
+
+fn tier_for(node: &AxNode, selector: &SemanticSelector) -> Option<(MatchTier, Option<MatchField>)> {
+    if selector.role().is_some_and(|role| node.role != role) {
+        return None;
+    }
+    if !selector
+        .states()
+        .iter()
+        .all(|state| state.matches(&node.states))
+    {
+        return None;
+    }
+    let Some(needle) = selector.folded_query.as_deref() else {
+        return Some((MatchTier::FilterOnly, None));
+    };
+    let folded_name = node.name.as_deref().map(str::to_lowercase);
+    if folded_name.as_deref() == Some(needle) {
+        return Some((MatchTier::ExactName, Some(MatchField::Name)));
+    }
+    if folded_name
+        .as_deref()
+        .is_some_and(|value| value.contains(needle))
+    {
+        return Some((MatchTier::NameSubstring, Some(MatchField::Name)));
+    }
+    if node
+        .description
+        .as_deref()
+        .map(str::to_lowercase)
+        .as_deref()
+        .is_some_and(|value| value.contains(needle))
+    {
+        return Some((
+            MatchTier::DescriptionSubstring,
+            Some(MatchField::Description),
+        ));
+    }
+    if !node.states.secure
+        && node
+            .value
+            .as_deref()
+            .map(str::to_lowercase)
+            .as_deref()
+            .is_some_and(|value| value.contains(needle))
+    {
+        return Some((MatchTier::ValueSubstring, Some(MatchField::Value)));
+    }
+    None
+}
+
+fn walk<'a>(node: &'a AxNode, nodes: &mut Vec<&'a AxNode>) {
+    nodes.push(node);
+    for child in &node.children {
+        walk(child, nodes);
+    }
+}
+
+fn query_tree(tree: &AxTree, query: &SemanticQuery) -> SemanticQueryResult {
+    let mut all_nodes = Vec::with_capacity(tree.count);
+    walk(&tree.root, &mut all_nodes);
+
+    let scope = if let Some(selector) = &query.within {
+        let observed_scopes: Vec<_> = all_nodes
+            .iter()
+            .copied()
+            .filter(|node| tier_for(node, selector).is_some())
+            .collect();
+        match observed_scopes.as_slice() {
+            [] => ScopeResolution::NotFound,
+            [node] => ScopeResolution::Resolved(node.id),
+            nodes => ScopeResolution::Ambiguous {
+                observed: nodes.len(),
+            },
+        }
+    } else {
+        ScopeResolution::Unscoped
+    };
+
+    let search_root = match scope {
+        ScopeResolution::Unscoped => Some(&tree.root),
+        ScopeResolution::Resolved(id) => tree.find(id),
+        ScopeResolution::NotFound | ScopeResolution::Ambiguous { .. } => None,
+    };
+    let mut candidates = Vec::new();
+    if let Some(search_root) = search_root {
+        let mut search_nodes = Vec::new();
+        walk(search_root, &mut search_nodes);
+        for (preorder_index, node) in search_nodes.into_iter().enumerate() {
+            if let Some((tier, field)) = tier_for(node, &query.target) {
+                candidates.push((tier, preorder_index, field, node));
+            }
+        }
+    }
+    candidates.sort_by_key(|(tier, preorder_index, _, _)| (*tier, *preorder_index));
+
+    let matches_in_walk = candidates.len();
+    let matches = candidates
+        .into_iter()
+        .take(query.max_results)
+        .map(|(tier, _, field, node)| {
+            let mut element = ElementInfo::from_node(node);
+            if element.states.secure {
+                element.value = None;
+            }
+            SemanticMatch {
+                element,
+                field,
+                tier,
+                context: context_for(tree, node, scope),
+            }
+        })
+        .collect();
+
+    SemanticQueryResult {
+        scope,
+        matches_in_walk,
+        matches,
+        omitted_by_max_results: matches_in_walk.saturating_sub(query.max_results),
+        search_complete: tree.can_prove_absence(),
+        tree_truncated: tree.truncated,
+        unreadable_subtrees: tree.unreadable,
+        unexposed_placeholders: tree.unexposed,
+    }
+}
+
+fn context_for(tree: &AxTree, node: &AxNode, scope: ScopeResolution) -> String {
+    let Some(path) = tree.path_to(node.id) else {
+        return String::new();
+    };
+    let scope_index = match scope {
+        ScopeResolution::Resolved(id) => path
+            .iter()
+            .position(|candidate| candidate.id == id)
+            .unwrap_or(0),
+        _ => 0,
+    };
+    let ancestors = &path[scope_index..path.len().saturating_sub(1)];
+    let retained_from = ancestors.len().saturating_sub(4);
+
+    let mut output = String::from("ancestors:\n");
+    if retained_from > 0 {
+        output.push_str("  … higher ancestors omitted\n");
+    }
+    for ancestor in &ancestors[retained_from..] {
+        crate::outline::write_line(ancestor, 1, &mut output, true);
+    }
+
+    output.push_str("neighbors:\n");
+    if path.len() >= 2 {
+        let parent = path[path.len() - 2];
+        if let Some(index) = parent
+            .children
+            .iter()
+            .position(|candidate| candidate.id == node.id)
+        {
+            if let Some(previous) = index.checked_sub(1).and_then(|i| parent.children.get(i)) {
+                crate::outline::write_line(previous, 1, &mut output, true);
+            }
+            if let Some(next) = parent.children.get(index + 1) {
+                crate::outline::write_line(next, 1, &mut output, true);
+            }
+        }
+    }
+
+    output.push_str("children:\n");
+    for child in node.children.iter().take(3) {
+        crate::outline::write_line(child, 1, &mut output, true);
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{AxNode, AxNodeId, AxRect, AxStates, AxTree};
+
+    fn node(role: AxRole, name: Option<&str>) -> AxNode {
+        AxNode {
+            id: AxNodeId(0),
+            role,
+            raw_role: String::new(),
+            name: name.map(str::to_string),
+            description: None,
+            value: None,
+            states: AxStates::default(),
+            bounds: None,
+            children: Vec::new(),
+        }
+    }
+
+    fn tree(children: Vec<AxNode>) -> AxTree {
+        let mut root = node(AxRole::Window, Some("App"));
+        root.children = children;
+        let mut tree = AxTree::new(root);
+        tree.assign_ids();
+        tree
+    }
+
+    #[test]
+    fn semantic_query_searches_all_public_text_case_insensitively() {
+        let mut by_name = node(AxRole::Button, Some("Save Account"));
+        by_name.bounds = Some(AxRect {
+            x: 1,
+            y: 2,
+            width: 3,
+            height: 4,
+        });
+        let mut by_description = node(AxRole::Button, None);
+        by_description.description = Some("SAVE draft".into());
+        let mut by_value = node(AxRole::TextField, Some("Status"));
+        by_value.value = Some("saved successfully".into());
+        let tree = tree(vec![by_name, by_description, by_value]);
+        let query = SemanticQuery::new(
+            SemanticSelector::new(Some("SaVe".into()), None, Vec::new()).unwrap(),
+            None,
+            10,
+        )
+        .unwrap();
+        let result = tree.semantic_query(&query);
+        assert_eq!(result.matches.len(), 3);
+        assert_eq!(result.matches[0].tier, MatchTier::NameSubstring);
+        assert_eq!(result.matches[1].field, Some(MatchField::Description));
+        assert_eq!(result.matches[2].field, Some(MatchField::Value));
+    }
+
+    #[test]
+    fn semantic_query_ranks_exact_name_before_other_substrings() {
+        let exact = node(AxRole::Button, Some("save"));
+        let name = node(AxRole::Button, Some("Save account"));
+        let mut description = node(AxRole::Button, Some("Other"));
+        description.description = Some("save account".into());
+        let mut value = node(AxRole::TextField, Some("Status"));
+        value.value = Some("save complete".into());
+        let tree = tree(vec![value, description, name, exact]);
+        let query = SemanticQuery::new(
+            SemanticSelector::new(Some("save".into()), None, Vec::new()).unwrap(),
+            None,
+            10,
+        )
+        .unwrap();
+        let tiers: Vec<_> = tree
+            .semantic_query(&query)
+            .matches
+            .into_iter()
+            .map(|m| m.tier)
+            .collect();
+        assert_eq!(
+            tiers,
+            vec![
+                MatchTier::ExactName,
+                MatchTier::NameSubstring,
+                MatchTier::DescriptionSubstring,
+                MatchTier::ValueSubstring,
+            ]
+        );
+    }
+
+    #[test]
+    fn secure_values_never_match_or_leave_query_output() {
+        let mut secret = node(AxRole::TextField, Some("Password"));
+        secret.value = Some("needle-secret".into());
+        secret.states.secure = true;
+        secret.states.editable = true;
+        let tree = tree(vec![secret]);
+        let query = SemanticQuery::new(
+            SemanticSelector::new(Some("needle".into()), None, Vec::new()).unwrap(),
+            None,
+            10,
+        )
+        .unwrap();
+        assert!(tree.semantic_query(&query).matches.is_empty());
+    }
+
+    #[test]
+    fn role_and_state_filters_are_anded_and_conflicts_are_rejected() {
+        let selector = SemanticSelector::new(
+            None,
+            Some(AxRole::Button),
+            vec![
+                SemanticState::Visible,
+                SemanticState::Enabled,
+                SemanticState::Enabled,
+            ],
+        )
+        .unwrap();
+        assert_eq!(selector.states().len(), 2);
+        let err = SemanticSelector::new(
+            None,
+            Some(AxRole::Button),
+            vec![SemanticState::Enabled, SemanticState::Disabled],
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            SemanticQueryError::ContradictoryStates { .. }
+        ));
+    }
+
+    #[test]
+    fn semantic_scope_is_unique_and_restricts_target_search() {
+        let mut first = node(AxRole::Document, Some("First"));
+        first.children.push(node(AxRole::Button, Some("Save")));
+        let mut second = node(AxRole::Document, Some("Second"));
+        second.children.push(node(AxRole::Button, Some("Save")));
+        let tree = tree(vec![first, second]);
+        let query = SemanticQuery::new(
+            SemanticSelector::new(Some("save".into()), Some(AxRole::Button), Vec::new()).unwrap(),
+            Some(
+                SemanticSelector::new(Some("second".into()), Some(AxRole::Document), Vec::new())
+                    .unwrap(),
+            ),
+            10,
+        )
+        .unwrap();
+        let result = tree.semantic_query(&query);
+        assert!(matches!(result.scope, ScopeResolution::Resolved(_)));
+        assert_eq!(result.matches.len(), 1);
+    }
+
+    #[test]
+    fn semantic_scope_reports_not_found_and_ambiguous() {
+        let first = node(AxRole::Document, Some("Page"));
+        let second = node(AxRole::Document, Some("Page"));
+        let tree = tree(vec![first, second]);
+        let target = SemanticSelector::new(Some("save".into()), None, Vec::new()).unwrap();
+        let missing = SemanticQuery::new(
+            target.clone(),
+            Some(
+                SemanticSelector::new(Some("missing".into()), Some(AxRole::Document), Vec::new())
+                    .unwrap(),
+            ),
+            10,
+        )
+        .unwrap();
+        assert_eq!(
+            tree.semantic_query(&missing).scope,
+            ScopeResolution::NotFound
+        );
+        let ambiguous = SemanticQuery::new(
+            target,
+            Some(
+                SemanticSelector::new(Some("page".into()), Some(AxRole::Document), Vec::new())
+                    .unwrap(),
+            ),
+            10,
+        )
+        .unwrap();
+        assert_eq!(
+            tree.semantic_query(&ambiguous).scope,
+            ScopeResolution::Ambiguous { observed: 2 }
+        );
+    }
+
+    #[test]
+    fn context_and_result_count_are_fixed_and_bounded() {
+        let mut group = node(AxRole::Group, Some("Account form"));
+        group.children = vec![
+            node(AxRole::Label, Some("before")),
+            node(AxRole::Button, Some("Save one")),
+            node(AxRole::Button, Some("Save two")),
+        ];
+        let tree = tree(vec![group]);
+        let query = SemanticQuery::new(
+            SemanticSelector::new(Some("save".into()), Some(AxRole::Button), Vec::new()).unwrap(),
+            None,
+            1,
+        )
+        .unwrap();
+        let result = tree.semantic_query(&query);
+        assert_eq!(result.matches_in_walk, 2);
+        assert_eq!(result.matches.len(), 1);
+        assert_eq!(result.omitted_by_max_results, 1);
+        assert!(result.matches[0].context.contains("Account form"));
+        assert!(result.matches[0].context.contains("Save two"));
+    }
+
+    #[test]
+    fn semantic_query_context_has_fixed_ancestor_neighbor_and_child_limits() {
+        let mut target = node(AxRole::Button, Some("Save target"));
+        target.children = (1..=4)
+            .map(|index| node(AxRole::Label, Some(&format!("child {index}"))))
+            .collect();
+        let mut innermost = node(AxRole::Group, Some("ancestor 6"));
+        innermost.children = vec![
+            node(AxRole::Label, Some("previous sibling")),
+            target,
+            node(AxRole::Label, Some("next sibling")),
+        ];
+        let nested = (1..=5).rev().fold(innermost, |child, index| {
+            let mut parent = node(AxRole::Group, Some(&format!("ancestor {index}")));
+            parent.children.push(child);
+            parent
+        });
+        let tree = tree(vec![nested]);
+        let query = SemanticQuery::new(
+            SemanticSelector::new(Some("save target".into()), Some(AxRole::Button), Vec::new())
+                .unwrap(),
+            None,
+            10,
+        )
+        .unwrap();
+
+        let context = &tree.semantic_query(&query).matches[0].context;
+        assert!(context.contains("… higher ancestors omitted"));
+        assert!(!context.contains("ancestor 1"));
+        assert!(!context.contains("ancestor 2"));
+        for name in ["ancestor 3", "ancestor 4", "ancestor 5", "ancestor 6"] {
+            assert!(context.contains(name));
+        }
+        assert!(context.contains("previous sibling"));
+        assert!(context.contains("next sibling"));
+        for name in ["child 1", "child 2", "child 3"] {
+            assert!(context.contains(name));
+        }
+        assert!(!context.contains("child 4"));
+    }
+}

--- a/crates/glass-core/src/accessibility/query.rs
+++ b/crates/glass-core/src/accessibility/query.rs
@@ -115,8 +115,14 @@ impl SemanticSelector {
         states: Vec<SemanticState>,
     ) -> Result<Self, SemanticQueryError> {
         let query = match query {
-            Some(query) if query.is_empty() => return Err(SemanticQueryError::EmptyQuery),
-            value => value,
+            Some(query) => {
+                let trimmed = query.trim();
+                if trimmed.is_empty() {
+                    return Err(SemanticQueryError::EmptyQuery);
+                }
+                Some(trimmed.to_owned())
+            }
+            None => None,
         };
         if query.is_none() && role.is_none() && states.is_empty() {
             return Err(SemanticQueryError::EmptySelector);
@@ -459,6 +465,24 @@ mod tests {
     }
 
     #[test]
+    fn semantic_selector_trims_query_before_storing_and_matching() {
+        let selector = SemanticSelector::new(Some("  SaVe  ".into()), None, Vec::new()).unwrap();
+        assert_eq!(selector.query(), Some("SaVe"));
+
+        let query = SemanticQuery::new(selector, None, 10).unwrap();
+        let result = tree(vec![node(AxRole::Button, Some("Save account"))]).semantic_query(&query);
+        assert_eq!(result.matches.len(), 1);
+    }
+
+    #[test]
+    fn semantic_selector_rejects_whitespace_only_query() {
+        assert_eq!(
+            SemanticSelector::new(Some(" \t\n ".into()), None, Vec::new()),
+            Err(SemanticQueryError::EmptyQuery)
+        );
+    }
+
+    #[test]
     fn semantic_query_ranks_exact_name_before_other_substrings() {
         let exact = node(AxRole::Button, Some("save"));
         let name = node(AxRole::Button, Some("Save account"));
@@ -504,6 +528,30 @@ mod tests {
         )
         .unwrap();
         assert!(tree.semantic_query(&query).matches.is_empty());
+    }
+
+    #[test]
+    fn secure_node_returned_by_role_has_no_value_or_context_secret() {
+        let mut secure = node(AxRole::TextField, Some("Password"));
+        secure.value = Some("returned-secret-sentinel".into());
+        secure.states.secure = true;
+        secure.states.editable = true;
+        let tree = tree(vec![secure]);
+        let query = SemanticQuery::new(
+            SemanticSelector::new(None, Some(AxRole::TextField), Vec::new()).unwrap(),
+            None,
+            10,
+        )
+        .unwrap();
+
+        let result = tree.semantic_query(&query);
+        assert_eq!(result.matches.len(), 1);
+        assert_eq!(result.matches[0].element.value, None);
+        assert!(
+            !result.matches[0]
+                .context
+                .contains("returned-secret-sentinel")
+        );
     }
 
     #[test]

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -94,8 +94,9 @@ pub mod accessibility;
 pub use accessibility::{
     Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget, AxTree,
     ChangeSignal, ChangeWait, ClickMethod, ElementCondition, ElementInfo, ElementMatch, MAX_DEPTH,
-    MAX_NODES, MAX_SIBLINGS, Subject, Truncation, TruncationLimit, WalkBudget, WalkLimits,
-    element_match, normalize_description, normalize_name,
+    MAX_NODES, MAX_SIBLINGS, MatchField, MatchTier, ScopeResolution, SemanticMatch, SemanticQuery,
+    SemanticQueryError, SemanticQueryResult, SemanticSelector, SemanticState, Subject, Truncation,
+    TruncationLimit, WalkBudget, WalkLimits, element_match, normalize_description, normalize_name,
 };
 
 pub mod marks;

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -120,8 +120,8 @@ pub use audit::{Actuation, ActuationContext, AuditOutcome, AuditSink, ElementRef
 
 pub mod session;
 pub use session::{
-    Backend, Glass, PlatformFactory, SCROLL_TO_DEFAULT_STEP, SCROLL_TO_DEFAULT_TIMEOUT_MS,
-    ScrollDirection, ScrollToElementOutcome, ScrollToElementParams, WaitElementOutcome,
-    WaitElementParams, WaitLogOutcome, WaitLogParams, WaitRegionOutcome, WaitRegionParams,
-    WaitStableOutcome, WaitStableParams,
+    Backend, FindElementsOutcome, FindElementsParams, Glass, PlatformFactory,
+    SCROLL_TO_DEFAULT_STEP, SCROLL_TO_DEFAULT_TIMEOUT_MS, ScrollDirection, ScrollToElementOutcome,
+    ScrollToElementParams, WaitElementOutcome, WaitElementParams, WaitLogOutcome, WaitLogParams,
+    WaitRegionOutcome, WaitRegionParams, WaitStableOutcome, WaitStableParams,
 };

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -59,14 +59,18 @@ impl ActiveSession {
 }
 
 impl Glass {
+    /// Install caller-selected accessibility walk limits for operations that begin with a fresh
+    /// tree read. Internal re-snapshots reuse these limits.
+    pub(crate) fn set_a11y_limits(&mut self, max_nodes: Option<usize>) -> Result<()> {
+        self.active_mut()?.a11y_limits = WalkLimits::from_max_nodes(max_nodes);
+        Ok(())
+    }
+
     /// Snapshot the active window's accessibility tree (normalized, window-
     /// relative, ids assigned by the core). Caches it for `click_element`.
     /// `AxUnsupported` if the backend has no accessibility reader.
     pub fn a11y_snapshot(&mut self, max_nodes: Option<usize>) -> Result<AxTree> {
-        // The ONLY place `a11y_limits` changes from a caller's `max_nodes` — every other walk
-        // reuses them.
-        self.active_mut()?.a11y_limits =
-            crate::accessibility::WalkLimits::from_max_nodes(max_nodes);
+        self.set_a11y_limits(max_nodes)?;
         // The tool takes no timeout, so the reader keeps its own budget. Inventing one here would
         // cap a plain snapshot at a number no caller asked for.
         self.snapshot_at_current_limits(Deadline::UNBOUNDED)
@@ -113,8 +117,8 @@ impl Glass {
     }
 
     /// The snapshot worker: walks the active window's tree bounded by the session's current
-    /// `a11y_limits` and caches it. Callers set `a11y_limits` first (or reuse it) — see
-    /// [`Glass::a11y_snapshot`] / [`Glass::a11y_resnapshot`].
+    /// `a11y_limits` and caches it. Callers install user-selected limits through
+    /// [`Glass::set_a11y_limits`] first (or reuse them).
     fn snapshot_at_current_limits(&mut self, deadline: Deadline) -> Result<AxTree> {
         self.snapshot_at_current_limits_with_wait_fallback(deadline, false)
     }

--- a/crates/glass-core/src/session/a11y_poll.rs
+++ b/crates/glass-core/src/session/a11y_poll.rs
@@ -1,0 +1,297 @@
+use super::*;
+
+/// Maximum wall-clock time a change signal may suppress tree reads.
+const REREAD_AFTER: std::time::Duration = std::time::Duration::from_secs(1);
+
+/// Reader headroom reserved before a quiet wait's deadline, capped at one quarter of the
+/// remaining budget.
+const FINAL_READ_HEADROOM: std::time::Duration = std::time::Duration::from_millis(20);
+
+pub(super) struct A11yPollOutcome<O> {
+    pub observation: O,
+    pub satisfied: bool,
+    pub elapsed_ms: u64,
+    pub timed_out_by: Option<crate::Whose>,
+}
+
+fn final_read_pause(left: std::time::Duration) -> std::time::Duration {
+    left.saturating_sub(FINAL_READ_HEADROOM.min(left / 4))
+}
+
+fn quiet_wait_needs_read(final_read: bool, since_last: std::time::Duration) -> bool {
+    final_read || since_last >= REREAD_AFTER
+}
+
+fn should_schedule_final_read(
+    already_scheduled: bool,
+    left: Option<std::time::Duration>,
+    interval: std::time::Duration,
+) -> bool {
+    !already_scheduled && left.is_some_and(|left| left <= interval)
+}
+
+fn reader_relative_caller_bound(error: &GlassError) -> bool {
+    error.bound_owner() == Some(crate::Whose::Caller)
+}
+
+fn outer_sequence_expired(owner: crate::Whose, expired: bool) -> bool {
+    owner == crate::Whose::Caller && expired
+}
+
+fn should_reclassify_nested_bound(effective_owner: crate::Whose, sequence_expired: bool) -> bool {
+    effective_owner == crate::Whose::Callee && !sequence_expired
+}
+
+/// Reclassify a reader-relative caller bound without overriding an expired outer sequence.
+fn resolve_nested_accessibility_bound(
+    error: GlassError,
+    effective_owner: crate::Whose,
+    sequence_deadline: Deadline,
+) -> GlassError {
+    if should_reclassify_nested_bound(effective_owner, sequence_deadline.has_passed()) {
+        match error {
+            GlassError::Bounded {
+                kind,
+                whose: crate::Whose::Caller,
+                dispatch,
+                message,
+            } => GlassError::Bounded {
+                kind,
+                whose: crate::Whose::Callee,
+                dispatch,
+                message,
+            },
+            error => error,
+        }
+    } else {
+        error
+    }
+}
+
+impl Glass {
+    pub(super) fn poll_accessibility_until<O>(
+        &mut self,
+        interval_ms: u64,
+        timeout_ms: u64,
+        sequence_deadline: Deadline,
+        operation: &'static str,
+        mut observe: impl FnMut(&AxTree) -> O,
+        mut satisfied: impl FnMut(&O) -> bool,
+    ) -> Result<A11yPollOutcome<O>> {
+        if sequence_deadline.has_passed() {
+            return Err(GlassError::deadline_not_started(operation));
+        }
+        self.require_active()?;
+        let started = std::time::Instant::now();
+        let (effective_duration, whose) =
+            sequence_deadline.budget(std::time::Duration::from_millis(timeout_ms), started);
+        let action_deadline = Deadline::at(started + effective_duration);
+        let mut signal = (interval_ms > 0)
+            .then(|| self.subscribe_a11y_changes(action_deadline))
+            .flatten();
+        let remaining = (effective_duration.as_millis() as u64)
+            .saturating_sub(started.elapsed().as_millis() as u64);
+        let mut last_read = std::time::Instant::now();
+        let mut unread: Option<GlassError> = None;
+        let mut unread_owner = whose;
+        let mut saw_a_tree = false;
+        let first_read_deadline = if timeout_ms == 0 {
+            sequence_deadline
+        } else {
+            action_deadline
+        };
+        let mut looked = false;
+        let mut last_observation = None;
+        let final_read_scheduled = std::cell::Cell::new(false);
+        let outcome = crate::poll::poll_until_with_pause(
+            interval_ms,
+            remaining,
+            |d| {
+                let left = action_deadline.remaining();
+                let final_read = should_schedule_final_read(final_read_scheduled.get(), left, d);
+                if final_read {
+                    final_read_scheduled.set(true);
+                }
+                let paused_at = std::time::Instant::now();
+                let pause_budget = if final_read {
+                    let left = left.expect("a final read is scheduled only for a bounded wait");
+                    final_read_pause(left)
+                } else {
+                    left.unwrap_or(d).min(d)
+                };
+                let read_now = match signal.as_mut() {
+                    Some(s) => match s.wait(pause_budget) {
+                        ChangeWait::Changed => true,
+                        ChangeWait::Quiet => quiet_wait_needs_read(final_read, last_read.elapsed()),
+                        ChangeWait::Unusable => {
+                            signal = None;
+                            true
+                        }
+                    },
+                    None => true,
+                };
+                if read_now {
+                    last_read = std::time::Instant::now();
+                }
+                std::thread::sleep(pause_budget.saturating_sub(paused_at.elapsed()));
+                read_now
+            },
+            || {
+                let first_read = !looked;
+                let bound = if first_read {
+                    first_read_deadline
+                } else {
+                    action_deadline
+                };
+                let read_owner =
+                    if first_read && timeout_ms == 0 && sequence_deadline.instant().is_some() {
+                        crate::Whose::Caller
+                    } else {
+                        whose
+                    };
+                if !first_read && bound.has_passed() {
+                    return Ok(None);
+                }
+                looked = true;
+                let tree = match self.a11y_resnapshot_for_wait(bound) {
+                    Ok(t) => {
+                        saw_a_tree = true;
+                        t
+                    }
+                    Err(e @ GlassError::AccessibilityNotReady(_)) => {
+                        unread_owner = read_owner;
+                        unread = Some(e);
+                        return Ok(None);
+                    }
+                    Err(e) if reader_relative_caller_bound(&e) => {
+                        unread_owner = read_owner;
+                        unread = Some(e);
+                        return Ok(None);
+                    }
+                    Err(e) => return Err(e),
+                };
+                let observation = observe(&tree);
+                let is_satisfied = satisfied(&observation);
+                last_observation = Some(observation);
+                Ok(is_satisfied.then_some(()))
+            },
+        )?;
+        if outcome.value.is_none()
+            && !saw_a_tree
+            && let Some(e) = unread
+        {
+            if e.bound_owner() == Some(crate::Whose::Caller) {
+                return Err(resolve_nested_accessibility_bound(
+                    e,
+                    unread_owner,
+                    sequence_deadline,
+                ));
+            }
+            if outer_sequence_expired(unread_owner, sequence_deadline.has_passed()) {
+                return Err(GlassError::caller_deadline_elapsed_with_guidance(
+                    operation,
+                    &e.to_string(),
+                ));
+            }
+            return Err(e);
+        }
+        Ok(A11yPollOutcome {
+            observation: last_observation
+                .expect("a successful or soft-timed-out poll observed a tree"),
+            satisfied: outcome.value.is_some(),
+            elapsed_ms: started.elapsed().as_millis() as u64,
+            timed_out_by: outcome.value.is_none().then_some(whose),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::test_support::*;
+
+    #[test]
+    fn accessibility_deadline_helpers_require_every_provenance_clause() {
+        assert!(should_reclassify_nested_bound(crate::Whose::Callee, false));
+        assert!(!should_reclassify_nested_bound(crate::Whose::Caller, false));
+        assert!(!should_reclassify_nested_bound(crate::Whose::Callee, true));
+
+        assert!(reader_relative_caller_bound(
+            &GlassError::caller_deadline_elapsed("reader")
+        ));
+        assert!(!reader_relative_caller_bound(&GlassError::Bounded {
+            kind: crate::BoundKind::TimedOut,
+            whose: crate::Whose::Callee,
+            dispatch: crate::BoundDispatch::MayHaveDispatched,
+            message: "reader ceiling".into(),
+        }));
+        assert!(!reader_relative_caller_bound(&GlassError::Backend(
+            "reader failed".into()
+        )));
+
+        assert!(outer_sequence_expired(crate::Whose::Caller, true));
+        assert!(!outer_sequence_expired(crate::Whose::Callee, true));
+        assert!(!outer_sequence_expired(crate::Whose::Caller, false));
+    }
+
+    #[test]
+    fn final_read_pause_reserves_a_quarter_up_to_the_headroom_cap() {
+        assert_eq!(
+            final_read_pause(Duration::from_millis(80)),
+            Duration::from_millis(60)
+        );
+        assert_eq!(
+            final_read_pause(Duration::from_millis(40)),
+            Duration::from_millis(30)
+        );
+        assert_eq!(
+            final_read_pause(Duration::from_millis(4)),
+            Duration::from_millis(3)
+        );
+    }
+
+    #[test]
+    fn a_quiet_signal_reads_only_for_a_safety_or_periodic_refresh() {
+        assert!(!quiet_wait_needs_read(
+            false,
+            REREAD_AFTER - Duration::from_millis(1)
+        ));
+        assert!(quiet_wait_needs_read(false, REREAD_AFTER));
+        assert!(quiet_wait_needs_read(true, Duration::ZERO));
+    }
+
+    #[test]
+    fn a_final_safety_read_is_scheduled_once_when_the_interval_reaches_the_deadline() {
+        let interval = Duration::from_millis(100);
+        assert!(should_schedule_final_read(false, Some(interval), interval));
+        assert!(!should_schedule_final_read(true, Some(interval), interval));
+        assert!(!should_schedule_final_read(false, None, interval));
+        assert!(!should_schedule_final_read(
+            false,
+            Some(interval + Duration::from_millis(1)),
+            interval
+        ));
+    }
+
+    #[test]
+    fn shared_poll_returns_the_last_fresh_observation_on_soft_timeout() {
+        let mut first = fake_tree();
+        first.root.name = Some("first".into());
+        let mut second = fake_tree();
+        second.root.name = Some("latest".into());
+        let mut glass = glass_with_a11y_seq(FakePlatform::new(100, 100), vec![first, second]);
+        glass.start(&spec()).unwrap();
+        let out = glass
+            .poll_accessibility_until(
+                0,
+                50,
+                Deadline::UNBOUNDED,
+                "test accessibility poll",
+                |tree| tree.root.name.clone().unwrap_or_default(),
+                |_| false,
+            )
+            .unwrap();
+        assert!(!out.satisfied);
+        assert_eq!(out.observation, "latest");
+    }
+}

--- a/crates/glass-core/src/session/find.rs
+++ b/crates/glass-core/src/session/find.rs
@@ -1,0 +1,255 @@
+use super::*;
+use crate::{ScopeResolution, SemanticQuery, SemanticQueryResult};
+
+#[derive(Clone, Debug)]
+pub struct FindElementsParams {
+    pub query: SemanticQuery,
+    pub max_nodes: Option<usize>,
+    pub timeout_ms: u64,
+}
+
+#[derive(Clone, Debug)]
+pub struct FindElementsOutcome {
+    pub result: SemanticQueryResult,
+    pub matched: bool,
+    pub timed_out: bool,
+    pub elapsed_ms: u64,
+    pub timed_out_by: Option<crate::Whose>,
+}
+
+impl Glass {
+    pub fn find_elements(&mut self, params: &FindElementsParams) -> Result<FindElementsOutcome> {
+        self.find_elements_by(params, Deadline::UNBOUNDED)
+    }
+
+    pub fn find_elements_by(
+        &mut self,
+        params: &FindElementsParams,
+        sequence_deadline: Deadline,
+    ) -> Result<FindElementsOutcome> {
+        self.set_a11y_limits(params.max_nodes)?;
+        let poll = self.poll_accessibility_until(
+            200,
+            params.timeout_ms,
+            sequence_deadline,
+            "find elements",
+            |tree| tree.semantic_query(&params.query),
+            |result| {
+                !result.matches.is_empty()
+                    || matches!(result.scope, ScopeResolution::Ambiguous { .. })
+            },
+        )?;
+        let matched = !poll.observation.matches.is_empty();
+        Ok(FindElementsOutcome {
+            result: poll.observation,
+            matched,
+            timed_out: params.timeout_ms > 0 && !matched && poll.timed_out_by.is_some(),
+            elapsed_ms: poll.elapsed_ms,
+            timed_out_by: poll.timed_out_by,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::test_support::*;
+    use crate::{
+        AxNodeId, AxRole, SemanticSelector, SemanticState, Truncation, TruncationLimit, WalkLimits,
+    };
+    use std::sync::atomic::Ordering;
+
+    fn query(text: &str) -> SemanticQuery {
+        SemanticQuery::new(
+            SemanticSelector::new(Some(text.into()), None, Vec::new()).unwrap(),
+            None,
+            10,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn find_elements_reads_fresh_and_returns_actionable_ids() {
+        let mut tree = fake_tree();
+        tree.root.children[0].name = Some("Save account".into());
+        let mut glass = glass_with_a11y(FakePlatform::new(100, 100), tree);
+        glass.start(&spec()).unwrap();
+        let out = glass
+            .find_elements(&FindElementsParams {
+                query: query("save"),
+                max_nodes: None,
+                timeout_ms: 0,
+            })
+            .unwrap();
+        assert_eq!(out.result.matches.len(), 1);
+        glass
+            .click_element(out.result.matches[0].element.id)
+            .unwrap();
+    }
+
+    #[test]
+    fn find_elements_waits_for_delayed_publication_and_caches_the_final_tree() {
+        let first = fake_tree();
+        let mut second = fake_tree();
+        second.root.children[0].name = Some("Save account".into());
+        let mut glass = glass_with_a11y_seq(FakePlatform::new(100, 100), vec![first, second]);
+        glass.start(&spec()).unwrap();
+        let out = glass
+            .find_elements(&FindElementsParams {
+                query: query("save account"),
+                max_nodes: None,
+                timeout_ms: 500,
+            })
+            .unwrap();
+        assert!(out.matched);
+        assert!(!out.timed_out);
+        assert_eq!(out.result.matches.len(), 1);
+    }
+
+    #[test]
+    fn scope_ambiguity_returns_after_one_fresh_read() {
+        let mut tree = fake_tree();
+        tree.root.children.push(tree.root.children[0].clone());
+        tree.assign_ids();
+        let scope = SemanticSelector::new(None, Some(AxRole::Button), Vec::new()).unwrap();
+        let query = SemanticQuery::new(
+            SemanticSelector::new(None, None, vec![SemanticState::Enabled]).unwrap(),
+            Some(scope),
+            10,
+        )
+        .unwrap();
+        let (mut glass, walks) =
+            glass_with_a11y_counted(FakePlatform::new(100, 100), vec![tree], None);
+        glass.start(&spec()).unwrap();
+        let out = glass
+            .find_elements(&FindElementsParams {
+                query,
+                max_nodes: None,
+                timeout_ms: 500,
+            })
+            .unwrap();
+        assert!(matches!(
+            out.result.scope,
+            ScopeResolution::Ambiguous { observed: 2 }
+        ));
+        assert!(!out.timed_out);
+        assert_eq!(walks.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn positive_timeout_without_a_match_is_soft() {
+        let mut glass = glass_with_a11y(FakePlatform::new(100, 100), fake_tree());
+        glass.start(&spec()).unwrap();
+        let out = glass
+            .find_elements(&FindElementsParams {
+                query: query("absent"),
+                max_nodes: None,
+                timeout_ms: 25,
+            })
+            .unwrap();
+        assert!(!out.matched);
+        assert!(out.timed_out);
+    }
+
+    #[test]
+    fn zero_timeout_is_one_read_not_a_timeout() {
+        let mut glass = glass_with_a11y(FakePlatform::new(100, 100), fake_tree());
+        glass.start(&spec()).unwrap();
+        let out = glass
+            .find_elements(&FindElementsParams {
+                query: query("absent"),
+                max_nodes: None,
+                timeout_ms: 0,
+            })
+            .unwrap();
+        assert!(!out.matched);
+        assert!(!out.timed_out);
+    }
+
+    #[test]
+    fn find_elements_uses_default_walk_limits_when_max_nodes_is_omitted() {
+        let (mut glass, ctx_log) = glass_with_a11y_ctx(FakePlatform::new(100, 100), fake_tree());
+        glass.start(&spec()).unwrap();
+
+        glass
+            .find_elements(&FindElementsParams {
+                query: query("save"),
+                max_nodes: None,
+                timeout_ms: 0,
+            })
+            .unwrap();
+
+        assert_eq!(
+            ctx_log.lock().unwrap().as_ref().unwrap().limits,
+            WalkLimits::DEFAULT
+        );
+    }
+
+    #[test]
+    fn find_elements_max_nodes_zero_lifts_only_the_node_cap() {
+        let (mut glass, ctx_log) = glass_with_a11y_ctx(FakePlatform::new(100, 100), fake_tree());
+        glass.start(&spec()).unwrap();
+
+        glass
+            .find_elements(&FindElementsParams {
+                query: query("save"),
+                max_nodes: Some(0),
+                timeout_ms: 0,
+            })
+            .unwrap();
+
+        assert_eq!(
+            ctx_log.lock().unwrap().as_ref().unwrap().limits,
+            WalkLimits::from_max_nodes(Some(0))
+        );
+    }
+
+    #[test]
+    fn find_elements_preserves_truncation_and_incomplete_search_data() {
+        let mut tree = fake_tree();
+        tree.truncated = Some(Truncation {
+            limit: TruncationLimit::Nodes,
+            limit_value: 2,
+            nodes_walked: 2,
+        });
+        let mut glass = glass_with_a11y(FakePlatform::new(100, 100), tree);
+        glass.start(&spec()).unwrap();
+
+        let out = glass
+            .find_elements(&FindElementsParams {
+                query: query("absent"),
+                max_nodes: None,
+                timeout_ms: 0,
+            })
+            .unwrap();
+
+        assert!(out.result.tree_truncated.is_some());
+        assert!(!out.result.search_complete);
+    }
+
+    #[test]
+    fn find_elements_soft_timeout_caches_the_last_fresh_tree() {
+        let first = fake_tree();
+        let mut second = fake_tree();
+        let mut preceding = second.root.children[0].clone();
+        preceding.role = AxRole::Label;
+        preceding.name = Some("Before".into());
+        second.root.children.insert(0, preceding);
+        second.assign_ids();
+        assert!(first.find(AxNodeId(2)).is_none());
+        assert!(second.find(AxNodeId(2)).is_some());
+        let mut glass = glass_with_a11y_seq(FakePlatform::new(100, 100), vec![first, second]);
+        glass.start(&spec()).unwrap();
+
+        let out = glass
+            .find_elements(&FindElementsParams {
+                query: query("absent"),
+                max_nodes: None,
+                timeout_ms: 25,
+            })
+            .unwrap();
+
+        assert!(out.timed_out);
+        glass.click_element(AxNodeId(2)).unwrap();
+    }
+}

--- a/crates/glass-core/src/session/find.rs
+++ b/crates/glass-core/src/session/find.rs
@@ -39,6 +39,9 @@ impl Glass {
                     || matches!(result.scope, ScopeResolution::Ambiguous { .. })
             },
         )?;
+        if poll.timed_out_by == Some(crate::Whose::Caller) {
+            return Err(GlassError::caller_deadline_elapsed("find elements"));
+        }
         let matched = !poll.observation.matches.is_empty();
         Ok(FindElementsOutcome {
             result: poll.observation,
@@ -149,6 +152,26 @@ mod tests {
             .unwrap();
         assert!(!out.matched);
         assert!(out.timed_out);
+    }
+
+    #[test]
+    fn caller_deadline_after_a_fresh_read_is_an_error() {
+        let mut glass = glass_with_a11y(FakePlatform::new(100, 100), fake_tree());
+        glass.start(&spec()).unwrap();
+
+        let error = glass
+            .find_elements_by(
+                &FindElementsParams {
+                    query: query("absent"),
+                    max_nodes: None,
+                    timeout_ms: 500,
+                },
+                Deadline::from_millis(25),
+            )
+            .unwrap_err();
+
+        assert_eq!(error.bound_owner(), Some(crate::Whose::Caller), "{error}");
+        assert!(error.to_string().contains("find elements:"), "{error}");
     }
 
     #[test]

--- a/crates/glass-core/src/session/find.rs
+++ b/crates/glass-core/src/session/find.rs
@@ -268,7 +268,7 @@ mod tests {
             .find_elements(&FindElementsParams {
                 query: query("absent"),
                 max_nodes: None,
-                timeout_ms: 25,
+                timeout_ms: 250,
             })
             .unwrap();
 

--- a/crates/glass-core/src/session/mod.rs
+++ b/crates/glass-core/src/session/mod.rs
@@ -22,6 +22,7 @@ use crate::platform::{
 use crate::stability::StabilityTracker;
 
 mod a11y;
+mod a11y_poll;
 mod baseline;
 mod capture;
 mod clipboard;

--- a/crates/glass-core/src/session/mod.rs
+++ b/crates/glass-core/src/session/mod.rs
@@ -26,11 +26,13 @@ mod a11y_poll;
 mod baseline;
 mod capture;
 mod clipboard;
+mod find;
 mod input;
 mod lifecycle;
 mod wait;
 mod window;
 
+pub use find::{FindElementsOutcome, FindElementsParams};
 pub use wait::{
     SCROLL_TO_DEFAULT_STEP, SCROLL_TO_DEFAULT_TIMEOUT_MS, ScrollDirection, ScrollToElementOutcome,
     ScrollToElementParams, WaitElementOutcome, WaitElementParams, WaitLogOutcome, WaitLogParams,

--- a/crates/glass-core/src/session/wait.rs
+++ b/crates/glass-core/src/session/wait.rs
@@ -3,17 +3,6 @@
 use super::*;
 use crate::accessibility::ElementSelector;
 
-/// Maximum wall-clock time a change signal may suppress tree reads.
-const REREAD_AFTER: std::time::Duration = std::time::Duration::from_secs(1);
-
-/// Reader headroom reserved before a quiet wait's deadline, capped at one quarter of the
-/// remaining budget.
-const FINAL_READ_HEADROOM: std::time::Duration = std::time::Duration::from_millis(20);
-
-fn should_reclassify_nested_bound(effective_owner: crate::Whose, sequence_expired: bool) -> bool {
-    effective_owner == crate::Whose::Callee && !sequence_expired
-}
-
 fn callee_wait_expired(looked: bool, owner: crate::Whose, expired: bool) -> bool {
     looked && owner == crate::Whose::Callee && expired
 }
@@ -60,58 +49,8 @@ fn needs_callee_timeout_full_capture(no_value: bool, owner: crate::Whose) -> boo
     no_value && owner == crate::Whose::Callee
 }
 
-fn final_read_pause(left: std::time::Duration) -> std::time::Duration {
-    left.saturating_sub(FINAL_READ_HEADROOM.min(left / 4))
-}
-
-fn quiet_wait_needs_read(final_read: bool, since_last: std::time::Duration) -> bool {
-    final_read || since_last >= REREAD_AFTER
-}
-
-fn should_schedule_final_read(
-    already_scheduled: bool,
-    left: Option<std::time::Duration>,
-    interval: std::time::Duration,
-) -> bool {
-    !already_scheduled && left.is_some_and(|left| left <= interval)
-}
-
-fn reader_relative_caller_bound(error: &GlassError) -> bool {
-    error.bound_owner() == Some(crate::Whose::Caller)
-}
-
-fn outer_sequence_expired(owner: crate::Whose, expired: bool) -> bool {
-    owner == crate::Whose::Caller && expired
-}
-
 fn prior_scroll_dispatched(steps: u32) -> bool {
     steps > 0
-}
-
-/// Reclassify a reader-relative caller bound without overriding an expired outer sequence.
-fn resolve_nested_accessibility_bound(
-    error: GlassError,
-    effective_owner: crate::Whose,
-    sequence_deadline: Deadline,
-) -> GlassError {
-    if should_reclassify_nested_bound(effective_owner, sequence_deadline.has_passed()) {
-        match error {
-            GlassError::Bounded {
-                kind,
-                whose: crate::Whose::Caller,
-                dispatch,
-                message,
-            } => GlassError::Bounded {
-                kind,
-                whose: crate::Whose::Callee,
-                dispatch,
-                message,
-            },
-            error => error,
-        }
-    } else {
-        error
-    }
 }
 
 fn after_scroll_dispatch(error: GlassError) -> GlassError {
@@ -188,6 +127,11 @@ pub struct WaitElementOutcome {
     /// Which timeout ended the wait. `None` when the predicate was satisfied.
     #[doc(hidden)]
     pub timed_out_by: Option<crate::Whose>,
+}
+
+enum WaitElementObservation {
+    Pending,
+    Satisfied(Option<ElementInfo>),
 }
 
 /// Wheel notches per scroll step; chosen so a step realizes at most a few rows
@@ -554,172 +498,35 @@ impl Glass {
         params: &WaitElementParams,
         sequence_deadline: Deadline,
     ) -> Result<WaitElementOutcome> {
-        if sequence_deadline.has_passed() {
-            return Err(GlassError::deadline_not_started("wait for element"));
-        }
-        self.require_active()?; // fail fast; a11y_snapshot rechecks inside the loop
-        let started = std::time::Instant::now();
-        // Every read this wait makes carries when the wait stops: the tick is synchronous, so the
-        // loop cannot take back a read a reader has started (glass#338).
-        let (effective_duration, whose) =
-            sequence_deadline.budget(std::time::Duration::from_millis(params.timeout_ms), started);
-        let action_deadline = Deadline::at(started + effective_duration);
-        // Before the first walk, not after: a change landing in that gap is announced to nobody,
-        // and the wait then burns its whole budget on a condition that already holds.
-        //
-        // An interval of 0 means "re-read as fast as you can", which never pauses — so there is
-        // nothing for a signal to save, and subscribing would only cost a round-trip.
-        let mut signal = (params.interval_ms > 0)
-            .then(|| self.subscribe_a11y_changes(action_deadline))
-            .flatten();
-        // Subscribing spends the caller's budget, so the poll loop gets what is left. That
-        // bounds the polling, not the call: a reader that does not honour `deadline` bounds its
-        // own handshake in seconds, so a wait told to give up after 500ms can return later.
-        let remaining = (effective_duration.as_millis() as u64)
-            .saturating_sub(started.elapsed().as_millis() as u64);
-        // Starts now rather than at the first read: the first tick follows immediately.
-        let mut last_read = std::time::Instant::now();
-        // Only a wait that never saw a tree reports why it saw none. A reader honouring
-        // `deadline` gives up on the tick that ends the wait, so without this every unmatched wait
-        // on such a backend failed instead of answering `{matched:false}` (glass#338).
-        let mut unread: Option<GlassError> = None;
-        let mut unread_owner = whose;
-        let mut saw_a_tree = false;
-        // A zero-timeout compatibility read uses the live sequence deadline; later reads use the
-        // action deadline.
-        let first_read_deadline = if params.timeout_ms == 0 {
-            sequence_deadline
-        } else {
-            action_deadline
+        let selector = ElementSelector {
+            name: params.name.as_deref(),
+            description: params.description.as_deref(),
+            role: params.role,
+            value: params.value.as_deref(),
+            value_contains: params.value_contains.as_deref(),
         };
-        let mut looked = false;
-        let final_read_scheduled = std::cell::Cell::new(false);
-        let outcome = crate::poll::poll_until_with_pause(
+        let poll = self.poll_accessibility_until(
             params.interval_ms,
-            remaining,
-            |d| {
-                // Schedule the skipped-tick safety read before expiry because accessibility
-                // snapshots cannot return late success.
-                let left = action_deadline.remaining();
-                let final_read = should_schedule_final_read(final_read_scheduled.get(), left, d);
-                if final_read {
-                    final_read_scheduled.set(true);
+            params.timeout_ms,
+            sequence_deadline,
+            "wait for element",
+            |tree| match tree.element_match_selector(selector, params.condition) {
+                ElementMatch::Satisfied(node) => {
+                    WaitElementObservation::Satisfied(node.map(ElementInfo::from_node))
                 }
-                let paused_at = std::time::Instant::now();
-                let pause_budget = if final_read {
-                    let left = left.expect("a final read is scheduled only for a bounded wait");
-                    final_read_pause(left)
-                } else {
-                    left.unwrap_or(d).min(d)
-                };
-                let read_now = match signal.as_mut() {
-                    Some(s) => match s.wait(pause_budget) {
-                        ChangeWait::Changed => true,
-                        // Read anyway now and then — see `REREAD_AFTER`.
-                        ChangeWait::Quiet => quiet_wait_needs_read(final_read, last_read.elapsed()),
-                        // See `ChangeWait`: an unusable signal must not read as a quiet one.
-                        ChangeWait::Unusable => {
-                            signal = None;
-                            true
-                        }
-                    },
-                    None => true,
-                };
-                if read_now {
-                    last_read = std::time::Instant::now();
-                }
-                // One interval between reads, whatever woke us. A chatty app (spinner, clock,
-                // progress bar) would otherwise drive back-to-back walks with no gap, hammering the
-                // same bus the app is trying to serve — and a signal that returns early without
-                // blocking, which nothing here can enforce, would spin this loop at full tilt.
-                std::thread::sleep(pause_budget.saturating_sub(paused_at.elapsed()));
-                read_now
+                ElementMatch::Pending => WaitElementObservation::Pending,
             },
-            || {
-                // fresh snapshot; assigns ids, caches, pumps
-                let first_read = !looked;
-                let bound = if first_read {
-                    first_read_deadline
-                } else {
-                    action_deadline
-                };
-                let read_owner = if first_read
-                    && params.timeout_ms == 0
-                    && sequence_deadline.instant().is_some()
-                {
-                    crate::Whose::Caller
-                } else {
-                    whose
-                };
-                // The pause already scheduled the safety read before expiry; skip the poller's
-                // post-timeout bookkeeping tick.
-                if !first_read && bound.has_passed() {
-                    return Ok(None);
-                }
-                looked = true;
-                let tree = match self.a11y_resnapshot_for_wait(bound) {
-                    Ok(t) => {
-                        saw_a_tree = true;
-                        t
-                    }
-                    // Kept so a spent budget can report this instead of "not found" (glass#329).
-                    Err(e @ GlassError::AccessibilityNotReady(_)) => {
-                        unread_owner = read_owner;
-                        unread = Some(e);
-                        return Ok(None);
-                    }
-                    // Resolve this reader-relative `Caller` against the enclosing wait below.
-                    Err(e) if reader_relative_caller_bound(&e) => {
-                        unread_owner = read_owner;
-                        unread = Some(e);
-                        return Ok(None);
-                    }
-                    Err(e) => return Err(e),
-                };
-                Ok(
-                    match tree.element_match_selector(
-                        ElementSelector {
-                            name: params.name.as_deref(),
-                            description: params.description.as_deref(),
-                            role: params.role,
-                            value: params.value.as_deref(),
-                            value_contains: params.value_contains.as_deref(),
-                        },
-                        params.condition,
-                    ) {
-                        ElementMatch::Satisfied(node) => Some(node.map(ElementInfo::from_node)),
-                        ElementMatch::Pending => None,
-                    },
-                )
-            },
+            |observation| matches!(observation, WaitElementObservation::Satisfied(_)),
         )?;
-        if outcome.value.is_none()
-            && !saw_a_tree
-            && let Some(e) = unread
-        {
-            if e.bound_owner() == Some(crate::Whose::Caller) {
-                return Err(resolve_nested_accessibility_bound(
-                    e,
-                    unread_owner,
-                    sequence_deadline,
-                ));
-            }
-            if outer_sequence_expired(unread_owner, sequence_deadline.has_passed()) {
-                return Err(GlassError::caller_deadline_elapsed_with_guidance(
-                    "accessibility wait",
-                    &e.to_string(),
-                ));
-            }
-            return Err(e);
-        }
-        let matched = outcome.value.is_some();
+        let element = match poll.observation {
+            WaitElementObservation::Satisfied(element) => element,
+            WaitElementObservation::Pending => None,
+        };
         Ok(WaitElementOutcome {
-            matched,
-            element: outcome.value.flatten(),
-            // From before the subscription, not from the poll loop: the agent is told how long the
-            // call took, and the subscribe is part of it.
-            elapsed_ms: started.elapsed().as_millis() as u64,
-            timed_out_by: (!matched).then_some(whose),
+            matched: poll.satisfied,
+            element,
+            elapsed_ms: poll.elapsed_ms,
+            timed_out_by: poll.timed_out_by,
         })
     }
 
@@ -1082,21 +889,15 @@ impl Glass {
 #[cfg(test)]
 mod tests {
     use super::{
-        REREAD_AFTER, callee_wait_expired, compatibility_capture, final_read_pause,
-        needs_callee_timeout_full_capture, offscreen_direction, outer_sequence_expired,
-        prior_scroll_dispatched, quiet_wait_needs_read, reader_relative_caller_bound,
-        scroll_anchor, settle_capture_result, should_reclassify_nested_bound,
-        should_schedule_final_read, soft_callee_capture_timeout,
+        callee_wait_expired, compatibility_capture, needs_callee_timeout_full_capture,
+        offscreen_direction, prior_scroll_dispatched, scroll_anchor, settle_capture_result,
+        soft_callee_capture_timeout,
     };
     use crate::BoundKind;
     use crate::session::test_support::*;
 
     #[test]
     fn wait_deadline_helpers_require_every_provenance_clause() {
-        assert!(should_reclassify_nested_bound(crate::Whose::Callee, false));
-        assert!(!should_reclassify_nested_bound(crate::Whose::Caller, false));
-        assert!(!should_reclassify_nested_bound(crate::Whose::Callee, true));
-
         assert!(callee_wait_expired(true, crate::Whose::Callee, true));
         assert!(!callee_wait_expired(false, crate::Whose::Callee, true));
         assert!(!callee_wait_expired(true, crate::Whose::Caller, true));
@@ -1154,64 +955,8 @@ mod tests {
             crate::Whose::Caller
         ));
 
-        assert!(reader_relative_caller_bound(
-            &GlassError::caller_deadline_elapsed("reader")
-        ));
-        assert!(!reader_relative_caller_bound(&GlassError::Bounded {
-            kind: crate::BoundKind::TimedOut,
-            whose: crate::Whose::Callee,
-            dispatch: crate::BoundDispatch::MayHaveDispatched,
-            message: "reader ceiling".into(),
-        }));
-        assert!(!reader_relative_caller_bound(&GlassError::Backend(
-            "reader failed".into()
-        )));
-
-        assert!(outer_sequence_expired(crate::Whose::Caller, true));
-        assert!(!outer_sequence_expired(crate::Whose::Callee, true));
-        assert!(!outer_sequence_expired(crate::Whose::Caller, false));
-
         assert!(!prior_scroll_dispatched(0));
         assert!(prior_scroll_dispatched(1));
-    }
-
-    #[test]
-    fn final_read_pause_reserves_a_quarter_up_to_the_headroom_cap() {
-        assert_eq!(
-            final_read_pause(Duration::from_millis(80)),
-            Duration::from_millis(60)
-        );
-        assert_eq!(
-            final_read_pause(Duration::from_millis(40)),
-            Duration::from_millis(30)
-        );
-        assert_eq!(
-            final_read_pause(Duration::from_millis(4)),
-            Duration::from_millis(3)
-        );
-    }
-
-    #[test]
-    fn a_quiet_signal_reads_only_for_a_safety_or_periodic_refresh() {
-        assert!(!quiet_wait_needs_read(
-            false,
-            REREAD_AFTER - Duration::from_millis(1)
-        ));
-        assert!(quiet_wait_needs_read(false, REREAD_AFTER));
-        assert!(quiet_wait_needs_read(true, Duration::ZERO));
-    }
-
-    #[test]
-    fn a_final_safety_read_is_scheduled_once_when_the_interval_reaches_the_deadline() {
-        let interval = Duration::from_millis(100);
-        assert!(should_schedule_final_read(false, Some(interval), interval));
-        assert!(!should_schedule_final_read(true, Some(interval), interval));
-        assert!(!should_schedule_final_read(false, None, interval));
-        assert!(!should_schedule_final_read(
-            false,
-            Some(interval + Duration::from_millis(1)),
-            interval
-        ));
     }
 
     #[test]

--- a/crates/glass-mcp/src/capabilities.rs
+++ b/crates/glass-mcp/src/capabilities.rs
@@ -28,6 +28,7 @@ pub(crate) const OPERATION_TOOLS: &[(&str, &[&str])] = &[
     (
         "accessibility",
         &[
+            "glass_find_elements",
             "glass_a11y_snapshot",
             "glass_a11y_marks",
             "glass_click_element",
@@ -180,6 +181,14 @@ fn render_value_resolved(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn accessibility_reports_find_elements() {
+        assert!(
+            tools_for("accessibility").contains(&"glass_find_elements"),
+            "accessibility capability must report glass_find_elements"
+        );
+    }
 
     #[test]
     fn available_only_for_compiled_in_backends() {

--- a/crates/glass-mcp/src/params.rs
+++ b/crates/glass-mcp/src/params.rs
@@ -163,6 +163,39 @@ pub struct SetValueArgs {
     pub return_: Option<String>,
 }
 
+/// Arguments for `glass_find_elements` selector fields.
+#[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[allow(dead_code)]
+pub struct FindSelectorArgs {
+    /// Case-insensitive substring searched across accessible name, description and non-secure value.
+    pub query: Option<String>,
+    /// Normalized accessibility role, e.g. "Button" or "Document".
+    pub role: Option<String>,
+    /// State predicates combined with AND, e.g. ["visible", "enabled"].
+    pub states: Option<Vec<String>>,
+}
+
+/// Arguments for `glass_find_elements`.
+#[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[allow(dead_code)]
+pub struct FindElementsArgs {
+    /// Approximate case-insensitive semantic text. Optional when role or states are supplied.
+    pub query: Option<String>,
+    /// Normalized target role.
+    pub role: Option<String>,
+    /// Target state predicates combined with AND.
+    pub states: Option<Vec<String>>,
+    /// Optional unique semantic scope resolved in the same fresh tree.
+    pub within: Option<FindSelectorArgs>,
+    /// Maximum ranked matches before the byte budget; default 10, range 1 through 20.
+    #[schemars(range(min = 1, max = 20))]
+    pub max_results: Option<u32>,
+    /// Existing accessibility walk limit semantics; 0 removes the node-count limit.
+    pub max_nodes: Option<u32>,
+    /// Optional wait for at least one match; default 0 performs one fresh read.
+    pub timeout_ms: Option<u64>,
+}
+
 /// Arguments for `glass_a11y_snapshot`.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct A11ySnapshotArgs {
@@ -817,6 +850,35 @@ mod tests {
         assert!(none.window_id.is_none());
         let some: WaitStableArgs = serde_json::from_str(r#"{"window_id":7}"#).unwrap();
         assert_eq!(some.window_id, Some(7));
+    }
+
+    #[test]
+    fn find_elements_args_parse_flat_target_and_nested_scope() {
+        let args: FindElementsArgs = serde_json::from_str(
+            r#"{
+            "query":"save",
+            "role":"Button",
+            "states":["visible","enabled"],
+            "within":{"role":"Document","states":["visible"]},
+            "max_results":10,
+            "max_nodes":500,
+            "timeout_ms":3000
+        }"#,
+        )
+        .unwrap();
+        assert_eq!(args.query.as_deref(), Some("save"));
+        assert_eq!(
+            args.within.as_ref().and_then(|scope| scope.role.as_deref()),
+            Some("Document")
+        );
+        assert_eq!(args.max_results, Some(10));
+    }
+
+    #[test]
+    fn find_elements_args_allow_filter_only_queries() {
+        let args: FindElementsArgs = serde_json::from_str(r#"{"role":"Button"}"#).unwrap();
+        assert!(args.query.is_none());
+        assert_eq!(args.role.as_deref(), Some("Button"));
     }
 
     #[test]

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -1167,6 +1167,67 @@ mod tests {
         assert!(first_text(&r).contains("done"), "got {:?}", first_text(&r));
     }
 
+    fn find_args() -> FindElementsArgs {
+        FindElementsArgs {
+            query: Some("save".into()),
+            role: None,
+            states: None,
+            within: None,
+            max_results: None,
+            max_nodes: None,
+            timeout_ms: None,
+        }
+    }
+
+    fn assert_bounded_find_error(result: ToolResult, category: &str, guidance: &str) {
+        let mapped = map_tool_result(result);
+        assert_eq!(mapped.is_error, Some(true));
+        let text = first_text(&mapped);
+        assert!(text.contains(category), "{text}");
+        assert!(text.contains(guidance), "{text}");
+        assert!(text.len() <= crate::tools::FIND_RESPONSE_MAX_BYTES);
+    }
+
+    #[test]
+    fn find_mcp_error_preserves_no_session_category_and_guidance() {
+        let mut glass =
+            crate::tools::testutil::glass_with(crate::tools::testutil::FakePlatform::new(100, 100));
+        assert_bounded_find_error(
+            crate::tools::find_elements(&mut glass, &find_args()),
+            "no_active_session",
+            "Call glass_start",
+        );
+    }
+
+    #[test]
+    fn find_mcp_error_preserves_unsupported_accessibility_category_and_guidance() {
+        let mut glass = crate::tools::testutil::started_without_a11y();
+        assert_bounded_find_error(
+            crate::tools::find_elements(&mut glass, &find_args()),
+            "unsupported_accessibility",
+            "Use glass_screenshot",
+        );
+    }
+
+    #[test]
+    fn find_mcp_transport_error_is_bounded_and_does_not_echo_backend_detail() {
+        let sentinel = "backend-secret-sentinel";
+        let mut glass = crate::tools::testutil::started_failing_a11y(
+            glass_core::GlassError::Backend(format!("{sentinel} {}", "x".repeat(20_000))),
+        );
+        let result = crate::tools::find_elements(&mut glass, &find_args());
+        let mapped = map_tool_result(result);
+        let text = first_text(&mapped);
+        assert_eq!(mapped.is_error, Some(true));
+        assert!(text.contains("transport_failure"), "{text}");
+        assert!(
+            text.contains("Retry after checking the backend connection"),
+            "{text}"
+        );
+        assert!(!text.contains(sentinel), "{text}");
+        assert!(text.len() <= crate::tools::FIND_RESPONSE_MAX_BYTES);
+    }
+
     /// android is always compiled in (host-OS-agnostic), so it's a stable choice for
     /// exercising the registered handler end to end without depending on the host OS.
     #[tokio::test]

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -535,6 +535,17 @@ impl GlassServer {
 
     #[tool(
         annotations(read_only_hint = true, open_world_hint = false),
+        description = "Find a bounded ranked set of accessibility elements from one fresh read. Use this when the target text is approximate, duplicated, or not yet identified; use glass_wait_for_element for one precise runtime condition and glass_a11y_snapshot for broad tree inspection. `query` is a deterministic case-insensitive substring over accessible name, description and non-secure value; optional `role`/`states` narrow targets, optional `within` must match one semantic scope, `max_results` defaults to 10 and is capped at 20, `max_nodes` uses snapshot walk-limit semantics, and positive `timeout_ms` waits for a match. Returns trusted counts plus one untrusted match array with actionable ids and compact context. Complete success and error text is capped at 8 KiB."
+    )]
+    async fn glass_find_elements(
+        &self,
+        Parameters(a): Parameters<FindElementsArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        self.run(move |glass| tools::find_elements(glass, &a)).await
+    }
+
+    #[tool(
+        annotations(read_only_hint = true, open_world_hint = false),
         description = "Capture the active window's current semantic state as a compact \
                        accessibility tree (role, name, description, bounded editable value, \
                        window-relative bounds and states). This is one observation, not proof of \
@@ -805,18 +816,20 @@ const SERVER_INSTRUCTIONS: &str = "glass gives you a build → see → interact 
      app — no app integration needed. One active session; tools target it implicitly; \
      choose a backend at glass_start (defaults to the host; see the `backend` param). \
      glass_start launches the app and captures its logs (glass_logs for stdout/stderr).\n\n\
+     SEE AND ADDRESS THE UI CHEAPLY FIRST — the low-token default. When the target is approximate, \
+     duplicated, or not yet identified, call glass_find_elements first: it returns a small ranked \
+     set of actionable ids and context from a fresh accessibility read. Use glass_a11y_snapshot for \
+     broad structural inspection, and glass_wait_for_element when one precise known condition must \
+     become true. Retain returned ids only until the UI changes. Prefer this semantic path over \
+     screenshots and pixel-hunting whenever it works.\n\n\
      BATCH KNOWN WORK: Prefer glass_do whenever at least two upcoming actions or verification waits \
      are already known. Typical form flow: take one fresh glass_a11y_snapshot, retain the needed ids, \
      then run set_value, wait_for_element, click_element, and wait_for_element in one ordered call. \
      Use standalone tools only when the next step depends on newly observed state. Inspect the \
      structured outcomes before recovery.\n\n\
-     SEE AND ADDRESS THE UI CHEAPLY FIRST — the low-token default. When the app exposes \
-     an accessibility tree, glass_a11y_snapshot returns its elements as TEXT (#id, role, \
-     name, window-relative bounds, and a description where the element carries a second \
-     label distinct from its name) — deterministic, no image tokens. Address \
-     elements by #id: glass_click_element clicks one, glass_set_value writes an editable element's \
-     value, and glass_wait_for_element verifies semantic transition completion, including exact \
-     editable text with value. Prefer this over screenshots and pixel-hunting whenever it works.\n\n\
+     ADDRESS RETURNED IDS DIRECTLY: glass_click_element clicks one, glass_set_value writes an \
+     editable element's value, and glass_wait_for_element verifies semantic transition completion, \
+     including exact editable text with value.\n\n\
      PIXELS ARE THE FALLBACK — for a canvas/black-box app with no tree (glass_a11y_snapshot \
      errors there): glass_screenshot to see it, then glass_click / glass_type / glass_key / \
      glass_scroll / glass_drag (glass_gesture for multi-touch where supported) to interact. \
@@ -1474,6 +1487,28 @@ mod tests {
         );
     }
 
+    #[test]
+    fn find_elements_is_registered_read_only_and_semantic_first() {
+        let tools = GlassServer::tool_router().list_all();
+        let find = tools
+            .iter()
+            .find(|tool| tool.name == "glass_find_elements")
+            .expect("registered");
+        assert_eq!(
+            find.annotations.as_ref().and_then(|a| a.read_only_hint),
+            Some(true)
+        );
+        assert_eq!(
+            find.annotations.as_ref().and_then(|a| a.open_world_hint),
+            Some(false)
+        );
+        let find_pos = SERVER_INSTRUCTIONS.find("glass_find_elements").unwrap();
+        let snapshot_pos = SERVER_INSTRUCTIONS.find("glass_a11y_snapshot").unwrap();
+        let screenshot_pos = SERVER_INSTRUCTIONS.find("glass_screenshot").unwrap();
+        assert!(find_pos < snapshot_pos);
+        assert!(snapshot_pos < screenshot_pos);
+    }
+
     /// `destructive_hint` and `open_world_hint` default to `true` in the MCP spec, so a tool
     /// shipping without annotations reads to a host as destructive and open-world.
     #[test]
@@ -1492,6 +1527,7 @@ mod tests {
             ("glass_do", false),
             ("glass_doctor", false),
             ("glass_drag", false),
+            ("glass_find_elements", true),
             ("glass_gesture", false),
             ("glass_key", false),
             ("glass_list_windows", true),
@@ -1601,6 +1637,22 @@ mod tests {
                 )
             })
             .collect();
+
+        let find = &descriptions["glass_find_elements"];
+        for required in [
+            "approximate, duplicated, or not yet identified",
+            "fresh read",
+            "defaults to 10",
+            "capped at 20",
+            "within` must match one semantic scope",
+            "timeout_ms",
+            "8 KiB",
+        ] {
+            assert!(
+                find.contains(required),
+                "glass_find_elements description missing {required:?}: {find}"
+            );
+        }
 
         let element = &descriptions["glass_wait_for_element"];
         assert!(element.contains("semantic transition completion"));
@@ -1741,6 +1793,41 @@ mod tests {
                 (tool.name.into_owned(), params)
             })
             .collect()
+    }
+
+    #[test]
+    fn find_elements_reference_documents_public_contract() {
+        let heading = "### `glass_find_elements`";
+        let start = TOOLS_MD.find(heading).expect("canonical reference heading");
+        let snapshot = TOOLS_MD
+            .find("### `glass_a11y_snapshot`")
+            .expect("snapshot reference heading");
+        assert!(
+            start < snapshot,
+            "find-elements reference must precede snapshot"
+        );
+        let section = &TOOLS_MD[start..snapshot];
+        for required in [
+            "`query` (string)",
+            "`role` (string)",
+            "`states` (array of string)",
+            "`within` (object)",
+            "`max_results` (integer, default 10, range 1 through 20)",
+            "`max_nodes` (integer)",
+            "`timeout_ms` (integer, default 0)",
+            "Ranking",
+            "context",
+            "soft timeout",
+            "ambiguous",
+            "Secure values",
+            "untrusted",
+            "8 KiB",
+        ] {
+            assert!(
+                section.contains(required),
+                "glass_find_elements reference missing {required:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -771,12 +771,16 @@ pub(crate) fn parse_button(s: Option<&str>) -> Result<MouseButton, String> {
 pub use self::batch::*;
 pub use self::capture::*;
 pub use self::clipboard::*;
+#[allow(unused_imports)]
+pub use self::find::*;
 pub use self::input::*;
 pub use self::wait::*;
 
 mod batch;
 mod capture; // filled in Task 6
 mod clipboard;
+#[allow(dead_code)]
+mod find;
 mod input; // filled in Task 5
 mod wait;
 

--- a/crates/glass-mcp/src/tools/find.rs
+++ b/crates/glass-mcp/src/tools/find.rs
@@ -327,14 +327,30 @@ fn truncate_text(text: &str, max_bytes: usize, preserve: Option<&str>) -> String
     if max_bytes < ellipsis.len() {
         return String::new();
     }
-    let content_bytes = max_bytes - ellipsis.len();
-    let start = preserve
+    let matched = preserve
         .filter(|needle| !needle.is_empty())
-        .and_then(|needle| text.to_lowercase().find(&needle.to_lowercase()))
-        .map(|position| position.saturating_sub(content_bytes / 3))
-        .unwrap_or(0);
-    let start = floor_char_boundary(text, start.min(text.len()));
-    let end = floor_char_boundary(text, (start + content_bytes).min(text.len()));
+        .and_then(|needle| case_insensitive_match_range(text, needle));
+    let leading_ellipsis = matched.as_ref().is_some_and(|range| range.start > 0);
+    let trailing_ellipsis = matched.as_ref().is_none_or(|range| range.end < text.len());
+    let content_bytes = max_bytes
+        .saturating_sub(usize::from(leading_ellipsis) * ellipsis.len())
+        .saturating_sub(usize::from(trailing_ellipsis) * ellipsis.len());
+    let (start, end) = if let Some(matched) = matched {
+        let retained_match_end =
+            floor_char_boundary(text, (matched.start + content_bytes).min(matched.end));
+        let retained_match_len = retained_match_end - matched.start;
+        let surrounding = content_bytes.saturating_sub(retained_match_len);
+        let start = floor_char_boundary(text, matched.start.saturating_sub(surrounding / 3));
+        let end = floor_char_boundary(text, (start + content_bytes).min(text.len()));
+        if end < retained_match_end {
+            let start = floor_char_boundary(text, retained_match_end.saturating_sub(content_bytes));
+            (start, retained_match_end)
+        } else {
+            (start, end)
+        }
+    } else {
+        (0, floor_char_boundary(text, content_bytes.min(text.len())))
+    };
     let mut output = String::new();
     if start > 0 {
         output.push('…');
@@ -348,6 +364,34 @@ fn truncate_text(text: &str, max_bytes: usize, preserve: Option<&str>) -> String
         output.truncate(end);
     }
     output
+}
+
+fn case_insensitive_match_range(text: &str, needle: &str) -> Option<std::ops::Range<usize>> {
+    let folded_needle = needle.to_lowercase();
+    let mut folded_text = String::new();
+    let mut spans = Vec::new();
+    for (start, character) in text.char_indices() {
+        let folded_start = folded_text.len();
+        folded_text.extend(character.to_lowercase());
+        spans.push((
+            folded_start,
+            folded_text.len(),
+            start,
+            start + character.len_utf8(),
+        ));
+    }
+
+    let folded_start = folded_text.find(&folded_needle)?;
+    let folded_end = folded_start + folded_needle.len();
+    let start = spans
+        .iter()
+        .find(|(_, end, _, _)| *end > folded_start)
+        .map(|(_, _, start, _)| *start)?;
+    let end = spans
+        .iter()
+        .find(|(start, end, _, _)| *start < folded_end && *end >= folded_end)
+        .map(|(_, _, _, end)| *end)?;
+    Some(start..end)
 }
 
 fn floor_char_boundary(text: &str, mut index: usize) -> usize {
@@ -544,6 +588,63 @@ mod tests {
         assert_eq!(envelope["tool"], serde_json::json!("glass_find_elements"));
         assert_eq!(envelope["result"]["matched"], serde_json::json!(false));
         assert!(!format!("{output:?}").contains("needle-secret"));
+    }
+
+    #[test]
+    fn truncation_preserves_a_long_match_near_the_end() {
+        let matched = "target-region-".repeat(5);
+        let text = format!("{}{}{}", "before-".repeat(40), matched, "after-".repeat(40));
+
+        let truncated = truncate_text(&text, 96, Some(&matched));
+
+        assert!(truncated.contains(&matched), "{truncated:?}");
+        assert!(truncated.len() <= 96);
+    }
+
+    #[test]
+    fn truncation_preserves_match_offsets_across_unicode_lowercase_expansion() {
+        let matched = "target-region-".repeat(5);
+        let text = format!("{}{}{}", "İ".repeat(80), matched, "after-".repeat(40));
+
+        let truncated = truncate_text(&text, 96, Some(&matched.to_uppercase()));
+
+        assert!(truncated.contains(&matched), "{truncated:?}");
+        assert!(truncated.len() <= 96);
+        assert!(truncated.is_char_boundary(truncated.len()));
+    }
+
+    #[test]
+    fn find_redacts_secure_neighbor_values_from_successful_match_context() {
+        let mut tree = fake_tree();
+        let mut secure_neighbor = tree.root.children[0].clone();
+        secure_neighbor.name = Some("Password".into());
+        secure_neighbor.states.secure = true;
+        secure_neighbor.states.editable = true;
+        secure_neighbor.value = Some("context-secret-sentinel".into());
+        tree.root.children.push(secure_neighbor);
+        tree.assign_ids();
+        let mut glass = started_a11y_with(tree);
+
+        let output = find_elements(
+            &mut glass,
+            &FindElementsArgs {
+                query: Some("save".into()),
+                role: Some("Button".into()),
+                states: None,
+                within: None,
+                max_results: None,
+                max_nodes: None,
+                timeout_ms: None,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(envelope_at(&output, 0)["result"]["matched"], json!(true));
+        let OutContent::Text(untrusted) = &output.0[1] else {
+            panic!("text block")
+        };
+        assert!(untrusted.contains("\"name\":\"Save\""));
+        assert!(!format!("{output:?}").contains("context-secret-sentinel"));
     }
 
     #[test]

--- a/crates/glass-mcp/src/tools/find.rs
+++ b/crates/glass-mcp/src/tools/find.rs
@@ -1,0 +1,579 @@
+use glass_core::{
+    AxRole, FindElementsParams, Glass, MatchField, MatchTier, ScopeResolution, SemanticMatch,
+    SemanticQuery, SemanticSelector, SemanticState,
+};
+use serde_json::{Value, json};
+
+use crate::params::{FindElementsArgs, FindSelectorArgs};
+use crate::tools::{OutContent, ToolOutput, ToolResult};
+
+const DEFAULT_MAX_RESULTS: usize = 10;
+pub(crate) const FIND_RESPONSE_MAX_BYTES: usize = 8_192;
+
+#[derive(Clone)]
+struct RenderedMatch {
+    id: u32,
+    role: String,
+    name: Option<String>,
+    description: Option<String>,
+    value: Option<String>,
+    bounds: Option<Value>,
+    states: Vec<&'static str>,
+    matched_field: Option<&'static str>,
+    match_tier: &'static str,
+    context: String,
+    context_stage: usize,
+    field_stages: [usize; 3],
+    fields_counted: [bool; 3],
+    context_counted: bool,
+    query: Option<String>,
+}
+
+#[derive(Default)]
+struct FitCounters {
+    omitted_by_budget: usize,
+    fields_truncated: usize,
+    contexts_truncated: usize,
+}
+
+struct Metadata {
+    matched: bool,
+    timed_out: bool,
+    elapsed_ms: u64,
+    scope_status: &'static str,
+    resolved_scope_id: Option<u32>,
+    matches_in_walk: usize,
+    omitted_by_max_results: usize,
+    search_complete: bool,
+    tree_truncated: bool,
+    unreadable_subtrees: usize,
+    unexposed_placeholders: usize,
+}
+
+pub fn find_elements(glass: &mut Glass, a: &FindElementsArgs) -> ToolResult {
+    let max_results = a.max_results.unwrap_or(DEFAULT_MAX_RESULTS as u32);
+    if !(1..=20).contains(&max_results) {
+        return Err(bounded_error("max_results must be between 1 and 20"));
+    }
+
+    let target = selector(a.query.clone(), a.role.as_deref(), a.states.as_deref())?;
+    let within = a.within.as_ref().map(selector_args).transpose()?;
+    let query = SemanticQuery::new(target, within, max_results as usize)
+        .map_err(|error| bounded_error(error.to_string()))?;
+    let outcome = glass
+        .find_elements(&FindElementsParams {
+            query: query.clone(),
+            max_nodes: a.max_nodes.map(|value| value as usize),
+            timeout_ms: a.timeout_ms.unwrap_or(0),
+        })
+        .map_err(|_| bounded_error("glass_find_elements failed"))?;
+
+    if let ScopeResolution::Ambiguous { observed } = outcome.result.scope {
+        return Err(bounded_error(format!(
+            "semantic scope matched {observed} elements; refine `within` so it matches exactly one"
+        )));
+    }
+
+    let (scope_status, resolved_scope_id) = match outcome.result.scope {
+        ScopeResolution::Unscoped => ("unscoped", None),
+        ScopeResolution::NotFound => ("not_found", None),
+        ScopeResolution::Resolved(id) => ("resolved", Some(id.0)),
+        ScopeResolution::Ambiguous { .. } => unreachable!(),
+    };
+    let metadata = Metadata {
+        matched: outcome.matched,
+        timed_out: outcome.timed_out,
+        elapsed_ms: outcome.elapsed_ms,
+        scope_status,
+        resolved_scope_id,
+        matches_in_walk: outcome.result.matches_in_walk,
+        omitted_by_max_results: outcome.result.omitted_by_max_results,
+        search_complete: outcome.result.search_complete,
+        tree_truncated: outcome.result.tree_truncated.is_some(),
+        unreadable_subtrees: outcome.result.unreadable_subtrees,
+        unexposed_placeholders: outcome.result.unexposed_placeholders,
+    };
+    let mut rendered = outcome
+        .result
+        .matches
+        .iter()
+        .map(|matched| render_match(matched, query.target.query()))
+        .collect::<Vec<_>>();
+    fit_output(&metadata, &mut rendered)
+}
+
+fn selector_args(args: &FindSelectorArgs) -> Result<SemanticSelector, String> {
+    selector(
+        args.query.clone(),
+        args.role.as_deref(),
+        args.states.as_deref(),
+    )
+}
+
+fn selector(
+    query: Option<String>,
+    role: Option<&str>,
+    states: Option<&[String]>,
+) -> Result<SemanticSelector, String> {
+    let role = role
+        .map(|name| {
+            AxRole::from_name(name)
+                .ok_or_else(|| bounded_error("unknown role; use a normalized accessibility role"))
+        })
+        .transpose()?;
+    let states = states
+        .unwrap_or_default()
+        .iter()
+        .map(|name| {
+            SemanticState::from_name(name).ok_or_else(|| {
+                bounded_error("unknown state; use a normalized semantic state predicate")
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    SemanticSelector::new(query, role, states).map_err(|error| bounded_error(error.to_string()))
+}
+
+fn render_match(matched: &SemanticMatch, query: Option<&str>) -> RenderedMatch {
+    RenderedMatch {
+        id: matched.element.id.0,
+        role: format!("{:?}", matched.element.role),
+        name: matched.element.name.clone(),
+        description: matched.element.description.clone(),
+        value: if matched.element.states.secure {
+            None
+        } else {
+            matched.element.value.clone()
+        },
+        bounds: matched.element.bounds.map(|bounds| {
+            json!({
+                "x": bounds.x,
+                "y": bounds.y,
+                "width": bounds.width,
+                "height": bounds.height,
+            })
+        }),
+        states: matched.element.states.active(),
+        matched_field: matched.field.map(match_field_name),
+        match_tier: match_tier_name(matched.tier),
+        context: matched.context.clone(),
+        context_stage: 0,
+        field_stages: [0; 3],
+        fields_counted: [false; 3],
+        context_counted: false,
+        query: query.map(str::to_owned),
+    }
+}
+
+fn fit_output(metadata: &Metadata, rendered: &mut Vec<RenderedMatch>) -> ToolResult {
+    let mut counters = FitCounters::default();
+    let mut output = build_output(metadata, rendered, &counters);
+    while text_bytes(&output) > FIND_RESPONSE_MAX_BYTES {
+        if shorten_lowest_ranked_context(rendered, &mut counters) {
+            output = build_output(metadata, rendered, &counters);
+            continue;
+        }
+        if shorten_lowest_ranked_field(rendered, &mut counters) {
+            output = build_output(metadata, rendered, &counters);
+            continue;
+        }
+        if let Some(omitted) = rendered.pop() {
+            counters.contexts_truncated -= usize::from(omitted.context_counted);
+            counters.fields_truncated -= omitted
+                .fields_counted
+                .into_iter()
+                .filter(|counted| *counted)
+                .count();
+            counters.omitted_by_budget += 1;
+            output = build_output(metadata, rendered, &counters);
+            continue;
+        }
+        return Err(bounded_error(
+            "glass_find_elements could not fit mandatory metadata within 8192 bytes",
+        ));
+    }
+    Ok(output)
+}
+
+fn build_output(
+    metadata: &Metadata,
+    rendered: &[RenderedMatch],
+    counters: &FitCounters,
+) -> ToolOutput {
+    let matches = rendered.iter().map(match_json).collect::<Vec<_>>();
+    let mut result = json!({
+        "matched": metadata.matched,
+        "timed_out": metadata.timed_out,
+        "elapsed_ms": metadata.elapsed_ms,
+        "scope_status": metadata.scope_status,
+        "matches_in_walk": metadata.matches_in_walk,
+        "returned": rendered.len(),
+        "omitted_by_max_results": metadata.omitted_by_max_results,
+        "omitted_by_budget": counters.omitted_by_budget,
+        "fields_truncated": counters.fields_truncated,
+        "contexts_truncated": counters.contexts_truncated,
+        "search_complete": metadata.search_complete,
+        "tree_truncated": metadata.tree_truncated,
+        "unreadable_subtrees": metadata.unreadable_subtrees,
+        "unexposed_placeholders": metadata.unexposed_placeholders,
+    });
+    if let Some(id) = metadata.resolved_scope_id {
+        result["resolved_scope_id"] = json!(id);
+    }
+    let body = json!({ "matches": matches }).to_string();
+    ToolOutput::result_with(
+        "glass_find_elements",
+        result,
+        vec![OutContent::Text(crate::untrusted::wrap_untrusted(&body))],
+    )
+}
+
+fn match_json(matched: &RenderedMatch) -> Value {
+    json!({
+        "id": matched.id,
+        "role": matched.role,
+        "name": matched.name,
+        "description": matched.description,
+        "value": matched.value,
+        "bounds": matched.bounds,
+        "states": matched.states,
+        "matched_field": matched.matched_field,
+        "match_tier": matched.match_tier,
+        "context": matched.context,
+    })
+}
+
+fn shorten_lowest_ranked_context(
+    rendered: &mut [RenderedMatch],
+    counters: &mut FitCounters,
+) -> bool {
+    for matched in rendered.iter_mut().rev() {
+        if matched.context_stage >= 3 {
+            continue;
+        }
+        matched.context_stage += 1;
+        let limit = [usize::MAX, 512, 128, 0][matched.context_stage];
+        let shortened = truncate_text(&matched.context, limit, None);
+        let changed = shortened != matched.context;
+        matched.context = shortened;
+        if changed && !matched.context_counted {
+            matched.context_counted = true;
+            counters.contexts_truncated += 1;
+        }
+        return true;
+    }
+    false
+}
+
+fn shorten_lowest_ranked_field(rendered: &mut [RenderedMatch], counters: &mut FitCounters) -> bool {
+    for matched in rendered.iter_mut().rev() {
+        for index in (0..3).rev() {
+            if matched.field_stages[index] >= 3 || field(matched, index).is_none() {
+                continue;
+            }
+            matched.field_stages[index] += 1;
+            let limit = [usize::MAX, 256, 96, 0][matched.field_stages[index]];
+            let preserve = (matched.matched_field == Some(field_name(index)))
+                .then_some(matched.query.as_deref())
+                .flatten();
+            let shortened = truncate_text(
+                field(matched, index).as_deref().unwrap_or(""),
+                limit,
+                preserve,
+            );
+            let changed = field(matched, index).as_deref() != Some(shortened.as_str());
+            *field_mut(matched, index) = Some(shortened);
+            if changed && !matched.fields_counted[index] {
+                matched.fields_counted[index] = true;
+                counters.fields_truncated += 1;
+            }
+            return true;
+        }
+    }
+    false
+}
+
+fn field(matched: &RenderedMatch, index: usize) -> &Option<String> {
+    match index {
+        0 => &matched.name,
+        1 => &matched.description,
+        _ => &matched.value,
+    }
+}
+
+fn field_mut(matched: &mut RenderedMatch, index: usize) -> &mut Option<String> {
+    match index {
+        0 => &mut matched.name,
+        1 => &mut matched.description,
+        _ => &mut matched.value,
+    }
+}
+
+fn field_name(index: usize) -> &'static str {
+    match index {
+        0 => "name",
+        1 => "description",
+        _ => "value",
+    }
+}
+
+fn truncate_text(text: &str, max_bytes: usize, preserve: Option<&str>) -> String {
+    if text.len() <= max_bytes {
+        return text.to_owned();
+    }
+    if max_bytes == 0 {
+        return String::new();
+    }
+    let ellipsis = "…";
+    if max_bytes < ellipsis.len() {
+        return String::new();
+    }
+    let content_bytes = max_bytes - ellipsis.len();
+    let start = preserve
+        .filter(|needle| !needle.is_empty())
+        .and_then(|needle| text.to_lowercase().find(&needle.to_lowercase()))
+        .map(|position| position.saturating_sub(content_bytes / 3))
+        .unwrap_or(0);
+    let start = floor_char_boundary(text, start.min(text.len()));
+    let end = floor_char_boundary(text, (start + content_bytes).min(text.len()));
+    let mut output = String::new();
+    if start > 0 {
+        output.push('…');
+    }
+    output.push_str(&text[start..end]);
+    if end < text.len() {
+        output.push('…');
+    }
+    while output.len() > max_bytes {
+        let end = floor_char_boundary(&output, output.len().saturating_sub(1));
+        output.truncate(end);
+    }
+    output
+}
+
+fn floor_char_boundary(text: &str, mut index: usize) -> usize {
+    while index > 0 && !text.is_char_boundary(index) {
+        index -= 1;
+    }
+    index
+}
+
+fn text_bytes(output: &ToolOutput) -> usize {
+    output
+        .0
+        .iter()
+        .map(|content| match content {
+            OutContent::Text(text) => text.len(),
+            OutContent::Image(_) => 0,
+        })
+        .sum()
+}
+
+fn match_field_name(field: MatchField) -> &'static str {
+    match field {
+        MatchField::Name => "name",
+        MatchField::Description => "description",
+        MatchField::Value => "value",
+    }
+}
+
+fn match_tier_name(tier: MatchTier) -> &'static str {
+    match tier {
+        MatchTier::ExactName => "exact_name",
+        MatchTier::NameSubstring => "name_substring",
+        MatchTier::DescriptionSubstring => "description_substring",
+        MatchTier::ValueSubstring => "value_substring",
+        MatchTier::FilterOnly => "filter_only",
+    }
+}
+
+pub(crate) fn bounded_error(error: impl AsRef<str>) -> String {
+    let error = error.as_ref();
+    let safe = if error.starts_with("specify query, role, and/or states")
+        || error.starts_with("query must not be empty")
+        || error.starts_with("contradictory states:")
+        || error.starts_with("max_results must be between 1 and 20")
+        || error.starts_with("unknown role;")
+        || error.starts_with("unknown state;")
+        || error.starts_with("semantic scope matched ")
+        || error.starts_with("glass_find_elements ")
+    {
+        error
+    } else {
+        "glass_find_elements failed"
+    };
+    truncate_text(safe, FIND_RESPONSE_MAX_BYTES, None)
+}
+
+#[cfg(test)]
+#[allow(clippy::needless_as_bytes)]
+mod tests {
+    use super::*;
+    use crate::tools::testutil::*;
+
+    fn assert_valid_wrapped_match_json(output: &ToolOutput) {
+        let OutContent::Text(text) = &output.0[1] else {
+            panic!("text block")
+        };
+        let after_note = text.split_once('\n').unwrap().1;
+        let after_open = after_note.split_once('\n').unwrap().1;
+        let body = after_open.rsplit_once('\n').unwrap().0;
+        let value: serde_json::Value = serde_json::from_str(body).unwrap();
+        assert!(value["matches"].is_array());
+    }
+
+    #[test]
+    fn find_rejects_an_empty_selector_before_snapshotting() {
+        let reads = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mut glass = started_counted_a11y(reads.clone(), fake_tree());
+        let error = find_elements(
+            &mut glass,
+            &FindElementsArgs {
+                query: None,
+                role: None,
+                states: None,
+                within: None,
+                max_results: None,
+                max_nodes: None,
+                timeout_ms: None,
+            },
+        )
+        .unwrap_err();
+        assert!(error.contains("specify query, role, and/or states"));
+        assert_eq!(reads.load(std::sync::atomic::Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn find_rejects_unknown_contradictory_and_out_of_range_selectors() {
+        let mut glass = started_a11y_with(fake_tree());
+        let unknown_role = find_elements(
+            &mut glass,
+            &FindElementsArgs {
+                query: Some("save".into()),
+                role: Some("NotARole".into()),
+                states: None,
+                within: None,
+                max_results: None,
+                max_nodes: None,
+                timeout_ms: None,
+            },
+        )
+        .unwrap_err();
+        assert!(unknown_role.contains("unknown role"));
+        let contradictory = find_elements(
+            &mut glass,
+            &FindElementsArgs {
+                query: None,
+                role: Some("Button".into()),
+                states: Some(vec!["enabled".into(), "disabled".into()]),
+                within: None,
+                max_results: None,
+                max_nodes: None,
+                timeout_ms: None,
+            },
+        )
+        .unwrap_err();
+        assert!(contradictory.contains("contradictory states"));
+        let out_of_range = find_elements(
+            &mut glass,
+            &FindElementsArgs {
+                query: Some("save".into()),
+                role: None,
+                states: None,
+                within: None,
+                max_results: Some(21),
+                max_nodes: None,
+                timeout_ms: None,
+            },
+        )
+        .unwrap_err();
+        assert!(out_of_range.contains("between 1 and 20"));
+    }
+
+    #[test]
+    fn find_returns_trusted_counts_and_one_untrusted_match_array() {
+        let mut tree = fake_tree();
+        tree.root.children[0].name = Some("Save account".into());
+        let mut glass = started_a11y_with(tree);
+        let output = find_elements(
+            &mut glass,
+            &FindElementsArgs {
+                query: Some("save".into()),
+                role: Some("Button".into()),
+                states: Some(vec!["enabled".into()]),
+                within: None,
+                max_results: None,
+                max_nodes: None,
+                timeout_ms: None,
+            },
+        )
+        .unwrap();
+        let envelope = envelope_at(&output, 0);
+        assert_eq!(envelope["tool"], serde_json::json!("glass_find_elements"));
+        let result = &envelope["result"];
+        assert_eq!(result["matched"], serde_json::json!(true));
+        assert!(result.get("matches").is_none());
+        assert_eq!(output.0.len(), 2);
+        let OutContent::Text(untrusted) = &output.0[1] else {
+            panic!("text block")
+        };
+        assert!(untrusted.starts_with(crate::untrusted::NOTE));
+        assert!(untrusted.contains("\"name\":\"Save account\""));
+    }
+
+    #[test]
+    fn find_never_searches_or_returns_secure_values() {
+        let mut tree = fake_tree();
+        tree.root.children[0].states.secure = true;
+        tree.root.children[0].states.editable = true;
+        tree.root.children[0].value = Some("needle-secret".into());
+        let mut glass = started_a11y_with(tree);
+        let output = find_elements(
+            &mut glass,
+            &FindElementsArgs {
+                query: Some("needle".into()),
+                role: None,
+                states: None,
+                within: None,
+                max_results: None,
+                max_nodes: None,
+                timeout_ms: None,
+            },
+        )
+        .unwrap();
+        let envelope = envelope_at(&output, 0);
+        assert_eq!(envelope["tool"], serde_json::json!("glass_find_elements"));
+        assert_eq!(envelope["result"]["matched"], serde_json::json!(false));
+        assert!(!format!("{output:?}").contains("needle-secret"));
+    }
+
+    #[test]
+    fn find_success_and_error_responses_never_exceed_8192_bytes() {
+        let mut tree = fake_tree();
+        for index in 0..20 {
+            let mut node = tree.root.children[0].clone();
+            node.name = Some(format!("Save {index} {}", "x".repeat(20_000)));
+            node.description = Some("y".repeat(20_000));
+            node.value = Some("z".repeat(20_000));
+            tree.root.children.push(node);
+        }
+        tree.assign_ids();
+        let mut glass = started_a11y_with(tree);
+        let output = find_elements(
+            &mut glass,
+            &FindElementsArgs {
+                query: Some("save".into()),
+                role: None,
+                states: None,
+                within: None,
+                max_results: Some(20),
+                max_nodes: Some(0),
+                timeout_ms: None,
+            },
+        )
+        .unwrap();
+        assert!(text_bytes(&output) <= FIND_RESPONSE_MAX_BYTES);
+        assert_valid_wrapped_match_json(&output);
+        let error = bounded_error("e".repeat(20_000));
+        assert!(error.as_bytes().len() <= FIND_RESPONSE_MAX_BYTES);
+    }
+}

--- a/crates/glass-mcp/src/tools/find.rs
+++ b/crates/glass-mcp/src/tools/find.rs
@@ -66,7 +66,7 @@ pub fn find_elements(glass: &mut Glass, a: &FindElementsArgs) -> ToolResult {
             max_nodes: a.max_nodes.map(|value| value as usize),
             timeout_ms: a.timeout_ms.unwrap_or(0),
         })
-        .map_err(|_| bounded_error("glass_find_elements failed"))?;
+        .map_err(safe_operational_error)?;
 
     if let ScopeResolution::Ambiguous { observed } = outcome.result.scope {
         return Err(bounded_error(format!(
@@ -252,7 +252,11 @@ fn shorten_lowest_ranked_context(
         }
         matched.context_stage += 1;
         let limit = [usize::MAX, 512, 128, 0][matched.context_stage];
-        let shortened = truncate_text(&matched.context, limit, None);
+        let shortened = if limit == 0 && !matched.context.is_empty() {
+            "<context omitted>".to_owned()
+        } else {
+            truncate_text(&matched.context, limit, None)
+        };
         let changed = shortened != matched.context;
         matched.context = shortened;
         if changed && !matched.context_counted {
@@ -448,6 +452,39 @@ pub(crate) fn bounded_error(error: impl AsRef<str>) -> String {
     truncate_text(safe, FIND_RESPONSE_MAX_BYTES, None)
 }
 
+fn safe_operational_error(error: glass_core::GlassError) -> String {
+    let (category, guidance) = match error.cause() {
+        glass_core::GlassError::NoActiveSession => (
+            "no_active_session",
+            "Call glass_start before glass_find_elements.",
+        ),
+        glass_core::GlassError::AxUnsupported
+        | glass_core::GlassError::AccessibilityUnavailable(_) => (
+            "unsupported_accessibility",
+            "Use glass_screenshot for pixel-based inspection, or start with accessibility enabled.",
+        ),
+        glass_core::GlassError::PermissionDenied { .. } => (
+            "permission_denied",
+            "Grant the platform accessibility permission, then retry.",
+        ),
+        glass_core::GlassError::CaptureFailed(_)
+        | glass_core::GlassError::Backend(_)
+        | glass_core::GlassError::ToolFailed { .. }
+        | glass_core::GlassError::Bounded { .. }
+        | glass_core::GlassError::Io(_) => (
+            "transport_failure",
+            "Retry after checking the backend connection and app session.",
+        ),
+        _ => (
+            "other",
+            "Check the active session and accessibility setup before retrying.",
+        ),
+    };
+    bounded_error(format!(
+        "glass_find_elements failed [{category}]. {guidance}"
+    ))
+}
+
 #[cfg(test)]
 #[allow(clippy::needless_as_bytes)]
 mod tests {
@@ -484,6 +521,65 @@ mod tests {
         .unwrap_err();
         assert!(error.contains("specify query, role, and/or states"));
         assert_eq!(reads.load(std::sync::atomic::Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn find_rejects_whitespace_only_target_and_within_queries_before_snapshotting() {
+        let reads = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mut glass = started_counted_a11y(reads.clone(), fake_tree());
+        let target_error = find_elements(
+            &mut glass,
+            &FindElementsArgs {
+                query: Some(" \t ".into()),
+                role: None,
+                states: None,
+                within: None,
+                max_results: None,
+                max_nodes: None,
+                timeout_ms: None,
+            },
+        )
+        .unwrap_err();
+        assert!(target_error.contains("query must not be empty"));
+
+        let within_error = find_elements(
+            &mut glass,
+            &FindElementsArgs {
+                query: Some("save".into()),
+                role: None,
+                states: None,
+                within: Some(FindSelectorArgs {
+                    query: Some(" \n ".into()),
+                    role: None,
+                    states: None,
+                }),
+                max_results: None,
+                max_nodes: None,
+                timeout_ms: None,
+            },
+        )
+        .unwrap_err();
+        assert!(within_error.contains("query must not be empty"));
+        assert_eq!(reads.load(std::sync::atomic::Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn find_matches_queries_with_surrounding_whitespace() {
+        let mut glass = started_a11y_with(fake_tree());
+        let output = find_elements(
+            &mut glass,
+            &FindElementsArgs {
+                query: Some("  save  ".into()),
+                role: None,
+                states: None,
+                within: None,
+                max_results: None,
+                max_nodes: None,
+                timeout_ms: None,
+            },
+        )
+        .unwrap();
+        assert_eq!(envelope_at(&output, 0)["result"]["matched"], json!(true));
     }
 
     #[test]
@@ -614,6 +710,36 @@ mod tests {
     }
 
     #[test]
+    fn final_context_reduction_retains_an_explicit_omission_marker() {
+        let mut matched = RenderedMatch {
+            id: 1,
+            role: "Button".into(),
+            name: Some("Save".into()),
+            description: None,
+            value: None,
+            bounds: None,
+            states: Vec::new(),
+            matched_field: Some("name"),
+            match_tier: "exact_name",
+            context: "context detail ".repeat(100),
+            context_stage: 0,
+            field_stages: [0; 3],
+            fields_counted: [false; 3],
+            context_counted: false,
+            query: Some("save".into()),
+        };
+        let mut counters = FitCounters::default();
+        for _ in 0..3 {
+            assert!(shorten_lowest_ranked_context(
+                std::slice::from_mut(&mut matched),
+                &mut counters
+            ));
+        }
+        assert_eq!(matched.context, "<context omitted>");
+        assert_eq!(counters.contexts_truncated, 1);
+    }
+
+    #[test]
     fn find_redacts_secure_neighbor_values_from_successful_match_context() {
         let mut tree = fake_tree();
         let mut secure_neighbor = tree.root.children[0].clone();
@@ -676,5 +802,17 @@ mod tests {
         assert_valid_wrapped_match_json(&output);
         let error = bounded_error("e".repeat(20_000));
         assert!(error.as_bytes().len() <= FIND_RESPONSE_MAX_BYTES);
+    }
+
+    #[test]
+    fn permission_denial_keeps_a_safe_actionable_category() {
+        let error = safe_operational_error(glass_core::GlassError::PermissionDenied {
+            which: "accessibility".into(),
+            remedy: "backend-controlled-secret".into(),
+        });
+        assert!(error.contains("permission_denied"), "{error}");
+        assert!(error.contains("Grant the platform accessibility permission"));
+        assert!(!error.contains("backend-controlled-secret"));
+        assert!(error.len() <= FIND_RESPONSE_MAX_BYTES);
     }
 }

--- a/crates/glass-mcp/src/tools/testutil.rs
+++ b/crates/glass-mcp/src/tools/testutil.rs
@@ -288,6 +288,7 @@ pub enum InvokeOutcome {
 
 pub struct FakeAccessibility {
     pub tree: AxTree,
+    pub reads: std::sync::Arc<std::sync::atomic::AtomicUsize>,
     pub set_log: std::sync::Arc<std::sync::Mutex<Vec<(AxTarget, String)>>>,
     pub set_outcome: SetOutcome,
     pub invoke_outcome: InvokeOutcome,
@@ -295,6 +296,8 @@ pub struct FakeAccessibility {
 
 impl Accessibility for FakeAccessibility {
     fn snapshot(&mut self, _ctx: &AxContext) -> Result<AxTree> {
+        self.reads
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         Ok(self.tree.clone())
     }
     fn set_value(&mut self, _ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
@@ -489,6 +492,22 @@ fn glass_with_a11y_full(
     set_outcome: SetOutcome,
     invoke_outcome: InvokeOutcome,
 ) -> Glass {
+    glass_with_a11y_full_and_reads(
+        platform,
+        tree,
+        set_outcome,
+        invoke_outcome,
+        std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+    )
+}
+
+fn glass_with_a11y_full_and_reads(
+    platform: FakePlatform,
+    tree: AxTree,
+    set_outcome: SetOutcome,
+    invoke_outcome: InvokeOutcome,
+    reads: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+) -> Glass {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path().join("baselines");
     std::mem::forget(dir);
@@ -496,6 +515,7 @@ fn glass_with_a11y_full(
         platform: Box::new(platform),
         accessibility: Some(Box::new(FakeAccessibility {
             tree,
+            reads,
             set_log: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
             set_outcome,
             invoke_outcome,
@@ -506,6 +526,49 @@ fn glass_with_a11y_full(
             .ok_or_else(|| GlassError::Backend("test factory called twice".into()))
     });
     Glass::new(factory, "x11".into(), BaselineStore::new(root), 100)
+}
+
+pub fn started_a11y_with(tree: AxTree) -> Glass {
+    let mut glass = glass_with_a11y(FakePlatform::new(100, 100), tree);
+    glass
+        .start(&AppSpec {
+            build: None,
+            run: vec!["app".into()],
+            cwd: None,
+            env: Vec::new(),
+            window_hint: None,
+            timeout_ms: 1,
+            sandbox: glass_core::SandboxLevel::Off,
+            a11y: true,
+        })
+        .unwrap();
+    glass
+}
+
+pub fn started_counted_a11y(
+    reads: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    tree: AxTree,
+) -> Glass {
+    let mut glass = glass_with_a11y_full_and_reads(
+        FakePlatform::new(100, 100),
+        tree,
+        SetOutcome::Ok,
+        InvokeOutcome::Unsupported,
+        reads,
+    );
+    glass
+        .start(&AppSpec {
+            build: None,
+            run: vec!["app".into()],
+            cwd: None,
+            env: Vec::new(),
+            window_hint: None,
+            timeout_ms: 1,
+            sandbox: glass_core::SandboxLevel::Off,
+            a11y: true,
+        })
+        .unwrap();
+    glass
 }
 
 /// Parse content block `i` as the `{ok,tool,result}` envelope.

--- a/crates/glass-mcp/src/tools/testutil.rs
+++ b/crates/glass-mcp/src/tools/testutil.rs
@@ -571,6 +571,61 @@ pub fn started_counted_a11y(
     glass
 }
 
+pub fn started_without_a11y() -> Glass {
+    let mut glass = glass_with(FakePlatform::new(100, 100));
+    glass
+        .start(&AppSpec {
+            build: None,
+            run: vec!["app".into()],
+            cwd: None,
+            env: Vec::new(),
+            window_hint: None,
+            timeout_ms: 1,
+            sandbox: glass_core::SandboxLevel::Off,
+            a11y: false,
+        })
+        .unwrap();
+    glass
+}
+
+struct FailingAccessibility {
+    error: Option<GlassError>,
+}
+
+impl Accessibility for FailingAccessibility {
+    fn snapshot(&mut self, _ctx: &AxContext) -> Result<AxTree> {
+        Err(self.error.take().expect("scripted accessibility error"))
+    }
+}
+
+pub fn started_failing_a11y(error: GlassError) -> Glass {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().join("baselines");
+    std::mem::forget(dir);
+    let mut held = Some(Backend {
+        platform: Box::new(FakePlatform::new(100, 100)),
+        accessibility: Some(Box::new(FailingAccessibility { error: Some(error) })),
+    });
+    let factory: PlatformFactory = Box::new(move |_backend| {
+        held.take()
+            .ok_or_else(|| GlassError::Backend("test factory called twice".into()))
+    });
+    let mut glass = Glass::new(factory, "x11".into(), BaselineStore::new(root), 100);
+    glass
+        .start(&AppSpec {
+            build: None,
+            run: vec!["app".into()],
+            cwd: None,
+            env: Vec::new(),
+            window_hint: None,
+            timeout_ms: 1,
+            sandbox: glass_core::SandboxLevel::Off,
+            a11y: true,
+        })
+        .unwrap();
+    glass
+}
+
 /// Parse content block `i` as the `{ok,tool,result}` envelope.
 pub(crate) fn envelope_at(out: &ToolOutput, i: usize) -> serde_json::Value {
     let OutContent::Text(t) = &out.0[i] else {

--- a/docs/explanation/web-content.md
+++ b/docs/explanation/web-content.md
@@ -28,6 +28,23 @@ the readers glass already runs, with no extra lever pulled to get there.
 
 ## What an agent sees
 
+When the likely target is known, an agent can search within the published page:
+
+```json
+{
+  "query": "save",
+  "role": "Button",
+  "within": {
+    "role": "Document",
+    "states": ["visible"]
+  },
+  "timeout_ms": 5000
+}
+```
+
+`glass_find_elements` resolves the scope and targets from the same fresh accessibility read. The
+scope must identify one observed `Document`; a positive timeout can wait for delayed publication.
+
 Web content shows up in a `glass_a11y_snapshot` outline as one of three shapes, plus a fourth,
 older case that isn't specific to web content at all:
 

--- a/docs/how-to/drive-glass-well.md
+++ b/docs/how-to/drive-glass-well.md
@@ -6,8 +6,9 @@ several turns rediscovering the loop by trial and error. The habits that matter:
 
 - **Verify with cheap text before spending a screenshot** — save a baseline, act, then check
   `glass_diff` or a `glass_wait_for_*` call (all text-only) before decoding a new image.
-- **Fall back from the accessibility tree to pixels** — try `glass_a11y_snapshot` first for
-  deterministic element addressing, and drop to screenshots on a canvas/black-box app.
+- **Use accessibility before pixels** — try `glass_find_elements` first when you know approximate
+  text, role or state; use `glass_a11y_snapshot` for broad inspection; fall back to pixels only when
+  the app publishes no usable semantic tree.
 - **Pace drags** so a frame-based GUI samples the motion, and **reach for multi-touch** where the app
   needs it.
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -539,6 +539,37 @@ reads the Simulator's accessibility tree over `idb_companion` (install it — se
 [setup-ios.md](../how-to/setup-ios.md#input--accessibility)). See
 [reference/platforms.md](platforms.md) for per-OS backends (AT-SPI / UI Automation / uiautomator / AX / idb).
 
+### `glass_find_elements`
+
+Find a small ranked set of accessibility elements from one fresh bounded read. Use this when target
+text is approximate, duplicated, or not yet identified. Returned ids are actionable with the element
+tools and remain valid only until the UI changes.
+
+- `query` (string) — case-insensitive substring over accessible name, description and non-secure
+  value; optional when `role` or `states` is present.
+- `role` (string) — normalized target role.
+- `states` (array of string) — target predicates combined with AND.
+- `within` (object) — unique semantic scope with its own `query`, `role`, and `states`.
+- `max_results` (integer, default 10, range 1 through 20) — ranked result ceiling before the byte
+  budget.
+- `max_nodes` (integer) — the same walk-limit control as `glass_a11y_snapshot`.
+- `timeout_ms` (integer, default 0) — one read at zero; a positive value waits for at least one
+  match.
+
+Ranking is deterministic: exact name, name substring, description substring, value substring, then
+filter-only matches, with tree order breaking ties. Every match includes fixed compact context from
+up to four ancestors, the adjacent siblings, and up to three children. Target fields and the
+`within` fields each combine with AND. A `within` selector that matches more than one element is an
+ambiguous-scope error rather than a guessed scope.
+
+A positive soft timeout performs fresh bounded accessibility reads until a match arrives or the
+timeout expires, then returns trusted `matched`, `timed_out`, elapsed, scope, completeness,
+truncation, and omission counts. Secure values are never searched, ranked, returned, or copied into
+context. Application-derived match fields and context are contained in one nonce-delimited
+untrusted match block. Complete success and error text is limited to 8 KiB; lower-ranked context and
+fields may be shortened, then lower-ranked matches omitted, with the trusted counters reporting
+those omissions.
+
 ### `glass_a11y_snapshot`
 
 Capture the active window's accessibility tree as compact text. Returns `{}`; the tree itself
@@ -837,8 +868,8 @@ from:
   `glass_move`, `glass_do`
 - **multi_touch** → `glass_gesture`
 - **clipboard** → `glass_clipboard_get`, `glass_clipboard_set`
-- **accessibility** → `glass_a11y_snapshot`, `glass_a11y_marks`, `glass_click_element`,
-  `glass_set_value`, `glass_wait_for_element`, `glass_scroll_to_element`
+- **accessibility** → `glass_find_elements`, `glass_a11y_snapshot`, `glass_a11y_marks`,
+  `glass_click_element`, `glass_set_value`, `glass_wait_for_element`, `glass_scroll_to_element`
 - **window_move_resize** → `glass_window`
 
 For a valid backend **not** built into the running binary:

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -437,9 +437,10 @@ the event — glass reports the binary and its build info if yours does not. Oth
 ### `glass_do`
 
 Prefer `glass_do` whenever at least two upcoming actions or verification waits are already known.
-For a semantic form, take one fresh accessibility snapshot, retain the required ids, then put the
-mutations and `wait_for_element` confirmations in one call. Use standalone tools only when the next
-step depends on newly observed state, and inspect the structured outcomes before recovery.
+Use `glass_find_elements` for each target that is not already known, retain the returned ids, then
+put the known mutations and waits into `glass_do`. Use `glass_a11y_snapshot` only when the task
+genuinely needs broad tree inspection. Use standalone tools only when the next step depends on newly
+observed state, and inspect the structured outcomes before recovery.
 
 The call runs a bounded, fixed sequence, then optionally observes. The sequence is a static list: it
 cannot use variables, references to earlier results, interpolation, branching, loops, retries, or

--- a/examples/web-role-fixture/index.html
+++ b/examples/web-role-fixture/index.html
@@ -8,6 +8,14 @@
 <body>
 <h1>Glass web fixture</h1>
 <p id="intro">One page of plain HTML controls, read back through each platform's accessibility API.</p>
+<section aria-labelledby="account-heading">
+  <h2 id="account-heading">Account</h2>
+  <label for="account-name">Account name</label>
+  <input id="account-name" type="text" value="">
+  <button id="save-account" type="button">Save account</button>
+  <p id="account-status" aria-live="polite">Not saved</p>
+</section>
+<div id="large-page" aria-label="Large page sections"></div>
 <section>
   <a id="link" href="#intro">a link</a>
 </section>
@@ -40,6 +48,15 @@
   <iframe id="frame" title="nested document" srcdoc="<h2>inside the frame</h2><button type='button'>frame button</button>"></iframe>
 </section>
 <script>
+document.getElementById('save-account').addEventListener('click', function () {
+  document.getElementById('account-status').textContent = 'Saved';
+});
+const largePage = document.getElementById('large-page');
+for (let index = 0; index < 200; index += 1) {
+  const section = document.createElement('section');
+  section.innerHTML = `<h2>Repeated section ${index}</h2><p>Repeated account documentation ${index}</p>`;
+  largePage.appendChild(section);
+}
 document.getElementById('button').addEventListener('click', function () {
   document.getElementById('result').textContent = 'clicked';
 });


### PR DESCRIPTION
## Summary

- add semantic accessibility selectors, ranked matching, optional unique scopes, and bounded fresh-tree discovery in `glass-core`
- expose `glass_find_elements` through MCP with actionable IDs, compact context, secure-value exclusion, explicit completeness metadata, and an 8 KiB response ceiling
- share accessibility polling behavior, preserve caller deadlines, and document when to use targeted discovery versus snapshots or precise waits
- add unit, integration, and browser-probe coverage for large and incomplete accessibility trees

## Testing

- `cargo test -p glass-core -p glass-mcp`
- `cargo clippy --workspace --all-targets -- -D warnings`