### PR TITLE
Add reliable semantic click, set-value, and targeted typing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y xvfb at-spi2-core bubblewrap python3-gi gir1.2-gtk-4.0 gir1.2-gtk-3.0
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
-      - name: Measure coverage (unit + X11; Wayland/AT-SPI self-skip)
+      - name: Measure coverage
         run: ./scripts/coverage.sh --lcov
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,12 +85,12 @@ jobs:
         with:
           workspaces: .
       - name: Install system deps
-        # The suite launches a real GTK4 app (python3-gi + gir1.2-gtk-4.0) under an X server it
-        # starts itself, against glass's own private bus + AT-SPI registry (at-spi2-core).
+        # The suite launches real GTK4 and GTK3 apps (python3-gi plus both typelibs) under an X
+        # server it starts itself, against glass's own private bus + AT-SPI registry (at-spi2-core).
         # bubblewrap, and the AppArmor knob Ubuntu 24.04 restricts it with, are for the four tests
         # that read the tree from inside a sandbox.
         run: |
-          sudo apt-get update && sudo apt-get install -y xvfb bubblewrap python3-gi gir1.2-gtk-4.0 at-spi2-core
+          sudo apt-get update && sudo apt-get install -y xvfb bubblewrap python3-gi gir1.2-gtk-4.0 gir1.2-gtk-3.0 at-spi2-core
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
       # This suite owns every Linux accessibility fact the repo asserts — which role a GTK switch
       # arrives as, whether an event subscription actually stops a wait re-walking — and until now
@@ -234,10 +234,11 @@ jobs:
         # coverage.sh runs once it sees a display — absent, half the crate reports uncovered.
         # bubblewrap for the sandbox_* tests, whose unprivileged user namespaces Ubuntu 24.04
         # restricts via AppArmor (the sysctl is a no-op on images without the knob), and GTK4 for
-        # the software_render test's real app.
+        # the software_render test's real app. The full AT-SPI suite also launches its GTK3
+        # focus fixture, so install both GTK typelibs.
         run: |
           sudo apt-get update
-          sudo apt-get install -y xvfb at-spi2-core bubblewrap python3-gi gir1.2-gtk-4.0
+          sudo apt-get install -y xvfb at-spi2-core bubblewrap python3-gi gir1.2-gtk-4.0 gir1.2-gtk-3.0
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
       - name: Measure coverage (unit + X11; Wayland/AT-SPI self-skip)
         run: ./scripts/coverage.sh --lcov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ internal refactors, CI, or test-only changes.
 ## [Unreleased]
 
 ### Added
+- `glass_click_element`, `glass_set_value`, and `glass_type` can now resolve a unique semantic target immediately before acting, wait within one action deadline, and disclose native or pointer actionability and dispatch truth. Pointer actions refuse ambiguous, stale, disabled, hidden, moving, off-window, or provably occluded targets without unsafe retry; native accessibility actions may bypass geometry blockers. Existing ID actions and untargeted typing remain compatible.
 - `glass_find_elements` performs a fresh bounded accessibility search across native and published web content, returning up to 20 ranked actionable matches with semantic scope, optional publication waiting, compact context, explicit incompleteness, secure-value exclusion, and an 8 KiB total response ceiling.
 - Tool responses now share an 8 KiB text ceiling, with oversized logical blocks recoverable exactly through read-only `glass-artifact://` MCP resources backed by secure, ephemeral server-process artifacts.
 

--- a/README.md
+++ b/README.md
@@ -49,22 +49,25 @@ finish. (`glass-mcp doctor` checks your environment if anything's off.)
 ## The loop in practice
 
 Point an agent at a GUI app and it runs the whole cycle itself. When the app exposes an accessibility
-tree, the agent drives it semantically — addressing widgets by `#id` and confirming each step from
-text, no per-step screenshot:
+tree, the agent resolves each intended unique widget immediately before acting and confirms each step
+from text, with no per-step screenshot or carried element id:
 
 ```jsonc
-glass_start         { "run": ["python3", "app.py"] }
-glass_find_elements { "query": "account", "states": ["visible"] } // returns field #4 and Save #5
-glass_do            { "actions": [
-  { "action": "set_value", "id": 4, "text": "hello" },
-  { "action": "click_element", "id": 5 },
+glass_start { "run": ["python3", "app.py"] }
+glass_do { "actions": [
+  { "action": "set_value",
+    "target": { "query": "account", "role": "TextField", "states": ["enabled"] },
+    "text": "hello" },
+  { "action": "click_element",
+    "target": { "query": "Save", "role": "Button", "states": ["enabled"] },
+    "mode": "auto" },
   { "action": "wait_for_element", "name": "Saved" }
 ] }
 glass_logs
 ```
 
-Use `glass_a11y_snapshot` when the agent needs broad structural inspection rather than a small set
-of likely targets.
+Use `glass_find_elements` to inspect candidates when the intended target is not unique or known well
+enough to act on directly. Use `glass_a11y_snapshot` for broad structural diagnosis.
 
 For a canvas or custom-rendered app with no accessibility tree, drive it by pixels instead —
 `glass_screenshot`, `glass_click {x,y}`, and `glass_diff`, which returns `changed_pct` + a `bbox` as
@@ -87,9 +90,10 @@ named. On the backends that attempt it, the native path re-checks the element ag
 the live tree, so a click whose element no longer matches errors instead of clicking stale
 coordinates; the pointer-only paths have no such live check.
 
-Clicking a control the tree reports **disabled** is an error on the native path, not a tap that
-silently does nothing — a contract change if you were relying on a click that lands on a greyed-out
-button and reports success.
+Selector clicks resolve uniquely and disclose which checks were passed, failed, or unavailable.
+Forced pointer mode waits for stable in-window bounds and refuses a target known to be disabled,
+hidden, moving, off-window, or occluded. Native accessibility actions can legitimately actuate a
+covered or off-screen control, so geometry and occlusion are optional disclosures on that path.
 
 ## Install at a glance
 

--- a/crates/glass-a11y-linux/src/mapping.rs
+++ b/crates/glass-a11y-linux/src/mapping.rs
@@ -170,6 +170,62 @@ mod tests {
         assert!(m.checkable && !m.checked);
     }
 
+    macro_rules! state_witness {
+        ($name:ident, $state:ident, $field:ident) => {
+            #[test]
+            fn $name() {
+                assert_eq!(
+                    map_states(&StateSet::new(State::$state)),
+                    AxStates {
+                        $field: true,
+                        ..AxStates::default()
+                    }
+                );
+            }
+        };
+    }
+
+    state_witness!(focused_has_an_independent_atspi_witness, Focused, focused);
+    state_witness!(
+        focusable_has_an_independent_atspi_witness,
+        Focusable,
+        focusable
+    );
+    state_witness!(enabled_has_an_independent_atspi_witness, Enabled, enabled);
+    state_witness!(visible_has_an_independent_atspi_witness, Showing, visible);
+    state_witness!(
+        selected_has_an_independent_atspi_witness,
+        Selected,
+        selected
+    );
+    state_witness!(checked_has_an_independent_atspi_witness, Checked, checked);
+    state_witness!(
+        checkable_has_an_independent_atspi_witness,
+        Checkable,
+        checkable
+    );
+    state_witness!(
+        expanded_has_an_independent_atspi_witness,
+        Expanded,
+        expanded
+    );
+    state_witness!(
+        editable_has_an_independent_atspi_witness,
+        Editable,
+        editable
+    );
+
+    #[test]
+    fn sensitive_is_an_independent_enabled_witness() {
+        assert_eq!(
+            map_states(&StateSet::new(State::Sensitive)),
+            AxStates {
+                enabled: true,
+                ..AxStates::default()
+            }
+        );
+    }
+
     /// One AT-SPI role per normalized role — the witness list the parity test walks.
     const ROLE_SAMPLES: &[(Role, AxRole)] = &[
         (Role::Application, AxRole::Application),

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -11,8 +11,8 @@ use atspi::proxy::component::ComponentProxy;
 use atspi_common::{CoordType, ObjectRefOwned};
 use glass_core::{
     A11yMutationDispatch, A11yThread, Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxTarget,
-    AxTree, Deadline, GlassError, Result, WalkBudget, Whose, normalize_description, normalize_name,
-    read_back_confirms, write_took_no_effect,
+    AxTree, Deadline, GlassError, PointerHit, Result, WalkBudget, Whose, normalize_description,
+    normalize_name, read_back_confirms, write_took_no_effect,
 };
 
 use crate::mapping::{map_role, map_states};
@@ -41,6 +41,42 @@ impl Accessibility for LinuxA11y {
     fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
         let ctx = ctx.clone();
         BUS.snapshot(ctx.deadline, move || run_snapshot(&ctx))
+    }
+
+    fn state_coverage(&self) -> glass_core::AxStateCoverage {
+        glass_core::AxStateCoverage {
+            enabled: true,
+            visible: true,
+            checkable: true,
+            checked: true,
+            selected: true,
+            expanded: true,
+            focused: true,
+            focusable: true,
+            editable: true,
+        }
+    }
+
+    fn focus(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<Option<AxNodeId>> {
+        let ctx = ctx.clone();
+        let target = target.clone();
+        BUS.focus(ctx.deadline, move |dispatch| {
+            run_focus(&ctx, &target, dispatch)
+        })?;
+        Ok(None)
+    }
+
+    fn pointer_target_at(
+        &mut self,
+        ctx: &AxContext,
+        target: &AxTarget,
+        point: (i32, i32),
+    ) -> Result<PointerHit> {
+        let ctx = ctx.clone();
+        let target = target.clone();
+        BUS.snapshot(ctx.deadline, move || {
+            run_pointer_target_at(&ctx, &target, point)
+        })
     }
 
     fn set_value(&mut self, ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
@@ -107,6 +143,26 @@ fn run_invoke(ctx: &AxContext, target: &AxTarget, dispatch: &A11yMutationDispatc
         .build()
         .map_err(|e| GlassError::AccessibilityUnavailable(format!("runtime: {e}")))?;
     rt.block_on(invoke_async(ctx, target, dispatch))
+}
+
+fn run_focus(ctx: &AxContext, target: &AxTarget, dispatch: &A11yMutationDispatch) -> Result<()> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| GlassError::AccessibilityUnavailable(format!("runtime: {e}")))?;
+    rt.block_on(focus_async(ctx, target, dispatch))
+}
+
+fn run_pointer_target_at(
+    ctx: &AxContext,
+    target: &AxTarget,
+    point: (i32, i32),
+) -> Result<PointerHit> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| GlassError::AccessibilityUnavailable(format!("runtime: {e}")))?;
+    rt.block_on(pointer_target_at_async(ctx, target, point))
 }
 
 fn bus_err(e: impl std::fmt::Display) -> GlassError {
@@ -742,11 +798,242 @@ enum NativeInvokeKind {
     Activate,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum NativeFocusKind {
+    Focus,
+    Unsupported,
+}
+
+fn native_focus_kind(role: glass_core::AxRole) -> NativeFocusKind {
+    match role {
+        glass_core::AxRole::TextField | glass_core::AxRole::TextArea => NativeFocusKind::Focus,
+        _ => NativeFocusKind::Unsupported,
+    }
+}
+
 fn native_invoke_kind(role: glass_core::AxRole) -> NativeInvokeKind {
     match role {
         glass_core::AxRole::TextField | glass_core::AxRole::TextArea => NativeInvokeKind::Focus,
         _ => NativeInvokeKind::Activate,
     }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ObjectIdentity<'a> {
+    bus_name: &'a str,
+    object_path: &'a str,
+}
+
+impl<'a> ObjectIdentity<'a> {
+    const fn new(bus_name: &'a str, object_path: &'a str) -> Self {
+        Self {
+            bus_name,
+            object_path,
+        }
+    }
+
+    fn from_object_ref(object: &'a ObjectRefOwned) -> Option<Self> {
+        Some(Self::new(object.name_as_str()?, object.path_as_str()))
+    }
+}
+
+fn classify_hit_reference(
+    target: ObjectIdentity<'_>,
+    accepted_ancestor: Option<ObjectIdentity<'_>>,
+    hit: Option<ObjectIdentity<'_>>,
+) -> glass_core::PointerHit {
+    let Some(hit) = hit else {
+        return glass_core::PointerHit::Inconclusive;
+    };
+    if hit == target {
+        glass_core::PointerHit::Target
+    } else if Some(hit) == accepted_ancestor {
+        glass_core::PointerHit::AcceptedAncestor
+    } else {
+        glass_core::PointerHit::Other
+    }
+}
+
+const POINTER_HIT_OP: &str = "pointer hit probe";
+
+fn pointer_reference_error(detail: impl std::fmt::Display) -> GlassError {
+    GlassError::AccessibilityUnavailable(format!("AT-SPI pointer hit probe failed: {detail}"))
+}
+
+fn required_object_identity(object: &ObjectRefOwned) -> Result<ObjectIdentity<'_>> {
+    ObjectIdentity::from_object_ref(object)
+        .ok_or_else(|| pointer_reference_error("malformed non-null object reference"))
+}
+
+async fn pointer_bus_call<T, F>(deadline: Deadline, operation: &str, future: F) -> Result<T>
+where
+    F: std::future::Future<Output = zbus::Result<T>>,
+{
+    if deadline.has_passed() {
+        return Err(GlassError::deadline_not_started(POINTER_HIT_OP));
+    }
+    await_caller_deadline(deadline, future)
+        .await
+        .map_err(|()| GlassError::caller_deadline_elapsed(POINTER_HIT_OP))?
+        .map_err(|e| pointer_reference_error(format!("{operation}: {e}")))
+}
+
+async fn pointer_accessible<'a>(
+    conn: &'a zbus::Connection,
+    object: &'a ObjectRefOwned,
+) -> Result<AccessibleProxy<'a>> {
+    if object.is_null() {
+        return Err(pointer_reference_error("unexpected null object reference"));
+    }
+    object
+        .as_accessible_proxy(conn)
+        .await
+        .map_err(|e| pointer_reference_error(format!("accessible proxy: {e}")))
+}
+
+async fn pointer_component<'a>(
+    ctx: &AxContext,
+    conn: &'a zbus::Connection,
+    object: &'a ObjectRefOwned,
+) -> Result<ComponentProxy<'a>> {
+    let identity = required_object_identity(object)?;
+    let builder = ComponentProxy::builder(conn)
+        .destination(identity.bus_name)
+        .map_err(|e| pointer_reference_error(format!("component destination: {e}")))?
+        .path(identity.object_path)
+        .map_err(|e| pointer_reference_error(format!("component path: {e}")))?;
+    pointer_bus_call(ctx.deadline, "component proxy", builder.build()).await
+}
+
+async fn pointer_window_root(
+    ctx: &AxContext,
+    conn: &zbus::Connection,
+    app_ref: &ObjectRefOwned,
+    app: &AccessibleProxy<'_>,
+) -> Result<ObjectRefOwned> {
+    let children =
+        pointer_bus_call(ctx.deadline, "application children", app.get_children()).await?;
+    for child in children.into_iter().take(ctx.limits.siblings) {
+        let child_proxy = pointer_accessible(conn, &child).await?;
+        let role = pointer_bus_call(ctx.deadline, "window role", child_proxy.get_role()).await?;
+        if map_role(role) == glass_core::AxRole::Window {
+            return Ok(child);
+        }
+    }
+    Ok(app_ref.clone())
+}
+
+async fn first_interactable_ancestor(
+    ctx: &AxContext,
+    conn: &zbus::Connection,
+    target_ref: &ObjectRefOwned,
+) -> Result<Option<ObjectRefOwned>> {
+    let mut current = target_ref.clone();
+    let mut seen = vec![current.clone()];
+    for _ in 0..ctx.limits.depth {
+        let current_proxy = pointer_accessible(conn, &current).await?;
+        let parent =
+            pointer_bus_call(ctx.deadline, "ancestor parent", current_proxy.parent()).await?;
+        if parent.is_null() {
+            return Ok(None);
+        }
+        if seen.contains(&parent) {
+            return Err(pointer_reference_error("cyclic ancestor references"));
+        }
+        let parent_proxy = pointer_accessible(conn, &parent).await?;
+        let role = pointer_bus_call(ctx.deadline, "ancestor role", parent_proxy.get_role()).await?;
+        if map_role(role).is_interactable() {
+            return Ok(Some(parent));
+        }
+        seen.push(parent.clone());
+        current = parent;
+    }
+    Err(pointer_reference_error(format!(
+        "ancestor walk exceeded the configured depth limit ({})",
+        ctx.limits.depth
+    )))
+}
+
+async fn classify_pointer_hit(
+    ctx: &AxContext,
+    conn: &zbus::Connection,
+    target_ref: &ObjectRefOwned,
+    accepted_ancestor: Option<&ObjectRefOwned>,
+    hit: ObjectRefOwned,
+) -> Result<PointerHit> {
+    if hit.is_null() {
+        return Ok(PointerHit::Inconclusive);
+    }
+    let target_identity = required_object_identity(target_ref)?;
+    let accepted_identity = accepted_ancestor
+        .map(required_object_identity)
+        .transpose()?;
+    let mut current = hit;
+    let mut seen = Vec::new();
+    for _ in 0..=ctx.limits.depth {
+        let current_identity = required_object_identity(&current)?;
+        let classification =
+            classify_hit_reference(target_identity, accepted_identity, Some(current_identity));
+        if classification != PointerHit::Other {
+            return Ok(classification);
+        }
+        if seen.contains(&current) {
+            return Err(pointer_reference_error("cyclic hit ancestry"));
+        }
+        seen.push(current.clone());
+        let current_proxy = pointer_accessible(conn, &current).await?;
+        let role = pointer_bus_call(ctx.deadline, "hit role", current_proxy.get_role()).await?;
+        if map_role(role).is_interactable() {
+            return Ok(PointerHit::Other);
+        }
+        let parent = pointer_bus_call(ctx.deadline, "hit parent", current_proxy.parent()).await?;
+        if parent.is_null() {
+            return Ok(PointerHit::Other);
+        }
+        current = parent;
+    }
+    Err(pointer_reference_error(format!(
+        "hit ancestry exceeded the configured depth limit ({})",
+        ctx.limits.depth
+    )))
+}
+
+async fn pointer_target_at_async(
+    ctx: &AxContext,
+    target: &AxTarget,
+    point: (i32, i32),
+) -> Result<PointerHit> {
+    if ctx.deadline.has_passed() {
+        return Err(GlassError::deadline_not_started(POINTER_HIT_OP));
+    }
+    let (app_ref, conn) = find_app(ctx).await?;
+    let app = app_ref.as_accessible_proxy(&conn).await.map_err(bus_err)?;
+    let mut budget = WalkBudget::with_limits(ctx.limits);
+    let target_ref = Box::pin(find_nth(&app_ref, &app, &conn, 0, target.id.0, &mut budget))
+        .await?
+        .ok_or(GlassError::AxElementChanged(target.id.0))?;
+    let target_proxy = pointer_accessible(&conn, &target_ref).await?;
+    let role =
+        map_role(pointer_bus_call(ctx.deadline, "target role", target_proxy.get_role()).await?);
+    let name = nonempty(pointer_bus_call(ctx.deadline, "target name", target_proxy.name()).await?);
+    if !target.matches(role, name.as_deref()) {
+        return Err(GlassError::AxElementChanged(target.id.0));
+    }
+
+    let accepted_ancestor = if role.is_interactable() {
+        None
+    } else {
+        first_interactable_ancestor(ctx, &conn, &target_ref).await?
+    };
+    let root_ref = pointer_window_root(ctx, &conn, &app_ref, &app).await?;
+    let component = pointer_component(ctx, &conn, &root_ref).await?;
+    let hit = pointer_bus_call(
+        ctx.deadline,
+        "GetAccessibleAtPoint",
+        component.get_accessible_at_point(point.0, point.1, CoordType::Window),
+    )
+    .await?;
+    classify_pointer_hit(ctx, &conn, &target_ref, accepted_ancestor.as_ref(), hit).await
 }
 
 const FOCUS_CONFIRM_POLL: Duration = Duration::from_millis(10);
@@ -965,6 +1252,30 @@ async fn invoke_async(
     }
 }
 
+async fn focus_async(
+    ctx: &AxContext,
+    target: &AxTarget,
+    dispatch: &A11yMutationDispatch,
+) -> Result<()> {
+    let (app_ref, conn) = find_app(ctx).await?;
+    let app = app_ref.as_accessible_proxy(&conn).await.map_err(bus_err)?;
+    let mut budget = WalkBudget::with_limits(ctx.limits);
+    let node_ref = Box::pin(find_nth(&app_ref, &app, &conn, 0, target.id.0, &mut budget))
+        .await?
+        .ok_or(GlassError::AxElementChanged(target.id.0))?;
+    let node = node_ref.as_accessible_proxy(&conn).await.map_err(bus_err)?;
+    let role = map_role(node.get_role().await.map_err(bus_err)?);
+    let name = nonempty(node.name().await.unwrap_or_default());
+    if !target.matches(role, name.as_deref()) {
+        return Err(GlassError::AxElementChanged(target.id.0));
+    }
+    let states = map_states(&node.get_state().await.map_err(bus_err)?);
+    if native_focus_kind(role) != NativeFocusKind::Focus || !states.editable {
+        return Err(GlassError::AxActionUnavailable(target.id.0));
+    }
+    focus_text_editor(ctx, &conn, &node, target.id.0, dispatch).await
+}
+
 /// Window-relative bounds via the Component interface, or `None` if the node has no
 /// geometry / doesn't implement Component / reports a zero-area rect.
 ///
@@ -1106,6 +1417,24 @@ mod tests {
     use super::*;
 
     #[test]
+    fn linux_reader_declares_every_state_fact_its_atspi_mapping_populates() {
+        assert_eq!(
+            LinuxA11y::new().state_coverage(),
+            glass_core::AxStateCoverage {
+                enabled: true,
+                visible: true,
+                checkable: true,
+                checked: true,
+                selected: true,
+                expanded: true,
+                focused: true,
+                focusable: true,
+                editable: true,
+            }
+        );
+    }
+
+    #[test]
     fn linux_set_value_forwards_ax_context_deadline_to_a11y_thread() {
         let ctx = AxContext {
             pids: vec![],
@@ -1233,35 +1562,39 @@ mod tests {
     fn text_roles_use_native_focus_and_other_controls_activate() {
         use glass_core::AxRole::*;
 
-        for role in [TextField, TextArea] {
-            assert_eq!(
-                native_invoke_kind(role),
-                NativeInvokeKind::Focus,
-                "{role:?}"
-            );
-        }
-        for role in [
-            Button,
-            ToggleButton,
-            CheckBox,
-            ComboBox,
-            SpinButton,
-            Slider,
-            Link,
-            MenuItem,
-        ] {
-            assert_eq!(
-                native_invoke_kind(role),
-                NativeInvokeKind::Activate,
-                "{role:?}"
-            );
-        }
+        assert_eq!(native_focus_kind(TextField), NativeFocusKind::Focus);
+        assert_eq!(native_focus_kind(TextArea), NativeFocusKind::Focus);
+        assert_eq!(native_focus_kind(Button), NativeFocusKind::Unsupported);
+        assert_eq!(native_invoke_kind(TextField), NativeInvokeKind::Focus);
+        assert_eq!(native_invoke_kind(Button), NativeInvokeKind::Activate);
+    }
+
+    #[test]
+    fn hit_classifier_accepts_target_or_its_actuating_ancestor_and_rejects_another_branch() {
+        let target = ObjectIdentity::new(":1.42", "/app/window/save/label");
+        let ancestor = ObjectIdentity::new(":1.42", "/app/window/save");
+        let other = ObjectIdentity::new(":1.42", "/app/window/occluder");
+        let same_path_on_another_bus = ObjectIdentity::new(":1.43", "/app/window/save/label");
+
         assert_eq!(
-            glass_core::AxRole::ALL
-                .into_iter()
-                .filter(|&role| native_invoke_kind(role) == NativeInvokeKind::Focus)
-                .collect::<Vec<_>>(),
-            vec![TextField, TextArea]
+            classify_hit_reference(target, Some(ancestor), Some(target)),
+            glass_core::PointerHit::Target
+        );
+        assert_eq!(
+            classify_hit_reference(target, Some(ancestor), Some(ancestor)),
+            glass_core::PointerHit::AcceptedAncestor
+        );
+        assert_eq!(
+            classify_hit_reference(target, Some(ancestor), Some(other)),
+            glass_core::PointerHit::Other
+        );
+        assert_eq!(
+            classify_hit_reference(target, Some(ancestor), Some(same_path_on_another_bus)),
+            glass_core::PointerHit::Other
+        );
+        assert_eq!(
+            classify_hit_reference(target, Some(ancestor), None),
+            glass_core::PointerHit::Inconclusive
         );
     }
 

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -865,9 +865,10 @@ fn required_object_identity(object: &ObjectRefOwned) -> Result<ObjectIdentity<'_
         .ok_or_else(|| pointer_reference_error("malformed non-null object reference"))
 }
 
-async fn pointer_bus_call<T, F>(deadline: Deadline, operation: &str, future: F) -> Result<T>
+async fn pointer_bus_call<T, E, F>(deadline: Deadline, operation: &str, future: F) -> Result<T>
 where
-    F: std::future::Future<Output = zbus::Result<T>>,
+    E: std::fmt::Display,
+    F: std::future::Future<Output = std::result::Result<T, E>>,
 {
     if deadline.has_passed() {
         return Err(GlassError::deadline_not_started(POINTER_HIT_OP));
@@ -876,6 +877,25 @@ where
         .await
         .map_err(|()| GlassError::caller_deadline_elapsed(POINTER_HIT_OP))?
         .map_err(|e| pointer_reference_error(format!("{operation}: {e}")))
+}
+
+fn validate_strict_reference<'a>(
+    object: &'a ObjectRefOwned,
+    description: &str,
+) -> Result<ObjectIdentity<'a>> {
+    ObjectIdentity::from_object_ref(object).ok_or_else(|| {
+        pointer_reference_error(format!(
+            "{description} is an explicit null object reference"
+        ))
+    })
+}
+
+fn strict_pid_match(pids: &[u32], pid: Result<u32>) -> Result<bool> {
+    if pids.is_empty() {
+        Ok(true)
+    } else {
+        Ok(pids.contains(&pid?))
+    }
 }
 
 async fn pointer_accessible<'a>(
@@ -905,22 +925,173 @@ async fn pointer_component<'a>(
     pointer_bus_call(ctx.deadline, "component proxy", builder.build()).await
 }
 
-async fn pointer_window_root(
-    ctx: &AxContext,
-    conn: &zbus::Connection,
-    app_ref: &ObjectRefOwned,
-    app: &AccessibleProxy<'_>,
-) -> Result<ObjectRefOwned> {
-    let children =
-        pointer_bus_call(ctx.deadline, "application children", app.get_children()).await?;
-    for child in children.into_iter().take(ctx.limits.siblings) {
-        let child_proxy = pointer_accessible(conn, &child).await?;
-        let role = pointer_bus_call(ctx.deadline, "window role", child_proxy.get_role()).await?;
-        if map_role(role) == glass_core::AxRole::Window {
-            return Ok(child);
+/// Pointer-action app lookup. Unlike snapshot discovery, every registry reference and PID read is
+/// evidence used for an action decision, so an unreadable entry is an error rather than a skipped
+/// non-match.
+async fn find_app_strict(ctx: &AxContext) -> Result<(ObjectRefOwned, zbus::Connection)> {
+    let conn = match ctx.a11y_bus_addr.as_deref() {
+        Some(addr) => {
+            let parsed = addr.try_into().map_err(|e| {
+                GlassError::AccessibilityUnavailable(format!("bad a11y address: {e}"))
+            })?;
+            pointer_bus_call(
+                ctx.deadline,
+                "private accessibility bus connection",
+                AccessibilityConnection::from_address(parsed),
+            )
+            .await?
+        }
+        None => {
+            return Err(GlassError::AccessibilityUnavailable(
+                "no accessibility bus for this launch — relaunch the app with a11y:true \
+                 to enable the accessibility tree (Linux)"
+                    .into(),
+            ));
+        }
+    };
+    let zbus_conn = conn.connection().clone();
+    let root = pointer_bus_call(
+        ctx.deadline,
+        "registry root",
+        conn.root_accessible_on_registry(),
+    )
+    .await?;
+    let app_refs =
+        pointer_bus_call(ctx.deadline, "registry applications", root.get_children()).await?;
+    let dbus = if ctx.pids.is_empty() {
+        None
+    } else {
+        Some(
+            pointer_bus_call(
+                ctx.deadline,
+                "D-Bus proxy",
+                zbus::fdo::DBusProxy::new(&zbus_conn),
+            )
+            .await?,
+        )
+    };
+    for app_ref in app_refs {
+        let identity = validate_strict_reference(&app_ref, "registry application")?;
+        let _app = pointer_accessible(&zbus_conn, &app_ref).await?;
+        let pid = match &dbus {
+            Some(dbus) => pointer_bus_call(
+                ctx.deadline,
+                "application PID",
+                dbus.get_connection_unix_process_id(
+                    app_ref
+                        .name()
+                        .expect("a validated non-null reference has a unique name")
+                        .clone()
+                        .into(),
+                ),
+            )
+            .await
+            .map_err(|e| {
+                pointer_reference_error(format!(
+                    "application {} PID lookup: {e}",
+                    identity.bus_name
+                ))
+            }),
+            None => Ok(0),
+        };
+        if strict_pid_match(&ctx.pids, pid)? {
+            return Ok((app_ref, zbus_conn));
         }
     }
-    Ok(app_ref.clone())
+    Err(GlassError::AccessibilityNotReady(no_app_tree_message(
+        &ctx.pids,
+    )))
+}
+
+/// Action rewalk with the same pre-order and bounds as [`find_nth`], but without its
+/// snapshot-compatible null/proxy skips. Skipping here could shift the requested id onto another
+/// object, so every unreadable reference propagates.
+async fn find_nth_strict(
+    ctx: &AxContext,
+    node_ref: &ObjectRefOwned,
+    proxy: &AccessibleProxy<'_>,
+    conn: &zbus::Connection,
+    depth: usize,
+    target: u32,
+    budget: &mut WalkBudget,
+) -> Result<Option<ObjectRefOwned>> {
+    validate_strict_reference(node_ref, "walk node")?;
+    if budget.nodes_walked() == target as usize {
+        return Ok(Some(node_ref.clone()));
+    }
+    budget.visit();
+    let child_refs =
+        pointer_bus_call(ctx.deadline, "target walk children", proxy.get_children()).await?;
+    if child_refs.is_empty() || !budget.may_explore_children(depth) {
+        return Ok(None);
+    }
+    for (scanned, child_ref) in child_refs.into_iter().enumerate() {
+        if !budget.may_visit_sibling(scanned) {
+            break;
+        }
+        validate_strict_reference(&child_ref, "target walk child")?;
+        let child = pointer_accessible(conn, &child_ref).await?;
+        if let Some(found) = Box::pin(find_nth_strict(
+            ctx,
+            &child_ref,
+            &child,
+            conn,
+            depth + 1,
+            target,
+            budget,
+        ))
+        .await?
+        {
+            return Ok(Some(found));
+        }
+    }
+    Ok(None)
+}
+
+fn is_window_coordinate_root(role: atspi_common::Role) -> bool {
+    matches!(
+        role,
+        atspi_common::Role::Frame
+            | atspi_common::Role::Window
+            | atspi_common::Role::Dialog
+            | atspi_common::Role::Alert
+            | atspi_common::Role::FileChooser
+            | atspi_common::Role::ColorChooser
+            | atspi_common::Role::FontChooser
+    )
+}
+
+async fn containing_window_root(
+    ctx: &AxContext,
+    conn: &zbus::Connection,
+    target_ref: &ObjectRefOwned,
+) -> Result<ObjectRefOwned> {
+    let mut current = target_ref.clone();
+    let mut seen = Vec::new();
+    for _ in 0..=ctx.limits.depth {
+        validate_strict_reference(&current, "target ancestry object")?;
+        if seen.contains(&current) {
+            return Err(pointer_reference_error("cyclic target ancestry"));
+        }
+        seen.push(current.clone());
+        let proxy = pointer_accessible(conn, &current).await?;
+        let role = pointer_bus_call(ctx.deadline, "target ancestor role", proxy.get_role()).await?;
+        if is_window_coordinate_root(role) {
+            return Ok(current);
+        }
+        let parent =
+            pointer_bus_call(ctx.deadline, "target ancestor parent", proxy.parent()).await?;
+        if parent.is_null() {
+            return Err(pointer_reference_error(
+                "target has no containing window, frame, or dialog",
+            ));
+        }
+        current = parent;
+    }
+    Err(pointer_reference_error(format!(
+        "target ancestry exceeded the configured depth limit ({})",
+        ctx.limits.depth
+    )))
 }
 
 async fn first_interactable_ancestor(
@@ -1006,12 +1177,20 @@ async fn pointer_target_at_async(
     if ctx.deadline.has_passed() {
         return Err(GlassError::deadline_not_started(POINTER_HIT_OP));
     }
-    let (app_ref, conn) = find_app(ctx).await?;
-    let app = app_ref.as_accessible_proxy(&conn).await.map_err(bus_err)?;
+    let (app_ref, conn) = find_app_strict(ctx).await?;
+    let app = pointer_accessible(&conn, &app_ref).await?;
     let mut budget = WalkBudget::with_limits(ctx.limits);
-    let target_ref = Box::pin(find_nth(&app_ref, &app, &conn, 0, target.id.0, &mut budget))
-        .await?
-        .ok_or(GlassError::AxElementChanged(target.id.0))?;
+    let target_ref = Box::pin(find_nth_strict(
+        ctx,
+        &app_ref,
+        &app,
+        &conn,
+        0,
+        target.id.0,
+        &mut budget,
+    ))
+    .await?
+    .ok_or(GlassError::AxElementChanged(target.id.0))?;
     let target_proxy = pointer_accessible(&conn, &target_ref).await?;
     let role =
         map_role(pointer_bus_call(ctx.deadline, "target role", target_proxy.get_role()).await?);
@@ -1025,7 +1204,7 @@ async fn pointer_target_at_async(
     } else {
         first_interactable_ancestor(ctx, &conn, &target_ref).await?
     };
-    let root_ref = pointer_window_root(ctx, &conn, &app_ref, &app).await?;
+    let root_ref = containing_window_root(ctx, &conn, &target_ref).await?;
     let component = pointer_component(ctx, &conn, &root_ref).await?;
     let hit = pointer_bus_call(
         ctx.deadline,
@@ -1596,6 +1775,36 @@ mod tests {
             classify_hit_reference(target, Some(ancestor), None),
             glass_core::PointerHit::Inconclusive
         );
+    }
+
+    #[test]
+    fn strict_pointer_lookup_rejects_null_references_and_propagates_pid_failures() {
+        let null = ObjectRefOwned::new(ObjectRef::Null);
+        assert!(validate_strict_reference(&null, "registry application").is_err());
+
+        let error = strict_pid_match(
+            &[42],
+            Err(pointer_reference_error("PID lookup permission denied")),
+        )
+        .expect_err("a PID lookup failure is not an absent application");
+        assert!(error.to_string().contains("permission denied"));
+    }
+
+    #[test]
+    fn pointer_window_coordinate_root_roles_include_frames_and_dialogs_but_not_applications() {
+        for role in [
+            atspi_common::Role::Frame,
+            atspi_common::Role::Window,
+            atspi_common::Role::Dialog,
+            atspi_common::Role::Alert,
+            atspi_common::Role::FileChooser,
+            atspi_common::Role::ColorChooser,
+            atspi_common::Role::FontChooser,
+        ] {
+            assert!(is_window_coordinate_root(role), "{role:?}");
+        }
+        assert!(!is_window_coordinate_root(atspi_common::Role::Application));
+        assert!(!is_window_coordinate_root(atspi_common::Role::Panel));
     }
 
     #[test]

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -898,6 +898,13 @@ fn strict_pid_match(pids: &[u32], pid: Result<u32>) -> Result<bool> {
     }
 }
 
+fn contextualize_pid_lookup_error(bus_name: &str, error: GlassError) -> GlassError {
+    match error {
+        error @ GlassError::Bounded { .. } => error,
+        error => pointer_reference_error(format!("application {bus_name} PID lookup: {error}")),
+    }
+}
+
 async fn pointer_accessible<'a>(
     conn: &'a zbus::Connection,
     object: &'a ObjectRefOwned,
@@ -986,12 +993,7 @@ async fn find_app_strict(ctx: &AxContext) -> Result<(ObjectRefOwned, zbus::Conne
                 ),
             )
             .await
-            .map_err(|e| {
-                pointer_reference_error(format!(
-                    "application {} PID lookup: {e}",
-                    identity.bus_name
-                ))
-            }),
+            .map_err(|error| contextualize_pid_lookup_error(identity.bus_name, error)),
             None => Ok(0),
         };
         if strict_pid_match(&ctx.pids, pid)? {
@@ -1782,12 +1784,31 @@ mod tests {
         let null = ObjectRefOwned::new(ObjectRef::Null);
         assert!(validate_strict_reference(&null, "registry application").is_err());
 
-        let error = strict_pid_match(
-            &[42],
-            Err(pointer_reference_error("PID lookup permission denied")),
-        )
-        .expect_err("a PID lookup failure is not an absent application");
+        let pid_error = contextualize_pid_lookup_error(
+            ":1.42",
+            pointer_reference_error("PID lookup permission denied"),
+        );
+        let error = strict_pid_match(&[42], Err(pid_error))
+            .expect_err("a PID lookup failure is not an absent application");
         assert!(error.to_string().contains("permission denied"));
+        assert!(error.to_string().contains(":1.42"));
+    }
+
+    #[test]
+    fn strict_pid_lookup_timeout_preserves_exact_deadline_metadata() {
+        let timeout = GlassError::caller_deadline_elapsed(POINTER_HIT_OP);
+        let original_message = timeout.to_string();
+
+        let error = contextualize_pid_lookup_error(":1.42", timeout);
+
+        assert!(matches!(error, GlassError::Bounded { .. }), "{error}");
+        assert_eq!(error.bound(), Some(glass_core::BoundKind::TimedOut));
+        assert_eq!(error.bound_owner(), Some(Whose::Caller));
+        assert_eq!(
+            error.bound_dispatch(),
+            Some(glass_core::BoundDispatch::MayHaveDispatched)
+        );
+        assert_eq!(error.to_string(), original_message);
     }
 
     #[test]

--- a/crates/glass-a11y-linux/tests/fixtures/a11y_fixture.py
+++ b/crates/glass-a11y-linux/tests/fixtures/a11y_fixture.py
@@ -16,9 +16,36 @@ and presents its window immediately without waiting for portal services to settl
 import sys
 import gi
 
-gi.require_version("Gtk", "4.0")
+GTK3_FOCUS_MODE = "--gtk3-focus" in sys.argv
+
+gi.require_version("Gtk", "3.0" if GTK3_FOCUS_MODE else "4.0")
 gi.require_version("Gio", "2.0")
-from gi.repository import Gio, Gtk  # noqa: E402
+from gi.repository import Gio, GLib, Gtk  # noqa: E402
+
+if GTK3_FOCUS_MODE:
+    gi.require_version("Atk", "1.0")
+    from gi.repository import Atk  # noqa: E402
+
+
+class FocusFixtureApp(Gtk.Application):
+    def __init__(self):
+        super().__init__(
+            application_id="net.jesterscourt.GlassA11yFocusFixture",
+            flags=Gio.ApplicationFlags.NON_UNIQUE,
+        )
+
+    def do_activate(self):
+        win = Gtk.ApplicationWindow(
+            application=self, title="Glass A11y Focus Fixture"
+        )
+        win.set_default_size(320, 120)
+        entry = Gtk.Entry()
+        entry.set_text("hello")
+        accessible = entry.get_accessible()
+        accessible.set_name("Field")
+        accessible.set_role(Atk.Role.ENTRY)
+        win.add(entry)
+        win.show_all()
 
 
 class FixtureApp(Gtk.Application):
@@ -33,6 +60,50 @@ class FixtureApp(Gtk.Application):
         win.set_default_size(320, 420)
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
         box.append(Gtk.Label(label="Ready"))
+
+        moving = Gtk.Button(label="Moving semantic")
+
+        def _start_moving(_button):
+            print("SEMANTIC_SAVE", flush=True)
+            started = GLib.get_monotonic_time()
+
+            def _move():
+                elapsed_ms = (GLib.get_monotonic_time() - started) // 1000
+                if elapsed_ms >= 300:
+                    print("MOVING_SETTLED", flush=True)
+                    return GLib.SOURCE_REMOVE
+                moving.set_margin_start((elapsed_ms // 30) * 4)
+                return GLib.SOURCE_CONTINUE
+
+            GLib.timeout_add(30, _move)
+
+        save_semantic = Gtk.Button(label="Semantic Save")
+        save_semantic.connect("clicked", _start_moving)
+
+        blocked = Gtk.Button(label="Disabled semantic")
+        blocked.set_sensitive(False)
+
+        duplicate_one = Gtk.Button(label="Duplicate semantic")
+        duplicate_two = Gtk.Button(label="Duplicate semantic")
+
+        occlusion_stage = Gtk.Overlay()
+        occluded = Gtk.Button(label="Occluded semantic")
+        occluded.set_hexpand(True)
+        occlusion_stage.set_child(occluded)
+        occluder = Gtk.Button(label="Occluder")
+        occluder.set_halign(Gtk.Align.CENTER)
+        occluder.set_valign(Gtk.Align.CENTER)
+        occlusion_stage.add_overlay(occluder)
+
+        semantic_grid = Gtk.Grid(row_spacing=4, column_spacing=8)
+        semantic_grid.attach(save_semantic, 0, 0, 1, 1)
+        semantic_grid.attach(blocked, 1, 0, 1, 1)
+        semantic_grid.attach(duplicate_one, 0, 1, 1, 1)
+        semantic_grid.attach(duplicate_two, 1, 1, 1, 1)
+        semantic_grid.attach(moving, 0, 2, 1, 1)
+        semantic_grid.attach(occlusion_stage, 1, 2, 1, 1)
+        box.append(semantic_grid)
+
         box.append(Gtk.Button(label="Save"))
         bold = Gtk.Button(label="Bold")
         # update_property(DESCRIPTION) populates AT-SPI Description (verified on the bus).
@@ -141,4 +212,5 @@ class FixtureApp(Gtk.Application):
 
 
 if __name__ == "__main__":
-    FixtureApp().run(sys.argv)
+    app_args = [arg for arg in sys.argv if arg != "--gtk3-focus"]
+    (FocusFixtureApp() if GTK3_FOCUS_MODE else FixtureApp()).run(app_args)

--- a/crates/glass-a11y-linux/tests/fixtures/a11y_fixture.py
+++ b/crates/glass-a11y-linux/tests/fixtures/a11y_fixture.py
@@ -62,6 +62,9 @@ class FixtureApp(Gtk.Application):
         box.append(Gtk.Label(label="Ready"))
 
         moving = Gtk.Button(label="Moving semantic")
+        moving.connect(
+            "clicked", lambda _button: print("MOVING_CLICKED", flush=True)
+        )
 
         def _start_moving(_button):
             print("SEMANTIC_SAVE", flush=True)
@@ -119,6 +122,27 @@ class FixtureApp(Gtk.Application):
         entry.set_text("hello")
         entry.update_property([Gtk.AccessibleProperty.LABEL], ["Field"])
         box.append(entry)
+        unconfirmed = Gtk.Entry()
+        unconfirmed.set_text("untouched")
+        unconfirmed.set_focus_on_click(False)
+
+        def _restore_focusable():
+            unconfirmed.set_can_focus(True)
+            return GLib.SOURCE_REMOVE
+
+        def _refuse_pointer_focus(_gesture, _presses, _x, _y):
+            unconfirmed.set_can_focus(False)
+            win.set_focus(save_semantic)
+            GLib.timeout_add(300, _restore_focusable)
+
+        refusal_gesture = Gtk.GestureClick()
+        refusal_gesture.set_propagation_phase(Gtk.PropagationPhase.CAPTURE)
+        refusal_gesture.connect("pressed", _refuse_pointer_focus)
+        unconfirmed.add_controller(refusal_gesture)
+        unconfirmed.update_property(
+            [Gtk.AccessibleProperty.LABEL], ["Refusing Editor"]
+        )
+        box.append(unconfirmed)
         # A SpinButton exposes BOTH the AT-SPI EditableText and Value interfaces; only
         # Value commits to the adjustment, so set_value must go through Value.
         spin = Gtk.SpinButton(

--- a/crates/glass-a11y-linux/tests/integration.rs
+++ b/crates/glass-a11y-linux/tests/integration.rs
@@ -736,6 +736,88 @@ fn semantic_actions_cover_native_focus_pointer_stability_disabled_duplicates_and
     let row = find_role(&initial.root, AxRole::ListItem).expect("first realized row");
     assert!(!row.states.selected);
 
+    let pointer_typed = glass
+        .type_target(
+            &glass_core::TypeTargetParams {
+                target: semantic_target(
+                    AxRole::TextArea,
+                    "Field",
+                    vec![SemanticState::Enabled, SemanticState::Visible],
+                ),
+                focus_mode: ActionMode::Pointer,
+                timeout_ms: 5_000,
+                max_nodes: None,
+            },
+            "P",
+        )
+        .expect("pointer focus and one key batch");
+    assert_eq!(
+        pointer_typed.focus,
+        Some(glass_core::MutationReport {
+            method: ActionMethod::Pointer {
+                native_fallback: None,
+            },
+            dispatch: DispatchStatus::Dispatched,
+            confirmation: ConfirmationStatus::FocusConfirmed,
+        })
+    );
+    assert_eq!(pointer_typed.action.method, ActionMethod::Keyboard);
+    let pointer_typed_deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    loop {
+        let tree = glass
+            .a11y_snapshot(None)
+            .expect("pointer-typed value snapshot");
+        if find_node(&tree.root, "Field")
+            .and_then(|node| node.value.as_deref())
+            .is_some_and(|value| value != "hello" && value.contains('P'))
+        {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < pointer_typed_deadline,
+            "pointer-focused key batch did not change Field"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(25));
+    }
+
+    let unconfirmed = glass
+        .type_target(
+            &glass_core::TypeTargetParams {
+                target: semantic_target(
+                    AxRole::TextArea,
+                    "Refusing Editor",
+                    vec![SemanticState::Enabled, SemanticState::Visible],
+                ),
+                focus_mode: ActionMode::Pointer,
+                timeout_ms: 5_000,
+                max_nodes: None,
+            },
+            "must not type",
+        )
+        .expect_err("typing must stop when pointer focus is not confirmed");
+    assert_eq!(
+        unconfirmed.kind,
+        SemanticActionFailureKind::FocusUnconfirmed
+    );
+    assert_eq!(unconfirmed.action_dispatch, DispatchStatus::NotDispatched);
+    assert_eq!(
+        unconfirmed.focus,
+        Some(glass_core::MutationReport {
+            method: ActionMethod::Pointer {
+                native_fallback: None,
+            },
+            dispatch: DispatchStatus::Dispatched,
+            confirmation: ConfirmationStatus::Unconfirmed,
+        })
+    );
+    let unconfirmed_tree = glass
+        .a11y_snapshot(None)
+        .expect("unconfirmed field snapshot");
+    assert_eq!(
+        find_node(&unconfirmed_tree.root, "Refusing Editor").and_then(|node| node.value.as_deref()),
+        Some("untouched")
+    );
+
     let save = glass
         .click_target(&glass_core::ClickTargetParams {
             target: ActionTarget::Semantic(semantic_target(
@@ -804,6 +886,19 @@ fn semantic_actions_cover_native_focus_pointer_stability_disabled_duplicates_and
     assert!(
         !settled.is_empty(),
         "pointer dispatch returned before the GTK bounds stopped moving"
+    );
+    let moving_click = glass
+        .wait_for_log(&glass_core::WaitLogParams {
+            contains: "MOVING_CLICKED".into(),
+            stream: None,
+            cursor: Some(0),
+            interval_ms: 25,
+            timeout_ms: 2_000,
+        })
+        .expect("moving click log");
+    assert!(
+        moving_click.matched,
+        "forced pointer click did not reach Moving semantic"
     );
 
     let disabled = glass

--- a/crates/glass-a11y-linux/tests/integration.rs
+++ b/crates/glass-a11y-linux/tests/integration.rs
@@ -514,8 +514,12 @@ fn set_value_on_button_is_not_editable() {
     let button = find_role(&tree.root, glass_core::AxRole::Button).expect("button");
     let err = glass.set_value(button.id, "x").unwrap_err();
     assert!(
-        matches!(err, glass_core::GlassError::AxElementNotEditable(_)),
+        matches!(err.cause(), glass_core::GlassError::AxElementNotEditable(id) if *id == button.id.0),
         "got: {err:?}"
+    );
+    assert_eq!(
+        err.bound_dispatch(),
+        Some(glass_core::BoundDispatch::NotDispatched)
     );
     glass.stop().expect("stop");
 }

--- a/crates/glass-a11y-linux/tests/integration.rs
+++ b/crates/glass-a11y-linux/tests/integration.rs
@@ -121,6 +121,16 @@ fn fixture_spec() -> AppSpec {
     }
 }
 
+fn focus_fixture_spec() -> AppSpec {
+    let mut spec = fixture_spec();
+    spec.run.push("--gtk3-focus".into());
+    spec.window_hint = Some(WindowHint {
+        title: Some("Glass A11y Focus Fixture".into()),
+        class: None,
+    });
+    spec
+}
+
 /// How long a fixture gets to publish its tree — this bounds a hang, it does not pace anything.
 const A11Y_READY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
 
@@ -593,6 +603,263 @@ fn launch_fixture() -> Glass {
     glass.start(&fixture_spec()).expect("launch");
     await_a11y_ready(&mut glass);
     glass
+}
+
+fn launch_focus_fixture() -> Glass {
+    let mut glass = glass_x11_with_a11y();
+    glass
+        .start(&focus_fixture_spec())
+        .expect("launch GTK3 focus fixture");
+    await_a11y_ready(&mut glass);
+    glass
+}
+
+fn semantic_target(
+    role: glass_core::AxRole,
+    name: &str,
+    states: Vec<glass_core::SemanticState>,
+) -> glass_core::SemanticTarget {
+    glass_core::SemanticTarget {
+        target: glass_core::SemanticSelector::new(Some(name.into()), Some(role), states)
+            .expect("valid semantic selector"),
+        within: None,
+    }
+}
+
+fn actionability_verdict(
+    report: &glass_core::ActionabilityReport,
+    name: glass_core::ActionabilityCheckName,
+) -> glass_core::ActionabilityVerdict {
+    report
+        .checks
+        .iter()
+        .find(|check| check.name == name)
+        .unwrap_or_else(|| {
+            panic!(
+                "missing {name:?} actionability check in {:?}",
+                report.checks
+            )
+        })
+        .verdict
+}
+
+#[test]
+#[ignore = "needs private AT-SPI bus + GTK fixture"]
+fn semantic_actions_cover_native_focus_pointer_stability_disabled_duplicates_and_occlusion() {
+    use glass_core::{
+        ActionMethod, ActionMode, ActionTarget, ActionabilityCheckName, ActionabilityVerdict,
+        AxRole, ConfirmationStatus, DispatchStatus, SemanticActionFailureKind, SemanticState,
+    };
+
+    let mut focus_glass = launch_focus_fixture();
+    let focus_tree = focus_glass
+        .a11y_snapshot(None)
+        .expect("GTK3 focus fixture snapshot");
+    let field = find_node(&focus_tree.root, "Field").expect("GTK3 Field");
+    assert_eq!(field.role, AxRole::TextField);
+    assert!(field.states.editable);
+    assert!(field.states.focusable);
+    let typed = focus_glass
+        .type_target(
+            &glass_core::TypeTargetParams {
+                target: semantic_target(
+                    AxRole::TextField,
+                    "Field",
+                    vec![SemanticState::Enabled, SemanticState::Visible],
+                ),
+                focus_mode: ActionMode::Native,
+                timeout_ms: 5_000,
+                max_nodes: None,
+            },
+            "Z",
+        )
+        .expect("native focus and one key batch");
+    let focus = typed.focus.expect("targeted type focus report");
+    assert_eq!(focus.confirmation, ConfirmationStatus::FocusConfirmed);
+    assert_eq!(focus.dispatch, DispatchStatus::Dispatched);
+    assert_eq!(typed.action.method, ActionMethod::Keyboard);
+    let typed_deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    loop {
+        let tree = focus_glass
+            .a11y_snapshot(None)
+            .expect("typed value snapshot");
+        if find_node(&tree.root, "Field")
+            .and_then(|node| node.value.as_deref())
+            .is_some_and(|value| value != "hello" && value.contains('Z'))
+        {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < typed_deadline,
+            "one targeted key batch did not change Field"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(25));
+    }
+    focus_glass.stop().expect("stop GTK3 focus fixture");
+
+    let mut glass = launch_fixture();
+    await_a11y_settled(&mut glass);
+    let initial = glass
+        .a11y_snapshot(None)
+        .expect("initial semantic snapshot");
+    let coverage = glass_core::Accessibility::state_coverage(&glass_a11y_linux::LinuxA11y::new());
+    assert_eq!(
+        coverage,
+        glass_core::AxStateCoverage {
+            enabled: true,
+            visible: true,
+            checkable: true,
+            checked: true,
+            selected: true,
+            expanded: true,
+            focused: true,
+            focusable: true,
+            editable: true,
+        }
+    );
+    let semantic_save = find_node(&initial.root, "Semantic Save").expect("semantic save");
+    assert!(semantic_save.states.enabled);
+    assert!(semantic_save.states.visible);
+    assert!(semantic_save.states.focusable);
+    let disabled = find_node(&initial.root, "Disabled semantic").expect("disabled semantic");
+    assert!(!disabled.states.enabled);
+    assert!(disabled.states.visible);
+    let field = find_node(&initial.root, "Field").expect("Field");
+    assert_eq!(field.role, AxRole::TextArea);
+    assert!(field.states.editable);
+    assert!(field.states.focusable);
+    let active = find_node(&initial.root, "Active").expect("Active switch");
+    assert!(active.states.checkable);
+    assert!(!active.states.checked);
+    let company = find_role(&initial.root, AxRole::ComboBox).expect("Company dropdown");
+    assert!(!company.states.expanded);
+    let row = find_role(&initial.root, AxRole::ListItem).expect("first realized row");
+    assert!(!row.states.selected);
+
+    let save = glass
+        .click_target(&glass_core::ClickTargetParams {
+            target: ActionTarget::Semantic(semantic_target(
+                AxRole::Button,
+                "Semantic Save",
+                vec![SemanticState::Enabled],
+            )),
+            mode: ActionMode::Native,
+            timeout_ms: Some(5_000),
+            max_nodes: None,
+        })
+        .expect("native semantic save");
+    assert_eq!(
+        save.action.method,
+        ActionMethod::NativeAction { actuated: None }
+    );
+    assert_eq!(save.action.dispatch, DispatchStatus::Dispatched);
+    let save_log = glass
+        .wait_for_log(&glass_core::WaitLogParams {
+            contains: "SEMANTIC_SAVE".into(),
+            stream: None,
+            cursor: Some(0),
+            interval_ms: 25,
+            timeout_ms: 2_000,
+        })
+        .expect("semantic save log");
+    assert!(
+        save_log.matched,
+        "native action did not reach the GTK button"
+    );
+
+    let moving_started = std::time::Instant::now();
+    let moving = glass
+        .click_target(&glass_core::ClickTargetParams {
+            target: ActionTarget::Semantic(semantic_target(
+                AxRole::Button,
+                "Moving semantic",
+                vec![SemanticState::Enabled, SemanticState::Visible],
+            )),
+            mode: ActionMode::Pointer,
+            timeout_ms: Some(5_000),
+            max_nodes: None,
+        })
+        .expect("stable pointer click");
+    assert!(
+        moving_started.elapsed() >= std::time::Duration::from_millis(100),
+        "semantic pointer click skipped the two-sample stability interval"
+    );
+    assert_eq!(
+        moving.action.method,
+        ActionMethod::Pointer {
+            native_fallback: None
+        }
+    );
+    assert_eq!(
+        actionability_verdict(&moving.actionability, ActionabilityCheckName::Stable),
+        ActionabilityVerdict::Passed
+    );
+    assert_eq!(
+        actionability_verdict(&moving.actionability, ActionabilityCheckName::NonOccluded,),
+        ActionabilityVerdict::Passed
+    );
+    let (settled, _) = glass
+        .logs(0, 100, None, Some("MOVING_SETTLED"))
+        .expect("movement logs");
+    assert!(
+        !settled.is_empty(),
+        "pointer dispatch returned before the GTK bounds stopped moving"
+    );
+
+    let disabled = glass
+        .click_target(&glass_core::ClickTargetParams {
+            target: ActionTarget::Semantic(semantic_target(
+                AxRole::Button,
+                "Disabled semantic",
+                vec![],
+            )),
+            mode: ActionMode::Pointer,
+            timeout_ms: Some(0),
+            max_nodes: None,
+        })
+        .expect_err("disabled semantic target must be refused");
+    assert_eq!(disabled.kind, SemanticActionFailureKind::NotActionable);
+    assert_eq!(disabled.action_dispatch, DispatchStatus::NotDispatched);
+    assert_eq!(
+        actionability_verdict(&disabled.actionability, ActionabilityCheckName::Enabled),
+        ActionabilityVerdict::Failed
+    );
+
+    let duplicate = glass
+        .click_target(&glass_core::ClickTargetParams {
+            target: ActionTarget::Semantic(semantic_target(
+                AxRole::Button,
+                "Duplicate semantic",
+                vec![],
+            )),
+            mode: ActionMode::Native,
+            timeout_ms: Some(0),
+            max_nodes: None,
+        })
+        .expect_err("duplicate semantic target must be refused");
+    assert_eq!(duplicate.kind, SemanticActionFailureKind::AmbiguousTarget);
+    assert_eq!(duplicate.action_dispatch, DispatchStatus::NotDispatched);
+
+    let occluded = glass
+        .click_target(&glass_core::ClickTargetParams {
+            target: ActionTarget::Semantic(semantic_target(
+                AxRole::Button,
+                "Occluded semantic",
+                vec![SemanticState::Enabled, SemanticState::Visible],
+            )),
+            mode: ActionMode::Pointer,
+            timeout_ms: Some(5_000),
+            max_nodes: None,
+        })
+        .expect_err("AT-SPI must prove the occluder before pointer dispatch");
+    assert_eq!(occluded.kind, SemanticActionFailureKind::NotActionable);
+    assert_eq!(occluded.action_dispatch, DispatchStatus::NotDispatched);
+    assert_eq!(
+        actionability_verdict(&occluded.actionability, ActionabilityCheckName::NonOccluded,),
+        ActionabilityVerdict::Failed
+    );
+
+    glass.stop().expect("stop semantic fixture");
 }
 
 /// Every description case in one launch: the AT-SPI bus is shared per process and the suite

--- a/crates/glass-a11y-linux/tests/web_probe.rs
+++ b/crates/glass-a11y-linux/tests/web_probe.rs
@@ -32,9 +32,12 @@ use std::process::Command;
 use std::time::{Duration, Instant};
 
 use glass_core::{
-    AppSpec, AxNode, AxRole, AxTree, Backend, BaselineStore, FindElementsParams, Glass, GlassError,
-    KeyEvent, PlatformFactory, SandboxLevel, ScopeResolution, SemanticQuery, SemanticSelector,
-    SemanticState, WindowHint, read_back_confirms, role_histogram,
+    ActionMethod, ActionMode, ActionTarget, ActionabilityCheckName, ActionabilityReport,
+    ActionabilityVerdict, AppSpec, AxNode, AxRole, AxTree, Backend, BaselineStore,
+    ClickTargetParams, DispatchStatus, ElementCondition, FindElementsParams, Glass, GlassError,
+    PlatformFactory, SandboxLevel, ScopeResolution, SemanticActionFailureKind, SemanticQuery,
+    SemanticSelector, SemanticState, SemanticTarget, TypeTargetParams, WaitElementParams,
+    WindowHint, role_histogram,
 };
 
 const BROWSERS_VAR: &str = "GLASS_WEB_PROBE_BROWSERS";
@@ -43,6 +46,7 @@ const LEVER_VAR: &str = "GLASS_WEB_PROBE_LEVER";
 /// How long to keep re-reading the tree for the page's own elements before calling the content
 /// missing. The reading this bounds is "time to content", so it is deliberately generous.
 const SETTLE: Duration = Duration::from_secs(20);
+const SEMANTIC_READ_TIMEOUT_MS: u64 = 20_000;
 
 /// Window-discovery budget. A cold browser opening a fresh profile under a software renderer
 /// maps its window far later than the GTK fixture does.
@@ -50,16 +54,6 @@ const LAUNCH_TIMEOUT_MS: u64 = 30_000;
 
 /// The fixture button's accessible name — the page content the probe waits for, then clicks.
 const BUTTON: &str = "click me";
-/// The fixture text input's accessible name, from its `<label for>`.
-const INPUT: &str = "text input";
-/// What the page's result paragraph reads before the button fires, and after.
-const NOT_CLICKED: &str = "not clicked";
-/// See [`NOT_CLICKED`].
-const CLICKED: &str = "clicked";
-/// What `set_value` writes into the text input.
-const TYPED: &str = "typed by glass";
-/// What the keyboard control types into the text input — a second route to the same field.
-const KEYED: &str = "keyed by glass";
 
 fn page_url() -> String {
     format!(
@@ -227,37 +221,6 @@ fn named<'a>(tree: &'a AxTree, name: &str) -> Option<&'a AxNode> {
     find(tree, &|n| n.name.as_deref() == Some(name))
 }
 
-/// The fixture's text input, not its `<label for>`: both carry the same accessible name, and
-/// the label comes first in pre-order, so `named` alone writes to the wrong element.
-fn text_input(tree: &AxTree) -> Option<&AxNode> {
-    find(tree, &|n| {
-        n.name.as_deref() == Some(INPUT) && n.states.editable
-    })
-}
-
-/// The fixture's result paragraph, found by the text it carries. The text of a `<p>` is a
-/// node's `value` (the reader reads the AT-SPI `Text` interface for text-bearing roles), not
-/// its name, and the outline render does not print values — so this is the only place the
-/// before/after of the click is visible.
-fn valued<'a>(tree: &'a AxTree, value: &str) -> Option<&'a AxNode> {
-    find(tree, &|n| n.value.as_deref() == Some(value))
-}
-
-/// Every editable node in the tree, in pre-order.
-fn editable(tree: &AxTree) -> Vec<&AxNode> {
-    fn walk<'a>(node: &'a AxNode, out: &mut Vec<&'a AxNode>) {
-        if node.states.editable {
-            out.push(node);
-        }
-        for child in &node.children {
-            walk(child, out);
-        }
-    }
-    let mut out = Vec::new();
-    walk(&tree.root, &mut out);
-    out
-}
-
 /// Every `Document` in the tree, in pre-order — the web-content boundary this probe reads.
 fn documents(tree: &AxTree) -> Vec<&AxNode> {
     fn walk<'a>(node: &'a AxNode, out: &mut Vec<&'a AxNode>) {
@@ -355,319 +318,423 @@ fn report_tree(tree: &AxTree) {
     println!("outline:\n{}", tree.to_outline());
 }
 
-/// How many times to re-snapshot-and-click. A browser's tree keeps changing while its other
-/// tabs load, and an id whose node has moved since the snapshot is rejected as changed —
-/// retrying reads the button's clickability rather than the retry's luck.
-const CLICK_ATTEMPTS: usize = 4;
-
-/// Push `e` into `failures` unless it is [`GlassError::AccessibilityNotReady`] — a caller not
-/// yet answering is expected here just as it is in `snapshot_until_page`; every other snapshot
-/// error means the a11y bus broke after it had already been serving this session.
-fn record_snapshot_failure(failures: &mut Vec<String>, label: &str, context: &str, e: &GlassError) {
-    if !matches!(e, GlassError::AccessibilityNotReady(_)) {
-        failures.push(format!("{label}: {context}: {e}"));
-    }
-}
-
-/// The actuation readings. Each step re-snapshots first: `click_element` and `set_value` resolve
-/// ids against the session's most recent tree, so an id from an older one addresses nothing.
-fn exercise(glass: &mut Glass, label: &str, failures: &mut Vec<String>) {
-    for attempt in 1..=CLICK_ATTEMPTS {
-        let before = match glass.a11y_snapshot(Some(0)) {
-            Ok(tree) => tree,
-            Err(e) => {
-                println!("snapshot before the click failed: {e} — no click reading");
-                record_snapshot_failure(failures, label, "snapshot before the click failed", &e);
-                return;
-            }
-        };
-        let Some(button) = named(&before, BUTTON) else {
-            println!("no node named {BUTTON:?} — no click reading");
-            return;
-        };
-        if attempt == 1 {
-            println!(
-                "button: #{} role={:?} raw_role={} bounds={:?}",
-                button.id.0, button.role, button.raw_role, button.bounds
-            );
-            println!(
-                "result paragraph before the click: {:?}",
-                valued(&before, NOT_CLICKED).map(|n| (n.id.0, n.role, n.raw_role.clone()))
-            );
-        }
-        match glass.click_element(button.id) {
-            Ok(method) => {
-                std::thread::sleep(Duration::from_millis(500));
-                match glass.a11y_snapshot(Some(0)) {
-                    Ok(after) => println!(
-                        "click_element (attempt {attempt}): {method:?} → result paragraph reads \
-                         {CLICKED:?}: {}",
-                        valued(&after, CLICKED).is_some()
-                    ),
-                    Err(e) => {
-                        println!("click_element: {method:?} → re-snapshot failed: {e}");
-                        record_snapshot_failure(
-                            failures,
-                            label,
-                            "re-snapshot after click_element failed",
-                            &e,
-                        );
-                    }
-                }
-                break;
-            }
-            Err(e) => {
-                println!("click_element (attempt {attempt}) failed: {e}");
-                // A retry that lands is a reading, not a failure — only the exhausted attempt
-                // means click_element never worked at all.
-                if attempt == CLICK_ATTEMPTS {
-                    record_snapshot_failure(
-                        failures,
-                        label,
-                        &format!("click_element failed after {CLICK_ATTEMPTS} attempts"),
-                        &e,
-                    );
-                }
-                std::thread::sleep(Duration::from_millis(500));
-            }
-        }
-    }
-
-    let after = match glass.a11y_snapshot(Some(0)) {
-        Ok(tree) => tree,
-        Err(e) => {
-            println!("snapshot before set_value failed: {e} — no set_value reading");
-            record_snapshot_failure(failures, label, "snapshot before set_value failed", &e);
-            return;
-        }
-    };
-    let Some(field) = text_input(&after) else {
-        println!("no editable node named {INPUT:?} — no set_value reading");
-        return;
-    };
-    println!(
-        "text input: #{} role={:?} raw_role={} value={:?}",
-        field.id.0, field.role, field.raw_role, field.value
-    );
-    // The baseline glass's own rule compares against — read before the write, not after.
-    let before = field.value.clone();
-    let set = glass.set_value(field.id, TYPED);
-    std::thread::sleep(Duration::from_millis(500));
-    let after = match glass.a11y_snapshot(Some(0)) {
-        Ok(tree) => tree,
-        Err(e) => {
-            println!("set_value: {set:?} → re-snapshot failed: {e}");
-            record_snapshot_failure(failures, label, "re-snapshot after set_value failed", &e);
-            return;
-        }
-    };
-    let held = text_input(&after).and_then(|n| n.value.clone());
-    println!("set_value: {set:?} → text input value={held:?}");
-    // A claim about glass, not about the engine: whatever this browser does with the write, the
-    // verdict has to agree with `read_back_confirms`, the readers' own rule — `Ok` it cannot
-    // confirm is a false success, `Err` it can a false failure. Do not tighten this to
-    // `held == TYPED`: that fails the probe for an engine that reformatted the value and that
-    // glass accepts.
-    let confirms = read_back_confirms(held.as_deref(), before.as_deref(), TYPED);
-    if set.is_ok() != confirms {
-        failures.push(format!(
-            "{label}: set_value returned {set:?} while the field reads back {held:?} (was \
-             {before:?}) — a verdict that disagrees with glass's own read-back rule"
-        ));
-    }
-
-    // The control for the line above. An empty readback has two causes — the write never
-    // landed, or this engine never reports a web input's text over AT-SPI — and only text
-    // that reached the field by another route tells them apart. Typed through the pointer
-    // and keyboard, which do not touch the accessibility write path.
-    if let Some(field) = text_input(&after) {
-        let focus = glass.click_element(field.id);
-        let keyed = glass.key(&KeyEvent::Text(KEYED.to_string()));
-        std::thread::sleep(Duration::from_millis(500));
-        match glass.a11y_snapshot(Some(0)) {
-            Ok(after) => println!(
-                "control — click {focus:?} then key {keyed:?} → text input value={:?}",
-                text_input(&after).and_then(|n| n.value.clone())
-            ),
-            Err(e) => {
-                println!("control — re-snapshot failed: {e}");
-                record_snapshot_failure(failures, label, "control re-snapshot failed", &e);
-            }
-        }
-    }
-
-    match glass.a11y_snapshot(Some(0)) {
-        Ok(after) => {
-            println!("every editable node at the end:");
-            for node in editable(&after) {
-                println!(
-                    "  #{} role={:?} raw_role={} name={:?} value={:?}",
-                    node.id.0, node.role, node.raw_role, node.name, node.value
-                );
-            }
-            println!("--- tree after actuation ---");
-            report_tree(&after);
-        }
-        Err(e) => {
-            println!("final snapshot failed: {e}");
-            record_snapshot_failure(failures, label, "final snapshot failed", &e);
-        }
-    }
-}
-
 /// Discover the large fixture's account controls before any explicit unbounded diagnostic
 /// snapshot. Browser non-publication remains evidence-only, while malformed published content is
 /// recorded as a probe failure.
-fn discover_account_controls(glass: &mut Glass, label: &str, failures: &mut Vec<String>) {
+fn account_scope() -> SemanticTarget {
+    SemanticTarget {
+        target: SemanticSelector::new(
+            Some("Account name".into()),
+            Some(AxRole::TextField),
+            vec![SemanticState::Enabled],
+        )
+        .expect("account selector"),
+        within: Some(
+            SemanticSelector::new(
+                Some("Glass web fixture".into()),
+                Some(AxRole::Document),
+                Vec::new(),
+            )
+            .expect("document scope"),
+        ),
+    }
+}
+
+fn save_account_target() -> SemanticTarget {
+    SemanticTarget {
+        target: SemanticSelector::new(
+            Some("Save account".into()),
+            Some(AxRole::Button),
+            vec![SemanticState::Enabled],
+        )
+        .expect("save selector"),
+        within: account_scope().within,
+    }
+}
+
+fn usable_account_controls_are_published(glass: &mut Glass) -> bool {
     let within = SemanticSelector::new(
         Some("Glass web fixture".into()),
         Some(AxRole::Document),
-        vec![SemanticState::Visible],
+        Vec::new(),
     )
     .expect("document scope");
     let account = SemanticQuery::new(
         SemanticSelector::new(
-            Some("account name".into()),
+            Some("Account name".into()),
             Some(AxRole::TextField),
-            vec![SemanticState::Visible],
+            vec![SemanticState::Enabled],
         )
         .expect("account selector"),
-        Some(within.clone()),
-        10,
+        Some(within),
+        1,
     )
     .expect("account query");
-    let found = glass.find_elements(&FindElementsParams {
-        query: account,
-        max_nodes: None,
-        timeout_ms: SETTLE.as_millis() as u64,
-    });
+    glass
+        .find_elements(&FindElementsParams {
+            query: account,
+            max_nodes: None,
+            timeout_ms: 0,
+        })
+        .is_ok_and(|outcome| {
+            matches!(outcome.result.scope, ScopeResolution::Resolved(_))
+                && outcome.result.matches.len() == 1
+        })
+}
 
-    let account = match found {
-        Err(GlassError::AccessibilityNotReady(message)) => {
+/// Run the account mutation entirely through fresh semantic targets before any diagnostic tree
+/// snapshot. Returns false only when the browser published no usable Account controls at all.
+fn exercise_account_semantically(
+    glass: &mut Glass,
+    label: &str,
+    failures: &mut Vec<String>,
+) -> bool {
+    let started = Instant::now();
+    let typed = glass.type_target(
+        &TypeTargetParams {
+            target: account_scope(),
+            focus_mode: ActionMode::Native,
+            timeout_ms: 20_000,
+            max_nodes: None,
+        },
+        "Ada",
+    );
+    let typed = match typed {
+        Ok(outcome) => outcome,
+        Err(error) => {
             println!(
-                "targeted discovery: page accessibility remained not ready for {SETTLE:?}: \
-                 {message}"
+                "semantic Account targeted type failed after {:?}: kind={} dispatch={} \
+                 error={error:?}",
+                started.elapsed(),
+                error.kind.as_str(),
+                error.action_dispatch.as_str(),
             );
-            return;
-        }
-        Err(e) => {
+            if !usable_account_controls_are_published(glass) {
+                println!("no usable page controls published — preserving evidence-only behavior");
+                return false;
+            }
             failures.push(format!(
-                "{label}: targeted Account name discovery failed: {e}"
+                "{label}: semantic Account targeted type failed with usable controls published: \
+                 kind={} dispatch={} error={error:?}",
+                error.kind.as_str(),
+                error.action_dispatch.as_str(),
             ));
-            return;
+            return true;
         }
-        Ok(out) => out,
     };
-
-    if let ScopeResolution::Ambiguous { observed } = account.result.scope {
-        failures.push(format!(
-            "{label}: targeted Account name discovery found {observed} visible Documents named \
-             \"Glass web fixture\""
-        ));
-        return;
-    }
-    if !account.matched && account.result.unexposed_placeholders > 0 {
-        println!(
-            "targeted discovery: browser withheld {} placeholder(s); preserving evidence-only \
-             behavior",
-            account.result.unexposed_placeholders
-        );
-        return;
-    }
-    if !matches!(account.result.scope, ScopeResolution::Resolved(_)) {
-        failures.push(format!(
-            "{label}: targeted Account name discovery did not uniquely resolve the visible \
-             Document scope: {:?}",
-            account.result.scope
-        ));
-        return;
-    }
-    if account.timed_out || account.result.matches.len() != 1 {
-        failures.push(format!(
-            "{label}: targeted Account name discovery expected one match before any unbounded \
-             diagnostic snapshot, got matched={} timed_out={} matches={}",
-            account.matched,
-            account.timed_out,
-            account.result.matches.len()
-        ));
-        return;
-    }
-    let field = &account.result.matches[0].element;
-    if field.name.as_deref() != Some("Account name")
-        || field.role != AxRole::TextField
-        || !field.states.visible
-        || field.states.secure
-    {
-        failures.push(format!(
-            "{label}: targeted Account name discovery returned the wrong, hidden, or secure element: \
-             name={:?} role={:?} visible={} secure={} value={:?}",
-            field.name, field.role, field.states.visible, field.states.secure, field.value
-        ));
-        return;
-    }
+    let focus = typed.focus.as_ref().expect("targeted type focus report");
     println!(
-        "targeted discovery before any unbounded diagnostic snapshot: Account name → #{} \
-         {:?}",
-        field.id.0, field.role
+        "semantic Account targeted type after {:?}: focus_method={} focus_dispatch={} \
+         focus_confirmation={} type_method={} type_dispatch={} type_confirmation={} \
+         actionability={:?}",
+        started.elapsed(),
+        focus.method.as_str(),
+        focus.dispatch.as_str(),
+        focus.confirmation.as_str(),
+        typed.action.method.as_str(),
+        typed.action.dispatch.as_str(),
+        typed.action.confirmation.as_str(),
+        typed.actionability.checks,
     );
 
-    let save = SemanticQuery::new(
-        SemanticSelector::new(
-            Some("save account".into()),
-            Some(AxRole::Button),
-            vec![SemanticState::Visible],
-        )
-        .expect("save selector"),
-        Some(within),
-        10,
-    )
-    .expect("save query");
-    let save = match glass.find_elements(&FindElementsParams {
-        query: save,
+    let field = glass
+        .wait_for_element(&WaitElementParams {
+            name: Some("Account name".into()),
+            description: None,
+            role: Some(AxRole::TextField),
+            value: Some("Ada".into()),
+            value_contains: None,
+            condition: ElementCondition::Appears,
+            interval_ms: 25,
+            timeout_ms: SEMANTIC_READ_TIMEOUT_MS,
+        })
+        .expect("wait for Account value");
+    if !field.matched {
+        failures.push(format!("{label}: Account field did not read back as Ada"));
+        return true;
+    }
+
+    let clicked_at = Instant::now();
+    let click = match glass.click_target(&ClickTargetParams {
+        target: ActionTarget::Semantic(save_account_target()),
+        mode: ActionMode::Auto,
+        timeout_ms: Some(20_000),
         max_nodes: None,
-        timeout_ms: 0,
     }) {
-        Ok(out) => out,
-        Err(e) => {
+        Ok(outcome) => outcome,
+        Err(error) => {
             failures.push(format!(
-                "{label}: targeted Save account discovery failed: {e}"
+                "{label}: semantic Save account click failed: kind={} dispatch={} error={error:?}",
+                error.kind.as_str(),
+                error.action_dispatch.as_str(),
             ));
-            return;
+            return true;
         }
     };
-    if let ScopeResolution::Ambiguous { observed } = save.result.scope {
-        failures.push(format!(
-            "{label}: zero-timeout Save account discovery found {observed} visible Documents named \
-             \"Glass web fixture\""
-        ));
-        return;
-    }
-    if !matches!(save.result.scope, ScopeResolution::Resolved(_)) || save.result.matches.len() != 1
-    {
-        failures.push(format!(
-            "{label}: zero-timeout Save account discovery expected one match in the resolved \
-             Document scope, got scope={:?} matches={}",
-            save.result.scope,
-            save.result.matches.len()
-        ));
-        return;
-    }
-    let button = &save.result.matches[0].element;
-    if button.name.as_deref() != Some("Save account")
-        || button.role != AxRole::Button
-        || !button.states.visible
-        || button.states.secure
-    {
-        failures.push(format!(
-            "{label}: zero-timeout Save account discovery returned the wrong, hidden, or secure \
-             element: name={:?} role={:?} visible={} secure={} value={:?}",
-            button.name, button.role, button.states.visible, button.states.secure, button.value
-        ));
-        return;
+    println!(
+        "semantic Save account click after {:?}: method={} dispatch={} confirmation={} actionability={:?}",
+        clicked_at.elapsed(),
+        click.action.method.as_str(),
+        click.action.dispatch.as_str(),
+        click.action.confirmation.as_str(),
+        click.actionability.checks,
+    );
+    let saved = glass
+        .wait_for_element(&WaitElementParams {
+            name: None,
+            description: None,
+            role: Some(AxRole::TextArea),
+            value: Some("Saved".into()),
+            value_contains: None,
+            condition: ElementCondition::Appears,
+            interval_ms: 25,
+            timeout_ms: SEMANTIC_READ_TIMEOUT_MS,
+        })
+        .expect("wait for Saved status");
+    if !saved.matched {
+        failures.push(format!("{label}: Save click did not produce Saved status"));
     }
     println!(
-        "zero-timeout targeted discovery: Save account → #{} {:?}",
-        button.id.0, button.role
+        "semantic Account workflow: field=Ada status=Saved matched={}",
+        saved.matched
+    );
+    true
+}
+
+fn fixture_target(name: &str, states: Vec<SemanticState>) -> SemanticTarget {
+    SemanticTarget {
+        target: SemanticSelector::new(Some(name.into()), Some(AxRole::Button), states)
+            .expect("fixture selector"),
+        within: account_scope().within,
+    }
+}
+
+fn fixture_click(name: &str, mode: ActionMode, timeout_ms: u64) -> ClickTargetParams {
+    ClickTargetParams {
+        target: ActionTarget::Semantic(fixture_target(name, Vec::new())),
+        mode,
+        timeout_ms: Some(timeout_ms),
+        max_nodes: None,
+    }
+}
+
+fn actionability_verdict(
+    report: &ActionabilityReport,
+    name: ActionabilityCheckName,
+) -> ActionabilityVerdict {
+    report
+        .checks
+        .iter()
+        .find(|check| check.name == name)
+        .unwrap_or_else(|| {
+            panic!(
+                "missing {name:?} actionability check in {:?}",
+                report.checks
+            )
+        })
+        .verdict
+}
+
+fn status_is(glass: &mut Glass, expected: &str) -> bool {
+    glass
+        .wait_for_element(&WaitElementParams {
+            name: None,
+            description: None,
+            role: None,
+            value: Some(expected.into()),
+            value_contains: None,
+            condition: ElementCondition::Appears,
+            interval_ms: 25,
+            timeout_ms: SEMANTIC_READ_TIMEOUT_MS,
+        })
+        .expect("semantic status read")
+        .matched
+}
+
+fn assert_quiet_status(glass: &mut Glass, expected: &str, context: &str) {
+    std::thread::sleep(Duration::from_millis(350));
+    assert!(
+        status_is(glass, expected),
+        "{context} changed status during the 350 ms quiet window"
+    );
+}
+
+fn exercise_actionability(glass: &mut Glass) {
+    const INITIAL: &str = "No semantic action activated";
+    assert!(status_is(glass, INITIAL));
+
+    let disabled_started = Instant::now();
+    let disabled = glass
+        .click_target(&fixture_click("Disabled semantic", ActionMode::Native, 0))
+        .expect_err("disabled target must be refused");
+    let disabled_elapsed = disabled_started.elapsed();
+    assert_eq!(disabled.kind, SemanticActionFailureKind::NotActionable);
+    assert_eq!(disabled.action_dispatch, DispatchStatus::NotDispatched);
+    assert_quiet_status(glass, INITIAL, "disabled refusal");
+    println!(
+        "disabled refusal after {:?}: kind={} dispatch={} actionability={:?}; quiet_ms=350",
+        disabled_elapsed,
+        disabled.kind.as_str(),
+        disabled.action_dispatch.as_str(),
+        disabled.actionability.checks,
+    );
+
+    let duplicate_started = Instant::now();
+    let duplicate = glass
+        .click_target(&fixture_click("Duplicate semantic", ActionMode::Native, 0))
+        .expect_err("duplicate target must be refused");
+    let duplicate_elapsed = duplicate_started.elapsed();
+    assert_eq!(duplicate.kind, SemanticActionFailureKind::AmbiguousTarget);
+    assert_eq!(duplicate.action_dispatch, DispatchStatus::NotDispatched);
+    assert_quiet_status(glass, INITIAL, "ambiguous refusal");
+    println!(
+        "duplicate refusal after {:?}: kind={} dispatch={}; quiet_ms=350",
+        duplicate_elapsed,
+        duplicate.kind.as_str(),
+        duplicate.action_dispatch.as_str(),
+    );
+
+    let delayed_query = SemanticQuery::new(
+        fixture_target("Delayed semantic", vec![SemanticState::Enabled]).target,
+        account_scope().within,
+        1,
+    )
+    .expect("delayed query");
+    let absent = glass
+        .find_elements(&FindElementsParams {
+            query: delayed_query,
+            max_nodes: None,
+            timeout_ms: 0,
+        })
+        .expect("one fresh delayed absence read");
+    assert!(
+        !absent.matched,
+        "delayed target was not absent before its action"
+    );
+    assert_eq!(absent.result.matches_in_walk, 0);
+    assert!(absent.result.search_complete);
+    glass
+        .click_target(&fixture_click("Start delay", ActionMode::Native, 20_000))
+        .expect("start delayed publication");
+    let delayed_started = Instant::now();
+    let delayed = glass
+        .click_target(&fixture_click("Delayed semantic", ActionMode::Auto, 20_000))
+        .expect("delayed selector action waits and clicks");
+    let delayed_elapsed = delayed_started.elapsed();
+    assert_eq!(delayed.action.dispatch, DispatchStatus::Dispatched);
+    assert!(status_is(glass, "Delayed activated 1"));
+    assert_quiet_status(glass, "Delayed activated 1", "delayed activation");
+    println!(
+        "delayed action after observed absence waited {:?}: method={} dispatch={} confirmation={} \
+         actionability={:?}; exact_activations=1",
+        delayed_elapsed,
+        delayed.action.method.as_str(),
+        delayed.action.dispatch.as_str(),
+        delayed.action.confirmation.as_str(),
+        delayed.actionability.checks,
+    );
+
+    glass
+        .click_target(&fixture_click("Start motion", ActionMode::Native, 20_000))
+        .expect("restart motion");
+    let first_tree = glass.a11y_snapshot(Some(0)).expect("first moving sample");
+    let first_bounds = named(&first_tree, "Moving semantic")
+        .and_then(|node| node.bounds)
+        .expect("first moving bounds");
+    let observed_deadline = Instant::now() + Duration::from_millis(250);
+    let changed_bounds = loop {
+        let tree = glass
+            .a11y_snapshot(Some(0))
+            .expect("changing moving sample");
+        let bounds = named(&tree, "Moving semantic")
+            .and_then(|node| node.bounds)
+            .expect("changing moving bounds");
+        if bounds != first_bounds {
+            break bounds;
+        }
+        assert!(
+            Instant::now() < observed_deadline,
+            "moving target bounds never changed after Start motion"
+        );
+    };
+    let moving_started = Instant::now();
+    let moving = glass
+        .click_target(&fixture_click(
+            "Moving semantic",
+            ActionMode::Pointer,
+            20_000,
+        ))
+        .expect("forced pointer waits for stable bounds and clicks");
+    let moving_elapsed = moving_started.elapsed();
+    assert_eq!(
+        moving.action.method,
+        ActionMethod::Pointer {
+            native_fallback: None
+        }
+    );
+    assert_eq!(moving.action.dispatch, DispatchStatus::Dispatched);
+    assert_eq!(
+        actionability_verdict(&moving.actionability, ActionabilityCheckName::Stable),
+        ActionabilityVerdict::Passed
+    );
+    assert!(status_is(glass, "Moving activated 1"));
+    assert_quiet_status(glass, "Moving activated 1", "moving activation");
+    println!(
+        "moving generation bounds changed {first_bounds:?} -> {changed_bounds:?}; pointer waited \
+         {:?}: method={} dispatch={} confirmation={} actionability={:?}; exact_activations=1",
+        moving_elapsed,
+        moving.action.method.as_str(),
+        moving.action.dispatch.as_str(),
+        moving.action.confirmation.as_str(),
+        moving.actionability.checks,
+    );
+
+    let occlusion_tree = glass
+        .a11y_snapshot(Some(0))
+        .expect("occlusion identity snapshot");
+    let occluded = named(&occlusion_tree, "Occluded semantic").expect("occluded target");
+    let occluder = named(&occlusion_tree, "Occluder").expect("occluder identity");
+    assert_eq!(occluder.role, AxRole::Button);
+    let target_bounds = occluded.bounds.expect("occluded bounds");
+    let cover_bounds = occluder.bounds.expect("occluder bounds");
+    let center = (
+        target_bounds.x + target_bounds.width as i32 / 2,
+        target_bounds.y + target_bounds.height as i32 / 2,
+    );
+    assert!(
+        center.0 >= cover_bounds.x
+            && center.0 < cover_bounds.x + cover_bounds.width as i32
+            && center.1 >= cover_bounds.y
+            && center.1 < cover_bounds.y + cover_bounds.height as i32,
+        "named Occluder does not cover the target center: target={target_bounds:?} \
+         occluder={cover_bounds:?}"
+    );
+    let occluded_started = Instant::now();
+    let refusal = glass
+        .click_target(&fixture_click(
+            "Occluded semantic",
+            ActionMode::Pointer,
+            20_000,
+        ))
+        .expect_err("AT-SPI must prove the named occluder before pointer dispatch");
+    let occluded_elapsed = occluded_started.elapsed();
+    println!("occlusion outcome before assertions: {refusal:?}");
+    assert_eq!(refusal.kind, SemanticActionFailureKind::NotActionable);
+    assert_eq!(refusal.action_dispatch, DispatchStatus::NotDispatched);
+    assert_eq!(
+        actionability_verdict(&refusal.actionability, ActionabilityCheckName::NonOccluded),
+        ActionabilityVerdict::Failed
+    );
+    assert_quiet_status(glass, "Moving activated 1", "occlusion refusal");
+    println!(
+        "occlusion refusal after {:?}: target_center={center:?} named_occluder=#{} {:?} \
+         kind={} dispatch={} actionability={:?}; quiet_ms=350",
+        occluded_elapsed,
+        occluder.id.0,
+        cover_bounds,
+        refusal.kind.as_str(),
+        refusal.action_dispatch.as_str(),
+        refusal.actionability.checks,
     );
 }
 
@@ -676,6 +743,7 @@ fn discover_account_controls(glass: &mut Glass, label: &str, failures: &mut Vec<
 /// `failures` rather than panicking, so the rest of the requested browsers still get their turn
 /// and this browser's `stop` still runs.
 fn probe(backend: &str, browser: &str, lever: Lever, failures: &mut Vec<String>) {
+    let failures_before = failures.len();
     let label = format!("{backend}/{browser}/lever={lever:?}");
     println!("=== {label} ===");
     println!("engine: {}", version_of(browser));
@@ -698,14 +766,14 @@ fn probe(backend: &str, browser: &str, lever: Lever, failures: &mut Vec<String>)
     }
     println!("window mapped after {:?}", started.elapsed());
 
-    discover_account_controls(&mut glass, &label, failures);
+    let account_controls_published = exercise_account_semantically(&mut glass, &label, failures);
     let (tree, settle, arrived) = snapshot_until_page(&mut glass, &label, failures);
     println!("page content arrived: {arrived} after {settle:?}");
     match tree {
         Some(tree) => {
             report_tree(&tree);
-            if arrived {
-                exercise(&mut glass, &label, failures);
+            if arrived && account_controls_published && failures.len() == failures_before {
+                exercise_actionability(&mut glass);
             } else if let Some(hint) = tree.document_guidance().or_else(|| tree.unexposed_notice())
             {
                 println!("disclosure rendered:\n{hint}");

--- a/crates/glass-a11y-macos/src/ffi.rs
+++ b/crates/glass-a11y-macos/src/ffi.rs
@@ -55,6 +55,7 @@ pub(crate) mod attr {
     pub(crate) const SIZE: &str = "AXSize";
     pub(crate) const ENABLED: &str = "AXEnabled";
     pub(crate) const FOCUSED: &str = "AXFocused";
+    pub(crate) const PARENT: &str = "AXParent";
 }
 
 // `AXIsProcessTrusted` is a plain C predicate not surfaced by the objc2 bindings, declared
@@ -93,7 +94,7 @@ pub(crate) fn app_element(pid: i32) -> CFRetained<AXUIElement> {
 /// `AXUIElementCopyAttributeValue(el, attr_name, ...)` in its "any non-`Success` is an error"
 /// form: it collapses *every* non-`Success` `AXError` — an absent attribute included — into a
 /// structured [`GlassError::Backend`]. The value accessors that treat "absent" as "no value"
-/// (`attribute_string`/`attribute_bool`) reach it through `.ok()`, so the distinction doesn't
+/// (`attribute_string`) reach it through `.ok()`, so the distinction doesn't
 /// matter to them; callers that must tell "absent" from "real failure" apart use
 /// [`copy_attribute_checked`] directly.
 pub(crate) fn copy_attribute(el: &AXUIElement, attr_name: &str) -> Result<CFRetained<CFType>> {
@@ -116,13 +117,12 @@ fn is_absent_error(err: AXError) -> bool {
 /// *legitimately absent* ([`is_absent_error`]), and `Err` for any *real* AX failure. Wraps the
 /// already-retained (+1, per Core Foundation's Copy/Create rule) raw result in a
 /// `CFRetained<CFType>` so it is released automatically when dropped.
-fn copy_attribute_checked(el: &AXUIElement, attr_name: &str) -> Result<Option<CFRetained<CFType>>> {
-    let attr = CFString::from_str(attr_name);
+fn copy_attribute_checked_by(
+    attr_name: &str,
+    call: impl FnOnce(NonNull<*const CFType>) -> AXError,
+) -> Result<Option<CFRetained<CFType>>> {
     let mut raw: *const CFType = std::ptr::null();
-    // SAFETY: `el` is a live `AXUIElement`; `raw` is a valid local out-param slot matching
-    // `AXUIElementCopyAttributeValue`'s documented signature (mirrors
-    // `axwindow::copy_attribute`).
-    let err = unsafe { el.copy_attribute_value(&attr, NonNull::from(&mut raw)) };
+    let err = call(NonNull::from(&mut raw));
     if err != AXError::Success {
         return if is_absent_error(err) {
             Ok(None)
@@ -135,10 +135,18 @@ fn copy_attribute_checked(el: &AXUIElement, attr_name: &str) -> Result<Option<CF
             "{attr_name}: AX reported success but returned a null value"
         ))
     })?;
-    // SAFETY: `AXUIElementCopyAttributeValue` follows Core Foundation's Copy/Create
-    // ownership rule — an already-retained (+1) `CFTypeRef` on success — so
-    // `CFRetained::from_raw` takes ownership without an extra retain (mirrors `axwindow`).
+    // SAFETY: The injected Copy call returned an already-retained (+1) value on success.
     Ok(Some(unsafe { CFRetained::from_raw(nn) }))
+}
+
+fn copy_attribute_checked(el: &AXUIElement, attr_name: &str) -> Result<Option<CFRetained<CFType>>> {
+    let attr = CFString::from_str(attr_name);
+    // SAFETY: `el` is a live `AXUIElement`; `raw` is a valid local out-param slot matching
+    // `AXUIElementCopyAttributeValue`'s documented signature (mirrors
+    // `axwindow::copy_attribute`).
+    copy_attribute_checked_by(attr_name, |raw| unsafe {
+        el.copy_attribute_value(&attr, raw)
+    })
 }
 
 /// One system-wide accessibility read, for the doctor: does the AX API answer at all?
@@ -244,46 +252,152 @@ pub(crate) fn attribute_string_checked(
     }
 }
 
-/// Read `el`'s `attr_name` as a `bool` (`CFBoolean`), or `None` when the attribute is absent
-/// or isn't a boolean.
-pub(crate) fn attribute_bool(el: &AXUIElement, attr_name: &str) -> Option<bool> {
-    let value = copy_attribute(el, attr_name).ok()?;
-    value.downcast_ref::<CFBoolean>().map(CFBoolean::as_bool)
+fn attribute_bool_checked_by(
+    attr_name: &str,
+    call: impl FnOnce(NonNull<*const CFType>) -> AXError,
+) -> Result<Option<bool>> {
+    match copy_attribute_checked_by(attr_name, call)? {
+        Some(value) => Ok(value.downcast_ref::<CFBoolean>().map(CFBoolean::as_bool)),
+        None => Ok(None),
+    }
 }
 
-/// Read `el`'s `attr_name` as an `i64` (`CFNumber`), or `None` when the attribute is absent,
-/// isn't a `CFNumber`, or holds a value that doesn't fit an `i64`. A checkbox/radio/switch
-/// exposes `AXValue` as a `CFNumber` (`0`/`1` for off/on), which `attribute_string`/
-/// `attribute_bool` cannot read — this is how the reader learns the checked state. Absence
-/// collapses to `None` (via `copy_attribute(...).ok()`), like the siblings.
-pub(crate) fn attribute_i64(el: &AXUIElement, attr_name: &str) -> Option<i64> {
-    let value = copy_attribute(el, attr_name).ok()?;
-    let num = value.downcast_ref::<CFNumber>()?;
-    let mut out: i64 = 0;
-    // SAFETY: `num` was downcast-verified to be a real `CFNumber`; `out` is a valid, correctly
-    // sized `i64` slot matching the requested `SInt64Type`. `CFNumberGetValue` writes at most 8
-    // bytes into `out` and returns false (→ `None`) when the stored value isn't exactly
-    // representable as an `i64` — the same out-param idiom `ax_position`/`ax_size` use for
-    // `AXValue`.
-    let ok = unsafe { num.value(CFNumberType::SInt64Type, (&mut out as *mut i64).cast()) };
-    ok.then_some(out)
-}
-
-/// Whether `attr_name` is writable on `el` (`AXUIElement::is_attribute_settable`). `false`
-/// on any AX error, including the attribute being absent — the reader uses this for
-/// `editable` (settable `AXValue`) and `focusable` (settable `AXFocused`).
-pub(crate) fn is_settable(el: &AXUIElement, attr_name: &str) -> bool {
+/// Read a boolean AX attribute without collapsing transport and stale-element failures into
+/// absence.
+pub(crate) fn attribute_bool_checked(el: &AXUIElement, attr_name: &str) -> Result<Option<bool>> {
     let attr = CFString::from_str(attr_name);
-    let mut settable: u8 = 0;
-    // SAFETY: `el` is a live `AXUIElement`; `attr` is a valid `CFString`; `settable` is a
-    // valid local out-param matching `is_attribute_settable`'s documented `Boolean *`
-    // parameter (mirrors `copy_attribute`'s `NonNull`-out-param pattern above).
-    let err = unsafe { el.is_attribute_settable(&attr, NonNull::from(&mut settable)) };
-    err == AXError::Success && settable != 0
+    attribute_bool_checked_by(attr_name, |raw| unsafe {
+        el.copy_attribute_value(&attr, raw)
+    })
+}
+
+fn attribute_i64_checked_by(
+    attr_name: &str,
+    call: impl FnOnce(NonNull<*const CFType>) -> AXError,
+) -> Result<Option<i64>> {
+    let Some(value) = copy_attribute_checked_by(attr_name, call)? else {
+        return Ok(None);
+    };
+    let Some(num) = value.downcast_ref::<CFNumber>() else {
+        return Ok(None);
+    };
+    let mut out: i64 = 0;
+    // SAFETY: `num` was downcast-verified and `out` matches `SInt64Type`.
+    let ok = unsafe { num.value(CFNumberType::SInt64Type, (&mut out as *mut i64).cast()) };
+    Ok(ok.then_some(out))
+}
+
+/// Read an integer AX attribute while preserving genuine AX failures.
+pub(crate) fn attribute_i64_checked(el: &AXUIElement, attr_name: &str) -> Result<Option<i64>> {
+    let attr = CFString::from_str(attr_name);
+    attribute_i64_checked_by(attr_name, |raw| unsafe {
+        el.copy_attribute_value(&attr, raw)
+    })
+}
+
+fn is_settable_checked_by(
+    attr_name: &str,
+    call: impl FnOnce(NonNull<u8>) -> AXError,
+) -> Result<bool> {
+    let mut settable = 0;
+    let err = call(NonNull::from(&mut settable));
+    if err == AXError::Success {
+        Ok(settable != 0)
+    } else if is_absent_error(err) {
+        Ok(false)
+    } else {
+        Err(ax_err(attr_name, err))
+    }
+}
+
+/// Test whether an AX attribute is writable, distinguishing an unsupported attribute from a
+/// failed AX request.
+pub(crate) fn is_settable_checked(el: &AXUIElement, attr_name: &str) -> Result<bool> {
+    let attr = CFString::from_str(attr_name);
+    is_settable_checked_by(attr_name, |settable| unsafe {
+        el.is_attribute_settable(&attr, settable)
+    })
+}
+
+fn set_bool_attribute_by(
+    attr_name: &str,
+    value: bool,
+    call: impl FnOnce(&CFString, &CFType) -> AXError,
+) -> Result<()> {
+    let attr = CFString::from_str(attr_name);
+    let value = CFBoolean::new(value);
+    let err = call(&attr, value);
+    if err == AXError::Success {
+        Ok(())
+    } else {
+        Err(ax_err(attr_name, err))
+    }
+}
+
+/// Write a Core Foundation boolean to an AX attribute.
+pub(crate) fn set_bool_attribute(el: &AXUIElement, attr_name: &str, value: bool) -> Result<()> {
+    set_bool_attribute_by(attr_name, value, |attr, value| unsafe {
+        el.set_attribute_value(attr, value)
+    })
+}
+
+fn element_at_position_by(
+    x: f32,
+    y: f32,
+    call: impl FnOnce(f32, f32, NonNull<*const AXUIElement>) -> AXError,
+) -> Result<Option<CFRetained<AXUIElement>>> {
+    let mut raw: *const AXUIElement = std::ptr::null();
+    let err = call(x, y, NonNull::from(&mut raw));
+    if err != AXError::Success {
+        return if err == AXError::NoValue {
+            Ok(None)
+        } else {
+            Err(ax_err("AXUIElementCopyElementAtPosition", err))
+        };
+    }
+    let Some(raw) = NonNull::new(raw.cast_mut()) else {
+        return Ok(None);
+    };
+    // SAFETY: AXUIElementCopyElementAtPosition returned a copied (+1) element.
+    Ok(Some(unsafe { CFRetained::from_raw(raw) }))
+}
+
+/// Return the application element at a point in global AX coordinates.
+pub(crate) fn element_at_position(
+    app: &AXUIElement,
+    x: f32,
+    y: f32,
+) -> Result<Option<CFRetained<AXUIElement>>> {
+    element_at_position_by(x, y, |x, y, raw| unsafe {
+        app.copy_element_at_position(x, y, raw)
+    })
+}
+
+fn parent_by(
+    call: impl FnOnce(NonNull<*const CFType>) -> AXError,
+) -> Result<Option<CFRetained<AXUIElement>>> {
+    let Some(value) = copy_attribute_checked_by(attr::PARENT, call)? else {
+        return Ok(None);
+    };
+    value
+        .downcast::<AXUIElement>()
+        .map(Some)
+        .map_err(|_| GlassError::Backend("AXParent did not return an AXUIElement".into()))
+}
+
+/// Return an element's parent, preserving AX failures and validating the copied type.
+pub(crate) fn parent(el: &AXUIElement) -> Result<Option<CFRetained<AXUIElement>>> {
+    let attr = CFString::from_str(attr::PARENT);
+    parent_by(|raw| unsafe { el.copy_attribute_value(&attr, raw) })
+}
+
+/// Core Foundation equality for accessibility elements.
+pub(crate) fn same_element(a: &AXUIElement, b: &AXUIElement) -> bool {
+    a == b
 }
 
 /// Write `text` as `el`'s `AXValue` (`AXUIElement::set_attribute_value`). The caller
-/// (`reader::set_value`) gates this on [`is_settable`] first; this only performs the write —
+/// (`reader::set_value`) gates this on [`is_settable_checked`] first; this only performs the write —
 /// it does not read back to verify the value actually took (that honesty check is the
 /// caller's read-back poll, mirroring the Windows reader's `set_value` contract).
 pub(crate) fn set_string_value(el: &AXUIElement, text: &str) -> Result<()> {
@@ -434,9 +548,15 @@ fn ax_err(context: &str, err: AXError) -> GlassError {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_absent_error, probe_system_wide_attr};
+    use super::{
+        attr, attribute_bool_checked_by, attribute_i64_checked_by, element_at_position_by,
+        is_absent_error, is_settable_checked_by, parent_by, probe_system_wide_attr, same_element,
+        set_bool_attribute_by,
+    };
     use crate::doctor::SystemWideProbe;
-    use objc2_application_services::AXError;
+    use objc2_application_services::{AXError, AXUIElement};
+    use objc2_core_foundation::{CFBoolean, CFRetained};
+    use std::cell::Cell;
 
     // There is deliberately no live "the probe answers" test: on a granted process it answers and
     // on an untrusted one it does not, so the assertion would encode which binaries the running
@@ -517,5 +637,103 @@ mod tests {
                 "{err:?} must not be treated as absent"
             );
         }
+    }
+
+    #[test]
+    fn attribute_bool_checked_distinguishes_absence_from_real_ax_failure() {
+        assert_eq!(
+            attribute_bool_checked_by(attr::ENABLED, |_| AXError::NoValue)
+                .expect("absence is a normal state"),
+            None
+        );
+        let error = attribute_bool_checked_by(attr::ENABLED, |_| AXError::CannotComplete)
+            .expect_err("a failed AX read must propagate");
+        assert!(error.to_string().contains("AXEnabled"), "{error}");
+    }
+
+    #[test]
+    fn attribute_i64_checked_distinguishes_absence_from_real_ax_failure() {
+        assert_eq!(
+            attribute_i64_checked_by(attr::VALUE, |_| AXError::AttributeUnsupported)
+                .expect("absence is a normal state"),
+            None
+        );
+        let error = attribute_i64_checked_by(attr::VALUE, |_| AXError::InvalidUIElement)
+            .expect_err("a stale AX element must propagate");
+        assert!(error.to_string().contains("AXValue"), "{error}");
+    }
+
+    #[test]
+    fn is_settable_checked_distinguishes_false_from_real_ax_failure() {
+        assert!(
+            !is_settable_checked_by(attr::FOCUSED, |_| AXError::Success)
+                .expect("an explicit false result is valid")
+        );
+        assert!(
+            !is_settable_checked_by(attr::FOCUSED, |_| AXError::NoValue)
+                .expect("an absent attribute is not settable")
+        );
+        let error = is_settable_checked_by(attr::FOCUSED, |_| AXError::CannotComplete)
+            .expect_err("a failed settable query must propagate");
+        assert!(error.to_string().contains("AXFocused"), "{error}");
+    }
+
+    #[test]
+    fn set_bool_attribute_writes_cfboolean_true_to_axfocused() {
+        let called = Cell::new(false);
+        set_bool_attribute_by(attr::FOCUSED, true, |name, value| {
+            called.set(true);
+            assert_eq!(name.to_string(), attr::FOCUSED);
+            assert_eq!(
+                value.downcast_ref::<CFBoolean>().map(CFBoolean::as_bool),
+                Some(true)
+            );
+            AXError::Success
+        })
+        .expect("the injected AX write succeeds");
+        assert!(called.get());
+    }
+
+    #[test]
+    fn element_at_position_takes_global_points_and_owns_the_copied_element() {
+        let expected = unsafe { AXUIElement::new_application(42) };
+        let copied = CFRetained::into_raw(expected.clone());
+        let seen = Cell::new((0.0, 0.0));
+
+        let actual = element_at_position_by(120.5, -7.25, |x, y, out| {
+            seen.set((x, y));
+            // SAFETY: `out` is the wrapper's valid local result slot, and `copied` carries the
+            // +1 ownership that the simulated Copy call transfers into it.
+            unsafe { out.as_ptr().write(copied.as_ptr()) };
+            AXError::Success
+        })
+        .expect("the injected hit test succeeds")
+        .expect("the injected hit test returns an element");
+
+        assert_eq!(seen.get(), (120.5, -7.25));
+        assert!(same_element(&actual, &expected));
+        drop(actual);
+        assert!(same_element(&expected, &expected));
+        assert!(
+            element_at_position_by(0.0, 0.0, |_, _, _| AXError::NoValue)
+                .expect("NoValue means AX found no element")
+                .is_none()
+        );
+        assert!(
+            element_at_position_by(0.0, 0.0, |_, _, _| AXError::AttributeUnsupported).is_err(),
+            "unsupported hit testing is a failure, not an inconclusive no-hit"
+        );
+    }
+
+    #[test]
+    fn parent_attribute_distinguishes_absent_parent_from_real_ax_failure() {
+        assert!(
+            parent_by(|_| AXError::NoValue)
+                .expect("a root has no parent")
+                .is_none()
+        );
+        let error = parent_by(|_| AXError::CannotComplete)
+            .expect_err("a failed parent read must propagate");
+        assert!(error.to_string().contains("AXParent"), "{error}");
     }
 }

--- a/crates/glass-a11y-macos/src/ffi.rs
+++ b/crates/glass-a11y-macos/src/ffi.rs
@@ -355,9 +355,12 @@ fn element_at_position_by(
             Err(ax_err("AXUIElementCopyElementAtPosition", err))
         };
     }
-    let Some(raw) = NonNull::new(raw.cast_mut()) else {
-        return Ok(None);
-    };
+    let raw = NonNull::new(raw.cast_mut()).ok_or_else(|| {
+        GlassError::Backend(
+            "AXUIElementCopyElementAtPosition: AX reported success but returned a null element"
+                .into(),
+        )
+    })?;
     // SAFETY: AXUIElementCopyElementAtPosition returned a copied (+1) element.
     Ok(Some(unsafe { CFRetained::from_raw(raw) }))
 }
@@ -554,6 +557,7 @@ mod tests {
         set_bool_attribute_by,
     };
     use crate::doctor::SystemWideProbe;
+    use glass_core::GlassError;
     use objc2_application_services::{AXError, AXUIElement};
     use objc2_core_foundation::{CFBoolean, CFRetained};
     use std::cell::Cell;
@@ -723,6 +727,14 @@ mod tests {
             element_at_position_by(0.0, 0.0, |_, _, _| AXError::AttributeUnsupported).is_err(),
             "unsupported hit testing is a failure, not an inconclusive no-hit"
         );
+    }
+
+    #[test]
+    fn element_at_position_success_with_null_is_a_contract_failure() {
+        let error = element_at_position_by(0.0, 0.0, |_, _, _| AXError::Success)
+            .expect_err("AX success without a copied element must fail closed");
+        assert!(matches!(error, GlassError::Backend(_)), "{error}");
+        assert!(error.to_string().contains("null"), "{error}");
     }
 
     #[test]

--- a/crates/glass-a11y-macos/src/mapping.rs
+++ b/crates/glass-a11y-macos/src/mapping.rs
@@ -5,7 +5,20 @@
 //! `"AXButton"`/`"AXTextField"`/... constants; the reader passes the string so this
 //! module needs no macOS-only dependency.
 
-use glass_core::{AxRole, AxStates, normalize_description};
+use glass_core::{AxRole, AxStateCoverage, AxStates, normalize_description};
+
+/// State fields backed by error-preserving AX reads in the macOS reader.
+pub const STATE_COVERAGE: AxStateCoverage = AxStateCoverage {
+    enabled: true,
+    visible: false,
+    checkable: true,
+    checked: true,
+    selected: false,
+    expanded: false,
+    focused: true,
+    focusable: true,
+    editable: true,
+};
 
 /// Every AX role string glass maps. AX role strings are canonical constants, so lookup is
 /// case-sensitive.
@@ -218,6 +231,18 @@ mod tests {
 
     use super::*;
     use glass_core::AxRole;
+
+    #[test]
+    #[expect(clippy::assertions_on_constants)]
+    fn macos_mapping_declares_only_the_ax_facts_the_reader_proves() {
+        assert!(!STATE_COVERAGE.visible);
+        assert!(!STATE_COVERAGE.selected);
+        assert!(!STATE_COVERAGE.expanded);
+        assert!(STATE_COVERAGE.enabled);
+        assert!(STATE_COVERAGE.focused);
+        assert!(STATE_COVERAGE.focusable);
+        assert!(STATE_COVERAGE.editable);
+    }
 
     #[test]
     fn maps_common_ax_roles() {

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -186,7 +186,7 @@ impl Accessibility for MacosA11y {
             return Ok(PointerHit::Inconclusive);
         };
 
-        classify_pointer_hit(&target_el, target_role, hit, ctx.limits.depth, deadline)
+        classify_pointer_hit(target_el, target_role, hit, ctx.limits.depth, deadline)
     }
 
     fn set_value(&mut self, ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
@@ -345,61 +345,65 @@ fn same_element(a: &AXUIElement, b: &AXUIElement, deadline: SemanticDeadline) ->
     deadline.observe(|| ffi::same_element(a, b))
 }
 
-fn contains_element(
-    elements: &[CFRetained<AXUIElement>],
-    candidate: &AXUIElement,
-    deadline: SemanticDeadline,
+fn contains_element_by<N>(
+    elements: &[N],
+    candidate: &N,
+    same: &mut impl FnMut(&N, &N) -> Result<bool>,
 ) -> Result<bool> {
     for element in elements {
-        if same_element(element, candidate, deadline)? {
+        if same(element, candidate)? {
             return Ok(true);
         }
     }
     Ok(false)
 }
 
-fn first_interactable_ancestor(
-    target: &AXUIElement,
+fn first_interactable_ancestor_by<N: Clone>(
+    target: &N,
     depth_limit: usize,
-    deadline: SemanticDeadline,
-) -> Result<Option<CFRetained<AXUIElement>>> {
-    let mut current = deadline.observe(|| ffi::parent(target))??;
+    same: &mut impl FnMut(&N, &N) -> Result<bool>,
+    role: &mut impl FnMut(&N) -> Result<AxRole>,
+    parent: &mut impl FnMut(&N) -> Result<Option<N>>,
+) -> Result<Option<N>> {
+    let mut current = parent(target)?;
     let mut seen = Vec::new();
     for _ in 0..depth_limit {
-        let Some(parent) = current else {
+        let Some(ancestor) = current else {
             return Ok(None);
         };
-        if contains_element(&seen, &parent, deadline)? {
+        if contains_element_by(&seen, &ancestor, same)? {
             return Err(GlassError::Backend("cyclic AX target ancestry".into()));
         }
-        if checked_role(&parent, deadline)?.is_interactable() {
-            return Ok(Some(parent));
+        if role(&ancestor)?.is_interactable() {
+            return Ok(Some(ancestor));
         }
-        seen.push(parent.clone());
-        current = deadline.observe(|| ffi::parent(&parent))??;
+        seen.push(ancestor.clone());
+        current = parent(&ancestor)?;
     }
     Err(GlassError::Backend(format!(
         "AX target ancestry exceeded the configured depth limit ({depth_limit})"
     )))
 }
 
-fn classify_pointer_hit(
-    target: &AXUIElement,
+fn classify_pointer_hit_by<N: Clone>(
+    target: &N,
     target_role: AxRole,
-    hit: CFRetained<AXUIElement>,
+    hit: N,
     depth_limit: usize,
-    deadline: SemanticDeadline,
+    same: &mut impl FnMut(&N, &N) -> Result<bool>,
+    role: &mut impl FnMut(&N) -> Result<AxRole>,
+    parent: &mut impl FnMut(&N) -> Result<Option<N>>,
 ) -> Result<PointerHit> {
-    if same_element(&hit, target, deadline)? {
+    if same(&hit, target)? {
         return Ok(PointerHit::Target);
     }
     let accepted_ancestor = if target_role.is_interactable() {
         None
     } else {
-        first_interactable_ancestor(target, depth_limit, deadline)?
+        first_interactable_ancestor_by(target, depth_limit, same, role, parent)?
     };
     if let Some(ancestor) = &accepted_ancestor
-        && same_element(&hit, ancestor, deadline)?
+        && same(&hit, ancestor)?
     {
         return Ok(PointerHit::AcceptedAncestor);
     }
@@ -407,24 +411,42 @@ fn classify_pointer_hit(
     let mut current = hit;
     let mut seen = Vec::new();
     for _ in 0..=depth_limit {
-        if same_element(&current, target, deadline)? {
+        if same(&current, target)? {
             return Ok(PointerHit::Target);
         }
-        if checked_role(&current, deadline)?.is_interactable() {
+        if role(&current)?.is_interactable() {
             return Ok(PointerHit::Other);
         }
-        if contains_element(&seen, &current, deadline)? {
+        if contains_element_by(&seen, &current, same)? {
             return Err(GlassError::Backend("cyclic AX hit ancestry".into()));
         }
         seen.push(current.clone());
-        let Some(parent) = deadline.observe(|| ffi::parent(&current))?? else {
+        let Some(next) = parent(&current)? else {
             return Ok(PointerHit::Other);
         };
-        current = parent;
+        current = next;
     }
     Err(GlassError::Backend(format!(
         "AX hit ancestry exceeded the configured depth limit ({depth_limit})"
     )))
+}
+
+fn classify_pointer_hit(
+    target: CFRetained<AXUIElement>,
+    target_role: AxRole,
+    hit: CFRetained<AXUIElement>,
+    depth_limit: usize,
+    deadline: SemanticDeadline,
+) -> Result<PointerHit> {
+    classify_pointer_hit_by(
+        &target,
+        target_role,
+        hit,
+        depth_limit,
+        &mut |a, b| same_element(a, b, deadline),
+        &mut |element| checked_role(element, deadline),
+        &mut |element| deadline.observe(|| ffi::parent(element))?,
+    )
 }
 
 struct WriteVerification<'a> {
@@ -1058,6 +1080,7 @@ fn gather_states(
 mod tests {
     use super::*;
     use glass_core::{BoundDispatch, BoundKind, Deadline, WalkLimits, Whose};
+    use std::cell::Cell;
     use std::collections::VecDeque;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
@@ -1067,6 +1090,115 @@ mod tests {
         Gate,
         NativeCall,
         Finish,
+    }
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum HitNode {
+        Target,
+        ContentDescendant,
+        ActionableDescendant,
+        ContainerAncestor,
+        ButtonAncestor,
+    }
+
+    #[test]
+    fn non_actionable_hit_descendant_walks_to_the_target() {
+        let mut same = |left: &HitNode, right: &HitNode| Ok(left == right);
+        let mut role = |node: &HitNode| {
+            Ok(match node {
+                HitNode::Target | HitNode::ActionableDescendant | HitNode::ButtonAncestor => {
+                    AxRole::Button
+                }
+                HitNode::ContentDescendant | HitNode::ContainerAncestor => AxRole::Group,
+            })
+        };
+        let mut parent = |node: &HitNode| {
+            Ok(match node {
+                HitNode::ContentDescendant => Some(HitNode::Target),
+                _ => None,
+            })
+        };
+
+        let hit = classify_pointer_hit_by(
+            &HitNode::Target,
+            AxRole::Button,
+            HitNode::ContentDescendant,
+            4,
+            &mut same,
+            &mut role,
+            &mut parent,
+        )
+        .expect("a content descendant has a checked path to the target");
+
+        assert_eq!(hit, PointerHit::Target);
+    }
+
+    #[test]
+    fn exact_first_interactable_target_ancestor_is_accepted() {
+        let mut same = |left: &HitNode, right: &HitNode| Ok(left == right);
+        let mut role = |node: &HitNode| {
+            Ok(match node {
+                HitNode::ButtonAncestor | HitNode::ActionableDescendant => AxRole::Button,
+                HitNode::Target | HitNode::ContentDescendant | HitNode::ContainerAncestor => {
+                    AxRole::Group
+                }
+            })
+        };
+        let mut parent = |node: &HitNode| {
+            Ok(match node {
+                HitNode::Target => Some(HitNode::ContainerAncestor),
+                HitNode::ContainerAncestor => Some(HitNode::ButtonAncestor),
+                _ => None,
+            })
+        };
+
+        let hit = classify_pointer_hit_by(
+            &HitNode::Target,
+            AxRole::Group,
+            HitNode::ButtonAncestor,
+            4,
+            &mut same,
+            &mut role,
+            &mut parent,
+        )
+        .expect("the exact first interactable target ancestor is supported");
+
+        assert_eq!(hit, PointerHit::AcceptedAncestor);
+    }
+
+    #[test]
+    fn independent_actionable_descendant_is_rejected_before_ancestry_acceptance() {
+        let parent_reads = Cell::new(0);
+        let mut same = |left: &HitNode, right: &HitNode| Ok(left == right);
+        let mut role = |node: &HitNode| {
+            Ok(match node {
+                HitNode::ActionableDescendant | HitNode::Target | HitNode::ButtonAncestor => {
+                    AxRole::Button
+                }
+                HitNode::ContentDescendant | HitNode::ContainerAncestor => AxRole::Group,
+            })
+        };
+        let mut parent = |node: &HitNode| {
+            parent_reads.set(parent_reads.get() + 1);
+            Ok(match node {
+                HitNode::ActionableDescendant => Some(HitNode::Target),
+                _ => None,
+            })
+        };
+
+        let hit = classify_pointer_hit_by(
+            &HitNode::Target,
+            AxRole::Button,
+            HitNode::ActionableDescendant,
+            4,
+            &mut same,
+            &mut role,
+            &mut parent,
+        )
+        .expect("an actionable descendant is a supported negative hit result");
+
+        assert_eq!(hit, PointerHit::Other);
+        assert_eq!(parent_reads.get(), 0);
     }
 
     #[derive(Debug)]

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -20,7 +20,7 @@ use glass_core::coords::pixel_geometry_from_content_rect;
 use glass_core::platform::WindowGeometry;
 use glass_core::{
     Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxTarget, AxTree, GlassError,
-    Result, WalkBudget, normalize_name, read_back_confirms, write_took_no_effect,
+    PointerHit, Result, WalkBudget, normalize_name, read_back_confirms, write_took_no_effect,
 };
 use objc2_application_services::AXUIElement;
 use objc2_core_foundation::CFRetained;
@@ -134,6 +134,61 @@ impl Accessibility for MacosA11y {
         })
     }
 
+    fn state_coverage(&self) -> glass_core::AxStateCoverage {
+        mapping::STATE_COVERAGE
+    }
+
+    fn focus(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<Option<AxNodeId>> {
+        let deadline = SemanticDeadline::focus(ctx.deadline, target.id.0);
+        let (window_el, scale) = resolve_window(ctx, deadline)?;
+        let mut budget = WalkBudget::with_limits(ctx.limits);
+        let found = find_nth(window_el, 0, &mut budget, target.id.0, deadline)?;
+        let el = found.ok_or(GlassError::AxElementChanged(target.id.0))?;
+        verify_target_fingerprint(&el, ctx, target, scale, deadline)?;
+        if !deadline.observe(|| ffi::is_settable_checked(&el, attr::FOCUSED))?? {
+            return Err(GlassError::AxActionUnavailable(target.id.0));
+        }
+        deadline.dispatch(|| ffi::set_bool_attribute(&el, attr::FOCUSED, true))?;
+        Ok(None)
+    }
+
+    fn pointer_target_at(
+        &mut self,
+        ctx: &AxContext,
+        target: &AxTarget,
+        point: (i32, i32),
+    ) -> Result<PointerHit> {
+        let deadline = SemanticDeadline::snapshot(ctx.deadline);
+        let (window_el, scale) = resolve_window(ctx, deadline)?;
+        let mut budget = WalkBudget::with_limits(ctx.limits);
+        let found = find_nth(window_el, 0, &mut budget, target.id.0, deadline)?;
+        let target_el = found.ok_or(GlassError::AxElementChanged(target.id.0))?;
+        let target_role = verify_target_fingerprint(&target_el, ctx, target, scale, deadline)?;
+
+        let global_x = (f64::from(ctx.window.x) + f64::from(point.0)) / scale;
+        let global_y = (f64::from(ctx.window.y) + f64::from(point.1)) / scale;
+        if !global_x.is_finite()
+            || !global_y.is_finite()
+            || global_x < f64::from(f32::MIN)
+            || global_x > f64::from(f32::MAX)
+            || global_y < f64::from(f32::MIN)
+            || global_y > f64::from(f32::MAX)
+        {
+            return Err(GlassError::Backend(
+                "AX hit-test coordinate is not representable".into(),
+            ));
+        }
+        let &pid = ctx.pids.first().ok_or(GlassError::WindowNotFound)?;
+        let app = deadline.observe(|| ffi::app_element(pid as i32))?;
+        let hit = deadline
+            .observe(|| ffi::element_at_position(&app, global_x as f32, global_y as f32))??;
+        let Some(hit) = hit else {
+            return Ok(PointerHit::Inconclusive);
+        };
+
+        classify_pointer_hit(&target_el, target_role, hit, ctx.limits.depth, deadline)
+    }
+
     fn set_value(&mut self, ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
         let deadline = SemanticDeadline::set_value(ctx.deadline, target.id.0);
         deadline.require()?;
@@ -162,7 +217,7 @@ impl Accessibility for MacosA11y {
             return Err(GlassError::AxElementChanged(target.id.0));
         }
 
-        if !deadline.observe(|| ffi::is_settable(&el, attr::VALUE))? {
+        if !deadline.observe(|| ffi::is_settable_checked(&el, attr::VALUE))?? {
             return Err(GlassError::AxElementNotEditable(target.id.0));
         }
 
@@ -248,6 +303,128 @@ impl Accessibility for MacosA11y {
         })?;
         Ok(None)
     }
+}
+
+fn verify_target_fingerprint(
+    el: &AXUIElement,
+    ctx: &AxContext,
+    target: &AxTarget,
+    scale: f64,
+    deadline: SemanticDeadline,
+) -> Result<AxRole> {
+    let ax_role = deadline
+        .observe(|| ffi::attribute_string(el, attr::ROLE))?
+        .unwrap_or_default();
+    let subrole = read_subrole(el, &ax_role, deadline)?;
+    let role = mapping::map_role(&ax_role, subrole.as_deref());
+    let name = read_name(el, deadline)?;
+    let bounds = window_relative_rect(el, scale, &ctx.window, deadline)?;
+    if !target.matches(role, name.as_deref())
+        || !target.bounds_consistent(bounds, SET_VALUE_BOUNDS_TOL)
+    {
+        return Err(GlassError::AxElementChanged(target.id.0));
+    }
+    deadline.require()?;
+    Ok(role)
+}
+
+fn checked_role(el: &AXUIElement, deadline: SemanticDeadline) -> Result<AxRole> {
+    let ax_role = deadline
+        .observe(|| ffi::attribute_string_checked(el, attr::ROLE))??
+        .unwrap_or_default();
+    let subrole = if mapping::subrole_matters(&ax_role) {
+        deadline.observe(|| ffi::attribute_string_checked(el, attr::SUBROLE))??
+    } else {
+        deadline.require()?;
+        None
+    };
+    Ok(mapping::map_role(&ax_role, subrole.as_deref()))
+}
+
+fn same_element(a: &AXUIElement, b: &AXUIElement, deadline: SemanticDeadline) -> Result<bool> {
+    deadline.observe(|| ffi::same_element(a, b))
+}
+
+fn contains_element(
+    elements: &[CFRetained<AXUIElement>],
+    candidate: &AXUIElement,
+    deadline: SemanticDeadline,
+) -> Result<bool> {
+    for element in elements {
+        if same_element(element, candidate, deadline)? {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn first_interactable_ancestor(
+    target: &AXUIElement,
+    depth_limit: usize,
+    deadline: SemanticDeadline,
+) -> Result<Option<CFRetained<AXUIElement>>> {
+    let mut current = deadline.observe(|| ffi::parent(target))??;
+    let mut seen = Vec::new();
+    for _ in 0..depth_limit {
+        let Some(parent) = current else {
+            return Ok(None);
+        };
+        if contains_element(&seen, &parent, deadline)? {
+            return Err(GlassError::Backend("cyclic AX target ancestry".into()));
+        }
+        if checked_role(&parent, deadline)?.is_interactable() {
+            return Ok(Some(parent));
+        }
+        seen.push(parent.clone());
+        current = deadline.observe(|| ffi::parent(&parent))??;
+    }
+    Err(GlassError::Backend(format!(
+        "AX target ancestry exceeded the configured depth limit ({depth_limit})"
+    )))
+}
+
+fn classify_pointer_hit(
+    target: &AXUIElement,
+    target_role: AxRole,
+    hit: CFRetained<AXUIElement>,
+    depth_limit: usize,
+    deadline: SemanticDeadline,
+) -> Result<PointerHit> {
+    if same_element(&hit, target, deadline)? {
+        return Ok(PointerHit::Target);
+    }
+    let accepted_ancestor = if target_role.is_interactable() {
+        None
+    } else {
+        first_interactable_ancestor(target, depth_limit, deadline)?
+    };
+    if let Some(ancestor) = &accepted_ancestor
+        && same_element(&hit, ancestor, deadline)?
+    {
+        return Ok(PointerHit::AcceptedAncestor);
+    }
+
+    let mut current = hit;
+    let mut seen = Vec::new();
+    for _ in 0..=depth_limit {
+        if same_element(&current, target, deadline)? {
+            return Ok(PointerHit::Target);
+        }
+        if checked_role(&current, deadline)?.is_interactable() {
+            return Ok(PointerHit::Other);
+        }
+        if contains_element(&seen, &current, deadline)? {
+            return Err(GlassError::Backend("cyclic AX hit ancestry".into()));
+        }
+        seen.push(current.clone());
+        let Some(parent) = deadline.observe(|| ffi::parent(&current))?? else {
+            return Ok(PointerHit::Other);
+        };
+        current = parent;
+    }
+    Err(GlassError::Backend(format!(
+        "AX hit ancestry exceeded the configured depth limit ({depth_limit})"
+    )))
 }
 
 struct WriteVerification<'a> {
@@ -842,12 +1019,10 @@ fn gather_states(
     // extra AX IPC round-trip) only for those roles — every other node skips it. `ToggleButton`
     // is where a switch lands, whichever base role its toolkit gave it.
     let (checkable, checked) = if mapping::role_carries_checked(role) {
-        let value = deadline.observe(|| ffi::attribute_i64(el, attr::VALUE))?;
+        let value = deadline.observe(|| ffi::attribute_i64_checked(el, attr::VALUE))??;
         if value.is_none() {
-            // A control of this role with no readable numeric value claims neither checked nor
-            // unchecked (the #170 invariant), so `condition:"checked"` silently matches nothing —
-            // say why here, since the tree cannot. Reads through the error-blind `attribute_i64`,
-            // so this cannot distinguish an absent value from a failed read.
+            // A control of this role with no numeric value claims neither checked nor unchecked;
+            // genuine AX failures have already propagated from the checked read.
             eprintln!(
                 "glass-a11y-macos: {role:?} has no readable AXValue; \
                  it will report neither checked nor unchecked"
@@ -859,13 +1034,13 @@ fn gather_states(
         (false, false)
     };
     let enabled = deadline
-        .observe(|| ffi::attribute_bool(el, attr::ENABLED))?
+        .observe(|| ffi::attribute_bool_checked(el, attr::ENABLED))??
         .unwrap_or(false);
     let focused = deadline
-        .observe(|| ffi::attribute_bool(el, attr::FOCUSED))?
+        .observe(|| ffi::attribute_bool_checked(el, attr::FOCUSED))??
         .unwrap_or(false);
-    let focusable = deadline.observe(|| ffi::is_settable(el, attr::FOCUSED))?;
-    let editable = deadline.observe(|| ffi::is_settable(el, attr::VALUE))?;
+    let focusable = deadline.observe(|| ffi::is_settable_checked(el, attr::FOCUSED))??;
+    let editable = deadline.observe(|| ffi::is_settable_checked(el, attr::VALUE))??;
     deadline.require()?;
     Ok(AxStateFacts {
         enabled,

--- a/crates/glass-a11y-macos/src/semantic_deadline.rs
+++ b/crates/glass-a11y-macos/src/semantic_deadline.rs
@@ -7,6 +7,7 @@ pub(crate) enum SemanticOperation {
     Snapshot,
     SetValue(u32),
     Invoke,
+    Focus,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -37,6 +38,14 @@ impl SemanticDeadline {
         Self {
             deadline,
             operation: SemanticOperation::Invoke,
+            dispatched: false,
+        }
+    }
+
+    pub(crate) fn focus(deadline: Deadline, _target: u32) -> Self {
+        Self {
+            deadline,
+            operation: SemanticOperation::Focus,
             dispatched: false,
         }
     }
@@ -72,6 +81,12 @@ impl SemanticDeadline {
             }
             (SemanticOperation::Invoke, true) => {
                 GlassError::caller_deadline_elapsed("native accessibility invoke")
+            }
+            (SemanticOperation::Focus, false) => {
+                GlassError::deadline_not_started("native accessibility focus")
+            }
+            (SemanticOperation::Focus, true) => {
+                GlassError::caller_deadline_elapsed("native accessibility focus")
             }
         }
     }
@@ -378,11 +393,38 @@ mod tests {
         for guard in [
             SemanticDeadline::set_value(Deadline::at(now), 7),
             SemanticDeadline::invoke(Deadline::at(now)),
+            SemanticDeadline::focus(Deadline::at(now), 7),
         ] {
             let error = guard.require_at(now).unwrap_err();
             assert_eq!(error.bound_owner(), Some(Whose::Caller));
             assert_eq!(error.bound_dispatch(), Some(BoundDispatch::NotDispatched));
         }
+    }
+
+    #[test]
+    fn focus_spent_before_the_ax_write_is_not_dispatched() {
+        let now = Instant::now();
+        let error = SemanticDeadline::focus(Deadline::at(now), 7)
+            .require_at(now)
+            .expect_err("focus must stop before a write when its deadline is spent");
+
+        assert_eq!(error.bound_owner(), Some(Whose::Caller));
+        assert_eq!(error.bound_dispatch(), Some(BoundDispatch::NotDispatched));
+    }
+
+    #[test]
+    fn focus_expiry_after_the_ax_write_may_have_dispatched() {
+        let now = Instant::now();
+        let error = SemanticDeadline::focus(Deadline::at(now), 7)
+            .after_dispatch()
+            .require_at(now)
+            .expect_err("focus expiry after the write must remain ambiguous");
+
+        assert_eq!(error.bound_owner(), Some(Whose::Caller));
+        assert_eq!(
+            error.bound_dispatch(),
+            Some(BoundDispatch::MayHaveDispatched)
+        );
     }
 
     #[test]

--- a/crates/glass-a11y-windows/src/mapping.rs
+++ b/crates/glass-a11y-windows/src/mapping.rs
@@ -3,7 +3,9 @@
 //! Control-type ids are the stable UIA `ControlTypeId` constants (50000..=50040); the reader
 //! passes the numeric id so this module needs no `uiautomation` dependency.
 
-use glass_core::{AxRole, AxStates};
+#[cfg(any(target_os = "windows", test))]
+use glass_core::PointerHit;
+use glass_core::{AxRole, AxStateCoverage, AxStates};
 
 /// Every documented UIA control type (the contiguous 50000..=50040 range), as
 /// `(ControlTypeId, canonical name, mapped role)`.
@@ -126,6 +128,41 @@ pub fn map_role_with_framework(
 /// (a vendor-defined or future control type).
 pub fn canonical_name(control_type_id: u32) -> Option<&'static str> {
     control_type(control_type_id).map(|(_, name, _)| *name)
+}
+
+/// Every normalized state fact the UIA reader obtains from a property or applicable pattern.
+pub const STATE_COVERAGE: AxStateCoverage = AxStateCoverage {
+    enabled: true,
+    visible: true,
+    checkable: true,
+    checked: true,
+    selected: true,
+    expanded: true,
+    focused: true,
+    focusable: true,
+    editable: true,
+};
+
+/// Classify UIA element-from-point evidence from node-to-root runtime-id paths.
+#[cfg(any(target_os = "windows", test))]
+pub(crate) fn classify_uia_hit_path(
+    target_path: &[&[i32]],
+    hit_path: Option<&[&[i32]]>,
+    hit_is_interactable: bool,
+) -> PointerHit {
+    let (Some(target), Some(hit_path)) = (target_path.first(), hit_path) else {
+        return PointerHit::Inconclusive;
+    };
+    let Some(hit) = hit_path.first() else {
+        return PointerHit::Inconclusive;
+    };
+    if hit == target || hit_path.iter().skip(1).any(|ancestor| ancestor == target) {
+        PointerHit::Target
+    } else if hit_is_interactable && target_path.iter().skip(1).any(|ancestor| ancestor == hit) {
+        PointerHit::AcceptedAncestor
+    } else {
+        PointerHit::Other
+    }
 }
 
 /// Plain state facts the reader gathers from a UIA element (no `uiautomation` types here,
@@ -280,6 +317,54 @@ pub const fn announcing_property(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn windows_mapping_declares_every_uia_fact_gather_reads() {
+        assert_eq!(
+            STATE_COVERAGE,
+            glass_core::AxStateCoverage {
+                enabled: true,
+                visible: true,
+                checkable: true,
+                checked: true,
+                selected: true,
+                expanded: true,
+                focused: true,
+                focusable: true,
+                editable: true,
+            }
+        );
+    }
+
+    #[test]
+    fn uia_hit_path_accepts_target_and_descendant_content_but_not_an_unrelated_element() {
+        let root = [1];
+        let target = [42, 7];
+        let descendant = [99, 1];
+        let unrelated = [88, 3];
+        let target_path = [&target[..], &root[..]];
+
+        assert_eq!(
+            [
+                classify_uia_hit_path(&target_path, Some(&target_path), true),
+                classify_uia_hit_path(
+                    &target_path,
+                    Some(&[&descendant[..], &target[..], &root[..]]),
+                    false,
+                ),
+                classify_uia_hit_path(&target_path, Some(&[&root[..]]), true),
+                classify_uia_hit_path(&target_path, Some(&[&unrelated[..], &root[..]]), true,),
+                classify_uia_hit_path(&target_path, None, false),
+            ],
+            [
+                glass_core::PointerHit::Target,
+                glass_core::PointerHit::Target,
+                glass_core::PointerHit::AcceptedAncestor,
+                glass_core::PointerHit::Other,
+                glass_core::PointerHit::Inconclusive,
+            ]
+        );
+    }
 
     #[test]
     fn common_control_types_map() {

--- a/crates/glass-a11y-windows/src/mapping.rs
+++ b/crates/glass-a11y-windows/src/mapping.rs
@@ -156,8 +156,14 @@ pub(crate) fn classify_uia_hit_path(
     let Some(hit) = hit_path.first() else {
         return PointerHit::Inconclusive;
     };
-    if hit == target || hit_path.iter().skip(1).any(|ancestor| ancestor == target) {
+    if hit == target {
         PointerHit::Target
+    } else if hit_path.iter().skip(1).any(|ancestor| ancestor == target) {
+        if hit_is_interactable {
+            PointerHit::Other
+        } else {
+            PointerHit::Target
+        }
     } else if hit_is_interactable && target_path.iter().skip(1).any(|ancestor| ancestor == hit) {
         PointerHit::AcceptedAncestor
     } else {
@@ -352,6 +358,11 @@ mod tests {
                     Some(&[&descendant[..], &target[..], &root[..]]),
                     false,
                 ),
+                classify_uia_hit_path(
+                    &target_path,
+                    Some(&[&descendant[..], &target[..], &root[..]]),
+                    true,
+                ),
                 classify_uia_hit_path(&target_path, Some(&[&root[..]]), true),
                 classify_uia_hit_path(&target_path, Some(&[&unrelated[..], &root[..]]), true,),
                 classify_uia_hit_path(&target_path, None, false),
@@ -359,6 +370,7 @@ mod tests {
             [
                 glass_core::PointerHit::Target,
                 glass_core::PointerHit::Target,
+                glass_core::PointerHit::Other,
                 glass_core::PointerHit::AcceptedAncestor,
                 glass_core::PointerHit::Other,
                 glass_core::PointerHit::Inconclusive,

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -7,8 +7,8 @@ use std::time::{Duration, Instant};
 
 use glass_core::{
     A11yMutationDispatch, A11yThread, Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxTarget,
-    AxTree, ChangeSignal, GlassError, Result, WalkBudget, normalize_description, normalize_name,
-    read_back_confirms, write_took_no_effect,
+    AxTree, ChangeSignal, GlassError, PointerHit, Result, WalkBudget, normalize_description,
+    normalize_name, read_back_confirms, write_took_no_effect,
 };
 use uiautomation::patterns::{
     UIExpandCollapsePattern, UIInvokePattern, UIRangeValuePattern, UISelectionItemPattern,
@@ -60,6 +60,32 @@ impl Accessibility for WindowsA11y {
         crate::events::subscribe(ctx)
     }
 
+    fn state_coverage(&self) -> glass_core::AxStateCoverage {
+        crate::mapping::STATE_COVERAGE
+    }
+
+    fn focus(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<Option<AxNodeId>> {
+        let ctx = ctx.clone();
+        let target = target.clone();
+        focus_with_thread(&UIA, ctx, move |ctx, dispatch| {
+            run_focus(&ctx, &target, dispatch)
+        })?;
+        Ok(None)
+    }
+
+    fn pointer_target_at(
+        &mut self,
+        ctx: &AxContext,
+        target: &AxTarget,
+        point: (i32, i32),
+    ) -> Result<PointerHit> {
+        let ctx = ctx.clone();
+        let target = target.clone();
+        UIA.snapshot(ctx.deadline, move || {
+            run_pointer_target_at(&ctx, &target, point)
+        })
+    }
+
     fn set_value(&mut self, ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
         let ctx = ctx.clone();
         let target = target.clone();
@@ -97,8 +123,32 @@ fn invoke_with_thread(
     thread.invoke(ctx.deadline, move |dispatch| job(ctx, dispatch))
 }
 
+fn focus_with_thread(
+    thread: &A11yThread,
+    ctx: AxContext,
+    job: impl FnOnce(AxContext, &A11yMutationDispatch) -> Result<()> + Send + 'static,
+) -> Result<()> {
+    thread.focus(ctx.deadline, move |dispatch| job(ctx, dispatch))
+}
+
 fn uia_err(e: impl std::fmt::Display) -> GlassError {
     GlassError::AccessibilityUnavailable(format!("UI Automation error: {e}"))
+}
+
+fn required_uia<T>(result: uiautomation::Result<T>) -> Result<T> {
+    result.map_err(uia_err)
+}
+
+fn optional_uia<T>(result: uiautomation::Result<T>) -> Result<Option<T>> {
+    match result {
+        Ok(value) => Ok(Some(value)),
+        Err(error) if error.code() == 0 => Ok(None),
+        Err(error) => Err(uia_err(error)),
+    }
+}
+
+fn optional_pattern<T>(result: uiautomation::Result<T>) -> Result<Option<T>> {
+    optional_uia(result)
 }
 
 fn run_snapshot(ctx: &AxContext) -> Result<AxTree> {
@@ -173,7 +223,7 @@ fn walk(
     let name = nonempty(el.get_name().unwrap_or_default());
     let description = normalize_description(&help_text(el, ct_id), name.as_deref());
     let bounds = window_relative_bounds(el, origin);
-    let (facts, value) = gather(el, ct_id);
+    let (facts, value) = gather(el, ct_id)?;
     let states = crate::mapping::map_states(&facts);
 
     let mut children = Vec::new();
@@ -229,63 +279,53 @@ fn walk(
 /// same role regardless of which path reads it, and only one COM round-trip is spent per node
 /// either way — the same reason the value-pattern probe below fetches once for two facts.
 ///
-/// "This control has no Toggle pattern" and "the fetch failed" both yield `None` — a failure
-/// must not fail a whole snapshot over one node — but they are not the same event, and only one
-/// of them is a bug: a transient failure reports a toggle-capable `Button` as a plain `Button`,
-/// and since the same value feeds the `run_set_value`/`run_invoke` fingerprint, it surfaces to
-/// the caller as `AxElementChanged` ("the tree drifted") for an element that never moved. So the
-/// failure case logs. The two are told apart by the returned code: UIA documents
-/// `GetCurrentPattern` as returning success with a NULL interface for an unsupported pattern,
-/// which the bindings surface as an error carrying a *non-failure* code (`Error::result()` is
-/// `None`); a real COM failure carries a failure `HRESULT`. Neither path costs an extra
-/// round-trip.
-fn toggle_pattern(el: &UIElement, ct_id: u32) -> Option<UITogglePattern> {
+/// An unsupported pattern is the binding's explicit non-failure sentinel (`Error::code() == 0`),
+/// which [`optional_pattern`] maps to `None`. Every real HRESULT failure propagates so a transient
+/// provider error cannot silently change the node's role or state.
+fn toggle_pattern(el: &UIElement, ct_id: u32) -> Result<Option<UITogglePattern>> {
     if !matches!(ct_id, 50000 | 50002 | 50011 | 50031) {
         // Button/CheckBox/MenuItem/SplitButton
-        return None;
+        return Ok(None);
     }
-    match el.get_pattern::<UITogglePattern>() {
-        Ok(p) => Some(p),
-        Err(e) => {
-            if e.result().is_some() {
-                // Dev-tool diagnostic (stderr only, same shape as `select_window`'s in the
-                // macOS reader): without it, a control whose Toggle fetch broke is
-                // indistinguishable after the fact from one that never had the pattern.
-                eprintln!(
-                    "glass-a11y-windows: Toggle-pattern fetch failed on control type {ct_id} \
-                     (HRESULT {:#010x}: {e}); treating the element as not toggle-capable",
-                    e.code()
-                );
-            }
-            None
-        }
-    }
+    optional_pattern(el.get_pattern::<UITogglePattern>())
 }
 
 /// Gather state facts + the value string in one pass, gating each pattern probe by control type
 /// so we don't make a live cross-process `get_pattern` call for a pattern the control can't support
 /// (UIA is chatty — each probe is an out-of-process COM round-trip).
-fn gather(el: &UIElement, ct_id: u32) -> (crate::mapping::StateFacts, Option<String>) {
+fn gather(el: &UIElement, ct_id: u32) -> Result<(crate::mapping::StateFacts, Option<String>)> {
     // Fetch the Toggle pattern once: its mere presence is `checkable` (the control exposes
     // on/off semantics at all), independent of whether we can also read its current state.
-    let pattern = toggle_pattern(el, ct_id);
+    let pattern = toggle_pattern(el, ct_id)?;
     let checkable = pattern.is_some();
-    let toggled_on = pattern
-        .and_then(|p| p.get_toggle_state().ok())
-        .map(|s| s == ToggleState::On)
-        .unwrap_or(false);
-    let selected = matches!(ct_id, 50007 | 50019 | 50024 | 50029) // ListItem/TabItem/TreeItem/DataItem
-        && el.get_pattern::<UISelectionItemPattern>().ok()
-            .and_then(|p| p.is_selected().ok()).unwrap_or(false);
-    let expanded = matches!(ct_id, 50003 | 50009 | 50011 | 50023 | 50024 | 50026 | 50033) // ComboBox/Menu/MenuItem/Tree/TreeItem/Group/Pane
-        && el.get_pattern::<UIExpandCollapsePattern>().ok()
-            .and_then(|p| p.get_state().ok())
-            .map(|s| s == ExpandCollapseState::Expanded).unwrap_or(false);
+    let toggled_on = match pattern.as_ref() {
+        Some(pattern) => required_uia(pattern.get_toggle_state())? == ToggleState::On,
+        None => false,
+    };
+    let selected = if matches!(ct_id, 50007 | 50019 | 50024 | 50029) {
+        match optional_pattern(el.get_pattern::<UISelectionItemPattern>())? {
+            Some(pattern) => required_uia(pattern.is_selected())?,
+            None => false,
+        }
+    } else {
+        false
+    };
+    let expanded = if matches!(ct_id, 50003 | 50009 | 50011 | 50023 | 50024 | 50026 | 50033) {
+        match optional_pattern(el.get_pattern::<UIExpandCollapsePattern>())? {
+            Some(pattern) => required_uia(pattern.get_state())? == ExpandCollapseState::Expanded,
+            None => false,
+        }
+    } else {
+        false
+    };
     // Value pattern: one fetch for both the value string and read-only (Edit/ComboBox/Document)
     let (value_text, readonly) = if matches!(ct_id, 50003 | 50004 | 50030) {
-        match el.get_pattern::<UIValuePattern>() {
-            Ok(p) => (p.get_value().ok(), p.is_readonly().ok()),
-            Err(_) => (None, None),
+        match optional_pattern(el.get_pattern::<UIValuePattern>())? {
+            Some(pattern) => (
+                Some(required_uia(pattern.get_value())?),
+                Some(required_uia(pattern.is_readonly())?),
+            ),
+            None => (None, None),
         }
     } else {
         (None, None)
@@ -293,16 +333,18 @@ fn gather(el: &UIElement, ct_id: u32) -> (crate::mapping::StateFacts, Option<Str
     // RangeValue pattern: a Slider/Spinner/ProgressBar exposes its numeric position here, never
     // via ValuePattern, so read it (gated by control type — `get_pattern` is a COM round-trip) so
     // `value_contains`/`wait_for_element` can match the number.
-    let value = value_text.or_else(|| {
-        matches!(ct_id, 50012 | 50015 | 50016) // ProgressBar/Slider/Spinner
-            .then(|| {
-                el.get_pattern::<UIRangeValuePattern>()
-                    .ok()
-                    .and_then(|p| p.get_value().ok())
-                    .map(crate::mapping::format_range_value)
-            })
-            .flatten()
-    });
+    let value = if value_text.is_some() {
+        value_text
+    } else if matches!(ct_id, 50012 | 50015 | 50016) {
+        match optional_pattern(el.get_pattern::<UIRangeValuePattern>())? {
+            Some(pattern) => Some(crate::mapping::format_range_value(required_uia(
+                pattern.get_value(),
+            )?)),
+            None => None,
+        }
+    } else {
+        None
+    };
     // Editable iff a writable ValuePattern is present — for ANY value-bearing
     // control (Edit/ComboBox/Document), not just Edit; otherwise a writable
     // ComboBox/Document reports editable=false while set_value would succeed on
@@ -311,18 +353,18 @@ fn gather(el: &UIElement, ct_id: u32) -> (crate::mapping::StateFacts, Option<Str
     let editable =
         matches!(ct_id, 50003 | 50004 | 50030) && readonly.map(|ro| !ro).unwrap_or(false);
     let facts = crate::mapping::StateFacts {
-        enabled: el.is_enabled().unwrap_or(false),
-        offscreen: el.is_offscreen().unwrap_or(false),
-        focused: el.has_keyboard_focus().unwrap_or(false),
-        focusable: el.is_keyboard_focusable().unwrap_or(false),
+        enabled: required_uia(el.is_enabled())?,
+        offscreen: required_uia(el.is_offscreen())?,
+        focused: required_uia(el.has_keyboard_focus())?,
+        focusable: required_uia(el.is_keyboard_focusable())?,
         selected,
         toggled_on,
         expanded,
         editable,
-        secure: el.is_password().unwrap_or(false),
+        secure: required_uia(el.is_password())?,
         checkable,
     };
-    (facts, value)
+    Ok((facts, value))
 }
 
 /// `el`'s UIA `HelpText` — the tooltip, and the secondary label the outline renders as
@@ -379,6 +421,120 @@ fn framework_id(el: &UIElement, ct_id: u32) -> Option<String> {
     nonempty(el.get_framework_id().unwrap_or_default())
 }
 
+fn find_target(
+    walker: &UITreeWalker,
+    window: &UIElement,
+    ctx: &AxContext,
+    target: &AxTarget,
+) -> Result<UIElement> {
+    let mut budget = WalkBudget::with_limits(ctx.limits);
+    find_nth(walker, window, 0, &mut budget, target.id.0)?
+        .ok_or(GlassError::AxElementChanged(target.id.0))
+}
+
+fn verify_target_fingerprint(el: &UIElement, ctx: &AxContext, target: &AxTarget) -> Result<u32> {
+    let ct_id = required_uia(el.get_control_type())? as i32 as u32;
+    let role = crate::mapping::map_role_with_framework(
+        ct_id,
+        toggle_pattern(el, ct_id)?.is_some(),
+        framework_id(el, ct_id).as_deref(),
+    );
+    let name = nonempty(required_uia(el.get_name())?);
+    let bounds = window_relative_bounds(el, (ctx.window.x, ctx.window.y));
+    if !target.matches(role, name.as_deref())
+        || !target.bounds_consistent(bounds, SET_VALUE_BOUNDS_TOL)
+    {
+        return Err(GlassError::AxElementChanged(target.id.0));
+    }
+    Ok(ct_id)
+}
+
+fn run_focus(ctx: &AxContext, target: &AxTarget, dispatch: &A11yMutationDispatch) -> Result<()> {
+    let automation = UIAutomation::new().map_err(uia_err)?;
+    let root = find_app_window(&automation, ctx)?;
+    let walker = automation.get_control_view_walker().map_err(uia_err)?;
+    let element = find_target(&walker, &root, ctx, target)?;
+    let ct_id = verify_target_fingerprint(&element, ctx, target)?;
+    let (facts, _) = gather(&element, ct_id)?;
+    if !facts.focusable && !facts.editable {
+        return Err(GlassError::AxActionUnavailable(target.id.0));
+    }
+    dispatch.dispatch(|| element.set_focus().map_err(uia_err))
+}
+
+fn runtime_id_path(
+    automation: &UIAutomation,
+    walker: &UITreeWalker,
+    root: &UIElement,
+    element: &UIElement,
+    depth_limit: usize,
+) -> Result<Vec<Vec<i32>>> {
+    let mut path = Vec::new();
+    let mut current = element.clone();
+    for _ in 0..=depth_limit {
+        path.push(required_uia(current.get_runtime_id())?);
+        if required_uia(automation.compare_elements(&current, root))? {
+            return Ok(path);
+        }
+        let Some(parent) = optional_uia(walker.get_parent(&current))? else {
+            return Ok(path);
+        };
+        current = parent;
+    }
+    Err(GlassError::AccessibilityUnavailable(format!(
+        "UI Automation hit ancestry exceeded the configured depth limit ({depth_limit})"
+    )))
+}
+
+fn run_pointer_target_at(
+    ctx: &AxContext,
+    target: &AxTarget,
+    point: (i32, i32),
+) -> Result<PointerHit> {
+    if ctx.deadline.has_passed() {
+        return Err(GlassError::deadline_not_started("pointer hit probe"));
+    }
+    let automation = UIAutomation::new().map_err(uia_err)?;
+    let root = find_app_window(&automation, ctx)?;
+    let walker = automation.get_control_view_walker().map_err(uia_err)?;
+    let element = find_target(&walker, &root, ctx, target)?;
+    verify_target_fingerprint(&element, ctx, target)?;
+
+    let screen_x = ctx
+        .window
+        .x
+        .checked_add(point.0)
+        .ok_or_else(|| GlassError::Backend("UIA hit-test x coordinate overflow".into()))?;
+    let screen_y = ctx
+        .window
+        .y
+        .checked_add(point.1)
+        .ok_or_else(|| GlassError::Backend("UIA hit-test y coordinate overflow".into()))?;
+    let screen = uiautomation::types::Point::new(screen_x, screen_y);
+    let Some(hit) = optional_uia(automation.element_from_point(screen))? else {
+        return Ok(PointerHit::Inconclusive);
+    };
+    if required_uia(automation.compare_elements(&hit, &element))? {
+        return Ok(PointerHit::Target);
+    }
+
+    let hit_ct_id = required_uia(hit.get_control_type())? as i32 as u32;
+    let hit_role = crate::mapping::map_role_with_framework(
+        hit_ct_id,
+        toggle_pattern(&hit, hit_ct_id)?.is_some(),
+        framework_id(&hit, hit_ct_id).as_deref(),
+    );
+    let target_ids = runtime_id_path(&automation, &walker, &root, &element, ctx.limits.depth)?;
+    let hit_ids = runtime_id_path(&automation, &walker, &root, &hit, ctx.limits.depth)?;
+    let target_path = target_ids.iter().map(Vec::as_slice).collect::<Vec<_>>();
+    let hit_path = hit_ids.iter().map(Vec::as_slice).collect::<Vec<_>>();
+    Ok(crate::mapping::classify_uia_hit_path(
+        &target_path,
+        Some(&hit_path),
+        hit_role.is_interactable(),
+    ))
+}
+
 fn run_set_value(
     ctx: &AxContext,
     target: &AxTarget,
@@ -393,31 +549,16 @@ fn run_set_value(
 
     // Start at 0 so find_nth's pre-order numbering matches snapshot's walk +
     // assign_ids (root id = 0); the role+name verify backstops any drift.
-    let mut budget = WalkBudget::with_limits(ctx.limits);
-    let el = find_nth(&walker, &window, 0, &mut budget, target.id.0)
-        .ok_or(GlassError::AxElementChanged(target.id.0))?;
+    let el = find_target(&walker, &window, ctx, target)?;
 
     // Verify role + name + bounds (guards a stale id / tree drift). role+name
     // alone isn't unique (many controls share a role and an empty name), so if
     // drift lands a different same-role+name element on this pre-order id, the
     // bounds fingerprint — the element sits elsewhere — rejects it. A target
     // without captured bounds falls back to role+name only.
-    let ct_id = el.get_control_type().map_err(uia_err)? as i32 as u32;
-    let role = crate::mapping::map_role_with_framework(
-        ct_id,
-        toggle_pattern(&el, ct_id).is_some(),
-        framework_id(&el, ct_id).as_deref(),
-    );
-    let name = nonempty(el.get_name().unwrap_or_default());
-    let bounds = window_relative_bounds(&el, (ctx.window.x, ctx.window.y));
-    if !target.matches(role, name.as_deref())
-        || !target.bounds_consistent(bounds, SET_VALUE_BOUNDS_TOL)
-    {
-        return Err(GlassError::AxElementChanged(target.id.0));
-    }
-    let pat = el
-        .get_pattern::<UIValuePattern>()
-        .map_err(|_| GlassError::AxElementNotEditable(target.id.0))?;
+    verify_target_fingerprint(&el, ctx, target)?;
+    let pat = optional_pattern(el.get_pattern::<UIValuePattern>())?
+        .ok_or(GlassError::AxElementNotEditable(target.id.0))?;
     // Pre-write value: the baseline for the "changed" check. `None` (a failed pre-read) means the
     // baseline is unknown — the confirmation below then requires an exact match rather than
     // trusting a "differs from before" signal it cannot compute.
@@ -470,17 +611,12 @@ fn run_set_value(
 /// which `click_element` (glass-core) treats as a fall-back-to-pointer signal, not a fatal error.
 ///
 /// Only the Toggle rung has a post-state a client can read back, so only it verifies actuation;
-/// the other three are fire-and-report, exactly as their patterns define. That rung is also the
-/// one exception to "first pattern wins": if its state can't be read it is skipped rather than
-/// failed, since it cannot be verified and nothing has been dispatched yet.
+/// the other three are fire-and-report, exactly as their patterns define. A failed Toggle state
+/// read is a real provider error and propagates before dispatch.
 ///
-/// Known limitation, deliberate: `get_pattern` returning `Err` is indistinguishable here between
-/// "this control does not implement the pattern" and "the COM call itself failed", so both land
-/// on `AxActionUnavailable` and fall back to a pointer click. That is the safe direction —
-/// `get_pattern` dispatches no action, so the fallback actuates exactly once. UIA does publish
-/// `Is<Pattern>Available` properties that could tell the two apart, but acting on them would turn
-/// a disagreement between property and `get_pattern` into a hard, non-falling-back click failure
-/// (an error after dispatch never falls back), trading a harmless pointer click for a dead one.
+/// UIA explicitly identifies unsupported patterns with `UIA_E_NOTSUPPORTED`; only that result is
+/// treated as absence. Every other pattern lookup failure propagates, so a provider or COM failure
+/// cannot silently become pointer fallback.
 fn run_invoke(ctx: &AxContext, target: &AxTarget, dispatch: &A11yMutationDispatch) -> Result<()> {
     let automation = UIAutomation::new().map_err(|e| {
         GlassError::AccessibilityUnavailable(format!("UI Automation unavailable: {e}"))
@@ -490,65 +626,44 @@ fn run_invoke(ctx: &AxContext, target: &AxTarget, dispatch: &A11yMutationDispatc
 
     // Start at 0 so find_nth's pre-order numbering matches snapshot's walk + assign_ids, same as
     // run_set_value.
-    let mut budget = WalkBudget::with_limits(ctx.limits);
-    let el = find_nth(&walker, &window, 0, &mut budget, target.id.0)
-        .ok_or(GlassError::AxElementChanged(target.id.0))?;
+    let el = find_target(&walker, &window, ctx, target)?;
 
     // Same fingerprint gate as run_set_value: role + name + bounds.
-    let ct_id = el.get_control_type().map_err(uia_err)? as i32 as u32;
-    let role = crate::mapping::map_role_with_framework(
-        ct_id,
-        toggle_pattern(&el, ct_id).is_some(),
-        framework_id(&el, ct_id).as_deref(),
-    );
-    let name = nonempty(el.get_name().unwrap_or_default());
-    let bounds = window_relative_bounds(&el, (ctx.window.x, ctx.window.y));
-    if !target.matches(role, name.as_deref())
-        || !target.bounds_consistent(bounds, SET_VALUE_BOUNDS_TOL)
-    {
-        return Err(GlassError::AxElementChanged(target.id.0));
-    }
+    verify_target_fingerprint(&el, ctx, target)?;
 
     let fail = |e: uiautomation::Error| GlassError::AxActionFailed(target.id.0, e.to_string());
-    if let Ok(p) = el.get_pattern::<UIInvokePattern>() {
+    if let Some(p) = optional_pattern(el.get_pattern::<UIInvokePattern>())? {
         return dispatch.dispatch(|| p.invoke().map_err(fail));
     }
-    if let Ok(p) = el.get_pattern::<UITogglePattern>() {
+    if let Some(p) = optional_pattern(el.get_pattern::<UITogglePattern>())? {
         // Toggle is the one rung with a readable post-state, so don't take the ack as proof:
         // a provider that accepts `Toggle()` without applying it would otherwise report a
         // successful click on a control that never moved. Read before, fire, then poll until
-        // the state differs — same cadence as `run_set_value`'s write verify.
-        //
-        // A pattern whose state can't even be READ can't be verify-toggled, so this rung is
-        // unusable — fall through to the rest of the ladder instead of reporting a failure.
-        // Nothing has been dispatched at this point, so falling through is safe: the worst
-        // outcome is `AxActionUnavailable` and a single pointer click, whereas an error here
-        // would propagate (an error after dispatch never falls back) and kill the click.
-        if let Ok(before) = p.get_toggle_state() {
-            dispatch.dispatch(|| p.toggle().map_err(fail))?;
-            let deadline = Instant::now() + Duration::from_millis(SET_VALUE_VERIFY_MS);
-            loop {
-                // Past the dispatch, a failed read IS a failure: `fail` (AxActionFailed) is
-                // right here, because the toggle may have landed and must not be re-actuated.
-                if p.get_toggle_state().map_err(fail)? != before {
-                    return Ok(());
-                }
-                if Instant::now() >= deadline {
-                    // `AxActionFailed`, not `AxActionUnavailable`: the toggle WAS dispatched,
-                    // so this must not fall back to a pointer click that could actuate twice.
-                    return Err(GlassError::AxActionFailed(
-                        target.id.0,
-                        "the toggle action was acknowledged but the state did not change".into(),
-                    ));
-                }
-                std::thread::sleep(Duration::from_millis(VERIFY_POLL_MS));
+        // the state differs, using the same cadence as `run_set_value`'s write verification.
+        let before = p.get_toggle_state().map_err(fail)?;
+        dispatch.dispatch(|| p.toggle().map_err(fail))?;
+        let deadline = Instant::now() + Duration::from_millis(SET_VALUE_VERIFY_MS);
+        loop {
+            // Past the dispatch, a failed read IS a failure: `fail` (AxActionFailed) is
+            // right here, because the toggle may have landed and must not be re-actuated.
+            if p.get_toggle_state().map_err(fail)? != before {
+                return Ok(());
             }
+            if Instant::now() >= deadline {
+                // `AxActionFailed`, not `AxActionUnavailable`: the toggle WAS dispatched,
+                // so this must not fall back to a pointer click that could actuate twice.
+                return Err(GlassError::AxActionFailed(
+                    target.id.0,
+                    "the toggle action was acknowledged but the state did not change".into(),
+                ));
+            }
+            std::thread::sleep(Duration::from_millis(VERIFY_POLL_MS));
         }
     }
-    if let Ok(p) = el.get_pattern::<UISelectionItemPattern>() {
+    if let Some(p) = optional_pattern(el.get_pattern::<UISelectionItemPattern>())? {
         return dispatch.dispatch(|| p.select().map_err(fail));
     }
-    if let Ok(p) = el.get_pattern::<UIExpandCollapsePattern>() {
+    if let Some(p) = optional_pattern(el.get_pattern::<UIExpandCollapsePattern>())? {
         let expanded = p.get_state().map_err(fail)? == ExpandCollapseState::Expanded;
         return dispatch
             .dispatch(|| if expanded { p.collapse() } else { p.expand() }.map_err(fail));
@@ -567,20 +682,20 @@ fn find_nth(
     depth: usize,
     budget: &mut WalkBudget,
     target: u32,
-) -> Option<UIElement> {
+) -> Result<Option<UIElement>> {
     if budget.nodes_walked() == target as usize {
-        return Some(el.clone());
+        return Ok(Some(el.clone()));
     }
     budget.visit();
     // Resolved before the gate: a childless node must never be reported truncated for
     // declining to explore a list that was already empty.
-    let first_child = step(walker.get_first_child(el), budget);
+    let first_child = optional_uia(walker.get_first_child(el))?;
     // Same gap as `walk`: only tests whether a first child exists, before `is_offscreen` runs.
     // A node whose children are all offscreen, reached once the budget is spent, still records
     // a truncation though nothing real was declined — left as-is for the same reason: it would
     // mean walking the whole sibling chain, exactly the scan `MAX_SIBLINGS` exists to bound.
     if first_child.is_none() || !budget.may_explore_children(depth) {
-        return None;
+        return Ok(None);
     }
     let mut child = first_child;
     let mut siblings = 0usize;
@@ -592,19 +707,59 @@ fn find_nth(
             break;
         }
         siblings += 1;
-        if !c.is_offscreen().unwrap_or(false)
-            && let Some(found) = find_nth(walker, &c, depth + 1, budget, target)
+        if !required_uia(c.is_offscreen())?
+            && let Some(found) = find_nth(walker, &c, depth + 1, budget, target)?
         {
-            return Some(found);
+            return Ok(Some(found));
         }
-        child = step(walker.get_next_sibling(&c), budget);
+        child = optional_uia(walker.get_next_sibling(&c))?;
     }
-    None
+    Ok(None)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn uia_property_hresult_is_propagated_instead_of_becoming_false() {
+        let error = required_uia::<bool>(Err(uiautomation::Error::new(
+            0x8000_4005_u32 as i32,
+            "synthetic property failure",
+        )))
+        .expect_err("a failed required property read must remain an error");
+
+        assert!(
+            matches!(error, GlassError::AccessibilityUnavailable(ref message)
+                if message.contains("synthetic property failure")),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn uia_pattern_hresult_is_propagated_instead_of_becoming_absent() {
+        let error = optional_pattern::<()>(Err(uiautomation::Error::new(
+            0x8000_4005_u32 as i32,
+            "synthetic pattern failure",
+        )))
+        .expect_err("a real pattern HRESULT must remain an error");
+
+        assert!(
+            matches!(error, GlassError::AccessibilityUnavailable(ref message)
+                if message.contains("synthetic pattern failure")),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn only_explicit_unsupported_pattern_result_becomes_absent() {
+        let pattern =
+            optional_pattern::<()>(Err(uiautomation::Error::new(0, "unsupported pattern"))).expect(
+                "the dependency's explicit unsupported-pattern sentinel is not a COM failure",
+            );
+
+        assert_eq!(pattern, None);
+    }
 
     #[test]
     fn windows_set_value_forwards_ax_context_deadline_to_a11y_thread() {

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -7,8 +7,8 @@ use std::time::{Duration, Instant};
 
 use glass_core::{
     A11yMutationDispatch, A11yThread, Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxTarget,
-    AxTree, ChangeSignal, GlassError, PointerHit, Result, WalkBudget, normalize_description,
-    normalize_name, read_back_confirms, write_took_no_effect,
+    AxTree, ChangeSignal, Deadline, GlassError, PointerHit, Result, WalkBudget, Whose,
+    normalize_description, normalize_name, read_back_confirms, write_took_no_effect,
 };
 use uiautomation::patterns::{
     UIExpandCollapsePattern, UIInvokePattern, UIRangeValuePattern, UISelectionItemPattern,
@@ -147,21 +147,79 @@ fn optional_uia<T>(result: uiautomation::Result<T>) -> Result<Option<T>> {
     }
 }
 
+#[cfg(test)]
 fn optional_pattern<T>(result: uiautomation::Result<T>) -> Result<Option<T>> {
     optional_uia(result)
 }
 
+fn required_com<T>(
+    deadline: Deadline,
+    operation: &str,
+    call: impl FnOnce() -> uiautomation::Result<T>,
+) -> Result<T> {
+    ensure_com_deadline(deadline, operation)?;
+    required_uia(call())
+}
+
+fn optional_com<T>(
+    deadline: Deadline,
+    operation: &str,
+    call: impl FnOnce() -> uiautomation::Result<T>,
+) -> Result<Option<T>> {
+    ensure_com_deadline(deadline, operation)?;
+    optional_uia(call())
+}
+
+fn confirmation_com<T>(
+    deadline: Deadline,
+    operation: &str,
+    call: impl FnOnce() -> uiautomation::Result<T>,
+) -> Result<T> {
+    required_com(deadline, operation, call).map_err(GlassError::after_dispatch)
+}
+
+fn ensure_com_deadline(deadline: Deadline, operation: &str) -> Result<()> {
+    ensure_com_deadline_at(deadline, Instant::now(), operation)
+}
+
+fn ensure_com_deadline_at(deadline: Deadline, now: Instant, operation: &str) -> Result<()> {
+    if deadline
+        .remaining_at(now)
+        .is_some_and(|remaining| remaining.is_zero())
+    {
+        Err(GlassError::deadline_not_started(operation))
+    } else {
+        Ok(())
+    }
+}
+
+fn confirmation_end_at(deadline: Deadline, ceiling: Duration, now: Instant) -> Instant {
+    deadline.resolve(now + ceiling).0
+}
+
+fn may_request_parent(depth: usize, depth_limit: usize) -> bool {
+    depth < depth_limit
+}
+
 fn run_snapshot(ctx: &AxContext) -> Result<AxTree> {
     // UIAutomation::new() initializes COM (MTA) on this thread.
-    let automation = UIAutomation::new().map_err(|e| {
-        GlassError::AccessibilityUnavailable(format!("UI Automation unavailable: {e}"))
+    let automation = required_com(ctx.deadline, "initialize UI Automation", UIAutomation::new)?;
+    let walker = required_com(ctx.deadline, "get UIA control-view walker", || {
+        automation.get_control_view_walker()
     })?;
-    let walker = automation.get_control_view_walker().map_err(uia_err)?;
     let window = find_app_window(&automation, ctx)?;
 
     let origin = (ctx.window.x, ctx.window.y);
     let mut budget = WalkBudget::with_limits(ctx.limits);
-    let root_node = walk(&walker, &window, origin, 0, &mut budget)?;
+    let root_node = walk(
+        &walker,
+        &window,
+        origin,
+        (ctx.window.width, ctx.window.height),
+        0,
+        &mut budget,
+        ctx.deadline,
+    )?;
     let mut tree = AxTree::new(root_node);
     tree.truncated = budget.truncation();
     tree.unreadable = budget.unreadable();
@@ -180,9 +238,9 @@ pub(crate) fn find_app_window(automation: &UIAutomation, ctx: &AxContext) -> Res
             "no active window handle in the a11y context (the backend adopted no window)".into(),
         )
     })?;
-    automation
-        .element_from_handle(Handle::from(handle as isize))
-        .map_err(uia_err)
+    required_com(ctx.deadline, "get UIA element from window handle", || {
+        automation.element_from_handle(Handle::from(handle as isize))
+    })
 }
 
 /// A tree-walker step's result, with a genuine read failure counted on `budget`.
@@ -193,13 +251,20 @@ pub(crate) fn find_app_window(automation: &UIAutomation, ctx: &AxContext) -> Res
 /// empty-error sentinel back to `HRESULT(0)`), while a real failure carries a negative HRESULT,
 /// and `uiautomation::Error::result` is `Some` only for a negative code. A plain `.ok()` collapses
 /// the two, which is what let a dropped subtree read as an empty one.
-fn step(r: uiautomation::Result<UIElement>, budget: &mut WalkBudget) -> Option<UIElement> {
-    r.inspect_err(|e| {
-        if e.result().is_some() {
-            budget.note_unreadable();
-        }
-    })
-    .ok()
+fn step(
+    deadline: Deadline,
+    operation: &str,
+    budget: &mut WalkBudget,
+    call: impl FnOnce() -> uiautomation::Result<UIElement>,
+) -> Result<Option<UIElement>> {
+    ensure_com_deadline(deadline, operation)?;
+    Ok(call()
+        .inspect_err(|e| {
+            if e.result().is_some() {
+                budget.note_unreadable();
+            }
+        })
+        .ok())
 }
 
 /// Recursively build a normalized node, bounded by [`WalkBudget`] (node count, nesting depth,
@@ -209,34 +274,38 @@ fn walk(
     walker: &UITreeWalker,
     el: &UIElement,
     origin: (i32, i32),
+    window_size: (u32, u32),
     depth: usize,
     budget: &mut WalkBudget,
+    deadline: Deadline,
 ) -> Result<AxNode> {
     budget.visit();
-    let ct_id = el.get_control_type().map_err(uia_err)? as i32 as u32;
+    let ct_id =
+        required_com(deadline, "read UIA control type", || el.get_control_type())? as i32 as u32;
     // `canonical_name` knows every documented control type, mapped or not, so the numeric form
     // is reached only by a vendor-defined or future id — still reported, never dropped.
     let raw_role = crate::mapping::canonical_name(ct_id)
         .map(str::to_string)
         .unwrap_or_else(|| format!("UIA:{ct_id}"));
-    let framework = framework_id(el, ct_id);
-    let name = nonempty(el.get_name().unwrap_or_default());
-    let description = normalize_description(&help_text(el, ct_id), name.as_deref());
-    let bounds = window_relative_bounds(el, origin);
-    let (facts, value) = gather(el, ct_id)?;
+    let framework = framework_id(el, ct_id, deadline)?;
+    let name = nonempty(required_com(deadline, "read UIA name", || el.get_name())?);
+    let description = normalize_description(&help_text(el, ct_id, deadline)?, name.as_deref());
+    let bounds = window_relative_bounds(el, origin, deadline)?;
+    let (mut facts, value) = gather(el, ct_id, deadline)?;
+    facts.offscreen |= bounds_are_offscreen(bounds, window_size);
     let states = crate::mapping::map_states(&facts);
 
     let mut children = Vec::new();
     // Resolved before the gate: a childless node must never be reported truncated for
     // declining to explore a list that was already empty.
-    let first_child = step(walker.get_first_child(el), budget);
-    // Tests only whether a first child exists, before `is_offscreen` filters it. A node whose
-    // children are all offscreen, reached once the budget is spent, still records a truncation
-    // though nothing real was declined. Pre-filtering would mean walking the whole
-    // `get_first_child`/`get_next_sibling` chain — the unbounded scan `MAX_SIBLINGS` bounds.
+    let first_child = step(deadline, "read first UIA child", budget, || {
+        walker.get_first_child(el)
+    })?;
+    // Tests only whether a first child exists before applying the traversal budget. Offscreen
+    // elements remain in the normalized tree with `visible = false`; semantic actionability must
+    // be able to prove and refuse them rather than making them indistinguishable from absence.
     if first_child.is_some() && budget.may_explore_children(depth) {
-        // Offscreen children are skipped without entering, so they never count against
-        // `MAX_NODES` — a virtualized list of thousands (or a cyclic `get_next_sibling`
+        // A virtualized list of thousands (or a cyclic `get_next_sibling`
         // chain) would otherwise scan this level forever. `MAX_SIBLINGS` bounds the
         // per-level scan regardless of how many are skipped.
         let mut child = first_child;
@@ -248,10 +317,18 @@ fn walk(
                 break;
             }
             siblings += 1;
-            if !c.is_offscreen().unwrap_or(false) {
-                children.push(walk(walker, &c, origin, depth + 1, budget)?);
-            }
-            child = step(walker.get_next_sibling(&c), budget);
+            children.push(walk(
+                walker,
+                &c,
+                origin,
+                window_size,
+                depth + 1,
+                budget,
+                deadline,
+            )?);
+            child = step(deadline, "read next UIA sibling", budget, || {
+                walker.get_next_sibling(&c)
+            })?;
         }
     }
 
@@ -282,37 +359,60 @@ fn walk(
 /// An unsupported pattern is the binding's explicit non-failure sentinel (`Error::code() == 0`),
 /// which [`optional_pattern`] maps to `None`. Every real HRESULT failure propagates so a transient
 /// provider error cannot silently change the node's role or state.
-fn toggle_pattern(el: &UIElement, ct_id: u32) -> Result<Option<UITogglePattern>> {
+fn toggle_pattern(
+    el: &UIElement,
+    ct_id: u32,
+    deadline: Deadline,
+) -> Result<Option<UITogglePattern>> {
     if !matches!(ct_id, 50000 | 50002 | 50011 | 50031) {
         // Button/CheckBox/MenuItem/SplitButton
         return Ok(None);
     }
-    optional_pattern(el.get_pattern::<UITogglePattern>())
+    optional_com(deadline, "get UIA Toggle pattern", || {
+        el.get_pattern::<UITogglePattern>()
+    })
 }
 
 /// Gather state facts + the value string in one pass, gating each pattern probe by control type
 /// so we don't make a live cross-process `get_pattern` call for a pattern the control can't support
 /// (UIA is chatty — each probe is an out-of-process COM round-trip).
-fn gather(el: &UIElement, ct_id: u32) -> Result<(crate::mapping::StateFacts, Option<String>)> {
+fn gather(
+    el: &UIElement,
+    ct_id: u32,
+    deadline: Deadline,
+) -> Result<(crate::mapping::StateFacts, Option<String>)> {
     // Fetch the Toggle pattern once: its mere presence is `checkable` (the control exposes
     // on/off semantics at all), independent of whether we can also read its current state.
-    let pattern = toggle_pattern(el, ct_id)?;
+    let pattern = toggle_pattern(el, ct_id, deadline)?;
     let checkable = pattern.is_some();
     let toggled_on = match pattern.as_ref() {
-        Some(pattern) => required_uia(pattern.get_toggle_state())? == ToggleState::On,
+        Some(pattern) => {
+            required_com(deadline, "read UIA Toggle state", || {
+                pattern.get_toggle_state()
+            })? == ToggleState::On
+        }
         None => false,
     };
     let selected = if matches!(ct_id, 50007 | 50019 | 50024 | 50029) {
-        match optional_pattern(el.get_pattern::<UISelectionItemPattern>())? {
-            Some(pattern) => required_uia(pattern.is_selected())?,
+        match optional_com(deadline, "get UIA SelectionItem pattern", || {
+            el.get_pattern::<UISelectionItemPattern>()
+        })? {
+            Some(pattern) => required_com(deadline, "read UIA selection state", || {
+                pattern.is_selected()
+            })?,
             None => false,
         }
     } else {
         false
     };
     let expanded = if matches!(ct_id, 50003 | 50009 | 50011 | 50023 | 50024 | 50026 | 50033) {
-        match optional_pattern(el.get_pattern::<UIExpandCollapsePattern>())? {
-            Some(pattern) => required_uia(pattern.get_state())? == ExpandCollapseState::Expanded,
+        match optional_com(deadline, "get UIA ExpandCollapse pattern", || {
+            el.get_pattern::<UIExpandCollapsePattern>()
+        })? {
+            Some(pattern) => {
+                required_com(deadline, "read UIA expanded state", || pattern.get_state())?
+                    == ExpandCollapseState::Expanded
+            }
             None => false,
         }
     } else {
@@ -320,10 +420,16 @@ fn gather(el: &UIElement, ct_id: u32) -> Result<(crate::mapping::StateFacts, Opt
     };
     // Value pattern: one fetch for both the value string and read-only (Edit/ComboBox/Document)
     let (value_text, readonly) = if matches!(ct_id, 50003 | 50004 | 50030) {
-        match optional_pattern(el.get_pattern::<UIValuePattern>())? {
+        match optional_com(deadline, "get UIA Value pattern", || {
+            el.get_pattern::<UIValuePattern>()
+        })? {
             Some(pattern) => (
-                Some(required_uia(pattern.get_value())?),
-                Some(required_uia(pattern.is_readonly())?),
+                Some(required_com(deadline, "read UIA value", || {
+                    pattern.get_value()
+                })?),
+                Some(required_com(deadline, "read UIA read-only state", || {
+                    pattern.is_readonly()
+                })?),
             ),
             None => (None, None),
         }
@@ -336,9 +442,13 @@ fn gather(el: &UIElement, ct_id: u32) -> Result<(crate::mapping::StateFacts, Opt
     let value = if value_text.is_some() {
         value_text
     } else if matches!(ct_id, 50012 | 50015 | 50016) {
-        match optional_pattern(el.get_pattern::<UIRangeValuePattern>())? {
-            Some(pattern) => Some(crate::mapping::format_range_value(required_uia(
-                pattern.get_value(),
+        match optional_com(deadline, "get UIA RangeValue pattern", || {
+            el.get_pattern::<UIRangeValuePattern>()
+        })? {
+            Some(pattern) => Some(crate::mapping::format_range_value(required_com(
+                deadline,
+                "read UIA range value",
+                || pattern.get_value(),
             )?)),
             None => None,
         }
@@ -353,15 +463,19 @@ fn gather(el: &UIElement, ct_id: u32) -> Result<(crate::mapping::StateFacts, Opt
     let editable =
         matches!(ct_id, 50003 | 50004 | 50030) && readonly.map(|ro| !ro).unwrap_or(false);
     let facts = crate::mapping::StateFacts {
-        enabled: required_uia(el.is_enabled())?,
-        offscreen: required_uia(el.is_offscreen())?,
-        focused: required_uia(el.has_keyboard_focus())?,
-        focusable: required_uia(el.is_keyboard_focusable())?,
+        enabled: required_com(deadline, "read UIA enabled state", || el.is_enabled())?,
+        offscreen: required_com(deadline, "read UIA offscreen state", || el.is_offscreen())?,
+        focused: required_com(deadline, "read UIA focused state", || {
+            el.has_keyboard_focus()
+        })?,
+        focusable: required_com(deadline, "read UIA focusable state", || {
+            el.is_keyboard_focusable()
+        })?,
         selected,
         toggled_on,
         expanded,
         editable,
-        secure: required_uia(el.is_password())?,
+        secure: required_com(deadline, "read UIA password state", || el.is_password())?,
         checkable,
     };
     Ok((facts, value))
@@ -371,7 +485,8 @@ fn gather(el: &UIElement, ct_id: u32) -> Result<(crate::mapping::StateFacts, Opt
 /// `desc="…"`. Costs one cross-process property read per node.
 ///
 /// A failed read degrades to no description, since one unreadable property must not fail a whole
-/// snapshot, but it logs first (the treatment [`toggle_pattern`] already gives its own failures).
+/// snapshot, but it logs first. The caller deadline is still checked immediately before the COM
+/// read, so a detached worker cannot start this optional read after its budget expires.
 /// It matters more here than the `.ok()` on a pattern probe: `CurrentHelpText` answers an *unset*
 /// property with an empty string, so every `Err` is a genuine COM failure — a stale element, a hung
 /// or disconnected provider, a denied cross-integrity read — never "the app set no help text".
@@ -379,30 +494,48 @@ fn gather(el: &UIElement, ct_id: u32) -> Result<(crate::mapping::StateFacts, Opt
 /// `FullDescription` is UIA's other secondary label; `uiautomation` 0.25 exposes no accessor for it
 /// (only `UIProperty::FullDescription` through `get_property_value`), and no probed app was
 /// observed carrying one.
-fn help_text(el: &UIElement, ct_id: u32) -> String {
-    el.get_help_text().unwrap_or_else(|e| {
+fn help_text(el: &UIElement, ct_id: u32, deadline: Deadline) -> Result<String> {
+    ensure_com_deadline(deadline, "read UIA help text")?;
+    Ok(el.get_help_text().unwrap_or_else(|e| {
         eprintln!(
             "glass-a11y-windows: HelpText read failed on control type {ct_id} \
              (HRESULT {:#010x}: {e}); treating the element as having no description",
             e.code()
         );
         String::new()
-    })
+    }))
 }
 
 /// UIA `BoundingRectangle` (screen) → window-relative `AxRect`, or `None` for zero-area.
-fn window_relative_bounds(el: &UIElement, origin: (i32, i32)) -> Option<AxRect> {
-    let r: Rect = el.get_bounding_rectangle().ok()?;
+fn window_relative_bounds(
+    el: &UIElement,
+    origin: (i32, i32),
+    deadline: Deadline,
+) -> Result<Option<AxRect>> {
+    let r: Rect = required_com(deadline, "read UIA bounding rectangle", || {
+        el.get_bounding_rectangle()
+    })?;
     let (w, h) = (r.get_width(), r.get_height());
     if w <= 0 || h <= 0 {
-        return None;
+        return Ok(None);
     }
-    Some(AxRect {
+    Ok(Some(AxRect {
         x: r.get_left() - origin.0,
         y: r.get_top() - origin.1,
         width: w as u32,
         height: h as u32,
-    })
+    }))
+}
+
+fn bounds_are_offscreen(bounds: Option<AxRect>, window_size: (u32, u32)) -> bool {
+    let Some(bounds) = bounds else {
+        return false;
+    };
+    let left = i64::from(bounds.x);
+    let top = i64::from(bounds.y);
+    let right = left + i64::from(bounds.width);
+    let bottom = top + i64::from(bounds.height);
+    right <= 0 || bottom <= 0 || left >= i64::from(window_size.0) || top >= i64::from(window_size.1)
 }
 
 fn nonempty(s: String) -> Option<String> {
@@ -412,13 +545,17 @@ fn nonempty(s: String) -> Option<String> {
 /// The element's UIA `FrameworkId`, which `map_role_with_framework` decides a `Document` on.
 /// Gated by control type like `toggle_pattern`: only 50030 is decided by it, so no other node
 /// spends a cross-process property read. Read per node, never per app — a browser's window
-/// element reports `Win32` while the page inside it carries the engine's id. An empty id and a
-/// failed read both yield `None`.
-fn framework_id(el: &UIElement, ct_id: u32) -> Option<String> {
+/// element reports `Win32` while the page inside it carries the engine's id. An empty id yields
+/// `None`; a failed read propagates so it cannot silently change the mapped role.
+fn framework_id(el: &UIElement, ct_id: u32, deadline: Deadline) -> Result<Option<String>> {
     if ct_id != 50030 {
-        return None;
+        return Ok(None);
     }
-    nonempty(el.get_framework_id().unwrap_or_default())
+    Ok(nonempty(required_com(
+        deadline,
+        "read UIA framework id",
+        || el.get_framework_id(),
+    )?))
 }
 
 fn find_target(
@@ -428,19 +565,23 @@ fn find_target(
     target: &AxTarget,
 ) -> Result<UIElement> {
     let mut budget = WalkBudget::with_limits(ctx.limits);
-    find_nth(walker, window, 0, &mut budget, target.id.0)?
+    find_nth(walker, window, 0, &mut budget, target.id.0, ctx.deadline)?
         .ok_or(GlassError::AxElementChanged(target.id.0))
 }
 
 fn verify_target_fingerprint(el: &UIElement, ctx: &AxContext, target: &AxTarget) -> Result<u32> {
-    let ct_id = required_uia(el.get_control_type())? as i32 as u32;
+    let ct_id = required_com(ctx.deadline, "read target UIA control type", || {
+        el.get_control_type()
+    })? as i32 as u32;
     let role = crate::mapping::map_role_with_framework(
         ct_id,
-        toggle_pattern(el, ct_id)?.is_some(),
-        framework_id(el, ct_id).as_deref(),
+        toggle_pattern(el, ct_id, ctx.deadline)?.is_some(),
+        framework_id(el, ct_id, ctx.deadline)?.as_deref(),
     );
-    let name = nonempty(required_uia(el.get_name())?);
-    let bounds = window_relative_bounds(el, (ctx.window.x, ctx.window.y));
+    let name = nonempty(required_com(ctx.deadline, "read target UIA name", || {
+        el.get_name()
+    })?);
+    let bounds = window_relative_bounds(el, (ctx.window.x, ctx.window.y), ctx.deadline)?;
     if !target.matches(role, name.as_deref())
         || !target.bounds_consistent(bounds, SET_VALUE_BOUNDS_TOL)
     {
@@ -450,12 +591,20 @@ fn verify_target_fingerprint(el: &UIElement, ctx: &AxContext, target: &AxTarget)
 }
 
 fn run_focus(ctx: &AxContext, target: &AxTarget, dispatch: &A11yMutationDispatch) -> Result<()> {
-    let automation = UIAutomation::new().map_err(uia_err)?;
+    let automation = required_com(
+        ctx.deadline,
+        "initialize UI Automation for focus",
+        UIAutomation::new,
+    )?;
     let root = find_app_window(&automation, ctx)?;
-    let walker = automation.get_control_view_walker().map_err(uia_err)?;
+    let walker = required_com(
+        ctx.deadline,
+        "get UIA control-view walker for focus",
+        || automation.get_control_view_walker(),
+    )?;
     let element = find_target(&walker, &root, ctx, target)?;
     let ct_id = verify_target_fingerprint(&element, ctx, target)?;
-    let (facts, _) = gather(&element, ct_id)?;
+    let (facts, _) = gather(&element, ct_id, ctx.deadline)?;
     if !facts.focusable && !facts.editable {
         return Err(GlassError::AxActionUnavailable(target.id.0));
     }
@@ -468,22 +617,33 @@ fn runtime_id_path(
     root: &UIElement,
     element: &UIElement,
     depth_limit: usize,
+    deadline: Deadline,
 ) -> Result<Vec<Vec<i32>>> {
     let mut path = Vec::new();
     let mut current = element.clone();
-    for _ in 0..=depth_limit {
-        path.push(required_uia(current.get_runtime_id())?);
-        if required_uia(automation.compare_elements(&current, root))? {
+    let mut depth = 0usize;
+    loop {
+        path.push(required_com(deadline, "read UIA runtime id", || {
+            current.get_runtime_id()
+        })?);
+        if required_com(deadline, "compare UIA ancestry element with root", || {
+            automation.compare_elements(&current, root)
+        })? {
             return Ok(path);
         }
-        let Some(parent) = optional_uia(walker.get_parent(&current))? else {
+        if !may_request_parent(depth, depth_limit) {
+            return Err(GlassError::AccessibilityUnavailable(format!(
+                "UI Automation hit ancestry exceeded the configured depth limit ({depth_limit})"
+            )));
+        }
+        let Some(parent) =
+            optional_com(deadline, "read UIA parent", || walker.get_parent(&current))?
+        else {
             return Ok(path);
         };
         current = parent;
+        depth += 1;
     }
-    Err(GlassError::AccessibilityUnavailable(format!(
-        "UI Automation hit ancestry exceeded the configured depth limit ({depth_limit})"
-    )))
 }
 
 fn run_pointer_target_at(
@@ -491,12 +651,17 @@ fn run_pointer_target_at(
     target: &AxTarget,
     point: (i32, i32),
 ) -> Result<PointerHit> {
-    if ctx.deadline.has_passed() {
-        return Err(GlassError::deadline_not_started("pointer hit probe"));
-    }
-    let automation = UIAutomation::new().map_err(uia_err)?;
+    let automation = required_com(
+        ctx.deadline,
+        "initialize UI Automation for pointer hit probe",
+        UIAutomation::new,
+    )?;
     let root = find_app_window(&automation, ctx)?;
-    let walker = automation.get_control_view_walker().map_err(uia_err)?;
+    let walker = required_com(
+        ctx.deadline,
+        "get UIA control-view walker for pointer hit probe",
+        || automation.get_control_view_walker(),
+    )?;
     let element = find_target(&walker, &root, ctx, target)?;
     verify_target_fingerprint(&element, ctx, target)?;
 
@@ -511,21 +676,42 @@ fn run_pointer_target_at(
         .checked_add(point.1)
         .ok_or_else(|| GlassError::Backend("UIA hit-test y coordinate overflow".into()))?;
     let screen = uiautomation::types::Point::new(screen_x, screen_y);
-    let Some(hit) = optional_uia(automation.element_from_point(screen))? else {
+    let Some(hit) = optional_com(ctx.deadline, "get UIA element from point", || {
+        automation.element_from_point(screen)
+    })?
+    else {
         return Ok(PointerHit::Inconclusive);
     };
-    if required_uia(automation.compare_elements(&hit, &element))? {
+    if required_com(ctx.deadline, "compare UIA hit with target", || {
+        automation.compare_elements(&hit, &element)
+    })? {
         return Ok(PointerHit::Target);
     }
 
-    let hit_ct_id = required_uia(hit.get_control_type())? as i32 as u32;
+    let hit_ct_id = required_com(ctx.deadline, "read hit UIA control type", || {
+        hit.get_control_type()
+    })? as i32 as u32;
     let hit_role = crate::mapping::map_role_with_framework(
         hit_ct_id,
-        toggle_pattern(&hit, hit_ct_id)?.is_some(),
-        framework_id(&hit, hit_ct_id).as_deref(),
+        toggle_pattern(&hit, hit_ct_id, ctx.deadline)?.is_some(),
+        framework_id(&hit, hit_ct_id, ctx.deadline)?.as_deref(),
     );
-    let target_ids = runtime_id_path(&automation, &walker, &root, &element, ctx.limits.depth)?;
-    let hit_ids = runtime_id_path(&automation, &walker, &root, &hit, ctx.limits.depth)?;
+    let target_ids = runtime_id_path(
+        &automation,
+        &walker,
+        &root,
+        &element,
+        ctx.limits.depth,
+        ctx.deadline,
+    )?;
+    let hit_ids = runtime_id_path(
+        &automation,
+        &walker,
+        &root,
+        &hit,
+        ctx.limits.depth,
+        ctx.deadline,
+    )?;
     let target_path = target_ids.iter().map(Vec::as_slice).collect::<Vec<_>>();
     let hit_path = hit_ids.iter().map(Vec::as_slice).collect::<Vec<_>>();
     Ok(crate::mapping::classify_uia_hit_path(
@@ -541,10 +727,16 @@ fn run_set_value(
     text: &str,
     dispatch: &A11yMutationDispatch,
 ) -> Result<()> {
-    let automation = UIAutomation::new().map_err(|e| {
-        GlassError::AccessibilityUnavailable(format!("UI Automation unavailable: {e}"))
-    })?;
-    let walker = automation.get_control_view_walker().map_err(uia_err)?;
+    let automation = required_com(
+        ctx.deadline,
+        "initialize UI Automation for set-value",
+        UIAutomation::new,
+    )?;
+    let walker = required_com(
+        ctx.deadline,
+        "get UIA control-view walker for set-value",
+        || automation.get_control_view_walker(),
+    )?;
     let window = find_app_window(&automation, ctx)?;
 
     // Start at 0 so find_nth's pre-order numbering matches snapshot's walk +
@@ -557,44 +749,58 @@ fn run_set_value(
     // bounds fingerprint — the element sits elsewhere — rejects it. A target
     // without captured bounds falls back to role+name only.
     verify_target_fingerprint(&el, ctx, target)?;
-    let pat = optional_pattern(el.get_pattern::<UIValuePattern>())?
-        .ok_or(GlassError::AxElementNotEditable(target.id.0))?;
-    // Pre-write value: the baseline for the "changed" check. `None` (a failed pre-read) means the
-    // baseline is unknown — the confirmation below then requires an exact match rather than
-    // trusting a "differs from before" signal it cannot compute.
-    let before = pat.get_value().ok();
+    let pat = optional_com(ctx.deadline, "get target UIA Value pattern", || {
+        el.get_pattern::<UIValuePattern>()
+    })?
+    .ok_or(GlassError::AxElementNotEditable(target.id.0))?;
+    // Pre-write value: the baseline for the "changed" check. A failed pre-read propagates before
+    // dispatch rather than weakening confirmation to an unknown baseline.
+    let before = required_com(ctx.deadline, "read UIA value before set-value", || {
+        pat.get_value()
+    })?;
     dispatch.dispatch(|| pat.set_value(text).map_err(uia_err))?;
     // Verify the write took, error-aware. egui/accesskit read-only editables accept SetValue
     // without error but never apply it (false success). Poll the value back — a real numeric set
-    // lands a frame later. `.ok()` maps a failed read to `None`, which never confirms, so neither
-    // a failed post-read nor a failed pre-read can masquerade as a successful change.
-    let deadline = Instant::now() + Duration::from_millis(SET_VALUE_VERIFY_MS);
+    // lands a frame later. A failed post-read propagates after dispatch, preserving that the write
+    // may already have landed rather than masquerading as successful confirmation.
+    let now = Instant::now();
+    let (confirmation_end, confirmation_owner) = ctx.deadline.resolve(confirmation_end_at(
+        Deadline::UNBOUNDED,
+        Duration::from_millis(SET_VALUE_VERIFY_MS),
+        now,
+    ));
+    let mut after = before.clone();
     loop {
-        let after = pat.get_value().ok();
-        if read_back_confirms(after.as_deref(), before.as_deref(), text) {
-            return Ok(());
-        }
-        if Instant::now() >= deadline {
-            // A read that failed, or one showing a value the element reformatted, is not evidence
-            // of a projection that accepted the write and kept its value.
-            return Err(match after.as_deref() {
-                None => GlassError::AxWriteUnconfirmed(
+        let now = Instant::now();
+        if now >= confirmation_end {
+            if confirmation_owner == Whose::Caller {
+                return Err(
+                    GlassError::deadline_not_started("UIA set-value confirmation").after_dispatch(),
+                );
+            }
+            return Err(if write_took_no_effect(&after, Some(&before)) {
+                GlassError::value_not_applied_because(
                     target.id.0,
-                    "the element exposes a writable value but no readable value was available after the write"
-                        .into(),
-                ),
-                Some(seen) if write_took_no_effect(seen, before.as_deref()) => {
-                    GlassError::value_not_applied_because(
-                        target.id.0,
-                        text,
-                        Some(seen),
-                        READ_ONLY_PROJECTION,
-                    )
-                }
-                Some(seen) => GlassError::value_not_applied(target.id.0, text, Some(seen)),
+                    text,
+                    Some(&after),
+                    READ_ONLY_PROJECTION,
+                )
+            } else {
+                GlassError::value_not_applied(target.id.0, text, Some(&after))
             });
         }
-        std::thread::sleep(Duration::from_millis(VERIFY_POLL_MS));
+        after = confirmation_com(
+            Deadline::at(confirmation_end),
+            "read UIA value after set-value",
+            || pat.get_value(),
+        )?;
+        if read_back_confirms(Some(&after), Some(&before), text) {
+            return Ok(());
+        }
+        std::thread::sleep(
+            Duration::from_millis(VERIFY_POLL_MS)
+                .min(confirmation_end.saturating_duration_since(Instant::now())),
+        );
     }
 }
 
@@ -618,10 +824,16 @@ fn run_set_value(
 /// treated as absence. Every other pattern lookup failure propagates, so a provider or COM failure
 /// cannot silently become pointer fallback.
 fn run_invoke(ctx: &AxContext, target: &AxTarget, dispatch: &A11yMutationDispatch) -> Result<()> {
-    let automation = UIAutomation::new().map_err(|e| {
-        GlassError::AccessibilityUnavailable(format!("UI Automation unavailable: {e}"))
-    })?;
-    let walker = automation.get_control_view_walker().map_err(uia_err)?;
+    let automation = required_com(
+        ctx.deadline,
+        "initialize UI Automation for invoke",
+        UIAutomation::new,
+    )?;
+    let walker = required_com(
+        ctx.deadline,
+        "get UIA control-view walker for invoke",
+        || automation.get_control_view_walker(),
+    )?;
     let window = find_app_window(&automation, ctx)?;
 
     // Start at 0 so find_nth's pre-order numbering matches snapshot's walk + assign_ids, same as
@@ -632,39 +844,69 @@ fn run_invoke(ctx: &AxContext, target: &AxTarget, dispatch: &A11yMutationDispatc
     verify_target_fingerprint(&el, ctx, target)?;
 
     let fail = |e: uiautomation::Error| GlassError::AxActionFailed(target.id.0, e.to_string());
-    if let Some(p) = optional_pattern(el.get_pattern::<UIInvokePattern>())? {
+    if let Some(p) = optional_com(ctx.deadline, "get target UIA Invoke pattern", || {
+        el.get_pattern::<UIInvokePattern>()
+    })? {
         return dispatch.dispatch(|| p.invoke().map_err(fail));
     }
-    if let Some(p) = optional_pattern(el.get_pattern::<UITogglePattern>())? {
+    if let Some(p) = optional_com(ctx.deadline, "get target UIA Toggle pattern", || {
+        el.get_pattern::<UITogglePattern>()
+    })? {
         // Toggle is the one rung with a readable post-state, so don't take the ack as proof:
         // a provider that accepts `Toggle()` without applying it would otherwise report a
         // successful click on a control that never moved. Read before, fire, then poll until
         // the state differs, using the same cadence as `run_set_value`'s write verification.
-        let before = p.get_toggle_state().map_err(fail)?;
+        let before = required_com(ctx.deadline, "read UIA Toggle state before invoke", || {
+            p.get_toggle_state()
+        })?;
         dispatch.dispatch(|| p.toggle().map_err(fail))?;
-        let deadline = Instant::now() + Duration::from_millis(SET_VALUE_VERIFY_MS);
+        let now = Instant::now();
+        let (confirmation_end, confirmation_owner) = ctx.deadline.resolve(confirmation_end_at(
+            Deadline::UNBOUNDED,
+            Duration::from_millis(SET_VALUE_VERIFY_MS),
+            now,
+        ));
         loop {
             // Past the dispatch, a failed read IS a failure: `fail` (AxActionFailed) is
             // right here, because the toggle may have landed and must not be re-actuated.
-            if p.get_toggle_state().map_err(fail)? != before {
+            let now = Instant::now();
+            if now >= confirmation_end {
+                return Err(if confirmation_owner == Whose::Caller {
+                    GlassError::deadline_not_started("UIA Toggle confirmation").after_dispatch()
+                } else {
+                    GlassError::AxActionFailed(
+                        target.id.0,
+                        "the toggle action was acknowledged but the state did not change".into(),
+                    )
+                });
+            }
+            if confirmation_com(
+                Deadline::at(confirmation_end),
+                "read UIA Toggle state after invoke",
+                || p.get_toggle_state(),
+            )? != before
+            {
                 return Ok(());
             }
-            if Instant::now() >= deadline {
-                // `AxActionFailed`, not `AxActionUnavailable`: the toggle WAS dispatched,
-                // so this must not fall back to a pointer click that could actuate twice.
-                return Err(GlassError::AxActionFailed(
-                    target.id.0,
-                    "the toggle action was acknowledged but the state did not change".into(),
-                ));
-            }
-            std::thread::sleep(Duration::from_millis(VERIFY_POLL_MS));
+            std::thread::sleep(
+                Duration::from_millis(VERIFY_POLL_MS)
+                    .min(confirmation_end.saturating_duration_since(Instant::now())),
+            );
         }
     }
-    if let Some(p) = optional_pattern(el.get_pattern::<UISelectionItemPattern>())? {
+    if let Some(p) = optional_com(ctx.deadline, "get target UIA SelectionItem pattern", || {
+        el.get_pattern::<UISelectionItemPattern>()
+    })? {
         return dispatch.dispatch(|| p.select().map_err(fail));
     }
-    if let Some(p) = optional_pattern(el.get_pattern::<UIExpandCollapsePattern>())? {
-        let expanded = p.get_state().map_err(fail)? == ExpandCollapseState::Expanded;
+    if let Some(p) = optional_com(
+        ctx.deadline,
+        "get target UIA ExpandCollapse pattern",
+        || el.get_pattern::<UIExpandCollapsePattern>(),
+    )? {
+        let expanded = required_com(ctx.deadline, "read UIA ExpandCollapse state", || {
+            p.get_state()
+        })? == ExpandCollapseState::Expanded;
         return dispatch
             .dispatch(|| if expanded { p.collapse() } else { p.expand() }.map_err(fail));
     }
@@ -682,6 +924,7 @@ fn find_nth(
     depth: usize,
     budget: &mut WalkBudget,
     target: u32,
+    deadline: Deadline,
 ) -> Result<Option<UIElement>> {
     if budget.nodes_walked() == target as usize {
         return Ok(Some(el.clone()));
@@ -689,11 +932,13 @@ fn find_nth(
     budget.visit();
     // Resolved before the gate: a childless node must never be reported truncated for
     // declining to explore a list that was already empty.
-    let first_child = optional_uia(walker.get_first_child(el))?;
-    // Same gap as `walk`: only tests whether a first child exists, before `is_offscreen` runs.
-    // A node whose children are all offscreen, reached once the budget is spent, still records
-    // a truncation though nothing real was declined — left as-is for the same reason: it would
-    // mean walking the whole sibling chain, exactly the scan `MAX_SIBLINGS` exists to bound.
+    let first_child = optional_com(
+        deadline,
+        "read first UIA child during target rewalk",
+        || walker.get_first_child(el),
+    )?;
+    // Same child and budget order as `walk`; offscreen nodes participate in ids so visibility can
+    // be proved and refused instead of disappearing from semantic resolution.
     if first_child.is_none() || !budget.may_explore_children(depth) {
         return Ok(None);
     }
@@ -707,12 +952,14 @@ fn find_nth(
             break;
         }
         siblings += 1;
-        if !required_uia(c.is_offscreen())?
-            && let Some(found) = find_nth(walker, &c, depth + 1, budget, target)?
-        {
+        if let Some(found) = find_nth(walker, &c, depth + 1, budget, target, deadline)? {
             return Ok(Some(found));
         }
-        child = optional_uia(walker.get_next_sibling(&c))?;
+        child = optional_com(
+            deadline,
+            "read next UIA sibling during target rewalk",
+            || walker.get_next_sibling(&c),
+        )?;
     }
     Ok(None)
 }
@@ -759,6 +1006,88 @@ mod tests {
             );
 
         assert_eq!(pattern, None);
+    }
+
+    #[test]
+    fn com_deadline_is_checked_at_the_exact_absolute_instant() {
+        let now = Instant::now();
+        let error = ensure_com_deadline_at(Deadline::at(now), now, "UIA property read")
+            .expect_err("a COM call at the caller deadline must not start");
+        assert_eq!(
+            error.bound_dispatch(),
+            Some(glass_core::BoundDispatch::NotDispatched)
+        );
+        assert!(
+            ensure_com_deadline_at(
+                Deadline::at(now + Duration::from_millis(1)),
+                now,
+                "UIA property read"
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn confirmation_deadline_preserves_the_already_dispatched_mutation() {
+        let mut calls = 0;
+        let error = confirmation_com(Deadline::at(Instant::now()), "UIA confirmation", || {
+            calls += 1;
+            Ok(())
+        })
+        .expect_err("expired confirmation must not issue another COM call");
+        assert_eq!(calls, 0);
+        assert_eq!(
+            error.bound_dispatch(),
+            Some(glass_core::BoundDispatch::MayHaveDispatched)
+        );
+        assert!(!error.invoke_fallback_eligible());
+    }
+
+    #[test]
+    fn confirmation_uses_the_nearer_caller_deadline_or_operation_ceiling() {
+        let now = Instant::now();
+        let ceiling = Duration::from_millis(800);
+        assert_eq!(
+            confirmation_end_at(Deadline::at(now + Duration::from_millis(20)), ceiling, now),
+            now + Duration::from_millis(20)
+        );
+        assert_eq!(
+            confirmation_end_at(Deadline::at(now + Duration::from_secs(5)), ceiling, now),
+            now + ceiling
+        );
+        assert_eq!(
+            confirmation_end_at(Deadline::UNBOUNDED, ceiling, now),
+            now + ceiling
+        );
+    }
+
+    #[test]
+    fn ancestry_limit_stops_before_requesting_one_more_parent() {
+        assert!(!may_request_parent(0, 0));
+        assert!(may_request_parent(0, 1));
+        assert!(!may_request_parent(1, 1));
+    }
+
+    #[test]
+    fn bounds_outside_the_window_are_offscreen_even_when_the_provider_omits_the_property() {
+        assert!(bounds_are_offscreen(
+            Some(AxRect {
+                x: 20,
+                y: 650,
+                width: 160,
+                height: 32,
+            }),
+            (700, 500),
+        ));
+        assert!(!bounds_are_offscreen(
+            Some(AxRect {
+                x: 20,
+                y: 20,
+                width: 160,
+                height: 32,
+            }),
+            (700, 500),
+        ));
     }
 
     #[test]
@@ -896,7 +1225,13 @@ mod tests {
         let mut budget = WalkBudget::new();
         // Zero is what the real chain yields for an absent child — see `step`.
         let absent = uiautomation::Error::new(0, "no such element");
-        assert!(step(Err(absent), &mut budget).is_none());
+        assert!(
+            step(Deadline::UNBOUNDED, "test child", &mut budget, || Err(
+                absent
+            ))
+            .expect("an absent child is not an error")
+            .is_none()
+        );
         assert_eq!(
             budget.unreadable(),
             0,
@@ -909,7 +1244,13 @@ mod tests {
         let mut budget = WalkBudget::new();
         // UIA_E_ELEMENTNOTAVAILABLE — a real failure, negative like every HRESULT error.
         let failed = uiautomation::Error::new(-2147220991, "element not available");
-        assert!(step(Err(failed), &mut budget).is_none());
+        assert!(
+            step(Deadline::UNBOUNDED, "test child", &mut budget, || Err(
+                failed
+            ))
+            .expect("a failed child read is accounted for in the walk budget")
+            .is_none()
+        );
         assert_eq!(budget.unreadable(), 1);
     }
 }

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -6,7 +6,9 @@ use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use glass_core::accessibility::{Accessibility, AxContext, AxNode, AxTarget, AxTree};
+use glass_core::accessibility::{
+    Accessibility, AxContext, AxNode, AxStateCoverage, AxTarget, AxTree, PointerHit,
+};
 use glass_core::{BoundDispatch, Deadline, Whose};
 use glass_core::{
     GlassError, KeyEvent, MouseButton, PointerEvent, Result, TAP_MAY_HAVE_MISSED, WindowGeometry,
@@ -605,6 +607,29 @@ impl Accessibility for AndroidA11y {
         self.snapshot_within(ctx, snapshot_bound(self.warmth(), ctx.deadline))
     }
 
+    fn state_coverage(&self) -> AxStateCoverage {
+        AxStateCoverage {
+            enabled: true,
+            visible: true,
+            checkable: true,
+            checked: true,
+            selected: true,
+            expanded: false,
+            focused: true,
+            focusable: true,
+            editable: true,
+        }
+    }
+
+    fn pointer_target_at(
+        &mut self,
+        _ctx: &AxContext,
+        _target: &AxTarget,
+        _point: (i32, i32),
+    ) -> Result<PointerHit> {
+        Ok(PointerHit::Inconclusive)
+    }
+
     fn set_value(&mut self, ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
         fn read_back_error(target: &AxTarget, error: GlassError) -> GlassError {
             GlassError::write_unconfirmed_because(
@@ -731,14 +756,15 @@ impl Accessibility for AndroidA11y {
 #[cfg(test)]
 mod tests {
     use super::{
-        Attempt, COLD_BOUND, RetryBound, Warmth, bound_fired, command_error, dump_once,
-        dump_until_ready, editable_target, locate_editable_target, locate_for_write, require_time,
-        snapshot_bound, snapshot_with_runner, verification_phase_owned_by_caller,
+        AndroidA11y, Attempt, COLD_BOUND, RetryBound, Warmth, bound_fired, command_error,
+        dump_once, dump_until_ready, editable_target, locate_editable_target, locate_for_write,
+        require_time, snapshot_bound, snapshot_with_runner, verification_phase_owned_by_caller,
     };
     use crate::adb::{AdbOp, a_failed_call, a_real_spawn_failure, a_real_timeout_hinted};
     use glass_core::Deadline;
     use glass_core::accessibility::{
-        AxContext, AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget, AxTree, WalkLimits,
+        Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxStateCoverage, AxStates,
+        AxTarget, AxTree, WalkLimits,
     };
     use glass_core::{BoundDispatch, Whose};
     use glass_core::{BoundKind, GlassError, Result, WindowGeometry};
@@ -748,6 +774,24 @@ mod tests {
     /// A deadline no test reaches, for the cases that are not about the bound.
     fn ample() -> Instant {
         Instant::now() + Duration::from_secs(60)
+    }
+
+    #[test]
+    fn uiautomator_state_coverage_matches_its_mapped_evidence() {
+        assert_eq!(
+            AndroidA11y::new().state_coverage(),
+            AxStateCoverage {
+                enabled: true,
+                visible: true,
+                checkable: true,
+                checked: true,
+                selected: true,
+                expanded: false,
+                focused: true,
+                focusable: true,
+                editable: true,
+            }
+        );
     }
 
     #[test]

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -1820,6 +1820,73 @@ mod tests {
     }
 
     #[test]
+    fn schema_downgrade_after_a_transient_attempt_stops_recovery_immediately() {
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let recorded = Arc::clone(&requests);
+        let server = std::thread::spawn(move || {
+            let (first, _) = listener.accept().expect("first connection");
+            let mut first_writer = first.try_clone().expect("clone first");
+            let mut first_reader = std::io::BufReader::new(first);
+            writeln!(first_writer, r#"{{"hello":{{"proto":1,"node_schema":2}}}}"#)
+                .expect("schema two hello");
+            loop {
+                let mut line = String::new();
+                if !matches!(first_reader.read_line(&mut line), Ok(n) if n > 0) {
+                    break;
+                }
+                let request: Value = serde_json::from_str(&line).expect("request json");
+                recorded.lock().unwrap().push("conn1:tree".to_string());
+                writeln!(
+                    first_writer,
+                    "{}",
+                    json!({"id": request["id"], "ok": false, "error": "no active window"})
+                )
+                .expect("refusal");
+            }
+
+            let (second, _) = listener.accept().expect("second connection");
+            second
+                .set_read_timeout(Some(std::time::Duration::from_millis(300)))
+                .expect("read timeout");
+            let mut second_writer = second.try_clone().expect("clone second");
+            let mut second_reader = std::io::BufReader::new(second);
+            writeln!(second_writer, r#"{{"hello":{{"proto":1}}}}"#).expect("schema one hello");
+            let mut line = String::new();
+            if second_reader.read_line(&mut line).is_ok_and(|n| n > 0) {
+                recorded.lock().unwrap().push("conn2:request".to_string());
+            }
+        });
+        let rebinds = AtomicUsize::new(0);
+        let restores = AtomicUsize::new(0);
+
+        let error = match ready_or_restore(
+            port,
+            std::time::Duration::from_millis(20),
+            3,
+            &|_| {
+                rebinds.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            },
+            &|| {
+                restores.fetch_add(1, Ordering::Relaxed);
+            },
+        ) {
+            Ok(_) => panic!("a later schema downgrade is permanent, not another readiness refusal"),
+            Err(error) => error,
+        };
+
+        server.join().expect("server");
+        assert!(error.to_string().contains(INCOMPATIBLE_NODE_SCHEMA));
+        assert_eq!(rebinds.load(Ordering::Relaxed), 1);
+        assert_eq!(restores.load(Ordering::Relaxed), 1);
+        let requests = requests.lock().unwrap();
+        assert!(!requests.is_empty());
+        assert!(requests.iter().all(|request| request == "conn1:tree"));
+    }
+
+    #[test]
     fn schema_two_missing_a_required_boolean_is_rejected_before_exposure() {
         let response = r#"{"ok":true,"tree":{"ref":0,"class":"android.widget.EditText","text":"SECRET_SENTINEL","bounds":{"x":0,"y":100,"w":10,"h":10},"enabled":true,"visible":true,"checkable":false,"checked":false,"focused":false,"focusable":true,"editable":true,"clickable":true,"scrollable":false,"showing_hint_text":false}}"#;
         let (port, seen) = fake_agent(r#"{"hello":{"proto":1,"node_schema":2}}"#, vec![response]);

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -8,8 +8,8 @@ use serde_json::{Value, json};
 
 use glass_core::Deadline;
 use glass_core::accessibility::{
-    Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget, AxTree,
-    Located, Subject, WalkBudget, WalkLimits,
+    Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxStateCoverage, AxStates,
+    AxTarget, AxTree, Located, PointerHit, Subject, WalkBudget, WalkLimits,
 };
 use glass_core::platform::WindowGeometry;
 use glass_core::{GlassError, Result, write_took_no_effect};
@@ -17,11 +17,75 @@ use glass_core::{GlassError, Result, write_took_no_effect};
 use crate::axmap::{LabelInputs, class_to_role, demote_web_hosts, labels};
 use crate::conn::{CallFailure, Conn};
 
-/// One walk of a device `tree` reply: the bounds it runs under, and the device `ref` of every
-/// node it keeps, in the pre-order those nodes are about to be numbered in.
+const REQUIRED_NODE_SCHEMA: i64 = 2;
+const INCOMPATIBLE_NODE_SCHEMA: &str = "incompatible Android accessibility node schema";
+
+fn service_connection(port: u16, deadline: Deadline) -> Result<Conn> {
+    let conn = Conn::open_by(port, deadline)?;
+    match conn.hello_capability("node_schema").and_then(Value::as_i64) {
+        Some(REQUIRED_NODE_SCHEMA) => Ok(conn),
+        advertised => Err(GlassError::AccessibilityUnavailable(format!(
+            "{INCOMPATIBLE_NODE_SCHEMA}: got {advertised:?}, require {REQUIRED_NODE_SCHEMA}; \
+             install a schema-{REQUIRED_NODE_SCHEMA} companion or use uiautomator"
+        ))),
+    }
+}
+
+fn incompatible_node_schema(error: &GlassError) -> bool {
+    matches!(error, GlassError::AccessibilityUnavailable(message) if message.starts_with(INCOMPATIBLE_NODE_SCHEMA))
+}
+
+fn validate_node_schema(tree: &Value) -> Result<()> {
+    const REQUIRED_BOOLEANS: &[&str] = &[
+        "visible",
+        "focused",
+        "focusable",
+        "password",
+        "editable",
+        "clickable",
+        "enabled",
+        "scrollable",
+        "checkable",
+        "checked",
+        "showing_hint_text",
+    ];
+
+    fn walk(node: &Value, path: &str) -> Result<()> {
+        let object = node.as_object().ok_or_else(|| {
+            GlassError::AccessibilityUnavailable(format!(
+                "schema-{REQUIRED_NODE_SCHEMA} node {path} is not an object"
+            ))
+        })?;
+        for field in REQUIRED_BOOLEANS {
+            if !object.get(*field).is_some_and(Value::is_boolean) {
+                return Err(GlassError::AccessibilityUnavailable(format!(
+                    "schema-{REQUIRED_NODE_SCHEMA} node {path} has no boolean {field}"
+                )));
+            }
+        }
+        match object.get("children") {
+            None => Ok(()),
+            Some(Value::Array(children)) => {
+                for (index, child) in children.iter().enumerate() {
+                    walk(child, &format!("{path}.children[{index}]"))?;
+                }
+                Ok(())
+            }
+            Some(_) => Err(GlassError::AccessibilityUnavailable(format!(
+                "schema-{REQUIRED_NODE_SCHEMA} node {path} has non-array children"
+            ))),
+        }
+    }
+
+    walk(tree, "root")
+}
+
+/// One walk of a device `tree` reply: the bounds it runs under, plus the device `ref` and native
+/// click capability of every node it keeps, in the pre-order those nodes are about to be numbered.
 struct Walk {
     budget: WalkBudget,
     refs: Vec<u32>,
+    clickable: Vec<bool>,
 }
 
 impl Walk {
@@ -29,6 +93,7 @@ impl Walk {
         Walk {
             budget: WalkBudget::with_limits(limits),
             refs: Vec::new(),
+            clickable: Vec::new(),
         }
     }
 }
@@ -58,22 +123,26 @@ fn json_to_node(v: &Value, win: &WindowGeometry, depth: usize, walk: &mut Walk) 
     walk.refs.push(device_ref);
     let cls = v.get("class").and_then(Value::as_str).unwrap_or("");
     let flag = |k: &str| v.get(k).and_then(Value::as_bool).unwrap_or(false);
+    walk.clickable.push(flag("clickable"));
     let editable = flag("editable");
+    let password = flag("password");
     // The device omits empty text; preserve it as empty for editable nodes.
-    let text = v
-        .get("text")
-        .and_then(Value::as_str)
-        .or_else(|| editable.then_some(""));
-    // Android can publish its displayed hint through `text`.
-    // Older companions omit the flag, preserving their legacy text mapping.
+    let text = (!password)
+        .then(|| {
+            v.get("text")
+                .and_then(Value::as_str)
+                .or_else(|| editable.then_some(""))
+        })
+        .flatten();
+    // Android can publish its displayed hint through `text`. The mapper remains tolerant of
+    // payloads without this optional label hint; production separately requires the state schema.
     let text = if flag("showing_hint_text") {
         None
     } else {
         text
     };
     let desc = v.get("desc").and_then(Value::as_str);
-    // Both keys are absent (not null) on an older companion; `get` returns `None` either way, so
-    // no version check is needed to stay compatible with it.
+    // Both optional label keys may be absent rather than null; `get` handles either shape.
     let resource_id = v.get("resource_id").and_then(Value::as_str);
     let hint = v.get("hint").and_then(Value::as_str);
     let (name, value, description) = labels(LabelInputs {
@@ -132,11 +201,10 @@ fn json_to_node(v: &Value, win: &WindowGeometry, depth: usize, walk: &mut Walk) 
         states: AxStates {
             enabled: flag("enabled"),
             editable: flag("editable"),
-            secure: flag("password"),
+            secure: password,
             focused: flag("focused"),
-            // Android "focusable" is keyboard-only; map isClickable -> focusable as the actability proxy.
-            focusable: flag("clickable"),
-            visible: true,
+            focusable: flag("focusable"),
+            visible: flag("visible"),
             // The companion carries isCheckable/isChecked (authoritative, unlike the baseline
             // uiautomator reader), so surface them directly; `AxStates::active()` and the
             // Checked/Unchecked `state_pred`s gate `checked` on `checkable`.
@@ -154,15 +222,16 @@ fn json_to_node(v: &Value, win: &WindowGeometry, depth: usize, walk: &mut Walk) 
     })
 }
 
-/// A tree read off the device, paired with the device `ref` of each of its nodes.
+/// A tree read off the device, paired with every node's device `ref` and click capability.
 ///
-/// The halves are only meaningful together: `refs[n]` is the `ref` the device gave the node this
-/// host numbered `AxNodeId(n)`, so an action a caller addresses by host id can be dispatched to
-/// the node the *device* knows by that name.
+/// The parts are only meaningful together: `refs[n]` and `clickable[n]` describe the node this
+/// host numbered `AxNodeId(n)`, so an action is dispatched to a ref that actually advertised
+/// `ACTION_CLICK` without substituting that capability for the node's truthful focusable state.
 #[derive(Debug)]
 pub(crate) struct RefTree {
     pub(crate) tree: AxTree,
     refs: Vec<u32>,
+    clickable: Vec<bool>,
     /// The package explicitly named by the companion. `AxTree::subject` intentionally cannot
     /// distinguish an explicit match from an omitted package, but retry authorization must.
     explicit_package: Option<String>,
@@ -175,6 +244,10 @@ impl RefTree {
             .get(id.0 as usize)
             .copied()
             .ok_or(GlassError::AxElementNotFound(id.0))
+    }
+
+    fn is_clickable(&self, id: AxNodeId) -> bool {
+        self.clickable.get(id.0 as usize).copied().unwrap_or(false)
     }
 
     /// The app whose nodes these refs number: what the tree actually described, falling back to
@@ -216,9 +289,15 @@ pub(crate) fn tree_from_json(
         walk.refs.len(),
         "one ref per kept node, or the index is meaningless"
     );
+    debug_assert_eq!(
+        tree.count,
+        walk.clickable.len(),
+        "one click capability per kept node, or the index is meaningless"
+    );
     Ok(RefTree {
         tree,
         refs: walk.refs,
+        clickable: walk.clickable,
         explicit_package: None,
     })
 }
@@ -240,7 +319,7 @@ pub struct ServiceClient {
 
 impl ServiceClient {
     pub fn connect(port: u16) -> Result<ServiceClient> {
-        let conn = Conn::open(port)?;
+        let conn = service_connection(port, Deadline::UNBOUNDED)?;
         Ok(ServiceClient {
             conn: Mutex::new(conn),
             port,
@@ -266,7 +345,7 @@ impl ServiceClient {
             )));
         }
         if conn.ensure_usable().is_err() {
-            *conn = Conn::open_by(self.port, deadline).map_err(CallFailure::NotSent)?;
+            *conn = service_connection(self.port, deadline).map_err(CallFailure::NotSent)?;
         }
         let first = conn
             .call_within(
@@ -279,7 +358,7 @@ impl ServiceClient {
             Ok(v) => Ok(v),
             Err(f) if resend(&f) => {
                 // The service's accept loop accepts a fresh connection after a drop.
-                *conn = Conn::open_by(self.port, deadline).map_err(|e| f.with_error(e))?;
+                *conn = service_connection(self.port, deadline).map_err(|e| f.with_error(e))?;
                 conn.call_within(req, deadline, "Android accessibility service retry")
                     .map_err(|e| f.with_error(e))?
                     .map_err(|retry| f.merge_retry(retry))
@@ -368,6 +447,7 @@ impl ServiceClient {
             .get("tree")
             .cloned()
             .ok_or_else(|| GlassError::AccessibilityUnavailable("no tree in response".into()))?;
+        validate_node_schema(&tree)?;
         Ok(TreeReply {
             tree,
             package: r.get("package").and_then(Value::as_str).map(str::to_owned),
@@ -588,7 +668,7 @@ impl ServiceA11y {
                     .refreshed_action_tree(ctx, explicit_acting_package, "click")
                     .map_err(|failure| action_error(target.id.0, failure))?;
                 let fresh_target = relocated_target(&fresh.tree, target)?;
-                let fresh_plan = invoke_plan(&fresh.tree, &fresh_target)?;
+                let fresh_plan = invoke_plan(&fresh, &fresh_target)?;
                 let fresh_ref = fresh.device_ref(fresh_plan.actuated.id)?;
                 require_semantic_time(ctx.deadline, "Android accessibility click", false)?;
                 self.client
@@ -762,22 +842,73 @@ impl Accessibility for ServiceA11y {
         Ok(self.snapshot_with_refs(ctx)?.tree)
     }
 
+    fn state_coverage(&self) -> AxStateCoverage {
+        AxStateCoverage {
+            enabled: true,
+            visible: true,
+            checkable: true,
+            checked: true,
+            selected: false,
+            expanded: false,
+            focused: true,
+            focusable: true,
+            editable: true,
+        }
+    }
+
+    fn focus(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<Option<AxNodeId>> {
+        let rt = self
+            .snapshot_with_refs(ctx)
+            .map_err(before_mutation_dispatch)?;
+        let device_ref = rt
+            .device_ref(
+                resolved_editable_target(&rt.tree, target)
+                    .map_err(before_mutation_dispatch)?
+                    .id,
+            )
+            .map_err(before_mutation_dispatch)?;
+        require_semantic_time(ctx.deadline, "Android accessibility focus", false)
+            .map_err(before_mutation_dispatch)?;
+        self.client
+            .click(device_ref, rt.acting_on(&self.package), ctx.deadline)
+            .map_err(|failure| focus_error(target.id.0, failure))?;
+        Ok(None)
+    }
+
+    fn pointer_target_at(
+        &mut self,
+        _ctx: &AxContext,
+        _target: &AxTarget,
+        _point: (i32, i32),
+    ) -> Result<PointerHit> {
+        Ok(PointerHit::Inconclusive)
+    }
+
     fn set_value(&mut self, ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
         // Guard: re-snapshot and verify the id still points at the same editable element before
         // acting — `invoke`'s guard plus the editable check.
-        let rt = self.snapshot_with_refs(ctx)?;
+        let rt = self
+            .snapshot_with_refs(ctx)
+            .map_err(before_mutation_dispatch)?;
         let acting_package = rt.acting_on(&self.package).to_owned();
         let explicit_acting_package = rt.explicit_acting_package();
         // Addressed by the node the guard approved, not by the id the caller named, so a guard
         // that ever relaxes into a search cannot dispatch to a node it never approved.
-        let device_ref = rt.device_ref(resolved_editable_target(&rt.tree, target)?.id)?;
+        let device_ref = rt
+            .device_ref(
+                resolved_editable_target(&rt.tree, target)
+                    .map_err(before_mutation_dispatch)?
+                    .id,
+            )
+            .map_err(before_mutation_dispatch)?;
         #[cfg(test)]
         std::thread::sleep(self.before_set_text_delay);
         #[cfg(test)]
         if std::mem::take(&mut self.retire_before_set_text) {
             self.client.conn.lock().expect("lock").poison();
         }
-        require_semantic_time(ctx.deadline, "Android accessibility set_text", false)?;
+        require_semantic_time(ctx.deadline, "Android accessibility set_text", false)
+            .map_err(before_mutation_dispatch)?;
         match self
             .client
             .set_text(device_ref, text, rt.acting_on(&self.package), ctx.deadline)
@@ -887,8 +1018,10 @@ impl Accessibility for ServiceA11y {
     }
 
     fn invoke(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<Option<AxNodeId>> {
-        let rt = self.snapshot_with_refs(ctx)?;
-        let plan = invoke_plan(&rt.tree, target)?;
+        let rt = self
+            .snapshot_with_refs(ctx)
+            .map_err(before_mutation_dispatch)?;
+        let plan = invoke_plan(&rt, target).map_err(before_mutation_dispatch)?;
         self.dispatch_click(ctx, target, &plan, &rt)
     }
 }
@@ -1170,6 +1303,10 @@ fn ready_or_restore(
     let started = std::time::Instant::now();
     let mut refusal = match wait_for_ready(port, attempt) {
         Ok(client) => return Ok(client),
+        Err(error) if error.contains(INCOMPATIBLE_NODE_SCHEMA) => {
+            restore();
+            return Err(GlassError::AccessibilityUnavailable(error));
+        }
         Err(e) => e,
     };
     let mut rebinds = 0u32;
@@ -1185,6 +1322,10 @@ fn ready_or_restore(
         rebinds += 1;
         match wait_for_ready(port, attempt) {
             Ok(client) => return Ok(client),
+            Err(error) if error.contains(INCOMPATIBLE_NODE_SCHEMA) => {
+                restore();
+                return Err(GlassError::AccessibilityUnavailable(error));
+            }
             Err(e) => refusal = e,
         }
     }
@@ -1209,6 +1350,7 @@ fn wait_for_ready(
     let client = loop {
         match ServiceClient::connect(port) {
             Ok(c) => break c,
+            Err(e) if incompatible_node_schema(&e) => return Err(e.to_string()),
             Err(e) if std::time::Instant::now() >= deadline => {
                 return Err(format!("never accepted a connection in {timeout:?}: {e}"));
             }
@@ -1378,12 +1520,20 @@ fn resolved_editable_target<'a>(tree: &'a AxTree, target: &AxTarget) -> Result<&
 ///
 /// The order is load-bearing: a Compose control omits `ACTION_CLICK` while disabled, so a climb
 /// run before the target's own `enabled` check walks past it and actuates whatever encloses it.
-fn invoke_plan(tree: &AxTree, target: &AxTarget) -> Result<InvokePlan> {
+fn invoke_plan(ref_tree: &RefTree, target: &AxTarget) -> Result<InvokePlan> {
+    invoke_plan_with(&ref_tree.tree, target, |id| ref_tree.is_clickable(id))
+}
+
+fn invoke_plan_with(
+    tree: &AxTree,
+    target: &AxTarget,
+    is_clickable: impl Fn(AxNodeId) -> bool,
+) -> Result<InvokePlan> {
     let node = resolved_target(tree, target)?;
     if !node.states.enabled {
         return Err(disabled_error(target.id.0, target.id));
     }
-    let chosen = actuable_node(tree, target)?;
+    let chosen = actuable_node_with(tree, target, is_clickable)?;
     if !chosen.states.enabled {
         return Err(disabled_error(target.id.0, chosen.id));
     }
@@ -1434,7 +1584,11 @@ fn check_state(after: &AxTree, act: &Actuated) -> CheckState {
 /// carries no name and the named child carries no `ACTION_CLICK`. When the target itself
 /// advertises no click, climb to the nearest node that does and encloses it. Only the ancestor
 /// chain is walked, so an overlapping sibling drawn above the target could still take a real tap.
-fn actuable_node<'a>(tree: &'a AxTree, target: &AxTarget) -> Result<&'a AxNode> {
+fn actuable_node_with<'a>(
+    tree: &'a AxTree,
+    target: &AxTarget,
+    is_clickable: impl Fn(AxNodeId) -> bool,
+) -> Result<&'a AxNode> {
     let mut path = Vec::new();
     if !path_to(&tree.root, target.id, &mut path) {
         return Err(GlassError::AxElementNotFound(target.id.0));
@@ -1442,9 +1596,23 @@ fn actuable_node<'a>(tree: &'a AxTree, target: &AxTarget) -> Result<&'a AxNode> 
     let want = path.last().expect("path_to leaves the target last").bounds;
     path.iter()
         .rev()
-        .find(|n| n.states.focusable && (n.id == target.id || encloses(n.bounds, want)))
+        .find(|n| is_clickable(n.id) && (n.id == target.id || encloses(n.bounds, want)))
         .copied()
         .ok_or(GlassError::AxActionUnavailable(target.id.0))
+}
+
+#[cfg(test)]
+fn actuable_node_for_tree<'a>(tree: &'a AxTree, target: &AxTarget) -> Result<&'a AxNode> {
+    actuable_node_with(tree, target, |id| {
+        tree.find(id).is_some_and(|node| node.states.focusable)
+    })
+}
+
+#[cfg(test)]
+fn invoke_plan_for_tree(tree: &AxTree, target: &AxTarget) -> Result<InvokePlan> {
+    invoke_plan_with(tree, target, |id| {
+        tree.find(id).is_some_and(|node| node.states.focusable)
+    })
 }
 
 /// The root-to-`id` path, inclusive of both ends. False when `id` is not in this subtree,
@@ -1514,6 +1682,12 @@ fn read_back_error(target: &AxTarget, error: GlassError) -> GlassError {
     GlassError::write_unconfirmed_because(target.id.0, "reading the element back failed", error)
 }
 
+/// Mark errors from a proven preflight guard without weakening provenance already attached by a
+/// lower layer.
+fn before_mutation_dispatch(error: GlassError) -> GlassError {
+    error.before_dispatch()
+}
+
 /// Map a click failure onto the invoke contract. No arm is fallback-eligible: a refusal may
 /// still have reached the toolkit, and a lost answer says nothing either way.
 fn action_error(target: u32, f: CallFailure) -> GlassError {
@@ -1540,6 +1714,17 @@ fn action_error(target: u32, f: CallFailure) -> GlassError {
     }
 }
 
+/// Preserve the click transport's delivery verdict for a native focus request.
+fn focus_error(target: u32, failure: CallFailure) -> GlassError {
+    let dispatched = !matches!(&failure, CallFailure::NotSent(_));
+    let error = action_error(target, failure);
+    if dispatched {
+        error.after_dispatch()
+    } else {
+        error.before_dispatch()
+    }
+}
+
 /// The error for a control whose click was accepted but whose state never reached `want`.
 fn check_timeout(target: u32, act: &Actuated, want: bool, seen: CheckState) -> GlassError {
     let id = act.id.0;
@@ -1562,6 +1747,7 @@ fn check_timeout(target: u32, act: &Actuated, want: bool, seen: CheckState) -> G
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent::fake_agent;
     use crate::conn::TimeoutFault;
     use glass_core::accessibility::{AxRole, TruncationLimit};
     use serde_json::json;
@@ -1577,6 +1763,145 @@ mod tests {
         }
     }
 
+    #[test]
+    fn schema_one_companion_is_rejected_before_any_tree_read() {
+        let (port, seen) = fake_agent(r#"{"hello":{"proto":1}}"#, vec![]);
+        let result = ServiceClient::connect(port);
+        assert!(
+            result.is_err(),
+            "schema 1 must not expose password-blind trees"
+        );
+        assert!(
+            seen.lock().unwrap().is_empty(),
+            "no tree request may be sent"
+        );
+    }
+
+    #[test]
+    fn node_schema_capability_must_be_the_exact_integer_two() {
+        for hello in [
+            r#"{"hello":{"proto":1,"node_schema":"2"}}"#,
+            r#"{"hello":{"proto":1,"node_schema":1}}"#,
+            r#"{"hello":{"proto":1,"node_schema":3}}"#,
+        ] {
+            let (port, seen) = fake_agent(hello, vec![]);
+            let error = match ServiceClient::connect(port) {
+                Ok(_) => panic!("accepted malformed or unsupported hello {hello}"),
+                Err(error) => error,
+            };
+            assert!(error.to_string().contains(INCOMPATIBLE_NODE_SCHEMA));
+            assert!(seen.lock().unwrap().is_empty(), "hello={hello}");
+        }
+    }
+
+    #[test]
+    fn schema_one_readiness_restores_immediately_without_rebinding() {
+        let (port, seen) = fake_agent(r#"{"hello":{"proto":1}}"#, vec![]);
+        let rebinds = AtomicUsize::new(0);
+        let restores = AtomicUsize::new(0);
+        let error = ready_or_restore(
+            port,
+            std::time::Duration::from_secs(6),
+            3,
+            &|_| {
+                rebinds.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            },
+            &|| {
+                restores.fetch_add(1, Ordering::Relaxed);
+            },
+        )
+        .err()
+        .expect("schema one is permanently incompatible");
+        assert!(error.to_string().contains(INCOMPATIBLE_NODE_SCHEMA));
+        assert_eq!(rebinds.load(Ordering::Relaxed), 0);
+        assert_eq!(restores.load(Ordering::Relaxed), 1);
+        assert!(seen.lock().unwrap().is_empty(), "no tree request");
+    }
+
+    #[test]
+    fn schema_two_missing_a_required_boolean_is_rejected_before_exposure() {
+        let response = r#"{"ok":true,"tree":{"ref":0,"class":"android.widget.EditText","text":"SECRET_SENTINEL","bounds":{"x":0,"y":100,"w":10,"h":10},"enabled":true,"visible":true,"checkable":false,"checked":false,"focused":false,"focusable":true,"editable":true,"clickable":true,"scrollable":false,"showing_hint_text":false}}"#;
+        let (port, seen) = fake_agent(r#"{"hello":{"proto":1,"node_schema":2}}"#, vec![response]);
+        let client = ServiceClient::connect(port).expect("schema 2 hello");
+        let mut reader = ServiceA11y::new(client, "com.example.app".to_string());
+        let error = reader
+            .snapshot(&ctx())
+            .expect_err("missing password must fail the whole snapshot");
+        assert!(error.to_string().contains("password"), "{error}");
+        assert!(!error.to_string().contains("SECRET_SENTINEL"), "{error}");
+        assert_eq!(seen.lock().unwrap().len(), 1, "one guarded tree read");
+    }
+
+    #[test]
+    fn a_reconnect_rejects_schema_downgrade_without_replaying_the_request() {
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let recorded = Arc::clone(&requests);
+        let tree = with_refs(&editable_field("old"));
+        let server = std::thread::spawn(move || {
+            let (first, _) = listener.accept().expect("first connection");
+            let mut first_writer = first.try_clone().expect("clone first");
+            let mut first_reader = std::io::BufReader::new(first);
+            writeln!(first_writer, r#"{{"hello":{{"proto":1,"node_schema":2}}}}"#)
+                .expect("schema two hello");
+            for request_index in 0..2 {
+                let mut line = String::new();
+                first_reader.read_line(&mut line).expect("first request");
+                let request: Value = serde_json::from_str(&line).expect("request json");
+                recorded
+                    .lock()
+                    .unwrap()
+                    .push(format!("conn1:{}", request["op"].as_str().unwrap_or("?")));
+                if request_index == 0 {
+                    writeln!(
+                        first_writer,
+                        "{}",
+                        json!({"id": request["id"], "ok": true, "tree": tree})
+                    )
+                    .expect("first tree reply");
+                }
+            }
+            drop(first_writer);
+            drop(first_reader);
+
+            let (second, _) = listener.accept().expect("second connection");
+            second
+                .set_read_timeout(Some(std::time::Duration::from_millis(300)))
+                .expect("read timeout");
+            let mut second_writer = second.try_clone().expect("clone second");
+            let mut second_reader = std::io::BufReader::new(second);
+            writeln!(second_writer, r#"{{"hello":{{"proto":1}}}}"#).expect("schema one hello");
+            let mut line = String::new();
+            if second_reader.read_line(&mut line).is_ok_and(|n| n > 0) {
+                recorded.lock().unwrap().push("conn2:request".to_string());
+            }
+        });
+
+        let client = ServiceClient::connect(port).expect("initial schema two");
+        client.tree("com.example.app").expect("initial tree");
+        let failure = client
+            .call(
+                json!({"op": "tree", "package": "com.example.app"}),
+                Deadline::UNBOUNDED,
+            )
+            .expect_err("lost reply cannot reconnect through schema one");
+        assert!(matches!(failure, CallFailure::AnswerLost(_)));
+        assert!(
+            failure
+                .into_error()
+                .to_string()
+                .contains(INCOMPATIBLE_NODE_SCHEMA)
+        );
+        server.join().expect("server");
+        assert_eq!(
+            *requests.lock().unwrap(),
+            vec!["conn1:tree".to_string(), "conn1:tree".to_string()],
+            "the request must not replay on the downgraded connection"
+        );
+    }
+
     /// Number every node that carries no `ref` the way the companion's `treeJson` does —
     /// pre-order, root = 0 — so a fixture reads like a real device reply without restating what
     /// every companion release already sends. A fixture that states its own refs keeps them,
@@ -1587,6 +1912,22 @@ mod tests {
             *next += 1;
             if let Some(o) = v.as_object_mut() {
                 o.entry("ref").or_insert(json!(r));
+                let focusable = o.get("clickable").cloned().unwrap_or(json!(false));
+                for (field, value) in [
+                    ("visible", json!(true)),
+                    ("focused", json!(false)),
+                    ("focusable", focusable),
+                    ("password", json!(false)),
+                    ("editable", json!(false)),
+                    ("clickable", json!(false)),
+                    ("enabled", json!(false)),
+                    ("scrollable", json!(false)),
+                    ("checkable", json!(false)),
+                    ("checked", json!(false)),
+                    ("showing_hint_text", json!(false)),
+                ] {
+                    o.entry(field).or_insert(value);
+                }
             }
             if let Some(kids) = v.get_mut("children").and_then(Value::as_array_mut) {
                 for c in kids {
@@ -2032,6 +2373,72 @@ mod tests {
         );
     }
 
+    #[test]
+    fn companion_claimed_state_coverage_is_backed_by_mapped_fields() {
+        let node = mapped_node(&json!({
+            "class": "android.widget.EditText",
+            "bounds": {"x": 0, "y": 100, "w": 10, "h": 10},
+            "enabled": true,
+            "visible": true,
+            "editable": true,
+            "focused": true,
+            "focusable": true,
+            "checkable": true,
+            "checked": true
+        }));
+
+        assert!(node.states.enabled);
+        assert!(node.states.visible);
+        assert!(node.states.checkable);
+        assert!(node.states.checked);
+        assert!(node.states.focused);
+        assert!(node.states.focusable);
+        assert!(node.states.editable);
+        assert!(!node.states.selected);
+        assert!(!node.states.expanded);
+    }
+
+    #[test]
+    fn password_text_is_dropped_before_label_and_value_mapping() {
+        let node = mapped_node(&json!({
+            "class": "android.widget.EditText",
+            "text": "PASSWORD_SENTINEL",
+            "desc": "Password",
+            "bounds": {"x": 0, "y": 100, "w": 10, "h": 10},
+            "password": true,
+            "editable": true
+        }));
+        assert!(node.states.secure);
+        assert_eq!(node.name.as_deref(), Some("Password"));
+        for exposed in [
+            node.name.as_deref(),
+            node.description.as_deref(),
+            node.value.as_deref(),
+        ] {
+            assert_ne!(exposed, Some("PASSWORD_SENTINEL"));
+        }
+    }
+
+    #[test]
+    fn companion_state_coverage_matches_its_mapped_evidence() {
+        let (port, _ops) = fake_service(vec![editable_field("old")], OnAction::Ok);
+        let reader = reader(port, std::time::Duration::ZERO);
+        assert_eq!(
+            reader.state_coverage(),
+            glass_core::AxStateCoverage {
+                enabled: true,
+                visible: true,
+                checkable: true,
+                checked: true,
+                selected: false,
+                expanded: false,
+                focused: true,
+                focusable: true,
+                editable: true,
+            }
+        );
+    }
+
     /// Device JSON for a root with `n` flat children, each a distinctly-named Button.
     fn wide_device_json(n: usize) -> Value {
         let kids: Vec<Value> = (0..n)
@@ -2461,7 +2868,7 @@ mod tests {
         let t = built(&compose_like());
         let label = target_for(&t, AxNodeId(2));
         assert_eq!(label.name.as_deref(), Some("Save"));
-        assert_eq!(actuable_node(&t, &label).unwrap().id, AxNodeId(1));
+        assert_eq!(actuable_node_for_tree(&t, &label).unwrap().id, AxNodeId(1));
     }
 
     #[test]
@@ -2470,7 +2877,21 @@ mod tests {
         // enclosing it that also advertises a click".
         let t = built(&nested_clickables());
         let btn = target_for(&t, AxNodeId(2));
-        assert_eq!(actuable_node(&t, &btn).unwrap().id, AxNodeId(2));
+        assert_eq!(actuable_node_for_tree(&t, &btn).unwrap().id, AxNodeId(2));
+    }
+
+    #[test]
+    fn a_clickable_but_not_focusable_node_remains_natively_actuable() {
+        let mut value = nested_clickables();
+        value["children"][0]["children"][0]["focusable"] = json!(false);
+        let ref_tree = read_json(&value, WalkLimits::DEFAULT).expect("maps");
+        let button = target_for(&ref_tree.tree, AxNodeId(2));
+
+        assert!(!ref_tree.tree.find(button.id).unwrap().states.focusable);
+        assert_eq!(
+            invoke_plan(&ref_tree, &button).unwrap().actuated.id,
+            AxNodeId(2)
+        );
     }
 
     #[test]
@@ -2482,7 +2903,7 @@ mod tests {
         let t = built(&v);
         let label = target_for(&t, AxNodeId(2));
         assert!(matches!(
-            actuable_node(&t, &label),
+            actuable_node_for_tree(&t, &label),
             Err(GlassError::AxActionUnavailable(2))
         ));
     }
@@ -2495,7 +2916,7 @@ mod tests {
         v["children"][0]["bounds"] = json!({"x": 120, "y": 520, "w": 80, "h": 50});
         let t = built(&v);
         let label = target_for(&t, AxNodeId(2));
-        assert_eq!(actuable_node(&t, &label).unwrap().id, AxNodeId(1));
+        assert_eq!(actuable_node_for_tree(&t, &label).unwrap().id, AxNodeId(1));
     }
 
     #[test]
@@ -2505,7 +2926,7 @@ mod tests {
         let t = built(&v);
         let label = target_for(&t, AxNodeId(2));
         assert!(matches!(
-            actuable_node(&t, &label),
+            actuable_node_for_tree(&t, &label),
             Err(GlassError::AxActionUnavailable(2))
         ));
     }
@@ -2515,7 +2936,7 @@ mod tests {
         let mut v = compose_like();
         v["children"][0]["clickable"] = json!(false);
         let t = built(&v);
-        let e = actuable_node(&t, &target_for(&t, AxNodeId(2))).unwrap_err();
+        let e = actuable_node_for_tree(&t, &target_for(&t, AxNodeId(2))).unwrap_err();
         assert!(e.invoke_fallback_eligible(), "{e}");
     }
 
@@ -2527,7 +2948,7 @@ mod tests {
         let mut label = target_for(&t, AxNodeId(2));
         label.name = Some("Send".into());
         assert!(matches!(
-            invoke_plan(&t, &label),
+            invoke_plan_for_tree(&t, &label),
             Err(GlassError::AxElementGone(2))
         ));
     }
@@ -2537,7 +2958,7 @@ mod tests {
         let t = built(&compose_like());
         let mut label = target_for(&t, AxNodeId(2));
         label.name = Some("Send".into());
-        let e = invoke_plan(&t, &label).unwrap_err();
+        let e = invoke_plan_for_tree(&t, &label).unwrap_err();
         assert!(!e.invoke_fallback_eligible(), "{e}");
     }
 
@@ -2570,7 +2991,7 @@ mod tests {
         let t = built(&target_follows_a_rejected_clickable_sibling());
         let target = target_for(&t, AxNodeId(2));
         assert!(matches!(
-            actuable_node(&t, &target),
+            actuable_node_for_tree(&t, &target),
             Err(GlassError::AxActionUnavailable(2))
         ));
     }
@@ -2719,7 +3140,7 @@ mod tests {
         let mut clicked = checkable_json("android.widget.CheckBox", "Agree", false);
         clicked["bounds"] = json!({"x": 40, "y": 400, "w": 200, "h": 100});
         let before = after_tree(vec![clicked.clone()]);
-        let plan = invoke_plan(&before, &target_for(&before, AxNodeId(1))).unwrap();
+        let plan = invoke_plan_for_tree(&before, &target_for(&before, AxNodeId(1))).unwrap();
 
         // Ids shifted between the click and this read-back: an already-checked impostor now
         // occupies id 1, and the control actually clicked is id 2, still unchecked.
@@ -2785,7 +3206,7 @@ mod tests {
         let label = target_for(&t, AxNodeId(3));
         assert_eq!(label.name.as_deref(), Some("Delete"));
         assert_eq!(
-            actuable_node(&t, &label).unwrap().id,
+            actuable_node_for_tree(&t, &label).unwrap().id,
             AxNodeId(2),
             "the enclosing Button, not the Card around it"
         );
@@ -2804,7 +3225,7 @@ mod tests {
     #[test]
     fn a_disabled_target_is_refused_even_when_something_around_it_is_clickable() {
         let t = built(&disabled_inside_a_clickable_card());
-        let e = invoke_plan(&t, &target_for(&t, AxNodeId(2))).unwrap_err();
+        let e = invoke_plan_for_tree(&t, &target_for(&t, AxNodeId(2))).unwrap_err();
         assert!(matches!(e, GlassError::AxActionFailed(2, _)), "{e}");
         assert!(e.to_string().contains("disabled"), "{e}");
         assert!(
@@ -2820,7 +3241,7 @@ mod tests {
         v["children"][0]["children"][0]["clickable"] = json!(false);
         v["children"][0]["enabled"] = json!(false);
         let t = built(&v);
-        let e = invoke_plan(&t, &target_for(&t, AxNodeId(3))).unwrap_err();
+        let e = invoke_plan_for_tree(&t, &target_for(&t, AxNodeId(3))).unwrap_err();
         assert!(e.to_string().contains("element 1 is disabled"), "{e}");
         assert!(!e.invoke_fallback_eligible(), "{e}");
     }
@@ -2832,7 +3253,7 @@ mod tests {
         let mut v = disabled_inside_a_clickable_card();
         v["children"][0]["clickable"] = json!(false);
         let t = built(&v);
-        let e = invoke_plan(&t, &target_for(&t, AxNodeId(2))).unwrap_err();
+        let e = invoke_plan_for_tree(&t, &target_for(&t, AxNodeId(2))).unwrap_err();
         assert!(e.to_string().contains("disabled"), "{e}");
         assert!(!e.invoke_fallback_eligible(), "{e}");
     }
@@ -2856,14 +3277,14 @@ mod tests {
         // A radio button already selected stays selected, so waiting for a flip fails a click
         // on a UI already in the requested state.
         let t = selection_tree("android.widget.RadioButton", true);
-        let plan = invoke_plan(&t, &target_for(&t, AxNodeId(1))).unwrap();
+        let plan = invoke_plan_for_tree(&t, &target_for(&t, AxNodeId(1))).unwrap();
         assert_eq!(plan.want_checked, None);
     }
 
     #[test]
     fn clicking_an_unselected_radio_button_asks_for_it_to_end_selected() {
         let t = selection_tree("android.widget.RadioButton", false);
-        let plan = invoke_plan(&t, &target_for(&t, AxNodeId(1))).unwrap();
+        let plan = invoke_plan_for_tree(&t, &target_for(&t, AxNodeId(1))).unwrap();
         assert_eq!(plan.want_checked, Some(true));
     }
 
@@ -2871,7 +3292,7 @@ mod tests {
     fn clicking_a_checkbox_asks_for_its_state_to_move_either_way() {
         for was in [false, true] {
             let t = selection_tree("android.widget.CheckBox", was);
-            let plan = invoke_plan(&t, &target_for(&t, AxNodeId(1))).unwrap();
+            let plan = invoke_plan_for_tree(&t, &target_for(&t, AxNodeId(1))).unwrap();
             assert_eq!(plan.want_checked, Some(!was), "checked was {was}");
         }
     }
@@ -2880,7 +3301,7 @@ mod tests {
     fn clicking_a_switch_asks_for_its_state_to_move_either_way() {
         for was in [false, true] {
             let t = selection_tree("android.widget.Switch", was);
-            let plan = invoke_plan(&t, &target_for(&t, AxNodeId(1))).unwrap();
+            let plan = invoke_plan_for_tree(&t, &target_for(&t, AxNodeId(1))).unwrap();
             assert_eq!(plan.want_checked, Some(!was), "checked was {was}");
         }
     }
@@ -2888,14 +3309,14 @@ mod tests {
     #[test]
     fn a_plain_button_has_no_state_to_wait_for() {
         let t = built(&compose_like());
-        let plan = invoke_plan(&t, &target_for(&t, AxNodeId(2))).unwrap();
+        let plan = invoke_plan_for_tree(&t, &target_for(&t, AxNodeId(2))).unwrap();
         assert_eq!(plan.want_checked, None);
     }
 
     #[test]
     fn the_plan_actuates_the_climbed_ancestor_and_reports_the_substitution() {
         let t = built(&compose_like());
-        let plan = invoke_plan(&t, &target_for(&t, AxNodeId(2))).unwrap();
+        let plan = invoke_plan_for_tree(&t, &target_for(&t, AxNodeId(2))).unwrap();
         assert_eq!(plan.actuated.id, AxNodeId(1));
         assert_eq!(plan.substituted(), Some(AxNodeId(1)));
     }
@@ -2903,7 +3324,7 @@ mod tests {
     #[test]
     fn a_target_actuated_in_its_own_right_substitutes_nothing() {
         let t = built(&nested_clickables());
-        let plan = invoke_plan(&t, &target_for(&t, AxNodeId(2))).unwrap();
+        let plan = invoke_plan_for_tree(&t, &target_for(&t, AxNodeId(2))).unwrap();
         assert_eq!(plan.actuated.id, AxNodeId(2));
         assert_eq!(plan.substituted(), None);
     }
@@ -2925,7 +3346,7 @@ mod tests {
         });
         assert_eq!(t.truncated.map(|x| x.limit), Some(TruncationLimit::Nodes));
         assert_eq!(
-            invoke_plan(&t, &target_for(&t, AxNodeId(1)))
+            invoke_plan_for_tree(&t, &target_for(&t, AxNodeId(1)))
                 .unwrap()
                 .actuated
                 .id,
@@ -3164,7 +3585,8 @@ mod tests {
                 let (sock, _) = listener.accept().expect("accept connection");
                 let mut writer = sock.try_clone().expect("clone connection");
                 let mut reader = std::io::BufReader::new(sock);
-                writeln!(writer, r#"{{"hello":{{"proto":1}}}}"#).expect("write hello");
+                writeln!(writer, r#"{{"hello":{{"proto":1,"node_schema":2}}}}"#)
+                    .expect("write hello");
                 let mut tree_confirmed = false;
                 loop {
                     let mut line = String::new();
@@ -3281,7 +3703,7 @@ mod tests {
                 let this_action = on_action[(conn - 1).min(on_action.len() - 1)];
                 let Ok(mut w) = sock.try_clone() else { break };
                 let mut r = std::io::BufReader::new(sock);
-                if writeln!(w, r#"{{"hello":{{"proto":1}}}}"#)
+                if writeln!(w, r#"{{"hello":{{"proto":1,"node_schema":2}}}}"#)
                     .and_then(|()| w.flush())
                     .is_err()
                 {
@@ -4483,7 +4905,7 @@ mod tests {
         let target = target_for(&t, AxNodeId(1));
 
         let rt = a.snapshot_with_refs(&ctx()).expect("snapshot");
-        let plan = invoke_plan(&rt.tree, &target).expect("plan resolves");
+        let plan = invoke_plan(&rt, &target).expect("plan resolves");
         retire_current_connection_before_dispatch(&mut a);
 
         a.dispatch_click(&ctx(), &target, &plan, &rt)
@@ -4522,7 +4944,7 @@ mod tests {
         let mut a = ServiceA11y::new(client, "com.example.app".to_string());
         let target = target_for(&built(&initial), AxNodeId(1));
         let rt = a.snapshot_with_refs(&ctx()).expect("snapshot");
-        let plan = invoke_plan(&rt.tree, &target).expect("plan resolves");
+        let plan = invoke_plan(&rt, &target).expect("plan resolves");
 
         retire_current_connection_before_dispatch(&mut a);
 
@@ -4564,7 +4986,7 @@ mod tests {
         let target = target_for(&t, AxNodeId(1));
 
         let rt = a.snapshot_with_refs(&ctx()).expect("snapshot");
-        let plan = invoke_plan(&rt.tree, &target).expect("plan resolves");
+        let plan = invoke_plan(&rt, &target).expect("plan resolves");
 
         retire_current_connection_before_dispatch(&mut a);
 
@@ -5094,7 +5516,7 @@ mod tests {
             let (sock, _) = listener.accept().expect("accept");
             let mut w = sock.try_clone().expect("clone");
             let mut r = std::io::BufReader::new(sock);
-            writeln!(w, r#"{{"hello":{{"proto":1}}}}"#)
+            writeln!(w, r#"{{"hello":{{"proto":1,"node_schema":2}}}}"#)
                 .and_then(|()| w.flush())
                 .expect("hello");
             let mut line = String::new();
@@ -5144,6 +5566,79 @@ mod tests {
     }
 
     #[test]
+    fn service_focus_clicks_the_resolved_editable_once() {
+        let tree = editable_field("old");
+        let (port, ops) = fake_service(vec![tree.clone()], OnAction::Ok);
+        let mut reader = reader(port, std::time::Duration::ZERO);
+        let seen = built(&tree);
+
+        let focused = reader
+            .focus(&ctx(), &target_for(&seen, AxNodeId(1)))
+            .expect("editable focus uses ACTION_CLICK");
+
+        assert_eq!(focused, None);
+        assert_eq!(
+            ops_of(&ops),
+            vec!["conn1:tree".to_string(), "conn1:click ref=1".to_string()]
+        );
+    }
+
+    #[test]
+    fn service_focus_refuses_a_non_editable_button() {
+        let tree = json!({
+            "class": "android.widget.FrameLayout",
+            "bounds": {"x": 0, "y": 0, "w": 1080, "h": 2400},
+            "enabled": true,
+            "children": [{
+                "class": "android.widget.Button", "desc": "Do not activate",
+                "bounds": {"x": 0, "y": 100, "w": 600, "h": 120},
+                "clickable": true, "enabled": true
+            }]
+        });
+        let (port, ops) = fake_service(vec![tree.clone()], OnAction::Ok);
+        let mut reader = reader(port, std::time::Duration::ZERO);
+        let seen = built(&tree);
+
+        let error = reader
+            .focus(&ctx(), &target_for(&seen, AxNodeId(1)))
+            .expect_err("focus must not activate a non-editable button");
+
+        assert!(
+            matches!(error.cause(), GlassError::AxElementNotEditable(1)),
+            "{error}"
+        );
+        assert_eq!(
+            error.bound_dispatch(),
+            Some(glass_core::BoundDispatch::NotDispatched)
+        );
+        assert_eq!(ops_of(&ops), vec!["conn1:tree".to_string()]);
+    }
+
+    #[test]
+    fn a_lost_focus_reply_is_may_have_dispatched_and_is_never_replayed() {
+        let tree = editable_field("old");
+        let (port, ops) = fake_service(vec![tree.clone()], OnAction::DropWithoutAnswering);
+        let mut reader = reader(port, std::time::Duration::ZERO);
+        let seen = built(&tree);
+
+        let error = reader
+            .focus(&ctx(), &target_for(&seen, AxNodeId(1)))
+            .expect_err("a lost focus reply is not a confirmed focus");
+
+        assert_eq!(
+            error.bound_dispatch(),
+            Some(glass_core::BoundDispatch::MayHaveDispatched),
+            "{error}"
+        );
+        assert!(!error.invoke_fallback_eligible(), "{error}");
+        assert_eq!(
+            ops_of(&ops),
+            vec!["conn1:tree".to_string(), "conn1:click ref=1".to_string()],
+            "the focus click is never replayed after its answer is lost"
+        );
+    }
+
+    #[test]
     fn the_click_is_sent_to_the_node_the_climb_resolved_to() {
         // Sending the caller's own id would click the label, which handles nothing — every
         // Compose click a no-op reported as success.
@@ -5175,6 +5670,27 @@ mod tests {
             vec!["conn1:tree".to_string()],
             "the refusal must happen before anything is dispatched"
         );
+    }
+
+    #[test]
+    fn a_stale_invoke_guard_is_annotated_before_dispatch() {
+        let tree = compose_like();
+        let (port, ops) = fake_service(vec![tree.clone()], OnAction::Ok);
+        let mut reader = reader(port, std::time::Duration::ZERO);
+        let seen = built(&tree);
+        let mut stale = target_for(&seen, AxNodeId(2));
+        stale.name = Some("no longer Save".into());
+
+        let error = reader
+            .invoke(&ctx(), &stale)
+            .expect_err("a stale target must be refused before ACTION_CLICK");
+
+        assert_eq!(
+            error.bound_dispatch(),
+            Some(glass_core::BoundDispatch::NotDispatched),
+            "{error}"
+        );
+        assert_eq!(ops_of(&ops), vec!["conn1:tree".to_string()]);
     }
 
     #[test]
@@ -5275,7 +5791,7 @@ mod tests {
             .expect_err("only position is forgiven");
         // Renaming the node left nothing in the tree presenting as the target, so the
         // relaxation is never reached.
-        assert!(matches!(e, GlassError::AxElementGone(2)), "{e}");
+        assert!(matches!(e.cause(), GlassError::AxElementGone(2)), "{e}");
         assert_eq!(
             ops_of(&ops),
             vec!["conn1:tree".to_string()],
@@ -5340,7 +5856,7 @@ mod tests {
         let e = a
             .set_value(&ctx(), &target_for(&seen, AxNodeId(1)), "new@example.com")
             .expect_err("a field holding other data is not the field that was addressed");
-        assert!(matches!(e, GlassError::AxElementChanged(1)), "{e}");
+        assert!(matches!(e.cause(), GlassError::AxElementChanged(1)), "{e}");
         assert_eq!(
             ops_of(&ops),
             vec!["conn1:tree".to_string()],
@@ -5361,7 +5877,7 @@ mod tests {
         let e = a
             .set_value(&ctx(), &gone, "new")
             .expect_err("an id that resolves to nothing is absent, not moved");
-        assert!(matches!(e, GlassError::AxElementNotFound(9)), "{e}");
+        assert!(matches!(e.cause(), GlassError::AxElementNotFound(9)), "{e}");
         assert_eq!(
             ops_of(&ops),
             vec!["conn1:tree".to_string()],
@@ -5380,7 +5896,7 @@ mod tests {
         let e = a
             .invoke(&ctx(), &target_for(&seen, AxNodeId(2)))
             .expect_err("a resize is not a translation");
-        assert!(matches!(e, GlassError::AxElementChanged(2)), "{e}");
+        assert!(matches!(e.cause(), GlassError::AxElementChanged(2)), "{e}");
         assert_eq!(
             ops_of(&ops),
             vec!["conn1:tree".to_string()],

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -642,6 +642,30 @@ mod tests {
     }
 
     #[test]
+    fn uiautomator_claimed_state_coverage_is_backed_by_mapped_attributes() {
+        let xml = concat!(
+            "<?xml version='1.0'?><hierarchy rotation=\"0\">",
+            "<node class=\"android.widget.EditText\" content-desc=\"State probe\" ",
+            "enabled=\"true\" focusable=\"true\" focused=\"true\" selected=\"true\" ",
+            "checkable=\"true\" checked=\"true\" password=\"false\" ",
+            "bounds=\"[0,0][100,50]\" />",
+            "</hierarchy>",
+        );
+        let tree = build_tree(xml, &win(), WalkLimits::DEFAULT).expect("state fixture maps");
+        let states = tree.root.children[0].states;
+
+        assert!(states.enabled);
+        assert!(states.visible);
+        assert!(states.checkable);
+        assert!(states.checked);
+        assert!(states.selected);
+        assert!(states.focused);
+        assert!(states.focusable);
+        assert!(states.editable);
+        assert!(!states.expanded);
+    }
+
+    #[test]
     fn container_classes_the_probe_found_map_to_group() {
         // Every class here was observed in a real app's uiautomator dump landing in
         // AxRole::Other. They are all containers, and the container rule cannot catch

--- a/crates/glass-android/src/conn.rs
+++ b/crates/glass-android/src/conn.rs
@@ -127,6 +127,7 @@ pub(crate) struct Conn {
     pub(crate) writer: TcpStream,
     pub(crate) reader: BufReader<TcpStream>,
     pub(crate) next_id: i64,
+    hello: Value,
     poisoned: bool,
     #[cfg(test)]
     timeout_faults: std::collections::VecDeque<TimeoutFault>,
@@ -180,6 +181,7 @@ impl Conn {
             writer: stream,
             reader,
             next_id: 1,
+            hello: Value::Null,
             poisoned: false,
             #[cfg(test)]
             timeout_faults: Default::default(),
@@ -205,8 +207,14 @@ impl Conn {
                 "agent protocol mismatch: got {proto:?}, want {PROTO}"
             )));
         }
+        c.hello = v.get("hello").cloned().unwrap_or(Value::Null);
         c.restore_timeouts()?;
         Ok(c)
+    }
+
+    /// One additive capability from the peer's protocol-1 hello.
+    pub(crate) fn hello_capability(&self, name: &str) -> Option<&Value> {
+        self.hello.get(name)
     }
 
     pub(crate) fn ensure_usable(&self) -> glass_core::Result<()> {
@@ -629,6 +637,16 @@ mod tests {
 
     const HELLO: &str = r#"{"hello":{"proto":1}}"#;
     const OK: &str = r#"{"ok":true}"#;
+
+    #[test]
+    fn additive_hello_capability_is_retained_without_changing_protocol_one() {
+        let (port, _) = fake_agent(r#"{"hello":{"proto":1,"node_schema":2}}"#, vec![]);
+        let conn = Conn::open(port).expect("protocol 1 with additive capability");
+        assert_eq!(
+            conn.hello_capability("node_schema").and_then(Value::as_i64),
+            Some(2)
+        );
+    }
 
     #[test]
     fn connection_retry_helpers_keep_short_writes_partial_and_retry_only_expected_errors() {

--- a/crates/glass-android/tests/a11y_loop.rs
+++ b/crates/glass-android/tests/a11y_loop.rs
@@ -13,7 +13,9 @@
 //! a write; and that a test which fails mid-interaction still hands the device back launchable.
 
 use glass_core::Deadline;
-use glass_core::accessibility::{Accessibility, AxContext, AxNode, AxTarget, AxTree, WalkLimits};
+use glass_core::accessibility::{
+    Accessibility, AxContext, AxNode, AxStateCoverage, AxTarget, AxTree, PointerHit, WalkLimits,
+};
 use glass_core::{
     AppSpec, AxRole, GlassError, MouseButton, Platform, PointerEvent, SandboxLevel, WindowGeometry,
 };
@@ -184,9 +186,16 @@ fn a_read_stops_at_the_deadline_its_caller_named() {
         .expect_err("50ms is not enough for a dump this device serves in seconds");
     let took = started.elapsed();
 
-    assert!(
-        matches!(e, GlassError::AccessibilityNotReady(_)),
-        "a read the caller cut short must not read as a broken device: {e}"
+    assert_eq!(
+        e.bound_owner(),
+        Some(glass_core::Whose::Caller),
+        "a read the caller cut short must retain caller ownership: {e}"
+    );
+    assert_eq!(e.bound(), Some(glass_core::BoundKind::TimedOut), "{e}");
+    assert_eq!(
+        e.bound_dispatch(),
+        Some(glass_core::BoundDispatch::MayHaveDispatched),
+        "the abandoned dump process may still have written its device file: {e}"
     );
     assert!(
         took < std::time::Duration::from_secs(5),
@@ -803,4 +812,93 @@ fn web_fixture_button_and_field_respond() {
         }
         None => println!("no editable node in the page to write into"),
     }
+}
+
+#[test]
+#[ignore = "requires a booted AVD + GLASS_ADB + GLASS_ANDROID_ROLE_FIXTURE_APK"]
+fn uiautomator_semantic_fixture_exposes_unique_and_duplicate_resolution_inputs() {
+    let fixture = std::env::var("GLASS_ANDROID_ROLE_FIXTURE_APK")
+        .expect("set GLASS_ANDROID_ROLE_FIXTURE_APK");
+    let mut session = Session::start_spec(AppSpec {
+        build: None,
+        run: vec![
+            fixture,
+            "tech.fixedwidth.glassrolefixture/.MainActivity".to_string(),
+        ],
+        cwd: None,
+        env: vec![],
+        window_hint: None,
+        timeout_ms: 15_000,
+        sandbox: SandboxLevel::Off,
+        a11y: true,
+    });
+    let ctx = session.ctx();
+    let mut a11y = glass_android::AndroidA11y::new();
+    let mut tree = a11y.snapshot(&ctx).expect("semantic role fixture snapshot");
+    tree.assign_ids();
+    assert!(!tree.to_outline().contains("PASSWORD_SENTINEL"));
+
+    fn named<'a>(node: &'a AxNode, name: &str, out: &mut Vec<&'a AxNode>) {
+        if node.name.as_deref() == Some(name) || node.description.as_deref() == Some(name) {
+            out.push(node);
+        }
+        for child in &node.children {
+            named(child, name, out);
+        }
+    }
+
+    let mut saves = Vec::new();
+    named(&tree.root, "Semantic Save", &mut saves);
+    assert_eq!(
+        saves.len(),
+        1,
+        "unique selector input:\n{}",
+        tree.to_outline()
+    );
+    let mut duplicates = Vec::new();
+    named(&tree.root, "Duplicate semantic", &mut duplicates);
+    assert_eq!(
+        duplicates.len(),
+        2,
+        "ambiguous selector input:\n{}",
+        tree.to_outline()
+    );
+    let mut fields = Vec::new();
+    named(&tree.root, "Semantic Field", &mut fields);
+    let field = fields.as_slice().first().copied().expect("semantic field");
+    let mut passwords = Vec::new();
+    named(&tree.root, "Semantic Password", &mut passwords);
+    let password = passwords.first().copied().expect("semantic password");
+    assert!(password.states.secure);
+    assert_ne!(password.value.as_deref(), Some("PASSWORD_SENTINEL"));
+    let target = AxTarget {
+        id: field.id,
+        role: field.role,
+        name: field.name.clone(),
+        bounds: field.bounds,
+        value: field.value.clone(),
+    };
+    assert!(matches!(
+        a11y.focus(&ctx, &target),
+        Err(GlassError::AxUnsupported)
+    ));
+    assert_eq!(
+        a11y.pointer_target_at(&ctx, &target, (0, 0))
+            .expect("honest hit probe"),
+        PointerHit::Inconclusive
+    );
+    assert_eq!(
+        a11y.state_coverage(),
+        AxStateCoverage {
+            enabled: true,
+            visible: true,
+            checkable: true,
+            checked: true,
+            selected: true,
+            expanded: false,
+            focused: true,
+            focusable: true,
+            editable: true,
+        }
+    );
 }

--- a/crates/glass-android/tests/a11y_service_loop.rs
+++ b/crates/glass-android/tests/a11y_service_loop.rs
@@ -11,7 +11,9 @@ use glass_android::{
     A11yServiceRegistry, AgentRegistry, AndroidPlatform, EmulatorRegistry, ServiceA11y,
 };
 use glass_core::Deadline;
-use glass_core::accessibility::{Accessibility, AxContext, AxNode, AxTarget, WalkLimits};
+use glass_core::accessibility::{
+    Accessibility, AxContext, AxNode, AxStateCoverage, AxTarget, PointerHit, WalkLimits,
+};
 use glass_core::{AppSpec, Platform, SandboxLevel, WindowGeometry};
 
 mod common;
@@ -308,4 +310,158 @@ fn native_invoke_actuates_the_fixture() {
 
     p.stop_app().ok();
     drop(p);
+}
+
+#[test]
+#[ignore = "requires a booted AVD + GLASS_ADB + GLASS_ANDROID_A11Y_APK + GLASS_ANDROID_ROLE_FIXTURE_APK"]
+fn companion_semantic_fixture_focuses_one_editable_and_exposes_duplicate_inputs() {
+    let _device = DEVICE.lock().unwrap_or_else(|e| e.into_inner());
+    let apk = std::env::var("GLASS_ANDROID_A11Y_APK").expect("set GLASS_ANDROID_A11Y_APK");
+    let fixture = std::env::var("GLASS_ANDROID_ROLE_FIXTURE_APK")
+        .expect("set GLASS_ANDROID_ROLE_FIXTURE_APK");
+    let agents = AgentRegistry::new();
+    let _stop_agent = common::StopAgent(&agents);
+    let mut platform =
+        AndroidPlatform::from_env(&EmulatorRegistry::new(), &agents).expect("attach");
+    let adb = platform.resolved_adb();
+    platform
+        .start_app(&AppSpec {
+            build: None,
+            run: vec![
+                fixture,
+                "tech.fixedwidth.glassrolefixture/.MainActivity".to_string(),
+            ],
+            cwd: None,
+            env: vec![],
+            window_hint: None,
+            timeout_ms: 10_000,
+            sandbox: SandboxLevel::Off,
+            a11y: false,
+        })
+        .expect("launch role fixture");
+    let registry = A11yServiceRegistry::new();
+    let _restore = common::RestoreServiceState(&registry);
+    let client = registry
+        .ensure(&adb, &apk)
+        .expect("install + enable + connect");
+    let mut a11y = ServiceA11y::new(client, "tech.fixedwidth.glassrolefixture".to_string());
+    let ctx = AxContext {
+        pids: vec![],
+        window: WindowGeometry {
+            x: 0,
+            y: 0,
+            width: 1080,
+            height: 2400,
+        },
+        window_handle: None,
+        a11y_bus_addr: None,
+        limits: WalkLimits::DEFAULT,
+        deadline: Deadline::from_millis(10_000),
+    };
+
+    fn matches<'a>(node: &'a AxNode, name: &str, out: &mut Vec<&'a AxNode>) {
+        if node.name.as_deref() == Some(name) || node.description.as_deref() == Some(name) {
+            out.push(node);
+        }
+        for child in &node.children {
+            matches(child, name, out);
+        }
+    }
+    fn target(node: &AxNode) -> AxTarget {
+        AxTarget {
+            id: node.id,
+            role: node.role,
+            name: node.name.clone(),
+            bounds: node.bounds,
+            value: node.value.clone(),
+        }
+    }
+
+    let mut tree = a11y.snapshot(&ctx).expect("semantic companion snapshot");
+    tree.assign_ids();
+    assert!(!tree.to_outline().contains("PASSWORD_SENTINEL"));
+    let mut saves = Vec::new();
+    matches(&tree.root, "Semantic Save", &mut saves);
+    assert_eq!(saves.len(), 1, "unique input:\n{}", tree.to_outline());
+    let mut duplicates = Vec::new();
+    matches(&tree.root, "Duplicate semantic", &mut duplicates);
+    assert_eq!(
+        duplicates.len(),
+        2,
+        "duplicate input:\n{}",
+        tree.to_outline()
+    );
+    let mut fields = Vec::new();
+    matches(&tree.root, "Semantic Field", &mut fields);
+    let field = fields.as_slice().first().copied().expect("semantic field");
+    let mut passwords = Vec::new();
+    matches(&tree.root, "Semantic Password", &mut passwords);
+    let password = passwords.first().copied().expect("semantic password");
+    assert!(password.states.secure);
+    assert_ne!(password.value.as_deref(), Some("PASSWORD_SENTINEL"));
+    let original_value = field.value.clone();
+    a11y.focus(&ctx, &target(field))
+        .expect("one companion focus click");
+
+    let started = std::time::Instant::now();
+    let (focused, focus_status) = loop {
+        let mut after = a11y.snapshot(&ctx).expect("fresh focus confirmation tree");
+        after.assign_ids();
+        let mut focused_fields = Vec::new();
+        matches(&after.root, "Semantic Field", &mut focused_fields);
+        let focused = focused_fields
+            .as_slice()
+            .first()
+            .copied()
+            .expect("focused semantic field");
+        let mut statuses = Vec::new();
+        matches(&after.root, "Semantic Focus Status", &mut statuses);
+        let status = statuses.as_slice().first().copied().expect("focus status");
+        if focused.states.focused {
+            break (focused.clone(), status.name.clone());
+        }
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(2),
+            "fresh trees never confirmed focus: {}",
+            after.to_outline()
+        );
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    };
+    assert_eq!(
+        focus_status.as_deref(),
+        Some("focus_click=1 request=true focused=true")
+    );
+    assert_eq!(
+        focused.value, original_value,
+        "focus must not type or clear"
+    );
+    assert_eq!(
+        a11y.pointer_target_at(&ctx, &target(&focused), (0, 0))
+            .expect("honest hit probe"),
+        PointerHit::Inconclusive
+    );
+    assert_eq!(
+        a11y.state_coverage(),
+        AxStateCoverage {
+            enabled: true,
+            visible: true,
+            checkable: true,
+            checked: true,
+            selected: false,
+            expanded: false,
+            focused: true,
+            focusable: true,
+            editable: true,
+        }
+    );
+    std::thread::sleep(std::time::Duration::from_millis(350));
+    let quiet = a11y.snapshot(&ctx).expect("quiet focus tree");
+    let mut statuses = Vec::new();
+    matches(&quiet.root, "Semantic Focus Status", &mut statuses);
+    assert_eq!(
+        statuses.first().and_then(|status| status.name.as_deref()),
+        Some("focus_click=1 request=true focused=true"),
+        "focus handler changed during the quiet window"
+    );
+    platform.stop_app().ok();
 }

--- a/crates/glass-core/src/a11y_thread.rs
+++ b/crates/glass-core/src/a11y_thread.rs
@@ -177,6 +177,7 @@ enum Op {
     Snapshot,
     SetValue,
     Invoke,
+    Focus,
 }
 
 impl Op {
@@ -185,6 +186,7 @@ impl Op {
             Op::Snapshot => "snapshot",
             Op::SetValue => "set_value",
             Op::Invoke => "invoke",
+            Op::Focus => "focus",
         }
     }
 
@@ -194,7 +196,7 @@ impl Op {
         match self {
             Op::Snapshot => "",
             Op::SetValue => "; the write may still land — re-snapshot before retrying",
-            Op::Invoke => "; the action may still land — re-snapshot before retrying",
+            Op::Invoke | Op::Focus => "; the action may still land — re-snapshot before retrying",
         }
     }
 }
@@ -287,57 +289,87 @@ impl A11yThread {
         deadline: Deadline,
         job: impl FnOnce(&A11yMutationDispatch) -> Result<()> + Send + 'static,
     ) -> Result<()> {
+        self.mutation(Op::Invoke, "invoke", deadline, job)
+    }
+
+    pub fn focus(
+        &self,
+        deadline: Deadline,
+        job: impl FnOnce(&A11yMutationDispatch) -> Result<()> + Send + 'static,
+    ) -> Result<()> {
+        self.mutation(Op::Focus, "focus", deadline, job)
+    }
+
+    fn mutation(
+        &self,
+        op: Op,
+        operation: &'static str,
+        deadline: Deadline,
+        job: impl FnOnce(&A11yMutationDispatch) -> Result<()> + Send + 'static,
+    ) -> Result<()> {
         if deadline.has_passed() {
-            return Err(GlassError::deadline_not_started(
-                "native accessibility invoke",
-            ));
+            return Err(GlassError::deadline_not_started(&format!(
+                "native accessibility {operation}"
+            )));
         }
         let (ends, ended_by) = self.bounded_wait(deadline);
-        let dispatch = A11yMutationDispatch::new("invoke", ends);
+        let dispatch = A11yMutationDispatch::new(operation, ends);
         let worker_dispatch = dispatch.duplicate();
         let timeout_dispatch = dispatch.duplicate();
         let panic_dispatch = dispatch.duplicate();
         let result = self.detached(
-            Op::Invoke,
+            op,
             ends,
             move || run_mutation_job(worker_dispatch, job),
-            || self.invoke_no_answer(ended_by, &timeout_dispatch),
-            || self.invoke_panicked(&panic_dispatch),
+            || self.mutation_no_answer(op, operation, ended_by, &timeout_dispatch),
+            || self.mutation_panicked(op, operation, &panic_dispatch),
         );
         dispatch.cancel_or_dispatched();
         result
     }
 
-    fn invoke_no_answer(&self, ended_by: Whose, dispatch: &A11yMutationDispatch) -> GlassError {
+    fn mutation_no_answer(
+        &self,
+        op: Op,
+        operation: &'static str,
+        ended_by: Whose,
+        dispatch: &A11yMutationDispatch,
+    ) -> GlassError {
         match (ended_by, dispatch.cancel_or_dispatched()) {
             (Whose::Caller, true) => GlassError::caller_deadline_elapsed_with_guidance(
-                "native accessibility invoke",
+                &format!("native accessibility {operation}"),
                 "the action may still land; re-snapshot before retrying",
             ),
             (Whose::Caller, false) => GlassError::Bounded {
                 kind: BoundKind::TimedOut,
                 whose: Whose::Caller,
                 dispatch: BoundDispatch::NotDispatched,
-                message: "native accessibility invoke: the caller deadline elapsed during target resolution; the action was not dispatched"
-                    .into(),
+                message: format!(
+                    "native accessibility {operation}: the caller deadline elapsed during target resolution; the action was not dispatched"
+                ),
             },
-            (Whose::Callee, true) => self.timed_out(Op::Invoke).after_dispatch(),
+            (Whose::Callee, true) => self.timed_out(op).after_dispatch(),
             (Whose::Callee, false) => GlassError::AccessibilityUnavailable(format!(
-                "accessibility invoke timed out ({} not responding) before the native action was dispatched",
+                "accessibility {operation} timed out ({} not responding) before the native action was dispatched",
                 self.backend
             ))
             .before_dispatch(),
         }
     }
 
-    fn invoke_panicked(&self, dispatch: &A11yMutationDispatch) -> GlassError {
-        let error = self.worker_panicked(Op::Invoke);
+    fn mutation_panicked(
+        &self,
+        op: Op,
+        operation: &'static str,
+        dispatch: &A11yMutationDispatch,
+    ) -> GlassError {
+        let error = self.worker_panicked(op);
         if dispatch.was_dispatched() {
             error.after_dispatch()
         } else {
             GlassError::AccessibilityUnavailable(format!(
-                "the {} accessibility worker panicked during invoke before the native action was dispatched — the panic is on glass's stderr",
-                self.backend
+                "the {} accessibility worker panicked during {operation} before the native action was dispatched — the panic is on glass's stderr",
+                self.backend,
             ))
             .before_dispatch()
         }
@@ -1159,6 +1191,70 @@ mod tests {
             error.to_string().contains("action may still land"),
             "{error}"
         );
+    }
+
+    #[test]
+    fn focus_timeout_before_dispatch_is_retry_safe() {
+        let ran = Arc::new(AtomicUsize::new(0));
+        let worker_ran = Arc::clone(&ran);
+        let thread = A11yThread::new("focus test", Duration::from_millis(100));
+        let error = thread
+            .focus(Deadline::from_millis(5), move |dispatch| {
+                std::thread::sleep(Duration::from_millis(20));
+                dispatch.dispatch(|| {
+                    worker_ran.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                })
+            })
+            .unwrap_err();
+        assert_eq!(error.bound_dispatch(), Some(BoundDispatch::NotDispatched));
+        assert_eq!(ran.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn focus_timeout_after_dispatch_is_may_have_dispatched() {
+        let ran = Arc::new(AtomicUsize::new(0));
+        let worker_ran = Arc::clone(&ran);
+        let thread = A11yThread::new("focus test", Duration::from_millis(100));
+        let error = thread
+            .focus(Deadline::from_millis(5), move |dispatch| {
+                dispatch.dispatch(|| {
+                    worker_ran.fetch_add(1, Ordering::SeqCst);
+                    std::thread::sleep(Duration::from_millis(20));
+                    Ok(())
+                })
+            })
+            .unwrap_err();
+        assert_eq!(
+            error.bound_dispatch(),
+            Some(BoundDispatch::MayHaveDispatched)
+        );
+        assert_eq!(ran.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn sequential_focus_dispatch_attempts_execute_only_one_mutation() {
+        let ran = Arc::new(AtomicUsize::new(0));
+        let worker_ran = Arc::clone(&ran);
+        let thread = A11yThread::new("focus test", Duration::from_secs(1));
+        thread
+            .focus(Deadline::UNBOUNDED, move |dispatch| {
+                dispatch.dispatch(|| {
+                    worker_ran.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                })?;
+                assert!(
+                    dispatch
+                        .dispatch(|| {
+                            worker_ran.fetch_add(1, Ordering::SeqCst);
+                            Ok(())
+                        })
+                        .is_err()
+                );
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(ran.load(Ordering::SeqCst), 1);
     }
 
     #[test]

--- a/crates/glass-core/src/a11y_thread.rs
+++ b/crates/glass-core/src/a11y_thread.rs
@@ -168,7 +168,14 @@ fn run_mutation_job(
     job: impl FnOnce(&A11yMutationDispatch) -> Result<()>,
 ) -> Result<()> {
     let _completion = MutationCompletion(dispatch.duplicate());
-    job(&dispatch)
+    let result = job(&dispatch);
+    let was_dispatched = dispatch.cancel_or_dispatched();
+    match result {
+        Err(error) if !was_dispatched && !error.invoke_fallback_eligible() => {
+            Err(error.before_dispatch())
+        }
+        result => result,
+    }
 }
 
 /// A bounded call, for the message its failure carries.
@@ -704,6 +711,74 @@ mod tests {
         let r: Result<()> =
             reader().set_value(0, Deadline::UNBOUNDED, |_| Err(GlassError::AxUnsupported));
         assert!(matches!(r, Err(GlassError::AxUnsupported)), "{r:?}");
+    }
+
+    #[test]
+    fn focus_property_error_before_the_dispatch_gate_is_not_dispatched() {
+        let error = reader()
+            .focus(Deadline::UNBOUNDED, |_| {
+                Err(GlassError::AccessibilityUnavailable(
+                    "scripted focus property HRESULT".into(),
+                ))
+            })
+            .expect_err("the scripted focus property read fails");
+
+        assert_eq!(error.bound_dispatch(), Some(BoundDispatch::NotDispatched));
+        assert!(
+            matches!(error.cause(), GlassError::AccessibilityUnavailable(message) if message == "scripted focus property HRESULT"),
+            "{error:?}"
+        );
+    }
+
+    #[test]
+    fn invoke_pattern_error_before_the_dispatch_gate_is_not_dispatched() {
+        let error = reader()
+            .invoke(Deadline::UNBOUNDED, |_| {
+                Err(GlassError::AccessibilityUnavailable(
+                    "scripted invoke pattern HRESULT".into(),
+                ))
+            })
+            .expect_err("the scripted invoke pattern lookup fails");
+
+        assert_eq!(error.bound_dispatch(), Some(BoundDispatch::NotDispatched));
+        assert!(
+            matches!(error.cause(), GlassError::AccessibilityUnavailable(message) if message == "scripted invoke pattern HRESULT"),
+            "{error:?}"
+        );
+    }
+
+    #[test]
+    fn set_value_pattern_error_before_the_dispatch_gate_is_not_dispatched() {
+        let error = reader()
+            .set_value(7, Deadline::UNBOUNDED, |_| {
+                Err(GlassError::AccessibilityUnavailable(
+                    "scripted set-value pattern HRESULT".into(),
+                ))
+            })
+            .expect_err("the scripted set-value pattern lookup fails");
+
+        assert_eq!(error.bound_dispatch(), Some(BoundDispatch::NotDispatched));
+        assert!(!error.set_value_failed_after_writing(), "{error:?}");
+        assert!(
+            matches!(error.cause(), GlassError::AccessibilityUnavailable(message) if message == "scripted set-value pattern HRESULT"),
+            "{error:?}"
+        );
+    }
+
+    #[test]
+    fn pre_dispatch_native_unavailable_keeps_its_typed_fallback_cause() {
+        for error in [
+            reader()
+                .invoke(Deadline::UNBOUNDED, |_| Err(GlassError::AxUnsupported))
+                .expect_err("unsupported invoke"),
+            reader()
+                .invoke(Deadline::UNBOUNDED, |_| {
+                    Err(GlassError::AxActionUnavailable(9))
+                })
+                .expect_err("unavailable invoke"),
+        ] {
+            assert!(error.invoke_fallback_eligible(), "{error:?}");
+        }
     }
 
     #[test]

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -1228,7 +1228,7 @@ pub trait Accessibility {
     }
 
     fn state_coverage(&self) -> AxStateCoverage {
-        AxStateCoverage::NONE
+        Default::default()
     }
 
     fn focus(&mut self, _ctx: &AxContext, _target: &AxTarget) -> Result<Option<AxNodeId>> {

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -10,6 +10,12 @@ use crate::deadline::Deadline;
 use crate::error::{GlassError, Result};
 use crate::platform::{Segment, WindowGeometry};
 
+mod actionability;
+pub use actionability::{
+    ActionabilityCheck, ActionabilityCheckName, ActionabilityReport, ActionabilitySource,
+    ActionabilityVerdict, AxStateCoverage, PointerHit,
+};
+
 mod query;
 pub use query::{
     MatchField, MatchTier, ScopeResolution, SemanticMatch, SemanticQuery, SemanticQueryError,
@@ -1221,6 +1227,23 @@ pub trait Accessibility {
         None
     }
 
+    fn state_coverage(&self) -> AxStateCoverage {
+        AxStateCoverage::NONE
+    }
+
+    fn focus(&mut self, _ctx: &AxContext, _target: &AxTarget) -> Result<Option<AxNodeId>> {
+        Err(crate::GlassError::AxUnsupported)
+    }
+
+    fn pointer_target_at(
+        &mut self,
+        _ctx: &AxContext,
+        _target: &AxTarget,
+        _point: (i32, i32),
+    ) -> Result<PointerHit> {
+        Ok(PointerHit::Inconclusive)
+    }
+
     /// Set the editable `target` after rewalking and verifying its fingerprint; default:
     /// unsupported.
     ///
@@ -1621,6 +1644,42 @@ mod tests {
             .set_value(&ctx, &target, "x")
             .expect_err("the default must refuse, not report success");
         assert!(matches!(err, crate::error::GlassError::AxUnsupported));
+    }
+
+    #[test]
+    fn actionability_capabilities_default_to_unavailable() {
+        struct Bare;
+        impl Accessibility for Bare {
+            fn snapshot(&mut self, _ctx: &AxContext) -> Result<AxTree> {
+                unreachable!("not exercised")
+            }
+        }
+        let ctx = AxContext {
+            pids: vec![],
+            window: WindowGeometry::default(),
+            window_handle: None,
+            a11y_bus_addr: None,
+            limits: WalkLimits::DEFAULT,
+            deadline: Deadline::UNBOUNDED,
+        };
+        let target = AxTarget {
+            id: AxNodeId(1),
+            role: AxRole::Button,
+            name: None,
+            bounds: None,
+            value: None,
+        };
+        let mut backend = Bare;
+
+        assert_eq!(backend.state_coverage(), AxStateCoverage::NONE);
+        assert!(matches!(
+            backend.focus(&ctx, &target),
+            Err(crate::error::GlassError::AxUnsupported)
+        ));
+        assert_eq!(
+            backend.pointer_target_at(&ctx, &target, (10, 20)).unwrap(),
+            PointerHit::Inconclusive
+        );
     }
 
     /// Every arm of the condition table, plus the predicate each one selects. `Appears` and

--- a/crates/glass-core/src/accessibility/actionability.rs
+++ b/crates/glass-core/src/accessibility/actionability.rs
@@ -189,6 +189,16 @@ impl ActionabilityReport {
             check.verdict = ActionabilityVerdict::Passed;
         }
     }
+
+    pub(crate) fn fail_in_window(&mut self) {
+        if let Some(check) = self
+            .checks
+            .iter_mut()
+            .find(|check| check.name == ActionabilityCheckName::InWindow)
+        {
+            check.verdict = ActionabilityVerdict::Failed;
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/glass-core/src/accessibility/actionability.rs
+++ b/crates/glass-core/src/accessibility/actionability.rs
@@ -1,0 +1,234 @@
+use super::SemanticState;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct AxStateCoverage {
+    pub enabled: bool,
+    pub visible: bool,
+    pub checkable: bool,
+    pub checked: bool,
+    pub selected: bool,
+    pub expanded: bool,
+    pub focused: bool,
+    pub focusable: bool,
+    pub editable: bool,
+}
+
+impl AxStateCoverage {
+    pub const NONE: Self = Self {
+        enabled: false,
+        visible: false,
+        checkable: false,
+        checked: false,
+        selected: false,
+        expanded: false,
+        focused: false,
+        focusable: false,
+        editable: false,
+    };
+
+    pub fn covers_selector_state(self, state: SemanticState) -> bool {
+        match state {
+            SemanticState::Enabled | SemanticState::Disabled => self.enabled,
+            SemanticState::Visible | SemanticState::Hidden => self.visible,
+            SemanticState::Checked | SemanticState::Unchecked => self.checkable && self.checked,
+            SemanticState::Selected | SemanticState::Unselected => self.selected,
+            SemanticState::Expanded | SemanticState::Collapsed => self.expanded,
+            SemanticState::Focused => self.focused,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ActionabilityVerdict {
+    Passed,
+    Failed,
+    Unproven,
+}
+
+impl ActionabilityVerdict {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Passed => "passed",
+            Self::Failed => "failed",
+            Self::Unproven => "unproven",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ActionabilityCheckName {
+    Unique,
+    Enabled,
+    Visible,
+    FocusEligible,
+    Stable,
+    InWindow,
+    NonOccluded,
+    Focused,
+    BackendFingerprint,
+}
+
+impl ActionabilityCheckName {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Unique => "unique",
+            Self::Enabled => "enabled",
+            Self::Visible => "visible",
+            Self::FocusEligible => "focus_eligible",
+            Self::Stable => "stable",
+            Self::InWindow => "in_window",
+            Self::NonOccluded => "non_occluded",
+            Self::Focused => "focused",
+            Self::BackendFingerprint => "backend_fingerprint",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ActionabilitySource {
+    SemanticResolution,
+    NormalizedState,
+    GeometrySamples,
+    WindowGeometry,
+    BackendHitProbe,
+    BackendRewalk,
+    ConfirmationPoll,
+    LegacyCache,
+}
+
+impl ActionabilitySource {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::SemanticResolution => "semantic_resolution",
+            Self::NormalizedState => "normalized_state",
+            Self::GeometrySamples => "geometry_samples",
+            Self::WindowGeometry => "window_geometry",
+            Self::BackendHitProbe => "backend_hit_probe",
+            Self::BackendRewalk => "backend_rewalk",
+            Self::ConfirmationPoll => "confirmation_poll",
+            Self::LegacyCache => "legacy_cache",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ActionabilityCheck {
+    pub name: ActionabilityCheckName,
+    pub verdict: ActionabilityVerdict,
+    pub required: bool,
+    pub source: ActionabilitySource,
+}
+
+impl ActionabilityCheck {
+    pub const fn new(
+        name: ActionabilityCheckName,
+        verdict: ActionabilityVerdict,
+        required: bool,
+        source: ActionabilitySource,
+    ) -> Self {
+        Self {
+            name,
+            verdict,
+            required,
+            source,
+        }
+    }
+
+    pub fn blocks_dispatch(self) -> bool {
+        self.required && self.verdict == ActionabilityVerdict::Failed
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ActionabilityReport {
+    pub checks: Vec<ActionabilityCheck>,
+}
+
+impl ActionabilityReport {
+    pub fn push(&mut self, check: ActionabilityCheck) {
+        self.checks.push(check);
+    }
+
+    pub fn blocking(&self) -> Option<ActionabilityCheck> {
+        self.checks
+            .iter()
+            .copied()
+            .find(|check| check.blocks_dispatch())
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PointerHit {
+    Target,
+    AcceptedAncestor,
+    Other,
+    Inconclusive,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::SemanticState;
+
+    #[test]
+    fn selector_state_pairs_require_the_underlying_reader_facts() {
+        let coverage = AxStateCoverage {
+            enabled: true,
+            visible: false,
+            checkable: true,
+            checked: true,
+            selected: false,
+            expanded: false,
+            focused: true,
+            focusable: true,
+            editable: true,
+        };
+        assert!(coverage.covers_selector_state(SemanticState::Enabled));
+        assert!(coverage.covers_selector_state(SemanticState::Disabled));
+        assert!(coverage.covers_selector_state(SemanticState::Checked));
+        assert!(coverage.covers_selector_state(SemanticState::Unchecked));
+        assert!(!coverage.covers_selector_state(SemanticState::Visible));
+        assert!(!coverage.covers_selector_state(SemanticState::Hidden));
+        assert!(!coverage.covers_selector_state(SemanticState::Selected));
+    }
+
+    #[test]
+    fn actionability_records_keep_verdict_required_and_source_separate() {
+        let check = ActionabilityCheck {
+            name: ActionabilityCheckName::NonOccluded,
+            verdict: ActionabilityVerdict::Unproven,
+            required: true,
+            source: ActionabilitySource::BackendHitProbe,
+        };
+        assert_eq!(check.name.as_str(), "non_occluded");
+        assert_eq!(check.verdict.as_str(), "unproven");
+        assert_eq!(check.source.as_str(), "backend_hit_probe");
+        assert!(check.required);
+        assert!(!check.blocks_dispatch());
+    }
+
+    #[test]
+    fn a_known_failed_required_check_blocks_but_optional_or_unproven_checks_do_not() {
+        let required_failure = ActionabilityCheck::new(
+            ActionabilityCheckName::Enabled,
+            ActionabilityVerdict::Failed,
+            true,
+            ActionabilitySource::NormalizedState,
+        );
+        let optional_failure = ActionabilityCheck::new(
+            ActionabilityCheckName::Visible,
+            ActionabilityVerdict::Failed,
+            false,
+            ActionabilitySource::NormalizedState,
+        );
+        let required_unknown = ActionabilityCheck::new(
+            ActionabilityCheckName::NonOccluded,
+            ActionabilityVerdict::Unproven,
+            true,
+            ActionabilitySource::BackendHitProbe,
+        );
+        assert!(required_failure.blocks_dispatch());
+        assert!(!optional_failure.blocks_dispatch());
+        assert!(!required_unknown.blocks_dispatch());
+    }
+}

--- a/crates/glass-core/src/accessibility/actionability.rs
+++ b/crates/glass-core/src/accessibility/actionability.rs
@@ -431,6 +431,32 @@ mod tests {
     }
 
     #[test]
+    fn checked_selectors_require_both_checkability_and_checked_coverage() {
+        for (checkable, checked, expected) in [
+            (false, false, false),
+            (false, true, false),
+            (true, false, false),
+            (true, true, true),
+        ] {
+            let coverage = AxStateCoverage {
+                checkable,
+                checked,
+                ..AxStateCoverage::NONE
+            };
+            assert_eq!(
+                coverage.covers_selector_state(SemanticState::Checked),
+                expected,
+                "checkable={checkable}, checked={checked}"
+            );
+            assert_eq!(
+                coverage.covers_selector_state(SemanticState::Unchecked),
+                expected,
+                "checkable={checkable}, checked={checked}"
+            );
+        }
+    }
+
+    #[test]
     fn actionability_records_keep_verdict_required_and_source_separate() {
         let check = ActionabilityCheck {
             name: ActionabilityCheckName::NonOccluded,
@@ -630,6 +656,50 @@ mod tests {
     }
 
     #[test]
+    fn passing_the_backend_fingerprint_changes_only_that_disclosed_check() {
+        let coverage = AxStateCoverage {
+            enabled: true,
+            visible: true,
+            ..AxStateCoverage::NONE
+        };
+        let mut report = ActionabilityReport::evaluate_click(
+            &target(
+                AxRole::Button,
+                AxStates {
+                    enabled: true,
+                    visible: true,
+                    ..AxStates::default()
+                },
+                Some(AxRect {
+                    x: 10,
+                    y: 10,
+                    width: 20,
+                    height: 20,
+                }),
+            ),
+            coverage,
+            Some(true),
+            (100, 100),
+            PointerHit::Target,
+            false,
+            true,
+        );
+        let before = report.clone();
+
+        report.pass_backend_fingerprint();
+
+        assert_eq!(
+            check(&report, ActionabilityCheckName::BackendFingerprint).verdict,
+            ActionabilityVerdict::Passed
+        );
+        for original in before.checks {
+            if original.name != ActionabilityCheckName::BackendFingerprint {
+                assert_eq!(check(&report, original.name), original);
+            }
+        }
+    }
+
+    #[test]
     fn focus_requires_focusable_or_editable_when_that_fact_is_covered() {
         let coverage = AxStateCoverage {
             enabled: true,
@@ -672,6 +742,39 @@ mod tests {
                 ActionabilitySource::NormalizedState,
             )
         );
+    }
+
+    #[test]
+    fn focus_eligibility_distinguishes_either_positive_fact_from_partial_negative_coverage() {
+        let cases = [
+            (true, true, false, false, ActionabilityVerdict::Passed),
+            (false, false, true, true, ActionabilityVerdict::Passed),
+            (true, false, false, false, ActionabilityVerdict::Unproven),
+            (false, false, true, false, ActionabilityVerdict::Unproven),
+            (true, false, true, false, ActionabilityVerdict::Failed),
+        ];
+
+        for (covers_focusable, focusable, covers_editable, editable, expected) in cases {
+            let coverage = AxStateCoverage {
+                focusable: covers_focusable,
+                editable: covers_editable,
+                ..AxStateCoverage::NONE
+            };
+            let element = target(
+                AxRole::Button,
+                AxStates {
+                    focusable,
+                    editable,
+                    ..AxStates::default()
+                },
+                None,
+            );
+            assert_eq!(
+                focus_eligibility(&element, coverage),
+                expected,
+                "coverage=({covers_focusable},{covers_editable}), state=({focusable},{editable})"
+            );
+        }
     }
 
     #[test]
@@ -749,5 +852,86 @@ mod tests {
                 "role {role:?} was not marked eligible"
             );
         }
+    }
+
+    #[test]
+    fn set_value_eligibility_requires_matching_state_evidence_or_complete_negative_coverage() {
+        let cases = [
+            (true, true, false, false, ActionabilityVerdict::Passed),
+            (false, false, true, true, ActionabilityVerdict::Passed),
+            (true, false, false, false, ActionabilityVerdict::Unproven),
+            (false, false, true, false, ActionabilityVerdict::Unproven),
+            (false, true, false, true, ActionabilityVerdict::Unproven),
+            (true, false, true, false, ActionabilityVerdict::Failed),
+        ];
+
+        for (covers_editable, editable, covers_checkable, checkable, expected) in cases {
+            let coverage = AxStateCoverage {
+                editable: covers_editable,
+                checkable: covers_checkable,
+                ..AxStateCoverage::NONE
+            };
+            let element = target(
+                AxRole::Button,
+                AxStates {
+                    editable,
+                    checkable,
+                    ..AxStates::default()
+                },
+                None,
+            );
+            assert_eq!(
+                set_value_eligibility(&element, coverage),
+                expected,
+                "coverage=({covers_editable},{covers_checkable}), state=({editable},{checkable})"
+            );
+        }
+    }
+
+    #[test]
+    fn legacy_pointer_actionability_is_disclosed_without_making_semantic_checks_required() {
+        let report = ActionabilityReport::evaluate_click(
+            &target(
+                AxRole::Button,
+                AxStates::default(),
+                Some(AxRect {
+                    x: 100,
+                    y: 100,
+                    width: 20,
+                    height: 20,
+                }),
+            ),
+            AxStateCoverage {
+                enabled: true,
+                visible: true,
+                ..AxStateCoverage::NONE
+            },
+            Some(false),
+            (100, 100),
+            PointerHit::Other,
+            true,
+            true,
+        );
+
+        assert!(report.checks.iter().all(|check| !check.required));
+        assert!(
+            report
+                .checks
+                .iter()
+                .all(|check| check.source == ActionabilitySource::LegacyCache)
+        );
+        assert_eq!(report.blocking(), None);
+        assert_eq!(
+            check(&report, ActionabilityCheckName::Unique).verdict,
+            ActionabilityVerdict::Unproven
+        );
+        assert_eq!(
+            check(&report, ActionabilityCheckName::Enabled).verdict,
+            ActionabilityVerdict::Failed
+        );
+        assert_eq!(
+            check(&report, ActionabilityCheckName::Visible).verdict,
+            ActionabilityVerdict::Failed
+        );
     }
 }

--- a/crates/glass-core/src/accessibility/actionability.rs
+++ b/crates/glass-core/src/accessibility/actionability.rs
@@ -1,4 +1,4 @@
-use super::SemanticState;
+use super::{AxRole, ElementInfo, SemanticState};
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct AxStateCoverage {
@@ -155,6 +155,40 @@ impl ActionabilityReport {
             .copied()
             .find(|check| check.blocks_dispatch())
     }
+
+    pub(crate) fn evaluate_click(
+        target: &ElementInfo,
+        coverage: AxStateCoverage,
+        stable: Option<bool>,
+        window: (u32, u32),
+        hit: PointerHit,
+        legacy_id: bool,
+        pointer: bool,
+    ) -> Self {
+        evaluate_actionability(
+            if pointer {
+                ActionabilityOperation::PointerClick
+            } else {
+                ActionabilityOperation::NativeClick
+            },
+            target,
+            coverage,
+            stable,
+            window,
+            hit,
+            legacy_id,
+        )
+    }
+
+    pub(crate) fn pass_backend_fingerprint(&mut self) {
+        if let Some(check) = self
+            .checks
+            .iter_mut()
+            .find(|check| check.name == ActionabilityCheckName::BackendFingerprint)
+        {
+            check.verdict = ActionabilityVerdict::Passed;
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -165,10 +199,204 @@ pub enum PointerHit {
     Inconclusive,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[allow(dead_code)]
+enum ActionabilityOperation {
+    NativeClick,
+    PointerClick,
+    NativeFocus,
+    PointerFocus,
+    SetValue,
+}
+
+impl ActionabilityOperation {
+    fn uses_pointer(self) -> bool {
+        matches!(self, Self::PointerClick | Self::PointerFocus)
+    }
+
+    fn requires_focus_eligibility(self) -> bool {
+        matches!(
+            self,
+            Self::NativeFocus | Self::PointerFocus | Self::SetValue
+        )
+    }
+}
+
+fn covered_flag(covered: bool, value: bool) -> ActionabilityVerdict {
+    if !covered {
+        ActionabilityVerdict::Unproven
+    } else if value {
+        ActionabilityVerdict::Passed
+    } else {
+        ActionabilityVerdict::Failed
+    }
+}
+
+fn focus_eligibility(target: &ElementInfo, coverage: AxStateCoverage) -> ActionabilityVerdict {
+    if (coverage.focusable && target.states.focusable)
+        || (coverage.editable && target.states.editable)
+    {
+        ActionabilityVerdict::Passed
+    } else if coverage.focusable && coverage.editable {
+        ActionabilityVerdict::Failed
+    } else {
+        ActionabilityVerdict::Unproven
+    }
+}
+
+fn set_value_eligibility(target: &ElementInfo, coverage: AxStateCoverage) -> ActionabilityVerdict {
+    if matches!(
+        target.role,
+        AxRole::ComboBox | AxRole::Slider | AxRole::SpinButton
+    ) || matches!(
+        target.role,
+        AxRole::ToggleButton | AxRole::RadioButton | AxRole::CheckBox
+    ) || (coverage.editable && target.states.editable)
+        || (coverage.checkable && target.states.checkable)
+    {
+        ActionabilityVerdict::Passed
+    } else if coverage.editable && coverage.checkable {
+        ActionabilityVerdict::Failed
+    } else {
+        ActionabilityVerdict::Unproven
+    }
+}
+
+#[allow(private_interfaces)]
+pub(crate) fn evaluate_actionability(
+    operation: ActionabilityOperation,
+    target: &ElementInfo,
+    coverage: AxStateCoverage,
+    stable: Option<bool>,
+    window: (u32, u32),
+    hit: PointerHit,
+    legacy_id: bool,
+) -> ActionabilityReport {
+    let mut report = ActionabilityReport::default();
+    let pointer_required = operation.uses_pointer() && !legacy_id;
+    let state_required = !legacy_id;
+    let source = |normal| {
+        if legacy_id {
+            ActionabilitySource::LegacyCache
+        } else {
+            normal
+        }
+    };
+
+    report.push(ActionabilityCheck::new(
+        ActionabilityCheckName::Unique,
+        if legacy_id {
+            ActionabilityVerdict::Unproven
+        } else {
+            ActionabilityVerdict::Passed
+        },
+        !legacy_id,
+        source(ActionabilitySource::SemanticResolution),
+    ));
+    report.push(ActionabilityCheck::new(
+        ActionabilityCheckName::Enabled,
+        covered_flag(coverage.enabled, target.states.enabled),
+        state_required,
+        source(ActionabilitySource::NormalizedState),
+    ));
+    report.push(ActionabilityCheck::new(
+        ActionabilityCheckName::Visible,
+        covered_flag(coverage.visible, target.states.visible),
+        pointer_required,
+        source(ActionabilitySource::NormalizedState),
+    ));
+    if operation.requires_focus_eligibility() {
+        report.push(ActionabilityCheck::new(
+            ActionabilityCheckName::FocusEligible,
+            if operation == ActionabilityOperation::SetValue {
+                set_value_eligibility(target, coverage)
+            } else {
+                focus_eligibility(target, coverage)
+            },
+            state_required,
+            source(ActionabilitySource::NormalizedState),
+        ));
+    }
+    report.push(ActionabilityCheck::new(
+        ActionabilityCheckName::Stable,
+        if legacy_id {
+            ActionabilityVerdict::Unproven
+        } else {
+            stable.map_or(ActionabilityVerdict::Unproven, |stable| {
+                if stable {
+                    ActionabilityVerdict::Passed
+                } else {
+                    ActionabilityVerdict::Failed
+                }
+            })
+        },
+        pointer_required,
+        source(ActionabilitySource::GeometrySamples),
+    ));
+    report.push(ActionabilityCheck::new(
+        ActionabilityCheckName::InWindow,
+        if target
+            .bounds
+            .and_then(|bounds| bounds.clamped_center(window.0, window.1))
+            .is_some()
+        {
+            ActionabilityVerdict::Passed
+        } else {
+            ActionabilityVerdict::Failed
+        },
+        pointer_required,
+        source(ActionabilitySource::WindowGeometry),
+    ));
+    report.push(ActionabilityCheck::new(
+        ActionabilityCheckName::NonOccluded,
+        if legacy_id {
+            ActionabilityVerdict::Unproven
+        } else {
+            match hit {
+                PointerHit::Target | PointerHit::AcceptedAncestor => ActionabilityVerdict::Passed,
+                PointerHit::Other => ActionabilityVerdict::Failed,
+                PointerHit::Inconclusive => ActionabilityVerdict::Unproven,
+            }
+        },
+        pointer_required,
+        source(ActionabilitySource::BackendHitProbe),
+    ));
+    report.push(ActionabilityCheck::new(
+        ActionabilityCheckName::BackendFingerprint,
+        ActionabilityVerdict::Unproven,
+        !legacy_id,
+        source(ActionabilitySource::BackendRewalk),
+    ));
+    report
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::SemanticState;
+    use crate::{AxNodeId, AxRect, AxRole, AxStates, ElementInfo, SemanticState};
+
+    fn target(role: AxRole, states: AxStates, bounds: Option<AxRect>) -> ElementInfo {
+        ElementInfo {
+            id: AxNodeId(1),
+            role,
+            name: Some("target".into()),
+            description: Some("description".into()),
+            value: None,
+            bounds,
+            states,
+        }
+    }
+
+    fn check(report: &ActionabilityReport, name: ActionabilityCheckName) -> ActionabilityCheck {
+        let matches = report
+            .checks
+            .iter()
+            .copied()
+            .filter(|check| check.name == name)
+            .collect::<Vec<_>>();
+        assert_eq!(matches.len(), 1, "expected one {name:?} record");
+        matches[0]
+    }
 
     #[test]
     fn selector_state_pairs_require_the_underlying_reader_facts() {
@@ -230,5 +458,286 @@ mod tests {
         assert!(required_failure.blocks_dispatch());
         assert!(!optional_failure.blocks_dispatch());
         assert!(!required_unknown.blocks_dispatch());
+    }
+
+    #[test]
+    fn native_click_requires_unique_and_known_enabled_but_not_visibility_or_occlusion() {
+        let coverage = AxStateCoverage {
+            enabled: true,
+            visible: true,
+            ..AxStateCoverage::NONE
+        };
+        let report = evaluate_actionability(
+            ActionabilityOperation::NativeClick,
+            &target(
+                AxRole::Button,
+                AxStates {
+                    enabled: false,
+                    visible: false,
+                    ..AxStates::default()
+                },
+                Some(AxRect {
+                    x: 200,
+                    y: 200,
+                    width: 20,
+                    height: 20,
+                }),
+            ),
+            coverage,
+            Some(false),
+            (100, 100),
+            PointerHit::Other,
+            false,
+        );
+
+        assert_eq!(
+            report
+                .checks
+                .iter()
+                .map(|check| check.name)
+                .collect::<Vec<_>>(),
+            vec![
+                ActionabilityCheckName::Unique,
+                ActionabilityCheckName::Enabled,
+                ActionabilityCheckName::Visible,
+                ActionabilityCheckName::Stable,
+                ActionabilityCheckName::InWindow,
+                ActionabilityCheckName::NonOccluded,
+                ActionabilityCheckName::BackendFingerprint,
+            ]
+        );
+        assert_eq!(
+            check(&report, ActionabilityCheckName::Unique),
+            ActionabilityCheck::new(
+                ActionabilityCheckName::Unique,
+                ActionabilityVerdict::Passed,
+                true,
+                ActionabilitySource::SemanticResolution,
+            )
+        );
+        assert_eq!(
+            report.blocking(),
+            Some(check(&report, ActionabilityCheckName::Enabled))
+        );
+        for name in [
+            ActionabilityCheckName::Visible,
+            ActionabilityCheckName::Stable,
+            ActionabilityCheckName::InWindow,
+            ActionabilityCheckName::NonOccluded,
+        ] {
+            let check = check(&report, name);
+            assert_eq!(check.verdict, ActionabilityVerdict::Failed);
+            assert!(!check.required);
+        }
+    }
+
+    #[test]
+    fn pointer_click_blocks_known_hidden_off_window_unstable_and_occluded_targets() {
+        let coverage = AxStateCoverage {
+            enabled: true,
+            visible: true,
+            ..AxStateCoverage::NONE
+        };
+        let report = evaluate_actionability(
+            ActionabilityOperation::PointerClick,
+            &target(
+                AxRole::Button,
+                AxStates {
+                    enabled: true,
+                    visible: false,
+                    ..AxStates::default()
+                },
+                Some(AxRect {
+                    x: 100,
+                    y: 100,
+                    width: 20,
+                    height: 20,
+                }),
+            ),
+            coverage,
+            Some(false),
+            (100, 100),
+            PointerHit::Other,
+            false,
+        );
+
+        assert_eq!(
+            report.blocking(),
+            Some(check(&report, ActionabilityCheckName::Visible))
+        );
+        for name in [
+            ActionabilityCheckName::Visible,
+            ActionabilityCheckName::Stable,
+            ActionabilityCheckName::InWindow,
+            ActionabilityCheckName::NonOccluded,
+        ] {
+            let check = check(&report, name);
+            assert_eq!(check.verdict, ActionabilityVerdict::Failed);
+            assert!(check.required);
+        }
+    }
+
+    #[test]
+    fn pointer_click_allows_an_inconclusive_hit_probe_and_marks_it_unproven() {
+        let coverage = AxStateCoverage {
+            enabled: true,
+            visible: true,
+            ..AxStateCoverage::NONE
+        };
+        let report = evaluate_actionability(
+            ActionabilityOperation::PointerClick,
+            &target(
+                AxRole::Button,
+                AxStates {
+                    enabled: true,
+                    visible: true,
+                    ..AxStates::default()
+                },
+                Some(AxRect {
+                    x: 10,
+                    y: 10,
+                    width: 20,
+                    height: 20,
+                }),
+            ),
+            coverage,
+            Some(true),
+            (100, 100),
+            PointerHit::Inconclusive,
+            false,
+        );
+
+        assert_eq!(report.blocking(), None);
+        assert_eq!(
+            check(&report, ActionabilityCheckName::NonOccluded),
+            ActionabilityCheck::new(
+                ActionabilityCheckName::NonOccluded,
+                ActionabilityVerdict::Unproven,
+                true,
+                ActionabilitySource::BackendHitProbe,
+            )
+        );
+    }
+
+    #[test]
+    fn focus_requires_focusable_or_editable_when_that_fact_is_covered() {
+        let coverage = AxStateCoverage {
+            enabled: true,
+            focusable: true,
+            editable: true,
+            ..AxStateCoverage::NONE
+        };
+        let report = evaluate_actionability(
+            ActionabilityOperation::NativeFocus,
+            &target(
+                AxRole::Button,
+                AxStates {
+                    enabled: true,
+                    ..AxStates::default()
+                },
+                Some(AxRect {
+                    x: 10,
+                    y: 10,
+                    width: 20,
+                    height: 20,
+                }),
+            ),
+            coverage,
+            None,
+            (100, 100),
+            PointerHit::Inconclusive,
+            false,
+        );
+
+        assert_eq!(
+            report.blocking(),
+            Some(check(&report, ActionabilityCheckName::FocusEligible))
+        );
+        assert_eq!(
+            check(&report, ActionabilityCheckName::FocusEligible),
+            ActionabilityCheck::new(
+                ActionabilityCheckName::FocusEligible,
+                ActionabilityVerdict::Failed,
+                true,
+                ActionabilitySource::NormalizedState,
+            )
+        );
+    }
+
+    #[test]
+    fn set_value_accepts_editable_combo_numeric_and_checkable_roles() {
+        let coverage = AxStateCoverage {
+            enabled: true,
+            focusable: true,
+            editable: true,
+            checkable: true,
+            ..AxStateCoverage::NONE
+        };
+        let cases = [
+            (
+                AxRole::TextField,
+                AxStates {
+                    enabled: true,
+                    editable: true,
+                    ..AxStates::default()
+                },
+            ),
+            (
+                AxRole::ComboBox,
+                AxStates {
+                    enabled: true,
+                    ..AxStates::default()
+                },
+            ),
+            (
+                AxRole::Slider,
+                AxStates {
+                    enabled: true,
+                    ..AxStates::default()
+                },
+            ),
+            (
+                AxRole::SpinButton,
+                AxStates {
+                    enabled: true,
+                    ..AxStates::default()
+                },
+            ),
+            (
+                AxRole::CheckBox,
+                AxStates {
+                    enabled: true,
+                    checkable: true,
+                    ..AxStates::default()
+                },
+            ),
+        ];
+
+        for (role, states) in cases {
+            let report = evaluate_actionability(
+                ActionabilityOperation::SetValue,
+                &target(
+                    role,
+                    states,
+                    Some(AxRect {
+                        x: 10,
+                        y: 10,
+                        width: 20,
+                        height: 20,
+                    }),
+                ),
+                coverage,
+                None,
+                (100, 100),
+                PointerHit::Inconclusive,
+                false,
+            );
+            assert_eq!(report.blocking(), None, "role {role:?} was rejected");
+            assert_eq!(
+                check(&report, ActionabilityCheckName::FocusEligible).verdict,
+                ActionabilityVerdict::Passed,
+                "role {role:?} was not marked eligible"
+            );
+        }
     }
 }

--- a/crates/glass-core/src/accessibility/query.rs
+++ b/crates/glass-core/src/accessibility/query.rs
@@ -413,7 +413,7 @@ fn context_for(tree: &AxTree, node: &AxNode, scope: ScopeResolution) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{AxNode, AxNodeId, AxRect, AxStates, AxTree};
+    use crate::{AxNode, AxNodeId, AxRect, AxStateCoverage, AxStates, AxTree, SemanticTarget};
 
     fn node(role: AxRole, name: Option<&str>) -> AxNode {
         AxNode {
@@ -435,6 +435,54 @@ mod tests {
         let mut tree = AxTree::new(root);
         tree.assign_ids();
         tree
+    }
+
+    #[test]
+    fn semantic_target_checks_target_and_scope_state_coverage() {
+        let target = SemanticTarget {
+            target: SemanticSelector::new(None, None, vec![SemanticState::Visible]).unwrap(),
+            within: Some(SemanticSelector::new(None, None, vec![SemanticState::Focused]).unwrap()),
+        };
+
+        assert_eq!(
+            target.uncovered_states(AxStateCoverage::NONE),
+            vec![SemanticState::Visible, SemanticState::Focused]
+        );
+    }
+
+    #[test]
+    fn semantic_target_coverage_observes_selector_state_deduplication() {
+        let target = SemanticTarget {
+            target: SemanticSelector::new(
+                None,
+                None,
+                vec![SemanticState::Visible, SemanticState::Visible],
+            )
+            .unwrap(),
+            within: None,
+        };
+
+        assert_eq!(
+            target.uncovered_states(AxStateCoverage::NONE),
+            vec![SemanticState::Visible]
+        );
+    }
+
+    #[test]
+    fn enabled_and_disabled_selectors_share_one_coverage_fact() {
+        let target = SemanticTarget {
+            target: SemanticSelector::new(None, None, vec![SemanticState::Enabled]).unwrap(),
+            within: Some(SemanticSelector::new(None, None, vec![SemanticState::Disabled]).unwrap()),
+        };
+
+        assert!(
+            target
+                .uncovered_states(AxStateCoverage {
+                    enabled: true,
+                    ..AxStateCoverage::NONE
+                })
+                .is_empty()
+        );
     }
 
     #[test]

--- a/crates/glass-core/src/audit.rs
+++ b/crates/glass-core/src/audit.rs
@@ -5,8 +5,6 @@
 
 use std::time::Duration;
 
-use crate::accessibility::ClickMethod;
-use crate::error::Result;
 use crate::platform::{AppSpec, KeyEvent, PointerEvent, WindowOp};
 
 /// The active window an actuation was directed at (best-effort).
@@ -38,8 +36,8 @@ pub struct AuditOutcome {
 }
 
 impl AuditOutcome {
-    /// Derive an outcome from a `glass-core` result (the error is stringified).
-    pub fn from_result<T>(r: &Result<T>) -> Self {
+    /// Derive an outcome from a result whose error can be safely stringified.
+    pub fn from_result<T, E: std::fmt::Display>(r: &std::result::Result<T, E>) -> Self {
         match r {
             Ok(_) => AuditOutcome {
                 ok: true,
@@ -76,10 +74,12 @@ pub enum Actuation<'a> {
     },
     ClickElement {
         element: ElementRef,
-        /// How the click actuated — the sink renders its label and, for the pointer
-        /// path, the reason the native action was not used. `None` when the click
-        /// ultimately failed (neither path succeeded).
-        method: Option<&'a ClickMethod>,
+        mode: &'a str,
+        method: Option<&'a str>,
+        native_fallback: Option<&'a str>,
+        actuated_id: Option<u32>,
+        dispatch: &'a str,
+        confirmation: &'a str,
     },
     SetValue {
         element: ElementRef,
@@ -109,39 +109,53 @@ mod tests {
 
     #[test]
     fn outcome_from_result_captures_ok_and_error() {
-        let ok: Result<()> = Ok(());
+        let ok: std::result::Result<(), &str> = Ok(());
         let o = AuditOutcome::from_result(&ok);
         assert!(o.ok && o.error.is_none());
 
-        let err: Result<()> = Err(GlassError::NoActiveSession);
+        let err: std::result::Result<(), GlassError> = Err(GlassError::NoActiveSession);
         let e = AuditOutcome::from_result(&err);
         assert!(!e.ok);
         assert!(e.error.unwrap().to_lowercase().contains("session"));
     }
 
     #[test]
-    fn click_element_actuation_carries_the_actuating_method() {
+    fn click_element_actuation_carries_safe_semantic_dispatch_metadata() {
         let element = ElementRef {
             id: 1,
             role: Some("Button".into()),
             name: Some("Save".into()),
         };
-        let method = ClickMethod::Pointer {
-            native_fallback: "element exposes no activation action".into(),
-        };
         let act = Actuation::ClickElement {
-            element,
-            method: Some(&method),
+            element: element.clone(),
+            mode: "auto",
+            method: Some("pointer"),
+            native_fallback: Some("target exposes no native accessibility action"),
+            actuated_id: None,
+            dispatch: "dispatched",
+            confirmation: "dispatch_confirmed",
         };
-        let Actuation::ClickElement { method: got, .. } = act else {
+        let Actuation::ClickElement {
+            element: got_element,
+            mode,
+            method,
+            native_fallback,
+            actuated_id,
+            dispatch,
+            confirmation,
+        } = act
+        else {
             panic!("wrong variant");
         };
-        // The sink renders both halves; borrowing the whole method (not a pre-rendered
-        // label) is what keeps the fallback reason reachable.
-        assert_eq!(got.map(ClickMethod::label), Some(method.label()));
+        assert_eq!(got_element, element);
+        assert_eq!(mode, "auto");
+        assert_eq!(method, Some("pointer"));
         assert_eq!(
-            got.and_then(ClickMethod::native_fallback),
-            Some("element exposes no activation action")
+            native_fallback,
+            Some("target exposes no native accessibility action")
         );
+        assert_eq!(actuated_id, None);
+        assert_eq!(dispatch, "dispatched");
+        assert_eq!(confirmation, "dispatch_confirmed");
     }
 }

--- a/crates/glass-core/src/audit.rs
+++ b/crates/glass-core/src/audit.rs
@@ -84,6 +84,8 @@ pub enum Actuation<'a> {
     SetValue {
         element: ElementRef,
         text: &'a str,
+        dispatch: &'a str,
+        confirmation: &'a str,
     },
 }
 

--- a/crates/glass-core/src/audit.rs
+++ b/crates/glass-core/src/audit.rs
@@ -87,6 +87,15 @@ pub enum Actuation<'a> {
         dispatch: &'a str,
         confirmation: &'a str,
     },
+    TypeTarget {
+        element: ElementRef,
+        text: &'a str,
+        focus_mode: &'a str,
+        focus_method: Option<&'a str>,
+        focus_dispatch: &'a str,
+        focus_confirmation: &'a str,
+        type_dispatch: &'a str,
+    },
 }
 
 /// Receives every actuation. Implemented in `glass-mcp` (`JsonlSink`). `Send` so it
@@ -159,5 +168,42 @@ mod tests {
         assert_eq!(actuated_id, None);
         assert_eq!(dispatch, "dispatched");
         assert_eq!(confirmation, "dispatch_confirmed");
+    }
+
+    #[test]
+    fn type_target_actuation_carries_focus_and_type_dispatch_metadata() {
+        let element = ElementRef {
+            id: 7,
+            role: Some("TextField".into()),
+            name: Some("Account name".into()),
+        };
+        let act = Actuation::TypeTarget {
+            element: element.clone(),
+            text: "submitted text",
+            focus_mode: "auto",
+            focus_method: Some("native_action"),
+            focus_dispatch: "dispatched",
+            focus_confirmation: "focus_confirmed",
+            type_dispatch: "dispatched",
+        };
+        let Actuation::TypeTarget {
+            element: got_element,
+            text,
+            focus_mode,
+            focus_method,
+            focus_dispatch,
+            focus_confirmation,
+            type_dispatch,
+        } = act
+        else {
+            panic!("wrong variant");
+        };
+        assert_eq!(got_element, element);
+        assert_eq!(text, "submitted text");
+        assert_eq!(focus_mode, "auto");
+        assert_eq!(focus_method, Some("native_action"));
+        assert_eq!(focus_dispatch, "dispatched");
+        assert_eq!(focus_confirmation, "focus_confirmed");
+        assert_eq!(type_dispatch, "dispatched");
     }
 }

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -93,11 +93,13 @@ pub use deadline::{Deadline, Whose};
 
 pub mod accessibility;
 pub use accessibility::{
-    Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget, AxTree,
-    ChangeSignal, ChangeWait, ClickMethod, ElementCondition, ElementInfo, ElementMatch, MAX_DEPTH,
-    MAX_NODES, MAX_SIBLINGS, MatchField, MatchTier, ScopeResolution, SemanticMatch, SemanticQuery,
-    SemanticQueryError, SemanticQueryResult, SemanticSelector, SemanticState, Subject, Truncation,
-    TruncationLimit, WalkBudget, WalkLimits, element_match, normalize_description, normalize_name,
+    Accessibility, ActionabilityCheck, ActionabilityCheckName, ActionabilityReport,
+    ActionabilitySource, ActionabilityVerdict, AxContext, AxNode, AxNodeId, AxRect, AxRole,
+    AxStateCoverage, AxStates, AxTarget, AxTree, ChangeSignal, ChangeWait, ClickMethod,
+    ElementCondition, ElementInfo, ElementMatch, MAX_DEPTH, MAX_NODES, MAX_SIBLINGS, MatchField,
+    MatchTier, PointerHit, ScopeResolution, SemanticMatch, SemanticQuery, SemanticQueryError,
+    SemanticQueryResult, SemanticSelector, SemanticState, Subject, Truncation, TruncationLimit,
+    WalkBudget, WalkLimits, element_match, normalize_description, normalize_name,
 };
 
 pub mod marks;

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -123,8 +123,12 @@ pub use audit::{Actuation, ActuationContext, AuditOutcome, AuditSink, ElementRef
 
 pub mod session;
 pub use session::{
-    Backend, FindElementsOutcome, FindElementsParams, Glass, PlatformFactory,
-    SCROLL_TO_DEFAULT_STEP, SCROLL_TO_DEFAULT_TIMEOUT_MS, ScrollDirection, ScrollToElementOutcome,
-    ScrollToElementParams, WaitElementOutcome, WaitElementParams, WaitLogOutcome, WaitLogParams,
-    WaitRegionOutcome, WaitRegionParams, WaitStableOutcome, WaitStableParams,
+    ActionDeadline, ActionMethod, ActionMode, ActionTarget, Backend, ClickTargetParams,
+    ConfirmationStatus, DispatchStatus, FindElementsOutcome, FindElementsParams, Glass,
+    MutationReport, PlatformFactory, ResolutionReport, RetryGuidance, SCROLL_TO_DEFAULT_STEP,
+    SCROLL_TO_DEFAULT_TIMEOUT_MS, SEMANTIC_ACTION_DEFAULT_TIMEOUT_MS,
+    SEMANTIC_ACTION_MAX_TIMEOUT_MS, ScrollDirection, ScrollToElementOutcome, ScrollToElementParams,
+    SemanticActionError, SemanticActionFailureKind, SemanticActionOutcome, SemanticTarget,
+    SetValueTargetParams, TypeTargetParams, WaitElementOutcome, WaitElementParams, WaitLogOutcome,
+    WaitLogParams, WaitRegionOutcome, WaitRegionParams, WaitStableOutcome, WaitStableParams,
 };

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -233,7 +233,7 @@ impl Glass {
             Err(e) if !e.invoke_fallback_eligible() => return Err(e),
             Err(e) => native_fallback_reason(&e),
         };
-        self.click_element_pointer_only(id, deadline)
+        self.click_element_pointer_only(id, None, deadline)
             .map(|()| ClickMethod::Pointer { native_fallback })
     }
 
@@ -242,7 +242,12 @@ impl Glass {
     /// one, or swiped across the trailing control for a row-shaped checkable on a
     /// trailing-toggle backend. Callable directly by an internal caller that must NOT take
     /// the native action (see [`Glass::set_combo_value`]).
-    fn click_element_pointer_only(&mut self, id: AxNodeId, deadline: Deadline) -> Result<()> {
+    pub(super) fn click_element_pointer_only(
+        &mut self,
+        id: AxNodeId,
+        plan: Option<&super::semantic_action::PlannedPointerInput>,
+        deadline: Deadline,
+    ) -> Result<()> {
         if deadline.has_passed() {
             return Err(GlassError::deadline_not_started("click element"));
         }
@@ -295,16 +300,41 @@ impl Glass {
                     .after_dispatch(),
                 });
             }
-            let primary = self.pointer_inner_by(
-                &PointerEvent::Click {
-                    x: bounds.x - container.x,
-                    y: bounds.y - container.y,
-                    button: MouseButton::Left,
-                    count: 1,
-                    modifiers: vec![],
-                },
-                deadline,
-            );
+            let primary = match plan {
+                Some(super::semantic_action::PlannedPointerInput::TrailingToggle {
+                    segment,
+                    ..
+                }) => self.pointer_inner_by(
+                    &PointerEvent::Drag {
+                        from_x: segment.from_x - container.x,
+                        from_y: segment.from_y - container.y,
+                        to_x: segment.to_x - container.x,
+                        to_y: segment.to_y - container.y,
+                        duration_ms: TOGGLE_SWIPE_MS,
+                        button: MouseButton::Left,
+                        modifiers: vec![],
+                    },
+                    deadline,
+                ),
+                planned => {
+                    let point = match planned {
+                        Some(super::semantic_action::PlannedPointerInput::Click { point }) => {
+                            *point
+                        }
+                        _ => (bounds.x, bounds.y),
+                    };
+                    self.pointer_inner_by(
+                        &PointerEvent::Click {
+                            x: point.0 - container.x,
+                            y: point.1 - container.y,
+                            button: MouseButton::Left,
+                            count: 1,
+                            modifiers: vec![],
+                        },
+                        deadline,
+                    )
+                }
+            };
             // Restore focus even after expiry; temporary selection already makes failure
             // after-dispatch.
             let restore = self.select_window_by(prev, Deadline::UNBOUNDED);
@@ -326,12 +356,18 @@ impl Glass {
         //
         // Gate on the backend capability, NOT geometry alone: a wide labeled checkbox on a
         // desktop backend is row-shaped too, but its indicator is at the LEADING edge.
+        let planned_segment = match plan {
+            Some(super::semantic_action::PlannedPointerInput::TrailingToggle {
+                segment, ..
+            }) => Some(*segment),
+            _ => None,
+        };
         let row_shaped_toggle = checkable
             && trailing_toggle_backend
             && bounds.width > bounds.height.saturating_mul(ROW_ASPECT);
-        if row_shaped_toggle {
-            let seg = bounds
-                .trailing_toggle_swipe(active_geo.width, active_geo.height)
+        if planned_segment.is_some() || (plan.is_none() && row_shaped_toggle) {
+            let seg = planned_segment
+                .or_else(|| bounds.trailing_toggle_swipe(active_geo.width, active_geo.height))
                 .ok_or(GlassError::AxElementNotClickable(id.0))?;
             self.pointer_inner_by(
                 &PointerEvent::Drag {
@@ -346,9 +382,12 @@ impl Glass {
                 deadline,
             )
         } else {
-            let (x, y) = bounds
-                .clamped_center(active_geo.width, active_geo.height)
-                .ok_or(GlassError::AxElementNotClickable(id.0))?;
+            let (x, y) = match plan {
+                Some(super::semantic_action::PlannedPointerInput::Click { point }) => *point,
+                _ => bounds
+                    .clamped_center(active_geo.width, active_geo.height)
+                    .ok_or(GlassError::AxElementNotClickable(id.0))?,
+            };
             self.pointer_inner_by(
                 &PointerEvent::Click {
                     x,
@@ -654,10 +693,11 @@ impl Glass {
                     // Use a pointer click because UIA programmatic expand does not move keyboard
                     // focus to the popup.
                     let open = self.audited_click(id, |g, id| {
-                        g.click_element_pointer_only(id, deadline)
-                            .map(|()| ClickMethod::Pointer {
+                        g.click_element_pointer_only(id, None, deadline).map(|()| {
+                            ClickMethod::Pointer {
                                 native_fallback: COMBO_OPEN_POINTER_REASON.into(),
-                            })
+                            }
+                        })
                     });
                     self.invalidate_ax_cache_after_possible_dispatch(open)?;
                     mutation_may_have_dispatched = true;

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -520,6 +520,63 @@ impl Glass {
         Ok(actuated)
     }
 
+    /// One native-focus attempt with the same fresh geometry, target fingerprint, and deadline
+    /// ordering as [`Self::try_native_invoke`].
+    pub(super) fn try_native_focus(
+        &mut self,
+        id: AxNodeId,
+        deadline: Deadline,
+    ) -> Result<Option<AxNodeId>> {
+        if deadline.has_passed() {
+            return Err(GlassError::deadline_not_started(
+                "native accessibility focus",
+            ));
+        }
+        {
+            let s = self.active_mut()?;
+            if s.accessibility.is_none() {
+                return Err(GlassError::AxUnsupported);
+            }
+            match s.platform.window_by(&WindowOp::Geometry, deadline) {
+                Ok(window) => s.geometry = window,
+                Err(_) if legacy_window_probe_is_best_effort(deadline) => {}
+                Err(error) => return Err(error),
+            }
+        }
+        if deadline.has_passed() {
+            return Err(GlassError::deadline_not_started(
+                "native accessibility focus",
+            ));
+        }
+        let (target, ctx) = {
+            let s = self.require_active()?;
+            let tree = s.last_ax.as_ref().ok_or(GlassError::NoAxSnapshot)?;
+            let node = tree.find(id).ok_or(GlassError::AxElementNotFound(id.0))?;
+            let target = AxTarget {
+                id,
+                role: node.role,
+                name: node.name.clone(),
+                bounds: node.bounds,
+                value: node.value.clone(),
+            };
+            let ctx = s.accessibility_context(s.geometry.clone(), deadline)?;
+            (target, ctx)
+        };
+        let s = self.active_mut()?;
+        if deadline.has_passed() {
+            return Err(GlassError::deadline_not_started(
+                "native accessibility focus",
+            ));
+        }
+        let focused = s
+            .accessibility
+            .as_mut()
+            .ok_or(GlassError::AxUnsupported)?
+            .focus(&ctx, &target)?;
+        s.pump();
+        Ok(focused)
+    }
+
     /// Set the value/text of element `id` (from the latest `a11y_snapshot`) via the
     /// platform a11y API. Errors `NoAxSnapshot`/`AxElementNotFound` (id not in the
     /// cached snapshot), `AxUnsupported` (no reader), or — from the backend —

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -16,6 +16,28 @@ const TOGGLE_SWIPE_MS: u64 = 250;
 const COMBO_OPEN_POINTER_REASON: &str =
     "combo popup opened by pointer so the keyboard commit lands in it";
 
+fn click_method_from_semantic_outcome(outcome: SemanticActionOutcome) -> ClickMethod {
+    match outcome.action.method {
+        ActionMethod::NativeAction { actuated } => ClickMethod::NativeAction { actuated },
+        ActionMethod::Pointer {
+            native_fallback: Some(native_fallback),
+        } => ClickMethod::Pointer { native_fallback },
+        ActionMethod::Pointer {
+            native_fallback: None,
+        } => unreachable!("legacy auto click always records its native fallback reason"),
+        ActionMethod::AccessibilityValue | ActionMethod::Keyboard => {
+            unreachable!("click actions cannot return a non-click method")
+        }
+    }
+}
+
+fn glass_error_from_semantic_action(mut error: SemanticActionError) -> GlassError {
+    error
+        .source
+        .take()
+        .expect("ID click failures always retain their original GlassError")
+}
+
 /// Poll cadence for `set_value`'s post-toggle verify: how often to re-snapshot while waiting for
 /// the swiped switch to read back the wanted state.
 const TOGGLE_VERIFY_INTERVAL_MS: u64 = 50;
@@ -188,17 +210,23 @@ impl Glass {
     }
 
     pub fn click_element_by(&mut self, id: AxNodeId, deadline: Deadline) -> Result<ClickMethod> {
-        self.audited_click(id, |g, id| g.click_element_inner(id, deadline))
+        self.click_target_by(
+            &ClickTargetParams {
+                target: ActionTarget::Id(id),
+                mode: ActionMode::Auto,
+                timeout_ms: None,
+                max_nodes: None,
+            },
+            deadline,
+        )
+        .map(click_method_from_semantic_outcome)
+        .map_err(glass_error_from_semantic_action)
     }
 
-    /// Run one element click and record it through the audit seam. Both clicks that stand on
-    /// their own go through here — the native-first [`Glass::click_element`] and the
-    /// deliberately pointer-only combo open — so the log can't miss one just because an
-    /// internal caller took a different route to the same actuation.
-    ///
-    /// The exception is `set_value_inner`'s trailing-toggle branch, which calls
-    /// `click_element_inner` directly: there the click is one step *inside* a `set_value`, and
-    /// the enclosing `SetValue` record already accounts for it.
+    /// Record an internal pointer-only click that does not pass through [`Glass::click_target_by`].
+    /// Public semantic and ID clicks are audited by that high-level owner. The combo open flow
+    /// remains here because it deliberately bypasses native invoke, while a trailing-toggle click
+    /// inside `set_value_inner` is already accounted for by the enclosing `SetValue` record.
     fn audited_click(
         &mut self,
         id: AxNodeId,
@@ -207,10 +235,33 @@ impl Glass {
         let t = std::time::Instant::now();
         let element = self.element_ref(id);
         let result = click(self, id);
+        let dispatch = match &result {
+            Ok(_) => DispatchStatus::Dispatched.as_str(),
+            Err(error) => match error.bound_dispatch() {
+                Some(crate::BoundDispatch::NotDispatched) => DispatchStatus::NotDispatched.as_str(),
+                Some(crate::BoundDispatch::MayHaveDispatched) | None => {
+                    DispatchStatus::MayHaveDispatched.as_str()
+                }
+            },
+        };
+        let confirmation = if result.is_ok() {
+            ConfirmationStatus::DispatchConfirmed.as_str()
+        } else {
+            ConfirmationStatus::Unconfirmed.as_str()
+        };
         self.emit_audit(
             &crate::audit::Actuation::ClickElement {
                 element,
-                method: result.as_ref().ok(),
+                mode: ActionMode::Pointer.as_str(),
+                method: result.as_ref().ok().map(ClickMethod::label),
+                native_fallback: result.as_ref().ok().and_then(ClickMethod::native_fallback),
+                actuated_id: result
+                    .as_ref()
+                    .ok()
+                    .and_then(ClickMethod::actuated)
+                    .map(|id| id.0),
+                dispatch,
+                confirmation,
             },
             crate::audit::AuditOutcome::from_result(&result),
             t.elapsed(),
@@ -219,22 +270,17 @@ impl Glass {
     }
 
     fn click_element_inner(&mut self, id: AxNodeId, deadline: Deadline) -> Result<ClickMethod> {
-        if deadline.has_passed() {
-            return Err(GlassError::deadline_not_started("click element"));
-        }
-        // Native action first: works for occluded/off-screen/boundless elements, and on a
-        // backend whose action API is out-of-band it doesn't move the cursor.
-        //
-        // Do not widen the fallback to a denylist: only an attempt that dispatched NOTHING may
-        // retry with the pointer (see [`GlassError::invoke_fallback_eligible`]), or a native
-        // action that may still land actuates the control twice.
-        let native_fallback = match self.try_native_invoke(id, deadline) {
-            Ok(actuated) => return Ok(ClickMethod::NativeAction { actuated }),
-            Err(e) if !e.invoke_fallback_eligible() => return Err(e),
-            Err(e) => native_fallback_reason(&e),
-        };
-        self.click_element_pointer_only(id, None, deadline)
-            .map(|()| ClickMethod::Pointer { native_fallback })
+        self.click_target_inner(
+            ClickTargetParams {
+                target: ActionTarget::Id(id),
+                mode: ActionMode::Auto,
+                timeout_ms: None,
+                max_nodes: None,
+            },
+            deadline,
+        )
+        .map(click_method_from_semantic_outcome)
+        .map_err(glass_error_from_semantic_action)
     }
 
     /// The synthetic-pointer half of [`Glass::click_element`], on its own: the center of the
@@ -404,7 +450,11 @@ impl Glass {
     /// One native-invoke attempt: the same fingerprint + context assembly as
     /// `set_value_inner` (over freshly re-read window geometry — see below), then the
     /// backend's `invoke`. Passes on the element the backend actuated when it is not `id`.
-    fn try_native_invoke(&mut self, id: AxNodeId, deadline: Deadline) -> Result<Option<AxNodeId>> {
+    pub(super) fn try_native_invoke(
+        &mut self,
+        id: AxNodeId,
+        deadline: Deadline,
+    ) -> Result<Option<AxNodeId>> {
         if deadline.has_passed() {
             return Err(GlassError::deadline_not_started(
                 "native accessibility action",
@@ -817,22 +867,6 @@ impl Glass {
             return Err(GlassError::deadline_not_started("semantic key input"));
         }
         self.key_by(event, deadline)
-    }
-}
-
-/// Short, agent-facing reason a native-invoke attempt fell back to the pointer path.
-/// `AxUnsupported`'s own `Display` is snapshot-oriented (it tells the agent to screenshot
-/// instead), which would mislead in a click result — map it.
-///
-/// Only the two fallback-eligible errors reach here (see
-/// [`GlassError::invoke_fallback_eligible`], the single place that decides). The `other` arm
-/// is unreachable defence-in-depth, kept so this stays a total function if the eligibility
-/// set ever widens.
-fn native_fallback_reason(e: &GlassError) -> String {
-    match e {
-        GlassError::AxUnsupported => "backend has no native action path".into(),
-        GlassError::AxActionUnavailable(_) => "element exposes no activation action".into(),
-        other => format!("native action error: {other}"),
     }
 }
 

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -16,6 +16,12 @@ const TOGGLE_SWIPE_MS: u64 = 250;
 const COMBO_OPEN_POINTER_REASON: &str =
     "combo popup opened by pointer so the keyboard commit lands in it";
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum SetValueExecution {
+    AlreadyApplied,
+    DispatchedAndConfirmed,
+}
+
 fn click_method_from_semantic_outcome(outcome: SemanticActionOutcome) -> ClickMethod {
     match outcome.action.method {
         ActionMethod::NativeAction { actuated } => ClickMethod::NativeAction { actuated },
@@ -35,7 +41,7 @@ fn glass_error_from_semantic_action(mut error: SemanticActionError) -> GlassErro
     error
         .source
         .take()
-        .expect("ID click failures always retain their original GlassError")
+        .expect("legacy ID action failures always retain their original GlassError")
 }
 
 /// Poll cadence for `set_value`'s post-toggle verify: how often to re-snapshot while waiting for
@@ -523,18 +529,25 @@ impl Glass {
     }
 
     pub fn set_value_by(&mut self, id: AxNodeId, text: &str, deadline: Deadline) -> Result<()> {
-        let t = std::time::Instant::now();
-        let element = self.element_ref(id);
-        let result = self.set_value_inner(id, text, deadline);
-        self.emit_audit(
-            &crate::audit::Actuation::SetValue { element, text },
-            crate::audit::AuditOutcome::from_result(&result),
-            t.elapsed(),
-        );
-        result
+        self.set_value_target_by(
+            &SetValueTargetParams {
+                target: ActionTarget::Id(id),
+                timeout_ms: None,
+                max_nodes: None,
+            },
+            text,
+            deadline,
+        )
+        .map(|_| ())
+        .map_err(glass_error_from_semantic_action)
     }
 
-    fn set_value_inner(&mut self, id: AxNodeId, text: &str, deadline: Deadline) -> Result<()> {
+    pub(super) fn set_value_inner(
+        &mut self,
+        id: AxNodeId,
+        text: &str,
+        deadline: Deadline,
+    ) -> Result<SetValueExecution> {
         if deadline.has_passed() {
             return Err(GlassError::deadline_not_started("set value"));
         }
@@ -579,7 +592,23 @@ impl Glass {
         //
         // Invalidate the cache unless input is proven pre-dispatch; a snapshot replaces it.
         if target.role == AxRole::ComboBox {
-            return self.set_combo_value(id, &target, text, deadline);
+            let already_applied = self
+                .require_active()?
+                .last_ax
+                .as_ref()
+                .and_then(|tree| tree.find(id))
+                .is_some_and(|combo| {
+                    !combo.states.expanded
+                        && combo
+                            .name
+                            .as_deref()
+                            .is_some_and(|name| name.eq_ignore_ascii_case(text.trim()))
+                });
+            if already_applied {
+                return Ok(SetValueExecution::AlreadyApplied);
+            }
+            self.set_combo_value(id, &target, text, deadline)?;
+            return Ok(SetValueExecution::DispatchedAndConfirmed);
         }
         // iOS's value-set (tap+type) can't drive a checkable: a tap doesn't toggle a UISwitch
         // and there's no text to type, so it takes the trailing-edge swipe instead.
@@ -609,7 +638,7 @@ impl Glass {
             let want = parse_bool(text)
                 .ok_or_else(|| GlassError::AxValueNotBoolean(id.0, text.to_string()))?;
             if st.checked == want {
-                return Ok(()); // truthful no-op, no actuation
+                return Ok(SetValueExecution::AlreadyApplied); // truthful no-op, no actuation
             }
             let actuation = self.click_element_inner(id, deadline);
             // Drop the pre-toggle cache after ambiguous actuation to prevent a reversing retry.
@@ -647,7 +676,7 @@ impl Glass {
                 seen = find_checkable_near(&tree.root, target.bounds.as_ref())
                     .map(|n| n.states.checked);
                 if seen == Some(want) {
-                    return Ok(());
+                    return Ok(SetValueExecution::DispatchedAndConfirmed);
                 }
                 let left = verify_deadline.remaining().unwrap_or_default();
                 if left.is_zero() {
@@ -704,7 +733,7 @@ impl Glass {
             node.value = (!text.is_empty()).then(|| text.to_string());
         }
         s.pump();
-        Ok(())
+        Ok(SetValueExecution::DispatchedAndConfirmed)
     }
 
     /// Select an option in a dropdown/combo by label (case-insensitive). Opens the popup when

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -4254,16 +4254,11 @@ mod tests {
         let root = dir.path().join("baselines");
         std::mem::forget(dir);
         let log2 = log.clone();
+        let mut accessibility = FakeAccessibility::new(fake_tree());
+        accessibility.set_log = log2;
         let mut held: Option<Backend> = Some(Backend {
             platform: Box::new(FakePlatform::new(100, 100)),
-            accessibility: Some(Box::new(FakeAccessibility {
-                tree: fake_tree(),
-                set_log: log2,
-                set_fail: false,
-                ctx_log: Arc::new(Mutex::new(None)),
-                invoke_behavior: InvokeBehavior::Unsupported,
-                invoke_log: Arc::new(Mutex::new(Vec::new())),
-            })),
+            accessibility: Some(Box::new(accessibility)),
         });
         let factory: PlatformFactory = Box::new(move |_b| {
             held.take()
@@ -4326,14 +4321,9 @@ mod tests {
         tree: AxTree,
         set_log: Arc<Mutex<Vec<(AxTarget, String)>>>,
     ) -> FakeAccessibility {
-        FakeAccessibility {
-            tree,
-            set_log,
-            set_fail: false,
-            ctx_log: Arc::new(Mutex::new(None)),
-            invoke_behavior: InvokeBehavior::Unsupported,
-            invoke_log: Arc::new(Mutex::new(Vec::new())),
-        }
+        let mut accessibility = FakeAccessibility::new(tree);
+        accessibility.set_log = set_log;
+        accessibility
     }
 
     fn glass_with_geometry_failure_ready_for_set_value(
@@ -4674,16 +4664,11 @@ mod tests {
         let root = dir.path().join("baselines");
         std::mem::forget(dir);
         let ctx_log = Arc::new(Mutex::new(None));
+        let mut accessibility = FakeAccessibility::new(fake_tree());
+        accessibility.ctx_log = ctx_log.clone();
         let mut held: Option<Backend> = Some(Backend {
             platform: Box::new(FakePlatform::new(100, 100)),
-            accessibility: Some(Box::new(FakeAccessibility {
-                tree: fake_tree(),
-                set_log: Arc::new(Mutex::new(Vec::new())),
-                set_fail: false,
-                ctx_log: ctx_log.clone(),
-                invoke_behavior: InvokeBehavior::Unsupported,
-                invoke_log: Arc::new(Mutex::new(Vec::new())),
-            })),
+            accessibility: Some(Box::new(accessibility)),
         });
         let factory: PlatformFactory = Box::new(move |_b| {
             held.take()
@@ -4724,16 +4709,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().join("baselines");
         std::mem::forget(dir);
+        let mut accessibility = FakeAccessibility::new(fake_tree());
+        accessibility.set_fail = true;
         let mut held: Option<Backend> = Some(Backend {
             platform: Box::new(FakePlatform::new(100, 100)),
-            accessibility: Some(Box::new(FakeAccessibility {
-                tree: fake_tree(),
-                set_log: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
-                set_fail: true,
-                ctx_log: Arc::new(Mutex::new(None)),
-                invoke_behavior: InvokeBehavior::Unsupported,
-                invoke_log: Arc::new(Mutex::new(Vec::new())),
-            })),
+            accessibility: Some(Box::new(accessibility)),
         });
         let factory: PlatformFactory = Box::new(move |_b| {
             held.take()
@@ -5185,20 +5165,16 @@ mod tests {
         let root = dir.path().join("baselines");
         std::mem::forget(dir);
         let log2 = log.clone();
+        let mut accessibility = FakeAccessibility::new(fake_tree());
+        accessibility.set_log = log2;
         let mut held: Option<Backend> = Some(Backend {
             platform: Box::new(
                 FakePlatform::new(100, 100)
                     .with_drag_log(drags.clone())
                     .with_trailing_toggle_backend(),
             ),
-            accessibility: Some(Box::new(FakeAccessibility {
-                tree: fake_tree(), // #1 is a non-checkable Button "Save"
-                set_log: log2,
-                set_fail: false,
-                ctx_log: Arc::new(Mutex::new(None)),
-                invoke_behavior: InvokeBehavior::Unsupported,
-                invoke_log: Arc::new(Mutex::new(Vec::new())),
-            })),
+            // fake_tree: #1 is a non-checkable Button "Save"
+            accessibility: Some(Box::new(accessibility)),
         });
         let factory: PlatformFactory = Box::new(move |_b| {
             held.take()
@@ -5234,20 +5210,16 @@ mod tests {
         let root = dir.path().join("baselines");
         std::mem::forget(dir);
         let log2 = log.clone();
+        let mut accessibility = FakeAccessibility::new(sw(false));
+        accessibility.set_log = log2;
         let mut held: Option<Backend> = Some(Backend {
             platform: Box::new(
                 FakePlatform::new(400, 400)
                     .with_drag_log(drags.clone())
                     .with_trailing_toggle_backend(),
             ),
-            accessibility: Some(Box::new(FakeAccessibility {
-                tree: sw(false), // #1 is the checkable switch "Sw"
-                set_log: log2,
-                set_fail: false,
-                ctx_log: Arc::new(Mutex::new(None)),
-                invoke_behavior: InvokeBehavior::Unsupported,
-                invoke_log: Arc::new(Mutex::new(Vec::new())),
-            })),
+            // sw(false): #1 is the checkable switch "Sw"
+            accessibility: Some(Box::new(accessibility)),
         });
         let factory: PlatformFactory = Box::new(move |_b| {
             held.take()

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -37,7 +37,7 @@ fn click_method_from_semantic_outcome(outcome: SemanticActionOutcome) -> ClickMe
     }
 }
 
-fn glass_error_from_semantic_action(mut error: SemanticActionError) -> GlassError {
+fn glass_error_from_semantic_action(mut error: Box<SemanticActionError>) -> GlassError {
     error
         .source
         .take()

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -2693,6 +2693,43 @@ mod tests {
         assert_eq!(invokes.lock().unwrap().len(), 1);
     }
 
+    #[test]
+    fn native_focus_geometry_failure_is_best_effort_only_for_an_unbounded_legacy_call() {
+        for (deadline, should_focus) in [
+            (Deadline::UNBOUNDED, true),
+            (Deadline::from_millis(1_000), false),
+        ] {
+            let focus_calls = Arc::new(AtomicUsize::new(0));
+            let accessibility = FakeAccessibility::new(fake_tree())
+                .with_focus_behavior(InvokeBehavior::Succeed)
+                .with_focus_calls(focus_calls.clone());
+            let mut g = glass_with_backend(
+                FakePlatform::new(100, 100).with_failing_geometry(),
+                Box::new(accessibility),
+            );
+            g.start(&spec()).unwrap();
+            let mut cached = fake_tree();
+            cached.assign_ids();
+            g.active.as_mut().unwrap().last_ax = Some(cached);
+
+            let result = g.try_native_focus(AxNodeId(1), deadline);
+
+            assert_eq!(result.is_ok(), should_focus, "deadline={deadline:?}");
+            assert_eq!(
+                focus_calls.load(Ordering::Relaxed),
+                usize::from(should_focus),
+                "deadline={deadline:?}"
+            );
+            if let Err(error) = result {
+                assert_eq!(error.bound(), Some(crate::BoundKind::NotStarted));
+                assert_eq!(
+                    error.bound_dispatch(),
+                    Some(crate::BoundDispatch::NotDispatched)
+                );
+            }
+        }
+    }
+
     /// The click is translated into the popover's container, on both axes. The validated
     /// fixture's container sits at x=0, where subtracting and adding its origin agree, so this
     /// repeats it with the container offset horizontally.
@@ -2732,6 +2769,93 @@ mod tests {
         // Item at x=70 inside a container at x=40 is 30 in; y is unchanged from the validated
         // fixture at 248 - 194.
         assert_eq!(clicks.lock().unwrap().last().copied(), Some((30, 54)));
+    }
+
+    #[test]
+    fn planned_popover_inputs_use_the_plan_and_translate_both_axes_into_the_container() {
+        let active = window_info(
+            1,
+            WindowGeometry {
+                x: 0,
+                y: 0,
+                width: 340,
+                height: 300,
+            },
+            true,
+        );
+        let popover = window_info(
+            2,
+            WindowGeometry {
+                x: -3,
+                y: 220,
+                width: 326,
+                height: 135,
+            },
+            false,
+        );
+        let clicks = Arc::new(Mutex::new(Vec::new()));
+        let drags = Arc::new(Mutex::new(Vec::new()));
+        let platform = FakePlatform::new(340, 300)
+            .with_windows(vec![active, popover])
+            .with_click_log(clicks.clone())
+            .with_drag_log(drags.clone());
+        let mut g = glass_with_a11y(platform, fake_tree_with_offset_popover_option());
+        g.start(&spec()).unwrap();
+        let tree = g.a11y_snapshot(None).unwrap();
+        let id = tree.root.children[0].children[0].id;
+
+        g.click_element_pointer_only(
+            id,
+            Some(&super::semantic_action::PlannedPointerInput::Click { point: (83, 267) }),
+            Deadline::UNBOUNDED,
+        )
+        .unwrap();
+        g.click_element_pointer_only(
+            id,
+            Some(
+                &super::semantic_action::PlannedPointerInput::TrailingToggle {
+                    segment: crate::Segment {
+                        from_x: 78,
+                        from_y: 254,
+                        to_x: 90,
+                        to_y: 270,
+                    },
+                    probe_point: (84, 262),
+                },
+            ),
+            Deadline::UNBOUNDED,
+        )
+        .unwrap();
+
+        assert_eq!(clicks.lock().unwrap().as_slice(), &[(43, 73)]);
+        assert!(matches!(
+            drags.lock().unwrap().as_slice(),
+            [PointerEvent::Drag {
+                from_x: 38,
+                from_y: 60,
+                to_x: 50,
+                to_y: 76,
+                ..
+            }]
+        ));
+    }
+
+    #[test]
+    fn planned_ordinary_click_uses_the_stored_point_instead_of_recomputing_center() {
+        let clicks = Arc::new(Mutex::new(Vec::new()));
+        let platform = FakePlatform::new(100, 100).with_click_log(clicks.clone());
+        let mut g = glass_with_a11y(platform, fake_tree());
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot(None).unwrap();
+
+        g.click_element_pointer_only(
+            AxNodeId(1),
+            Some(&super::semantic_action::PlannedPointerInput::Click { point: (13, 17) }),
+            Deadline::UNBOUNDED,
+        )
+        .unwrap();
+
+        assert_eq!(clicks.lock().unwrap().as_slice(), &[(13, 17)]);
     }
 
     #[test]

--- a/crates/glass-core/src/session/a11y_poll.rs
+++ b/crates/glass-core/src/session/a11y_poll.rs
@@ -164,6 +164,47 @@ impl Glass {
     }
 
     #[allow(clippy::too_many_arguments)]
+    pub(super) fn poll_accessibility_until_by_deadline_with_window<O>(
+        &mut self,
+        interval_ms: u64,
+        reread_after: std::time::Duration,
+        action_deadline: Deadline,
+        whose: crate::Whose,
+        allow_wait: bool,
+        sequence_deadline: Deadline,
+        operation: &'static str,
+        observe: impl FnMut(&AxTree, (u32, u32)) -> O,
+        satisfied: impl FnMut(&O) -> bool,
+    ) -> Result<A11yPollOutcome<O>> {
+        if sequence_deadline.has_passed() {
+            return Err(GlassError::deadline_not_started(operation));
+        }
+        self.require_active()?;
+        if allow_wait && action_deadline.has_passed() {
+            return Err(GlassError::Bounded {
+                kind: crate::BoundKind::NotStarted,
+                whose,
+                dispatch: crate::BoundDispatch::NotDispatched,
+                message: format!(
+                    "{operation}: its effective deadline was already spent, so it was not started"
+                ),
+            });
+        }
+        self.poll_accessibility_until_with_deadline_and_window(
+            interval_ms,
+            reread_after,
+            action_deadline,
+            whose,
+            allow_wait,
+            sequence_deadline,
+            operation,
+            std::time::Instant::now(),
+            observe,
+            satisfied,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
     fn poll_accessibility_until_with_deadline<O>(
         &mut self,
         interval_ms: u64,
@@ -175,6 +216,34 @@ impl Glass {
         operation: &'static str,
         started: std::time::Instant,
         mut observe: impl FnMut(&AxTree) -> O,
+        satisfied: impl FnMut(&O) -> bool,
+    ) -> Result<A11yPollOutcome<O>> {
+        self.poll_accessibility_until_with_deadline_and_window(
+            interval_ms,
+            reread_after,
+            action_deadline,
+            whose,
+            allow_wait,
+            sequence_deadline,
+            operation,
+            started,
+            move |tree, _window| observe(tree),
+            satisfied,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn poll_accessibility_until_with_deadline_and_window<O>(
+        &mut self,
+        interval_ms: u64,
+        reread_after: std::time::Duration,
+        action_deadline: Deadline,
+        whose: crate::Whose,
+        allow_wait: bool,
+        sequence_deadline: Deadline,
+        operation: &'static str,
+        started: std::time::Instant,
+        mut observe: impl FnMut(&AxTree, (u32, u32)) -> O,
         mut satisfied: impl FnMut(&O) -> bool,
     ) -> Result<A11yPollOutcome<O>> {
         let mut signal = (interval_ms > 0)
@@ -271,7 +340,11 @@ impl Glass {
                     }
                     Err(e) => return Err(e),
                 };
-                let observation = observe(&tree);
+                let window = {
+                    let active = self.require_active()?;
+                    (active.geometry.width, active.geometry.height)
+                };
+                let observation = observe(&tree, window);
                 let is_satisfied = satisfied(&observation);
                 last_observation = Some(observation);
                 Ok(is_satisfied.then_some(()))
@@ -396,5 +469,56 @@ mod tests {
             .unwrap();
         assert!(!out.satisfied);
         assert_eq!(out.observation, "latest");
+    }
+
+    #[test]
+    fn window_aware_exact_deadline_pairs_each_tree_with_its_refreshed_geometry() {
+        let mut first = fake_tree();
+        first.root.name = Some("first".into());
+        let mut second = fake_tree();
+        second.root.name = Some("second".into());
+        let first_window = WindowGeometry {
+            x: 0,
+            y: 0,
+            width: 40,
+            height: 50,
+        };
+        let second_window = WindowGeometry {
+            width: 80,
+            height: 90,
+            ..first_window.clone()
+        };
+        let platform = FakePlatform::new(100, 100)
+            .resized_to(first_window)
+            .resized_to(second_window);
+        let mut glass = glass_with_a11y_seq(platform, vec![first, second]);
+        glass.start(&spec()).unwrap();
+        let mut observed = Vec::new();
+
+        let outcome = glass
+            .poll_accessibility_until_by_deadline_with_window(
+                1,
+                Duration::from_millis(1),
+                Deadline::from_millis(100),
+                crate::Whose::Callee,
+                true,
+                Deadline::UNBOUNDED,
+                "observe geometry",
+                |tree, window| {
+                    observed.push((tree.root.name.clone(), window));
+                    tree.root.name.as_deref() == Some("second")
+                },
+                |matched| *matched,
+            )
+            .unwrap();
+
+        assert!(outcome.satisfied);
+        assert_eq!(
+            observed,
+            vec![
+                (Some("first".into()), (40, 50)),
+                (Some("second".into()), (80, 90)),
+            ]
+        );
     }
 }

--- a/crates/glass-core/src/session/a11y_poll.rs
+++ b/crates/glass-core/src/session/a11y_poll.rs
@@ -97,8 +97,8 @@ impl Glass {
         timeout_ms: u64,
         sequence_deadline: Deadline,
         operation: &'static str,
-        mut observe: impl FnMut(&AxTree) -> O,
-        mut satisfied: impl FnMut(&O) -> bool,
+        observe: impl FnMut(&AxTree) -> O,
+        satisfied: impl FnMut(&O) -> bool,
     ) -> Result<A11yPollOutcome<O>> {
         if sequence_deadline.has_passed() {
             return Err(GlassError::deadline_not_started(operation));
@@ -108,16 +108,93 @@ impl Glass {
         let (effective_duration, whose) =
             sequence_deadline.budget(std::time::Duration::from_millis(timeout_ms), started);
         let action_deadline = Deadline::at(started + effective_duration);
+        self.poll_accessibility_until_with_deadline(
+            interval_ms,
+            reread_after,
+            action_deadline,
+            whose,
+            timeout_ms > 0,
+            sequence_deadline,
+            operation,
+            started,
+            observe,
+            satisfied,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn poll_accessibility_until_by_deadline<O>(
+        &mut self,
+        interval_ms: u64,
+        reread_after: std::time::Duration,
+        action_deadline: Deadline,
+        whose: crate::Whose,
+        allow_wait: bool,
+        sequence_deadline: Deadline,
+        operation: &'static str,
+        observe: impl FnMut(&AxTree) -> O,
+        satisfied: impl FnMut(&O) -> bool,
+    ) -> Result<A11yPollOutcome<O>> {
+        if sequence_deadline.has_passed() {
+            return Err(GlassError::deadline_not_started(operation));
+        }
+        self.require_active()?;
+        if allow_wait && action_deadline.has_passed() {
+            return Err(GlassError::Bounded {
+                kind: crate::BoundKind::NotStarted,
+                whose,
+                dispatch: crate::BoundDispatch::NotDispatched,
+                message: format!(
+                    "{operation}: its effective deadline was already spent, so it was not started"
+                ),
+            });
+        }
+        self.poll_accessibility_until_with_deadline(
+            interval_ms,
+            reread_after,
+            action_deadline,
+            whose,
+            allow_wait,
+            sequence_deadline,
+            operation,
+            std::time::Instant::now(),
+            observe,
+            satisfied,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn poll_accessibility_until_with_deadline<O>(
+        &mut self,
+        interval_ms: u64,
+        reread_after: std::time::Duration,
+        action_deadline: Deadline,
+        whose: crate::Whose,
+        allow_wait: bool,
+        sequence_deadline: Deadline,
+        operation: &'static str,
+        started: std::time::Instant,
+        mut observe: impl FnMut(&AxTree) -> O,
+        mut satisfied: impl FnMut(&O) -> bool,
+    ) -> Result<A11yPollOutcome<O>> {
         let mut signal = (interval_ms > 0)
             .then(|| self.subscribe_a11y_changes(action_deadline))
             .flatten();
-        let remaining = (effective_duration.as_millis() as u64)
-            .saturating_sub(started.elapsed().as_millis() as u64);
+        let remaining = if allow_wait {
+            let deadline = action_deadline
+                .instant()
+                .expect("a waiting accessibility poll has a finite deadline");
+            let effective_duration = deadline.saturating_duration_since(started);
+            (effective_duration.as_millis() as u64)
+                .saturating_sub(started.elapsed().as_millis() as u64)
+        } else {
+            0
+        };
         let mut last_read = std::time::Instant::now();
         let mut unread: Option<GlassError> = None;
         let mut unread_owner = whose;
         let mut saw_a_tree = false;
-        let first_read_deadline = if timeout_ms == 0 {
+        let first_read_deadline = if !allow_wait {
             sequence_deadline
         } else {
             action_deadline
@@ -168,7 +245,7 @@ impl Glass {
                     action_deadline
                 };
                 let read_owner =
-                    if first_read && timeout_ms == 0 && sequence_deadline.instant().is_some() {
+                    if first_read && !allow_wait && sequence_deadline.instant().is_some() {
                         crate::Whose::Caller
                     } else {
                         whose

--- a/crates/glass-core/src/session/a11y_poll.rs
+++ b/crates/glass-core/src/session/a11y_poll.rs
@@ -11,6 +11,20 @@ pub(super) struct A11yPollOutcome<O> {
     pub timed_out_by: Option<crate::Whose>,
 }
 
+#[derive(Clone, Copy)]
+pub(super) struct A11yPollCadence {
+    pub interval_ms: u64,
+    pub reread_after: std::time::Duration,
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct A11yPollBound {
+    pub action_deadline: Deadline,
+    pub whose: crate::Whose,
+    pub allow_wait: bool,
+    pub sequence_deadline: Deadline,
+}
+
 fn final_read_pause(left: std::time::Duration) -> std::time::Duration {
     left.saturating_sub(FINAL_READ_HEADROOM.min(left / 4))
 }
@@ -80,8 +94,10 @@ impl Glass {
         satisfied: impl FnMut(&O) -> bool,
     ) -> Result<A11yPollOutcome<O>> {
         self.poll_accessibility_until_with_reread(
-            interval_ms,
-            std::time::Duration::from_secs(1),
+            A11yPollCadence {
+                interval_ms,
+                reread_after: std::time::Duration::from_secs(1),
+            },
             timeout_ms,
             sequence_deadline,
             operation,
@@ -92,8 +108,7 @@ impl Glass {
 
     pub(super) fn poll_accessibility_until_with_reread<O>(
         &mut self,
-        interval_ms: u64,
-        reread_after: std::time::Duration,
+        cadence: A11yPollCadence,
         timeout_ms: u64,
         sequence_deadline: Deadline,
         operation: &'static str,
@@ -109,12 +124,13 @@ impl Glass {
             sequence_deadline.budget(std::time::Duration::from_millis(timeout_ms), started);
         let action_deadline = Deadline::at(started + effective_duration);
         self.poll_accessibility_until_with_deadline(
-            interval_ms,
-            reread_after,
-            action_deadline,
-            whose,
-            timeout_ms > 0,
-            sequence_deadline,
+            cadence,
+            A11yPollBound {
+                action_deadline,
+                whose,
+                allow_wait: timeout_ms > 0,
+                sequence_deadline,
+            },
             operation,
             started,
             observe,
@@ -122,19 +138,20 @@ impl Glass {
         )
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub(super) fn poll_accessibility_until_by_deadline<O>(
         &mut self,
-        interval_ms: u64,
-        reread_after: std::time::Duration,
-        action_deadline: Deadline,
-        whose: crate::Whose,
-        allow_wait: bool,
-        sequence_deadline: Deadline,
+        cadence: A11yPollCadence,
+        bound: A11yPollBound,
         operation: &'static str,
         observe: impl FnMut(&AxTree) -> O,
         satisfied: impl FnMut(&O) -> bool,
     ) -> Result<A11yPollOutcome<O>> {
+        let A11yPollBound {
+            action_deadline,
+            whose,
+            allow_wait,
+            sequence_deadline,
+        } = bound;
         if sequence_deadline.has_passed() {
             return Err(GlassError::deadline_not_started(operation));
         }
@@ -150,12 +167,8 @@ impl Glass {
             });
         }
         self.poll_accessibility_until_with_deadline(
-            interval_ms,
-            reread_after,
-            action_deadline,
-            whose,
-            allow_wait,
-            sequence_deadline,
+            cadence,
+            bound,
             operation,
             std::time::Instant::now(),
             observe,
@@ -163,19 +176,20 @@ impl Glass {
         )
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub(super) fn poll_accessibility_until_by_deadline_with_window<O>(
         &mut self,
-        interval_ms: u64,
-        reread_after: std::time::Duration,
-        action_deadline: Deadline,
-        whose: crate::Whose,
-        allow_wait: bool,
-        sequence_deadline: Deadline,
+        cadence: A11yPollCadence,
+        bound: A11yPollBound,
         operation: &'static str,
         observe: impl FnMut(&AxTree, (u32, u32)) -> O,
         satisfied: impl FnMut(&O) -> bool,
     ) -> Result<A11yPollOutcome<O>> {
+        let A11yPollBound {
+            action_deadline,
+            whose,
+            allow_wait,
+            sequence_deadline,
+        } = bound;
         if sequence_deadline.has_passed() {
             return Err(GlassError::deadline_not_started(operation));
         }
@@ -191,12 +205,8 @@ impl Glass {
             });
         }
         self.poll_accessibility_until_with_deadline_and_window(
-            interval_ms,
-            reread_after,
-            action_deadline,
-            whose,
-            allow_wait,
-            sequence_deadline,
+            cadence,
+            bound,
             operation,
             std::time::Instant::now(),
             observe,
@@ -204,27 +214,18 @@ impl Glass {
         )
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn poll_accessibility_until_with_deadline<O>(
         &mut self,
-        interval_ms: u64,
-        reread_after: std::time::Duration,
-        action_deadline: Deadline,
-        whose: crate::Whose,
-        allow_wait: bool,
-        sequence_deadline: Deadline,
+        cadence: A11yPollCadence,
+        bound: A11yPollBound,
         operation: &'static str,
         started: std::time::Instant,
         mut observe: impl FnMut(&AxTree) -> O,
         satisfied: impl FnMut(&O) -> bool,
     ) -> Result<A11yPollOutcome<O>> {
         self.poll_accessibility_until_with_deadline_and_window(
-            interval_ms,
-            reread_after,
-            action_deadline,
-            whose,
-            allow_wait,
-            sequence_deadline,
+            cadence,
+            bound,
             operation,
             started,
             move |tree, _window| observe(tree),
@@ -232,20 +233,25 @@ impl Glass {
         )
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn poll_accessibility_until_with_deadline_and_window<O>(
         &mut self,
-        interval_ms: u64,
-        reread_after: std::time::Duration,
-        action_deadline: Deadline,
-        whose: crate::Whose,
-        allow_wait: bool,
-        sequence_deadline: Deadline,
+        cadence: A11yPollCadence,
+        bound: A11yPollBound,
         operation: &'static str,
         started: std::time::Instant,
         mut observe: impl FnMut(&AxTree, (u32, u32)) -> O,
         mut satisfied: impl FnMut(&O) -> bool,
     ) -> Result<A11yPollOutcome<O>> {
+        let A11yPollCadence {
+            interval_ms,
+            reread_after,
+        } = cadence;
+        let A11yPollBound {
+            action_deadline,
+            whose,
+            allow_wait,
+            sequence_deadline,
+        } = bound;
         let mut signal = (interval_ms > 0)
             .then(|| self.subscribe_a11y_changes(action_deadline))
             .flatten();
@@ -497,12 +503,16 @@ mod tests {
 
         let outcome = glass
             .poll_accessibility_until_by_deadline_with_window(
-                1,
-                Duration::from_millis(1),
-                Deadline::from_millis(100),
-                crate::Whose::Callee,
-                true,
-                Deadline::UNBOUNDED,
+                A11yPollCadence {
+                    interval_ms: 1,
+                    reread_after: Duration::from_millis(1),
+                },
+                A11yPollBound {
+                    action_deadline: Deadline::from_millis(100),
+                    whose: crate::Whose::Callee,
+                    allow_wait: true,
+                    sequence_deadline: Deadline::UNBOUNDED,
+                },
                 "observe geometry",
                 |tree, window| {
                     observed.push((tree.root.name.clone(), window));

--- a/crates/glass-core/src/session/a11y_poll.rs
+++ b/crates/glass-core/src/session/a11y_poll.rs
@@ -1,8 +1,5 @@
 use super::*;
 
-/// Maximum wall-clock time a change signal may suppress tree reads.
-const REREAD_AFTER: std::time::Duration = std::time::Duration::from_secs(1);
-
 /// Reader headroom reserved before a quiet wait's deadline, capped at one quarter of the
 /// remaining budget.
 const FINAL_READ_HEADROOM: std::time::Duration = std::time::Duration::from_millis(20);
@@ -18,8 +15,12 @@ fn final_read_pause(left: std::time::Duration) -> std::time::Duration {
     left.saturating_sub(FINAL_READ_HEADROOM.min(left / 4))
 }
 
-fn quiet_wait_needs_read(final_read: bool, since_last: std::time::Duration) -> bool {
-    final_read || since_last >= REREAD_AFTER
+fn quiet_wait_needs_read(
+    final_read: bool,
+    since_last: std::time::Duration,
+    reread_after: std::time::Duration,
+) -> bool {
+    final_read || since_last >= reread_after
 }
 
 fn should_schedule_final_read(
@@ -75,6 +76,27 @@ impl Glass {
         timeout_ms: u64,
         sequence_deadline: Deadline,
         operation: &'static str,
+        observe: impl FnMut(&AxTree) -> O,
+        satisfied: impl FnMut(&O) -> bool,
+    ) -> Result<A11yPollOutcome<O>> {
+        self.poll_accessibility_until_with_reread(
+            interval_ms,
+            std::time::Duration::from_secs(1),
+            timeout_ms,
+            sequence_deadline,
+            operation,
+            observe,
+            satisfied,
+        )
+    }
+
+    pub(super) fn poll_accessibility_until_with_reread<O>(
+        &mut self,
+        interval_ms: u64,
+        reread_after: std::time::Duration,
+        timeout_ms: u64,
+        sequence_deadline: Deadline,
+        operation: &'static str,
         mut observe: impl FnMut(&AxTree) -> O,
         mut satisfied: impl FnMut(&O) -> bool,
     ) -> Result<A11yPollOutcome<O>> {
@@ -122,7 +144,9 @@ impl Glass {
                 let read_now = match signal.as_mut() {
                     Some(s) => match s.wait(pause_budget) {
                         ChangeWait::Changed => true,
-                        ChangeWait::Quiet => quiet_wait_needs_read(final_read, last_read.elapsed()),
+                        ChangeWait::Quiet => {
+                            quiet_wait_needs_read(final_read, last_read.elapsed(), reread_after)
+                        }
                         ChangeWait::Unusable => {
                             signal = None;
                             true
@@ -252,12 +276,14 @@ mod tests {
 
     #[test]
     fn a_quiet_signal_reads_only_for_a_safety_or_periodic_refresh() {
+        let reread_after = Duration::from_secs(1);
         assert!(!quiet_wait_needs_read(
             false,
-            REREAD_AFTER - Duration::from_millis(1)
+            reread_after - Duration::from_millis(1),
+            reread_after,
         ));
-        assert!(quiet_wait_needs_read(false, REREAD_AFTER));
-        assert!(quiet_wait_needs_read(true, Duration::ZERO));
+        assert!(quiet_wait_needs_read(false, reread_after, reread_after));
+        assert!(quiet_wait_needs_read(true, Duration::ZERO, reread_after));
     }
 
     #[test]

--- a/crates/glass-core/src/session/input.rs
+++ b/crates/glass-core/src/session/input.rs
@@ -106,7 +106,7 @@ impl Glass {
         result
     }
 
-    fn key_inner_by(&mut self, event: &KeyEvent, deadline: Deadline) -> Result<()> {
+    pub(super) fn key_inner_by(&mut self, event: &KeyEvent, deadline: Deadline) -> Result<()> {
         let s = self.active_mut()?;
         s.platform.send_key_by(event, deadline)?;
         s.pump();

--- a/crates/glass-core/src/session/mod.rs
+++ b/crates/glass-core/src/session/mod.rs
@@ -29,10 +29,18 @@ mod clipboard;
 mod find;
 mod input;
 mod lifecycle;
+mod semantic_action;
 mod wait;
 mod window;
 
 pub use find::{FindElementsOutcome, FindElementsParams};
+pub use semantic_action::{
+    ActionDeadline, ActionMethod, ActionMode, ActionTarget, ClickTargetParams, ConfirmationStatus,
+    DispatchStatus, MutationReport, ResolutionReport, RetryGuidance,
+    SEMANTIC_ACTION_DEFAULT_TIMEOUT_MS, SEMANTIC_ACTION_MAX_TIMEOUT_MS, SemanticActionError,
+    SemanticActionFailureKind, SemanticActionOutcome, SemanticTarget, SetValueTargetParams,
+    TypeTargetParams,
+};
 pub use wait::{
     SCROLL_TO_DEFAULT_STEP, SCROLL_TO_DEFAULT_TIMEOUT_MS, ScrollDirection, ScrollToElementOutcome,
     ScrollToElementParams, WaitElementOutcome, WaitElementParams, WaitLogOutcome, WaitLogParams,

--- a/crates/glass-core/src/session/semantic_action.rs
+++ b/crates/glass-core/src/session/semantic_action.rs
@@ -312,8 +312,13 @@ impl PlannedPointerInput {
             |(x, y): (i32, i32)| x >= 0 && y >= 0 && (x as u32) < window.0 && (y as u32) < window.1;
         match self {
             Self::Click { point } => inside(*point),
-            Self::TrailingToggle { segment, .. } => {
-                inside((segment.from_x, segment.from_y)) && inside((segment.to_x, segment.to_y))
+            Self::TrailingToggle {
+                segment,
+                probe_point,
+            } => {
+                inside((segment.from_x, segment.from_y))
+                    && inside((segment.to_x, segment.to_y))
+                    && inside(*probe_point)
             }
         }
     }

--- a/crates/glass-core/src/session/semantic_action.rs
+++ b/crates/glass-core/src/session/semantic_action.rs
@@ -579,7 +579,7 @@ fn pointer_plan(
         let segment = bounds.trailing_toggle_swipe(window.0, window.1)?;
         let probe_point = (
             segment.from_x + (segment.to_x - segment.from_x) / 2,
-            segment.from_y + (segment.to_y - segment.from_y) / 2,
+            segment.from_y,
         );
         PlannedPointerInput::TrailingToggle {
             segment,

--- a/crates/glass-core/src/session/semantic_action.rs
+++ b/crates/glass-core/src/session/semantic_action.rs
@@ -1,0 +1,575 @@
+#![allow(dead_code)]
+
+use super::*;
+use crate::{
+    ActionabilityReport, AxStateCoverage, ScopeResolution, SemanticMatch, SemanticQuery,
+    SemanticQueryResult, SemanticSelector, SemanticState, Whose,
+};
+
+pub const SEMANTIC_ACTION_DEFAULT_TIMEOUT_MS: u64 = 10_000;
+pub const SEMANTIC_ACTION_MAX_TIMEOUT_MS: u64 = 120_000;
+pub const SEMANTIC_ACTION_STABILITY_MS: u64 = 100;
+pub const SEMANTIC_ACTION_CANDIDATE_LIMIT: usize = 5;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SemanticTarget {
+    pub target: SemanticSelector,
+    pub within: Option<SemanticSelector>,
+}
+
+impl SemanticTarget {
+    pub fn uncovered_states(&self, coverage: AxStateCoverage) -> Vec<SemanticState> {
+        self.target
+            .states()
+            .iter()
+            .chain(self.within.iter().flat_map(SemanticSelector::states))
+            .copied()
+            .filter(|state| !coverage.covers_selector_state(*state))
+            .collect()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ActionTarget {
+    Id(AxNodeId),
+    Semantic(SemanticTarget),
+}
+
+impl ActionTarget {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Id(_) => "id",
+            Self::Semantic(_) => "semantic",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ActionMode {
+    Auto,
+    Native,
+    Pointer,
+}
+
+impl ActionMode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Native => "native",
+            Self::Pointer => "pointer",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ActionMethod {
+    NativeAction { actuated: Option<AxNodeId> },
+    Pointer { native_fallback: Option<String> },
+    AccessibilityValue,
+    Keyboard,
+}
+
+impl ActionMethod {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::NativeAction { .. } => "native_action",
+            Self::Pointer { .. } => "pointer",
+            Self::AccessibilityValue => "accessibility_value",
+            Self::Keyboard => "keyboard",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DispatchStatus {
+    NotDispatched,
+    Dispatched,
+    MayHaveDispatched,
+}
+
+impl DispatchStatus {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::NotDispatched => "not_dispatched",
+            Self::Dispatched => "dispatched",
+            Self::MayHaveDispatched => "may_have_dispatched",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConfirmationStatus {
+    NotRequested,
+    DispatchConfirmed,
+    FocusConfirmed,
+    ValueConfirmed,
+    Unconfirmed,
+}
+
+impl ConfirmationStatus {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::NotRequested => "not_requested",
+            Self::DispatchConfirmed => "dispatch_confirmed",
+            Self::FocusConfirmed => "focus_confirmed",
+            Self::ValueConfirmed => "value_confirmed",
+            Self::Unconfirmed => "unconfirmed",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MutationReport {
+    pub method: ActionMethod,
+    pub dispatch: DispatchStatus,
+    pub confirmation: ConfirmationStatus,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ActionDeadline {
+    pub deadline: Deadline,
+    pub owner: Option<Whose>,
+    pub allow_wait: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResolutionReport {
+    pub elapsed_ms: u64,
+    pub scope: ScopeResolution,
+    pub matches_in_walk: usize,
+    pub search_complete: bool,
+    pub timed_out_by: Option<Whose>,
+    pub tree_truncated: bool,
+    pub unreadable_subtrees: usize,
+    pub unexposed_placeholders: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SemanticActionOutcome {
+    pub target: ElementInfo,
+    pub resolution: Option<ResolutionReport>,
+    pub actionability: ActionabilityReport,
+    pub focus: Option<MutationReport>,
+    pub action: MutationReport,
+    pub bound: ActionDeadline,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SemanticActionFailureKind {
+    NoMatch,
+    AmbiguousTarget,
+    AmbiguousScope,
+    IncompleteTree,
+    UnprovenSelectorState,
+    NotActionable,
+    UnstableTarget,
+    FocusUnconfirmed,
+    UnsupportedMode,
+    ActionDeadlineExceeded,
+    SequenceDeadlineExceeded,
+    ActionFailed,
+}
+
+impl SemanticActionFailureKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::NoMatch => "no_match",
+            Self::AmbiguousTarget => "ambiguous_target",
+            Self::AmbiguousScope => "ambiguous_scope",
+            Self::IncompleteTree => "incomplete_tree",
+            Self::UnprovenSelectorState => "unproven_selector_state",
+            Self::NotActionable => "not_actionable",
+            Self::UnstableTarget => "unstable_target",
+            Self::FocusUnconfirmed => "focus_unconfirmed",
+            Self::UnsupportedMode => "unsupported_mode",
+            Self::ActionDeadlineExceeded => "action_deadline_exceeded",
+            Self::SequenceDeadlineExceeded => "sequence_deadline_exceeded",
+            Self::ActionFailed => "action_failed",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RetryGuidance {
+    CorrectRequest,
+    WaitOrRefine,
+    Reobserve,
+    SafeToRetry,
+    DoNotRetry,
+}
+
+impl RetryGuidance {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::CorrectRequest => "correct_request",
+            Self::WaitOrRefine => "wait_or_refine",
+            Self::Reobserve => "reobserve",
+            Self::SafeToRetry => "safe_to_retry",
+            Self::DoNotRetry => "do_not_retry",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct SemanticActionError {
+    pub kind: SemanticActionFailureKind,
+    pub summary: &'static str,
+    pub resolution: Option<ResolutionReport>,
+    pub actionability: ActionabilityReport,
+    pub focus: Option<MutationReport>,
+    pub action_dispatch: DispatchStatus,
+    pub candidates: Vec<SemanticMatch>,
+    pub bound: ActionDeadline,
+    pub retry: RetryGuidance,
+    pub source: Option<GlassError>,
+}
+
+impl std::fmt::Display for SemanticActionError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.summary)
+    }
+}
+
+impl std::error::Error for SemanticActionError {}
+
+#[derive(Clone, Debug)]
+pub struct ClickTargetParams {
+    pub target: ActionTarget,
+    pub mode: ActionMode,
+    pub timeout_ms: Option<u64>,
+    pub max_nodes: Option<usize>,
+}
+
+#[derive(Clone, Debug)]
+pub struct SetValueTargetParams {
+    pub target: ActionTarget,
+    pub timeout_ms: Option<u64>,
+    pub max_nodes: Option<usize>,
+}
+
+#[derive(Clone, Debug)]
+pub struct TypeTargetParams {
+    pub target: SemanticTarget,
+    pub focus_mode: ActionMode,
+    pub timeout_ms: u64,
+    pub max_nodes: Option<usize>,
+}
+
+#[derive(Debug)]
+pub(super) struct ResolvedSemanticTarget {
+    pub(super) element: ElementInfo,
+    pub(super) resolution: ResolutionReport,
+    pub(super) target: AxTarget,
+    pub(super) coverage: AxStateCoverage,
+    pub(super) bound: ActionDeadline,
+}
+
+#[derive(Debug)]
+struct ResolutionObservation {
+    result: SemanticQueryResult,
+    eligible: bool,
+}
+
+fn empty_error(
+    kind: SemanticActionFailureKind,
+    summary: &'static str,
+    bound: ActionDeadline,
+    retry: RetryGuidance,
+    source: Option<GlassError>,
+) -> SemanticActionError {
+    SemanticActionError {
+        kind,
+        summary,
+        resolution: None,
+        actionability: ActionabilityReport::default(),
+        focus: None,
+        action_dispatch: DispatchStatus::NotDispatched,
+        candidates: Vec::new(),
+        bound,
+        retry,
+        source,
+    }
+}
+
+fn request_error(summary: &'static str, sequence_deadline: Deadline) -> SemanticActionError {
+    empty_error(
+        SemanticActionFailureKind::UnsupportedMode,
+        summary,
+        ActionDeadline {
+            deadline: sequence_deadline,
+            owner: sequence_deadline.instant().map(|_| Whose::Caller),
+            allow_wait: false,
+        },
+        RetryGuidance::CorrectRequest,
+        None,
+    )
+}
+
+fn target_deadline(
+    source: &ActionTarget,
+    timeout_ms: Option<u64>,
+    max_nodes: Option<usize>,
+    sequence_deadline: Deadline,
+) -> std::result::Result<ActionDeadline, SemanticActionError> {
+    let now = std::time::Instant::now();
+    match source {
+        ActionTarget::Id(_) => {
+            if timeout_ms.is_some() || max_nodes.is_some() {
+                return Err(request_error(
+                    "id targets do not accept timeout_ms or max_nodes",
+                    sequence_deadline,
+                ));
+            }
+            if sequence_deadline.instant().is_some() {
+                Ok(ActionDeadline {
+                    deadline: sequence_deadline,
+                    owner: Some(Whose::Caller),
+                    allow_wait: true,
+                })
+            } else {
+                Ok(ActionDeadline {
+                    deadline: Deadline::UNBOUNDED,
+                    owner: None,
+                    allow_wait: true,
+                })
+            }
+        }
+        ActionTarget::Semantic(_) => {
+            let timeout_ms = timeout_ms.unwrap_or(SEMANTIC_ACTION_DEFAULT_TIMEOUT_MS);
+            if timeout_ms > SEMANTIC_ACTION_MAX_TIMEOUT_MS {
+                return Err(request_error(
+                    "timeout_ms exceeds the semantic action maximum",
+                    sequence_deadline,
+                ));
+            }
+            if timeout_ms == 0 {
+                return Ok(ActionDeadline {
+                    deadline: sequence_deadline,
+                    owner: sequence_deadline.instant().map(|_| Whose::Caller),
+                    allow_wait: false,
+                });
+            }
+            let (duration, owner) =
+                sequence_deadline.budget(std::time::Duration::from_millis(timeout_ms), now);
+            Ok(ActionDeadline {
+                deadline: Deadline::at(now + duration),
+                owner: Some(owner),
+                allow_wait: true,
+            })
+        }
+    }
+}
+
+fn resolution_report(
+    result: &SemanticQueryResult,
+    elapsed_ms: u64,
+    timed_out_by: Option<Whose>,
+) -> ResolutionReport {
+    ResolutionReport {
+        elapsed_ms,
+        scope: result.scope,
+        matches_in_walk: result.matches_in_walk,
+        search_complete: result.search_complete,
+        timed_out_by,
+        tree_truncated: result.tree_truncated.is_some(),
+        unreadable_subtrees: result.unreadable_subtrees,
+        unexposed_placeholders: result.unexposed_placeholders,
+    }
+}
+
+fn classified_resolution_error(
+    observation: ResolutionObservation,
+    report: ResolutionReport,
+    bound: ActionDeadline,
+) -> SemanticActionError {
+    let (kind, summary, retry) =
+        if matches!(observation.result.scope, ScopeResolution::Ambiguous { .. }) {
+            (
+                SemanticActionFailureKind::AmbiguousScope,
+                "semantic scope matched more than one element",
+                RetryGuidance::CorrectRequest,
+            )
+        } else if observation.result.matches_in_walk >= 2 {
+            (
+                SemanticActionFailureKind::AmbiguousTarget,
+                "semantic target matched more than one element",
+                RetryGuidance::WaitOrRefine,
+            )
+        } else if !observation.result.search_complete {
+            (
+                SemanticActionFailureKind::IncompleteTree,
+                "accessibility tree could not prove a unique semantic target",
+                RetryGuidance::Reobserve,
+            )
+        } else if observation.result.matches_in_walk == 0 {
+            (
+                SemanticActionFailureKind::NoMatch,
+                "semantic target did not match any element",
+                RetryGuidance::WaitOrRefine,
+            )
+        } else {
+            debug_assert!(!observation.eligible);
+            (
+                SemanticActionFailureKind::NotActionable,
+                "semantic target is not actionable",
+                RetryGuidance::Reobserve,
+            )
+        };
+    SemanticActionError {
+        kind,
+        summary,
+        resolution: Some(report),
+        actionability: ActionabilityReport::default(),
+        focus: None,
+        action_dispatch: DispatchStatus::NotDispatched,
+        candidates: observation.result.matches,
+        bound,
+        retry,
+        source: None,
+    }
+}
+
+fn source_error(source: GlassError, bound: ActionDeadline) -> SemanticActionError {
+    let owner = source.bound_owner().or_else(|| {
+        matches!(&source, GlassError::AccessibilityNotReady(_))
+            .then_some(bound.owner)
+            .flatten()
+    });
+    let kind = match owner {
+        Some(Whose::Caller) => SemanticActionFailureKind::SequenceDeadlineExceeded,
+        Some(Whose::Callee) => SemanticActionFailureKind::ActionDeadlineExceeded,
+        None => SemanticActionFailureKind::ActionFailed,
+    };
+    let summary = match kind {
+        SemanticActionFailureKind::SequenceDeadlineExceeded => {
+            "semantic action sequence deadline exceeded"
+        }
+        SemanticActionFailureKind::ActionDeadlineExceeded => "semantic action deadline exceeded",
+        _ => "semantic action target resolution failed",
+    };
+    empty_error(
+        kind,
+        summary,
+        bound,
+        RetryGuidance::SafeToRetry,
+        Some(source),
+    )
+}
+
+impl Glass {
+    pub(super) fn resolve_semantic_target(
+        &mut self,
+        target: &SemanticTarget,
+        max_nodes: Option<usize>,
+        timeout_ms: u64,
+        sequence_deadline: Deadline,
+        eligibility: impl Fn(&ElementInfo, AxStateCoverage) -> bool,
+    ) -> std::result::Result<ResolvedSemanticTarget, SemanticActionError> {
+        let coverage = {
+            let active = self.active_mut().map_err(|source| {
+                source_error(
+                    source,
+                    ActionDeadline {
+                        deadline: sequence_deadline,
+                        owner: sequence_deadline.instant().map(|_| Whose::Caller),
+                        allow_wait: timeout_ms > 0,
+                    },
+                )
+            })?;
+            active
+                .accessibility
+                .as_ref()
+                .ok_or_else(|| {
+                    source_error(
+                        GlassError::AxUnsupported,
+                        ActionDeadline {
+                            deadline: sequence_deadline,
+                            owner: sequence_deadline.instant().map(|_| Whose::Caller),
+                            allow_wait: timeout_ms > 0,
+                        },
+                    )
+                })?
+                .state_coverage()
+        };
+        let bound = target_deadline(
+            &ActionTarget::Semantic(target.clone()),
+            Some(timeout_ms),
+            max_nodes,
+            sequence_deadline,
+        )?;
+        if !target.uncovered_states(coverage).is_empty() {
+            return Err(empty_error(
+                SemanticActionFailureKind::UnprovenSelectorState,
+                "accessibility backend cannot prove a requested selector state",
+                bound,
+                RetryGuidance::CorrectRequest,
+                None,
+            ));
+        }
+        self.set_a11y_limits(max_nodes)
+            .map_err(|source| source_error(source, bound))?;
+        let query = SemanticQuery::new(
+            target.target.clone(),
+            target.within.clone(),
+            SEMANTIC_ACTION_CANDIDATE_LIMIT,
+        )
+        .expect("the fixed candidate limit is valid");
+        let poll = self
+            .poll_accessibility_until(
+                SEMANTIC_ACTION_STABILITY_MS,
+                timeout_ms,
+                sequence_deadline,
+                "resolve semantic action target",
+                |tree| {
+                    let result = tree.semantic_query(&query);
+                    let eligible = result.matches_in_walk == 1
+                        && result
+                            .matches
+                            .first()
+                            .is_some_and(|candidate| eligibility(&candidate.element, coverage));
+                    ResolutionObservation { result, eligible }
+                },
+                |observation| {
+                    matches!(
+                        observation.result.scope,
+                        ScopeResolution::Unscoped | ScopeResolution::Resolved(_)
+                    ) && observation.result.matches_in_walk == 1
+                        && observation.result.search_complete
+                        && observation.result.matches.len() == 1
+                        && observation.eligible
+                },
+            )
+            .map_err(|source| source_error(source, bound))?;
+        let report =
+            resolution_report(&poll.observation.result, poll.elapsed_ms, poll.timed_out_by);
+        if !poll.satisfied {
+            return Err(classified_resolution_error(poll.observation, report, bound));
+        }
+
+        let id = poll.observation.result.matches[0].element.id;
+        let node = self
+            .active
+            .as_ref()
+            .and_then(|active| active.last_ax.as_ref())
+            .and_then(|tree| tree.find(id))
+            .ok_or_else(|| source_error(GlassError::AxElementNotFound(id.0), bound))?;
+        let element = ElementInfo::from_node(node);
+        let target = AxTarget {
+            id: node.id,
+            role: node.role,
+            name: node.name.clone(),
+            bounds: node.bounds,
+            value: node.value.clone(),
+        };
+        Ok(ResolvedSemanticTarget {
+            element,
+            resolution: report,
+            target,
+            coverage,
+            bound,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/glass-core/src/session/semantic_action.rs
+++ b/crates/glass-core/src/session/semantic_action.rs
@@ -826,6 +826,7 @@ fn key_source_error(source: GlassError, focused: ConfirmedFocus) -> SemanticActi
     } else {
         RetryGuidance::DoNotRetry
     };
+    error.source = None;
     error
 }
 
@@ -1996,6 +1997,26 @@ impl Glass {
         }
     }
 
+    fn native_focus_confirmation_target(
+        &self,
+        original: &AxTarget,
+        actuated: Option<AxNodeId>,
+    ) -> Result<AxTarget> {
+        let Some(id) = actuated else {
+            return Ok(original.clone());
+        };
+        let active = self.require_active()?;
+        let tree = active.last_ax.as_ref().ok_or(GlassError::NoAxSnapshot)?;
+        let node = tree.find(id).ok_or(GlassError::AxElementNotFound(id.0))?;
+        Ok(AxTarget {
+            id,
+            role: node.role,
+            name: node.name.clone(),
+            bounds: node.bounds,
+            value: node.value.clone(),
+        })
+    }
+
     fn focus_target_native_once(
         &mut self,
         params: &TypeTargetParams,
@@ -2053,8 +2074,20 @@ impl Glass {
             })?;
         actionability.pass_backend_fingerprint();
         let method = ActionMethod::NativeAction { actuated };
+        let confirmation_target = self
+            .native_focus_confirmation_target(&resolved.target, actuated)
+            .map_err(|source| {
+                focus_unconfirmed_error(
+                    Some(source),
+                    resolved.resolution.clone(),
+                    actionability.clone(),
+                    resolved.coverage,
+                    method.clone(),
+                    resolved.bound,
+                )
+            })?;
         let confirmed = self
-            .confirm_focused_target(&resolved.target, resolved.bound)
+            .confirm_focused_target(&confirmation_target, resolved.bound)
             .map_err(|error| {
                 focus_unconfirmed_error(
                     error.source,

--- a/crates/glass-core/src/session/semantic_action.rs
+++ b/crates/glass-core/src/session/semantic_action.rs
@@ -306,17 +306,32 @@ pub(super) enum PlannedPointerInput {
     },
 }
 
+impl PlannedPointerInput {
+    fn is_inside_window(&self, window: (u32, u32)) -> bool {
+        let inside =
+            |(x, y): (i32, i32)| x >= 0 && y >= 0 && (x as u32) < window.0 && (y as u32) < window.1;
+        match self {
+            Self::Click { point } => inside(*point),
+            Self::TrailingToggle { segment, .. } => {
+                inside((segment.from_x, segment.from_y)) && inside((segment.to_x, segment.to_y))
+            }
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 struct PointerCandidate {
     element: ElementInfo,
     target: AxTarget,
     plan: PlannedPointerInput,
+    window: (u32, u32),
 }
 
 #[derive(Debug)]
 struct PointerResolutionObservation {
     resolution: ResolutionObservation,
     candidate: Option<PointerCandidate>,
+    actionability: Option<ActionabilityReport>,
     stable: bool,
 }
 
@@ -521,24 +536,25 @@ fn pointer_plan(
 ) -> Option<PlannedPointerInput> {
     const ROW_ASPECT: u32 = 4;
     let bounds = element.bounds?;
-    if element.states.checkable
+    let plan = if element.states.checkable
         && trailing_toggle_backend
         && bounds.width > bounds.height.saturating_mul(ROW_ASPECT)
     {
         let segment = bounds.trailing_toggle_swipe(window.0, window.1)?;
         let probe_point = (
-            (segment.from_x + segment.to_x) / 2,
-            (segment.from_y + segment.to_y) / 2,
+            segment.from_x + (segment.to_x - segment.from_x) / 2,
+            segment.from_y + (segment.to_y - segment.from_y) / 2,
         );
-        Some(PlannedPointerInput::TrailingToggle {
+        PlannedPointerInput::TrailingToggle {
             segment,
             probe_point,
-        })
+        }
     } else {
-        Some(PlannedPointerInput::Click {
+        PlannedPointerInput::Click {
             point: bounds.clamped_center(window.0, window.1)?,
-        })
-    }
+        }
+    };
+    plan.is_inside_window(window).then_some(plan)
 }
 
 fn ax_target(element: &ElementInfo) -> AxTarget {
@@ -782,19 +798,16 @@ impl Glass {
             SEMANTIC_ACTION_CANDIDATE_LIMIT,
         )
         .expect("the fixed candidate limit is valid");
-        let (window, trailing_toggle_backend) = {
+        let trailing_toggle_backend = {
             let active = self
                 .active
                 .as_ref()
                 .ok_or_else(|| source_error(GlassError::NoActiveSession, bound))?;
-            (
-                (active.geometry.width, active.geometry.height),
-                active.platform.a11y_toggle_control_at_trailing_edge(),
-            )
+            active.platform.a11y_toggle_control_at_trailing_edge()
         };
         let mut sample: Option<StabilitySample> = None;
         let poll = self
-            .poll_accessibility_until_by_deadline(
+            .poll_accessibility_until_by_deadline_with_window(
                 SEMANTIC_ACTION_STABILITY_MS,
                 std::time::Duration::from_millis(SEMANTIC_ACTION_STABILITY_MS),
                 bound.deadline,
@@ -802,7 +815,7 @@ impl Glass {
                 bound.allow_wait,
                 sequence_deadline,
                 "stabilize semantic pointer target",
-                |tree| {
+                |tree, window| {
                     let result = tree.semantic_query(&query);
                     let complete_unique = matches!(
                         result.scope,
@@ -810,26 +823,37 @@ impl Glass {
                     ) && result.matches_in_walk == 1
                         && result.search_complete
                         && result.matches.len() == 1;
-                    let candidate = complete_unique
-                        .then(|| {
-                            let element = result.matches[0].element.clone();
-                            let plan = pointer_plan(&element, window, trailing_toggle_backend)?;
-                            let report = ActionabilityReport::evaluate_click(
-                                &element,
-                                coverage,
-                                Some(true),
-                                window,
-                                crate::PointerHit::Inconclusive,
-                                false,
-                                true,
-                            );
-                            report.blocking().is_none().then(|| PointerCandidate {
+                    let mut actionability = None;
+                    let candidate = if complete_unique {
+                        let element = result.matches[0].element.clone();
+                        let plan = pointer_plan(&element, window, trailing_toggle_backend);
+                        let mut report = ActionabilityReport::evaluate_click(
+                            &element,
+                            coverage,
+                            None,
+                            window,
+                            crate::PointerHit::Inconclusive,
+                            false,
+                            true,
+                        );
+                        if plan.is_none() {
+                            report.fail_in_window();
+                        }
+                        let candidate = if report.blocking().is_none() {
+                            plan.map(|plan| PointerCandidate {
                                 target: ax_target(&element),
                                 element,
                                 plan,
+                                window,
                             })
-                        })
-                        .flatten();
+                        } else {
+                            None
+                        };
+                        actionability = Some(report);
+                        candidate
+                    } else {
+                        None
+                    };
                     let now = std::time::Instant::now();
                     let mut stable = false;
                     if let Some(candidate) = &candidate {
@@ -858,6 +882,15 @@ impl Glass {
                                 });
                             }
                         }
+                        actionability = Some(ActionabilityReport::evaluate_click(
+                            &candidate.element,
+                            coverage,
+                            Some(stable),
+                            candidate.window,
+                            crate::PointerHit::Inconclusive,
+                            false,
+                            true,
+                        ));
                     } else {
                         sample = None;
                     }
@@ -867,6 +900,7 @@ impl Glass {
                             eligible: candidate.is_some(),
                         },
                         candidate,
+                        actionability,
                         stable,
                     }
                 },
@@ -879,32 +913,23 @@ impl Glass {
             poll.timed_out_by,
         );
         if !poll.satisfied {
-            if let Some(candidate) = poll.observation.candidate {
-                let actionability = ActionabilityReport::evaluate_click(
-                    &candidate.element,
-                    coverage,
-                    Some(false),
-                    window,
-                    crate::PointerHit::Inconclusive,
-                    false,
-                    true,
-                );
+            if poll.observation.candidate.is_some() {
                 return Err(actionability_error(
                     SemanticActionFailureKind::UnstableTarget,
                     "semantic pointer target did not remain stable",
                     Some(report),
-                    actionability,
+                    poll.observation
+                        .actionability
+                        .expect("a pointer candidate has an actionability report"),
                     bound,
                     RetryGuidance::WaitOrRefine,
                     None,
                     DispatchStatus::NotDispatched,
                 ));
             }
-            return Err(classified_resolution_error(
-                poll.observation.resolution,
-                report,
-                bound,
-            ));
+            let mut error = classified_resolution_error(poll.observation.resolution, report, bound);
+            error.actionability = poll.observation.actionability.unwrap_or_default();
+            return Err(error);
         }
         Ok(ResolvedPointerTarget {
             candidate: poll
@@ -928,6 +953,14 @@ impl Glass {
             limits: active.a11y_limits,
             deadline,
         })
+    }
+
+    fn refresh_action_window(&mut self, deadline: Deadline) -> Result<(u32, u32)> {
+        let active = self.active_mut()?;
+        let window = active.platform.window_by(&WindowOp::Geometry, deadline)?;
+        let dimensions = (window.width, window.height);
+        active.geometry = window;
+        Ok(dimensions)
     }
 
     fn invoke_semantic_target(
@@ -1034,13 +1067,50 @@ impl Glass {
         resolved: ResolvedPointerTarget,
         native_fallback: Option<String>,
     ) -> std::result::Result<SemanticActionOutcome, SemanticActionError> {
-        let window = {
-            let active = self
-                .active
-                .as_ref()
-                .ok_or_else(|| source_error(GlassError::NoActiveSession, resolved.bound))?;
-            (active.geometry.width, active.geometry.height)
-        };
+        let sample_actionability = ActionabilityReport::evaluate_click(
+            &resolved.candidate.element,
+            resolved.coverage,
+            Some(true),
+            resolved.candidate.window,
+            crate::PointerHit::Inconclusive,
+            false,
+            true,
+        );
+        let window = self
+            .refresh_action_window(resolved.bound.deadline)
+            .map_err(|source| {
+                action_source_error(
+                    source,
+                    Some(resolved.resolution.clone()),
+                    sample_actionability,
+                    resolved.bound,
+                    false,
+                )
+            })?;
+        let mut actionability = ActionabilityReport::evaluate_click(
+            &resolved.candidate.element,
+            resolved.coverage,
+            Some(true),
+            window,
+            crate::PointerHit::Inconclusive,
+            false,
+            true,
+        );
+        if !resolved.candidate.plan.is_inside_window(window) {
+            actionability.fail_in_window();
+        }
+        if actionability.blocking().is_some() {
+            return Err(actionability_error(
+                SemanticActionFailureKind::NotActionable,
+                "semantic pointer target is not actionable",
+                Some(resolved.resolution),
+                actionability,
+                resolved.bound,
+                RetryGuidance::Reobserve,
+                None,
+                DispatchStatus::NotDispatched,
+            ));
+        }
         let probe_point = match &resolved.candidate.plan {
             PlannedPointerInput::Click { point } => *point,
             PlannedPointerInput::TrailingToggle { probe_point, .. } => *probe_point,
@@ -1055,20 +1125,12 @@ impl Glass {
                 action_source_error(
                     source,
                     Some(resolved.resolution.clone()),
-                    ActionabilityReport::evaluate_click(
-                        &resolved.candidate.element,
-                        resolved.coverage,
-                        Some(true),
-                        window,
-                        crate::PointerHit::Inconclusive,
-                        false,
-                        true,
-                    ),
+                    actionability.clone(),
                     resolved.bound,
                     false,
                 )
             })?;
-        let actionability = ActionabilityReport::evaluate_click(
+        actionability = ActionabilityReport::evaluate_click(
             &resolved.candidate.element,
             resolved.coverage,
             Some(true),
@@ -1306,7 +1368,7 @@ impl Glass {
                     self.dispatch_pointer_click(resolved, None)
                 }
                 ActionMode::Auto => {
-                    let window = self
+                    let eligibility_window = self
                         .active
                         .as_ref()
                         .map(|active| (active.geometry.width, active.geometry.height))
@@ -1321,7 +1383,7 @@ impl Glass {
                                 element,
                                 coverage,
                                 None,
-                                window,
+                                eligibility_window,
                                 crate::PointerHit::Inconclusive,
                                 false,
                                 false,
@@ -1330,6 +1392,11 @@ impl Glass {
                             .is_none()
                         },
                     )?;
+                    let window = self
+                        .active
+                        .as_ref()
+                        .map(|active| (active.geometry.width, active.geometry.height))
+                        .ok_or_else(|| source_error(GlassError::NoActiveSession, bound))?;
                     match self.invoke_semantic_target(&resolved.target, bound.deadline) {
                         Ok(actuated) => {
                             let mut actionability = ActionabilityReport::evaluate_click(

--- a/crates/glass-core/src/session/semantic_action.rs
+++ b/crates/glass-core/src/session/semantic_action.rs
@@ -651,6 +651,184 @@ fn set_value_actionability(
     report
 }
 
+fn targeted_type_eligibility(
+    element: &ElementInfo,
+    coverage: AxStateCoverage,
+) -> ActionabilityVerdict {
+    if matches!(element.role, AxRole::TextField | AxRole::TextArea)
+        || (coverage.editable && element.states.editable)
+    {
+        ActionabilityVerdict::Passed
+    } else if coverage.editable {
+        ActionabilityVerdict::Failed
+    } else {
+        ActionabilityVerdict::Unproven
+    }
+}
+
+fn targeted_type_actionability(
+    element: &ElementInfo,
+    coverage: AxStateCoverage,
+    stable: Option<bool>,
+    window: (u32, u32),
+    pointer: bool,
+) -> ActionabilityReport {
+    let mut report = ActionabilityReport::evaluate_click(
+        element,
+        coverage,
+        stable,
+        window,
+        crate::PointerHit::Inconclusive,
+        false,
+        pointer,
+    );
+    insert_targeted_type_eligibility(&mut report, element, coverage);
+    report
+}
+
+fn insert_targeted_type_eligibility(
+    report: &mut ActionabilityReport,
+    element: &ElementInfo,
+    coverage: AxStateCoverage,
+) {
+    let insert_at = report
+        .checks
+        .iter()
+        .position(|check| check.name == ActionabilityCheckName::Stable)
+        .unwrap_or(report.checks.len());
+    report.checks.insert(
+        insert_at,
+        ActionabilityCheck::new(
+            ActionabilityCheckName::FocusEligible,
+            targeted_type_eligibility(element, coverage),
+            true,
+            ActionabilitySource::NormalizedState,
+        ),
+    );
+}
+
+fn record_focus_confirmation(
+    report: &mut ActionabilityReport,
+    coverage: AxStateCoverage,
+    confirmed: bool,
+) {
+    let verdict = if !coverage.focused {
+        ActionabilityVerdict::Unproven
+    } else if confirmed {
+        ActionabilityVerdict::Passed
+    } else {
+        ActionabilityVerdict::Failed
+    };
+    report.push(ActionabilityCheck::new(
+        ActionabilityCheckName::Focused,
+        verdict,
+        true,
+        ActionabilitySource::ConfirmationPoll,
+    ));
+}
+
+#[derive(Debug)]
+struct ConfirmedFocus {
+    element: ElementInfo,
+    resolution: ResolutionReport,
+    actionability: ActionabilityReport,
+    focus: MutationReport,
+    bound: ActionDeadline,
+}
+
+fn focus_dispatch(source: &GlassError, dispatch_started: bool) -> DispatchStatus {
+    if !dispatch_started
+        || source.invoke_fallback_eligible()
+        || source.bound_dispatch() == Some(crate::BoundDispatch::NotDispatched)
+        || matches!(
+            source.cause(),
+            GlassError::NoActiveSession
+                | GlassError::NoAxSnapshot
+                | GlassError::AxElementNotFound(_)
+                | GlassError::AxElementNotClickable(_)
+                | GlassError::AxElementInUnmappedPopover(_)
+                | GlassError::WindowNotFound
+        )
+    {
+        DispatchStatus::NotDispatched
+    } else {
+        DispatchStatus::MayHaveDispatched
+    }
+}
+
+fn focus_source_error(
+    source: GlassError,
+    resolution: Option<ResolutionReport>,
+    actionability: ActionabilityReport,
+    method: ActionMethod,
+    bound: ActionDeadline,
+    dispatch_started: bool,
+) -> SemanticActionError {
+    let dispatch = focus_dispatch(&source, dispatch_started);
+    let mut error = source_error(source, bound);
+    error.summary = "semantic target focus failed";
+    error.resolution = resolution;
+    error.actionability = actionability;
+    error.focus = Some(MutationReport {
+        method,
+        dispatch,
+        confirmation: ConfirmationStatus::Unconfirmed,
+    });
+    error.action_dispatch = DispatchStatus::NotDispatched;
+    if dispatch != DispatchStatus::NotDispatched {
+        error.retry = RetryGuidance::DoNotRetry;
+    }
+    error
+}
+
+fn focus_unconfirmed_error(
+    source: Option<GlassError>,
+    resolution: ResolutionReport,
+    mut actionability: ActionabilityReport,
+    coverage: AxStateCoverage,
+    method: ActionMethod,
+    bound: ActionDeadline,
+) -> SemanticActionError {
+    record_focus_confirmation(&mut actionability, coverage, false);
+    let mut error = actionability_error(
+        SemanticActionFailureKind::FocusUnconfirmed,
+        "semantic target focus could not be confirmed",
+        Some(resolution),
+        actionability,
+        bound,
+        RetryGuidance::Reobserve,
+        source,
+        DispatchStatus::NotDispatched,
+    );
+    error.focus = Some(MutationReport {
+        method,
+        dispatch: DispatchStatus::Dispatched,
+        confirmation: ConfirmationStatus::Unconfirmed,
+    });
+    error
+}
+
+fn key_source_error(source: GlassError, focused: ConfirmedFocus) -> SemanticActionError {
+    let proven_not_dispatched =
+        source.bound_dispatch() == Some(crate::BoundDispatch::NotDispatched);
+    let mut error = source_error(source, focused.bound);
+    error.summary = "semantic targeted typing failed";
+    error.resolution = Some(focused.resolution);
+    error.actionability = focused.actionability;
+    error.focus = Some(focused.focus);
+    error.action_dispatch = if proven_not_dispatched {
+        DispatchStatus::NotDispatched
+    } else {
+        DispatchStatus::MayHaveDispatched
+    };
+    error.retry = if proven_not_dispatched {
+        RetryGuidance::SafeToRetry
+    } else {
+        RetryGuidance::DoNotRetry
+    };
+    error
+}
+
 fn actionability_error(
     kind: SemanticActionFailureKind,
     summary: &'static str,
@@ -1745,6 +1923,359 @@ impl Glass {
                 text,
                 dispatch,
                 confirmation,
+            },
+            crate::audit::AuditOutcome::from_result(&result),
+            started.elapsed(),
+        );
+        result
+    }
+
+    fn confirm_focused_target(
+        &mut self,
+        target: &AxTarget,
+        deadline: ActionDeadline,
+    ) -> std::result::Result<ElementInfo, SemanticActionError> {
+        let coverage = self
+            .active
+            .as_ref()
+            .and_then(|active| active.accessibility.as_ref())
+            .map_or(AxStateCoverage::NONE, |reader| reader.state_coverage());
+        let observe = |tree: &crate::AxTree| {
+            if !coverage.focused {
+                return None;
+            }
+            match target.relocate(tree) {
+                crate::accessibility::Located::AtId(node)
+                | crate::accessibility::Located::Moved(node)
+                    if node.states.focused =>
+                {
+                    Some(ElementInfo::from_node(node))
+                }
+                _ => None,
+            }
+        };
+        if !deadline.allow_wait {
+            let tree = self
+                .a11y_resnapshot_for_wait(deadline.deadline)
+                .map_err(|source| source_error(source, deadline))?;
+            return observe(&tree).ok_or_else(|| {
+                empty_error(
+                    SemanticActionFailureKind::FocusUnconfirmed,
+                    "semantic target focus could not be confirmed",
+                    deadline,
+                    RetryGuidance::Reobserve,
+                    None,
+                )
+            });
+        }
+        let poll = self
+            .poll_accessibility_until_by_deadline(
+                SEMANTIC_ACTION_STABILITY_MS,
+                std::time::Duration::from_secs(1),
+                deadline.deadline,
+                deadline.owner.unwrap_or(Whose::Callee),
+                true,
+                Deadline::UNBOUNDED,
+                "confirm semantic target focus",
+                observe,
+                Option::is_some,
+            )
+            .map_err(|source| source_error(source, deadline))?;
+        if poll.satisfied {
+            Ok(poll
+                .observation
+                .expect("a satisfied focus confirmation observed a focused target"))
+        } else {
+            Err(empty_error(
+                SemanticActionFailureKind::FocusUnconfirmed,
+                "semantic target focus could not be confirmed",
+                deadline,
+                RetryGuidance::Reobserve,
+                None,
+            ))
+        }
+    }
+
+    fn focus_target_native_once(
+        &mut self,
+        params: &TypeTargetParams,
+        sequence_deadline: Deadline,
+        bound: ActionDeadline,
+    ) -> std::result::Result<ConfirmedFocus, SemanticActionError> {
+        let window = self
+            .active
+            .as_ref()
+            .map(|active| (active.geometry.width, active.geometry.height))
+            .unwrap_or_default();
+        let coverage = self
+            .active
+            .as_ref()
+            .and_then(|active| active.accessibility.as_ref())
+            .map_or(AxStateCoverage::NONE, |reader| reader.state_coverage());
+        let resolved = self
+            .resolve_semantic_target_by_bound(
+                &params.target,
+                params.max_nodes,
+                sequence_deadline,
+                bound,
+                |element, coverage| {
+                    targeted_type_eligibility(element, coverage) == ActionabilityVerdict::Passed
+                        && targeted_type_actionability(element, coverage, None, window, false)
+                            .blocking()
+                            .is_none()
+                },
+            )
+            .map_err(|mut error| {
+                if error.kind == SemanticActionFailureKind::NotActionable
+                    && let Some(element) = error
+                        .candidates
+                        .first()
+                        .map(|candidate| candidate.element.clone())
+                {
+                    error.actionability =
+                        targeted_type_actionability(&element, coverage, None, window, false);
+                }
+                error
+            })?;
+        let mut actionability =
+            targeted_type_actionability(&resolved.element, resolved.coverage, None, window, false);
+        let actuated = self
+            .try_native_focus(resolved.element.id, resolved.bound.deadline)
+            .map_err(|source| {
+                focus_source_error(
+                    source,
+                    Some(resolved.resolution.clone()),
+                    actionability.clone(),
+                    ActionMethod::NativeAction { actuated: None },
+                    resolved.bound,
+                    true,
+                )
+            })?;
+        actionability.pass_backend_fingerprint();
+        let method = ActionMethod::NativeAction { actuated };
+        let confirmed = self
+            .confirm_focused_target(&resolved.target, resolved.bound)
+            .map_err(|error| {
+                focus_unconfirmed_error(
+                    error.source,
+                    resolved.resolution.clone(),
+                    actionability.clone(),
+                    resolved.coverage,
+                    method.clone(),
+                    resolved.bound,
+                )
+            })?;
+        record_focus_confirmation(&mut actionability, resolved.coverage, true);
+        Ok(ConfirmedFocus {
+            element: confirmed,
+            resolution: resolved.resolution,
+            actionability,
+            focus: MutationReport {
+                method,
+                dispatch: DispatchStatus::Dispatched,
+                confirmation: ConfirmationStatus::FocusConfirmed,
+            },
+            bound: resolved.bound,
+        })
+    }
+
+    fn focus_target_pointer_once(
+        &mut self,
+        params: &TypeTargetParams,
+        sequence_deadline: Deadline,
+        bound: ActionDeadline,
+        native_fallback: Option<String>,
+    ) -> std::result::Result<ConfirmedFocus, SemanticActionError> {
+        let resolved = self.resolve_stable_pointer_target(
+            &params.target,
+            params.max_nodes,
+            sequence_deadline,
+            bound,
+        )?;
+        let mut pre_dispatch = targeted_type_actionability(
+            &resolved.candidate.element,
+            resolved.coverage,
+            Some(true),
+            resolved.candidate.window,
+            true,
+        );
+        if pre_dispatch.blocking().is_some() {
+            return Err(actionability_error(
+                SemanticActionFailureKind::NotActionable,
+                "semantic target is not eligible for targeted typing",
+                Some(resolved.resolution),
+                pre_dispatch,
+                resolved.bound,
+                RetryGuidance::Reobserve,
+                None,
+                DispatchStatus::NotDispatched,
+            ));
+        }
+        let target = resolved.candidate.target.clone();
+        let element = resolved.candidate.element.clone();
+        let coverage = resolved.coverage;
+        let method = ActionMethod::Pointer {
+            native_fallback: native_fallback.clone(),
+        };
+        let focused = self
+            .dispatch_pointer_click(resolved, native_fallback)
+            .map_err(|mut error| {
+                let focus_dispatch = error.action_dispatch;
+                insert_targeted_type_eligibility(&mut error.actionability, &element, coverage);
+                error.focus = Some(MutationReport {
+                    method: method.clone(),
+                    dispatch: focus_dispatch,
+                    confirmation: ConfirmationStatus::Unconfirmed,
+                });
+                error.action_dispatch = DispatchStatus::NotDispatched;
+                if focus_dispatch != DispatchStatus::NotDispatched {
+                    error.retry = RetryGuidance::DoNotRetry;
+                }
+                error
+            })?;
+        pre_dispatch = focused.actionability;
+        insert_targeted_type_eligibility(&mut pre_dispatch, &focused.target, coverage);
+        let confirmed = self
+            .confirm_focused_target(&target, focused.bound)
+            .map_err(|error| {
+                focus_unconfirmed_error(
+                    error.source,
+                    focused
+                        .resolution
+                        .clone()
+                        .expect("semantic pointer focus has a resolution report"),
+                    pre_dispatch.clone(),
+                    coverage,
+                    method.clone(),
+                    focused.bound,
+                )
+            })?;
+        record_focus_confirmation(&mut pre_dispatch, coverage, true);
+        Ok(ConfirmedFocus {
+            element: confirmed,
+            resolution: focused
+                .resolution
+                .expect("semantic pointer focus has a resolution report"),
+            actionability: pre_dispatch,
+            focus: MutationReport {
+                method,
+                dispatch: DispatchStatus::Dispatched,
+                confirmation: ConfirmationStatus::FocusConfirmed,
+            },
+            bound: focused.bound,
+        })
+    }
+
+    fn type_target_inner(
+        &mut self,
+        params: &TypeTargetParams,
+        text: &str,
+        sequence_deadline: Deadline,
+    ) -> std::result::Result<SemanticActionOutcome, SemanticActionError> {
+        let bound = target_deadline(
+            &ActionTarget::Semantic(params.target.clone()),
+            Some(params.timeout_ms),
+            params.max_nodes,
+            sequence_deadline,
+        )?;
+        let focused = match params.focus_mode {
+            ActionMode::Native => self.focus_target_native_once(params, sequence_deadline, bound),
+            ActionMode::Pointer => {
+                self.focus_target_pointer_once(params, sequence_deadline, bound, None)
+            }
+            ActionMode::Auto => {
+                match self.focus_target_native_once(params, sequence_deadline, bound) {
+                    Ok(focused) => Ok(focused),
+                    Err(error) if error.proves_pre_dispatch_native_unavailable() => {
+                        let reason = error.safe_fallback_reason();
+                        self.focus_target_pointer_once(
+                            params,
+                            sequence_deadline,
+                            bound,
+                            Some(reason),
+                        )
+                    }
+                    Err(error) => Err(error),
+                }
+            }
+        }?;
+        if let Err(source) =
+            self.key_inner_by(&KeyEvent::Text(text.to_owned()), focused.bound.deadline)
+        {
+            return Err(key_source_error(source, focused));
+        }
+        Ok(SemanticActionOutcome {
+            target: focused.element,
+            resolution: Some(focused.resolution),
+            actionability: focused.actionability,
+            focus: Some(focused.focus),
+            action: MutationReport {
+                method: ActionMethod::Keyboard,
+                dispatch: DispatchStatus::Dispatched,
+                confirmation: ConfirmationStatus::DispatchConfirmed,
+            },
+            bound: focused.bound,
+        })
+    }
+
+    pub fn type_target(
+        &mut self,
+        params: &TypeTargetParams,
+        text: &str,
+    ) -> std::result::Result<SemanticActionOutcome, SemanticActionError> {
+        self.type_target_by(params, text, Deadline::UNBOUNDED)
+    }
+
+    pub fn type_target_by(
+        &mut self,
+        params: &TypeTargetParams,
+        text: &str,
+        sequence_deadline: Deadline,
+    ) -> std::result::Result<SemanticActionOutcome, SemanticActionError> {
+        let started = std::time::Instant::now();
+        let result = self.type_target_inner(params, text, sequence_deadline);
+        let element = match &result {
+            Ok(outcome) => crate::audit::ElementRef {
+                id: outcome.target.id.0,
+                role: Some(format!("{:?}", outcome.target.role)),
+                name: outcome.target.name.clone(),
+            },
+            Err(error) => error
+                .candidates
+                .first()
+                .map(|candidate| crate::audit::ElementRef {
+                    id: candidate.element.id.0,
+                    role: Some(format!("{:?}", candidate.element.role)),
+                    name: candidate.element.name.clone(),
+                })
+                .unwrap_or_else(|| crate::audit::ElementRef {
+                    id: 0,
+                    role: params.target.target.role().map(|role| format!("{role:?}")),
+                    name: params.target.target.query().map(str::to_owned),
+                }),
+        };
+        let focus = match &result {
+            Ok(outcome) => outcome.focus.as_ref(),
+            Err(error) => error.focus.as_ref(),
+        };
+        let focus_method = focus.map(|report| report.method.as_str());
+        let focus_dispatch = focus.map_or(DispatchStatus::NotDispatched, |report| report.dispatch);
+        let focus_confirmation = focus.map_or(ConfirmationStatus::Unconfirmed, |report| {
+            report.confirmation
+        });
+        let type_dispatch = match &result {
+            Ok(outcome) => outcome.action.dispatch,
+            Err(error) => error.action_dispatch,
+        };
+        self.emit_audit(
+            &crate::audit::Actuation::TypeTarget {
+                element,
+                text,
+                focus_mode: params.focus_mode.as_str(),
+                focus_method,
+                focus_dispatch: focus_dispatch.as_str(),
+                focus_confirmation: focus_confirmation.as_str(),
+                type_dispatch: type_dispatch.as_str(),
             },
             crate::audit::AuditOutcome::from_result(&result),
             started.elapsed(),

--- a/crates/glass-core/src/session/semantic_action.rs
+++ b/crates/glass-core/src/session/semantic_action.rs
@@ -465,38 +465,22 @@ impl Glass {
         sequence_deadline: Deadline,
         eligibility: impl Fn(&ElementInfo, AxStateCoverage) -> bool,
     ) -> std::result::Result<ResolvedSemanticTarget, SemanticActionError> {
-        let coverage = {
-            let active = self.active_mut().map_err(|source| {
-                source_error(
-                    source,
-                    ActionDeadline {
-                        deadline: sequence_deadline,
-                        owner: sequence_deadline.instant().map(|_| Whose::Caller),
-                        allow_wait: timeout_ms > 0,
-                    },
-                )
-            })?;
-            active
-                .accessibility
-                .as_ref()
-                .ok_or_else(|| {
-                    source_error(
-                        GlassError::AxUnsupported,
-                        ActionDeadline {
-                            deadline: sequence_deadline,
-                            owner: sequence_deadline.instant().map(|_| Whose::Caller),
-                            allow_wait: timeout_ms > 0,
-                        },
-                    )
-                })?
-                .state_coverage()
-        };
         let bound = target_deadline(
             &ActionTarget::Semantic(target.clone()),
             Some(timeout_ms),
             max_nodes,
             sequence_deadline,
         )?;
+        let coverage = {
+            let active = self
+                .active_mut()
+                .map_err(|source| source_error(source, bound))?;
+            active
+                .accessibility
+                .as_ref()
+                .ok_or_else(|| source_error(GlassError::AxUnsupported, bound))?
+                .state_coverage()
+        };
         if !target.uncovered_states(coverage).is_empty() {
             return Err(empty_error(
                 SemanticActionFailureKind::UnprovenSelectorState,
@@ -515,9 +499,12 @@ impl Glass {
         )
         .expect("the fixed candidate limit is valid");
         let poll = self
-            .poll_accessibility_until(
+            .poll_accessibility_until_by_deadline(
                 SEMANTIC_ACTION_STABILITY_MS,
-                timeout_ms,
+                std::time::Duration::from_secs(1),
+                bound.deadline,
+                bound.owner.unwrap_or(Whose::Callee),
+                bound.allow_wait,
                 sequence_deadline,
                 "resolve semantic action target",
                 |tree| {

--- a/crates/glass-core/src/session/semantic_action.rs
+++ b/crates/glass-core/src/session/semantic_action.rs
@@ -228,6 +228,8 @@ pub struct SemanticActionError {
     pub source: Option<GlassError>,
 }
 
+type SemanticActionResult<T> = std::result::Result<T, Box<SemanticActionError>>;
+
 impl std::fmt::Display for SemanticActionError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter.write_str(self.summary)
@@ -237,7 +239,7 @@ impl std::fmt::Display for SemanticActionError {
 impl std::error::Error for SemanticActionError {}
 
 impl SemanticActionError {
-    fn with_target(mut self, target: ElementInfo) -> Self {
+    fn with_target(mut self: Box<Self>, target: ElementInfo) -> Box<Self> {
         self.target = Some(Box::new(target));
         self
     }
@@ -381,8 +383,8 @@ fn empty_error(
     bound: ActionDeadline,
     retry: RetryGuidance,
     source: Option<GlassError>,
-) -> SemanticActionError {
-    SemanticActionError {
+) -> Box<SemanticActionError> {
+    Box::new(SemanticActionError {
         kind,
         summary,
         resolution: None,
@@ -394,10 +396,10 @@ fn empty_error(
         bound,
         retry,
         source,
-    }
+    })
 }
 
-fn request_error(summary: &'static str, sequence_deadline: Deadline) -> SemanticActionError {
+fn request_error(summary: &'static str, sequence_deadline: Deadline) -> Box<SemanticActionError> {
     empty_error(
         SemanticActionFailureKind::UnsupportedMode,
         summary,
@@ -416,7 +418,7 @@ fn target_deadline(
     timeout_ms: Option<u64>,
     max_nodes: Option<usize>,
     sequence_deadline: Deadline,
-) -> std::result::Result<ActionDeadline, SemanticActionError> {
+) -> SemanticActionResult<ActionDeadline> {
     let now = std::time::Instant::now();
     match source {
         ActionTarget::Id(_) => {
@@ -487,7 +489,7 @@ fn classified_resolution_error(
     observation: ResolutionObservation,
     report: ResolutionReport,
     bound: ActionDeadline,
-) -> SemanticActionError {
+) -> Box<SemanticActionError> {
     let (kind, summary, retry) =
         if matches!(observation.result.scope, ScopeResolution::Ambiguous { .. }) {
             (
@@ -521,7 +523,7 @@ fn classified_resolution_error(
                 RetryGuidance::Reobserve,
             )
         };
-    SemanticActionError {
+    Box::new(SemanticActionError {
         kind,
         summary,
         resolution: Some(report),
@@ -533,10 +535,10 @@ fn classified_resolution_error(
         bound,
         retry,
         source: None,
-    }
+    })
 }
 
-fn source_error(source: GlassError, bound: ActionDeadline) -> SemanticActionError {
+fn source_error(source: GlassError, bound: ActionDeadline) -> Box<SemanticActionError> {
     let owner = source.bound_owner().or_else(|| {
         matches!(&source, GlassError::AccessibilityNotReady(_))
             .then_some(bound.owner)
@@ -773,7 +775,7 @@ fn focus_source_error(
     method: ActionMethod,
     bound: ActionDeadline,
     dispatch_started: bool,
-) -> SemanticActionError {
+) -> Box<SemanticActionError> {
     let dispatch = focus_dispatch(&source, dispatch_started);
     let mut error = source_error(source, bound);
     error.summary = "semantic target focus failed";
@@ -800,11 +802,13 @@ fn focus_unconfirmed_error(
     coverage: AxStateCoverage,
     method: ActionMethod,
     bound: ActionDeadline,
-) -> SemanticActionError {
+) -> Box<SemanticActionError> {
     record_focus_confirmation(&mut actionability, coverage, false);
     let mut error = actionability_error(
-        SemanticActionFailureKind::FocusUnconfirmed,
-        "semantic target focus could not be confirmed",
+        FailureSummary {
+            kind: SemanticActionFailureKind::FocusUnconfirmed,
+            summary: "semantic target focus could not be confirmed",
+        },
         Some(resolution),
         actionability,
         bound,
@@ -821,7 +825,7 @@ fn focus_unconfirmed_error(
     error
 }
 
-fn key_source_error(source: GlassError, focused: ConfirmedFocus) -> SemanticActionError {
+fn key_source_error(source: GlassError, focused: ConfirmedFocus) -> Box<SemanticActionError> {
     let proven_not_dispatched =
         source.bound_dispatch() == Some(crate::BoundDispatch::NotDispatched);
     let mut error = source_error(source, focused.bound);
@@ -844,19 +848,23 @@ fn key_source_error(source: GlassError, focused: ConfirmedFocus) -> SemanticActi
     error
 }
 
-fn actionability_error(
+struct FailureSummary {
     kind: SemanticActionFailureKind,
     summary: &'static str,
+}
+
+fn actionability_error(
+    failure: FailureSummary,
     resolution: Option<ResolutionReport>,
     actionability: ActionabilityReport,
     bound: ActionDeadline,
     retry: RetryGuidance,
     source: Option<GlassError>,
     dispatch: DispatchStatus,
-) -> SemanticActionError {
-    SemanticActionError {
-        kind,
-        summary,
+) -> Box<SemanticActionError> {
+    Box::new(SemanticActionError {
+        kind: failure.kind,
+        summary: failure.summary,
         resolution,
         actionability,
         focus: None,
@@ -866,7 +874,7 @@ fn actionability_error(
         bound,
         retry,
         source,
-    }
+    })
 }
 
 fn action_source_error(
@@ -876,7 +884,7 @@ fn action_source_error(
     actionability: ActionabilityReport,
     bound: ActionDeadline,
     dispatch_started: bool,
-) -> SemanticActionError {
+) -> Box<SemanticActionError> {
     let proves_not_dispatched = !dispatch_started
         || source.invoke_fallback_eligible()
         || source.bound_dispatch() == Some(crate::BoundDispatch::NotDispatched)
@@ -922,7 +930,7 @@ fn set_value_source_error(
     resolution: Option<ResolutionReport>,
     actionability: ActionabilityReport,
     bound: ActionDeadline,
-) -> SemanticActionError {
+) -> Box<SemanticActionError> {
     let possible_dispatch = source.set_value_failed_after_writing()
         || source.bound_dispatch() == Some(crate::BoundDispatch::MayHaveDispatched);
     let cause = source.cause();
@@ -989,7 +997,7 @@ impl Glass {
         timeout_ms: u64,
         sequence_deadline: Deadline,
         eligibility: impl Fn(&ElementInfo, AxStateCoverage) -> bool,
-    ) -> std::result::Result<ResolvedSemanticTarget, SemanticActionError> {
+    ) -> SemanticActionResult<ResolvedSemanticTarget> {
         let bound = target_deadline(
             &ActionTarget::Semantic(target.clone()),
             Some(timeout_ms),
@@ -1012,7 +1020,7 @@ impl Glass {
         sequence_deadline: Deadline,
         bound: ActionDeadline,
         eligibility: impl Fn(&ElementInfo, AxStateCoverage) -> bool,
-    ) -> std::result::Result<ResolvedSemanticTarget, SemanticActionError> {
+    ) -> SemanticActionResult<ResolvedSemanticTarget> {
         let coverage = {
             let active = self
                 .active_mut()
@@ -1042,12 +1050,16 @@ impl Glass {
         .expect("the fixed candidate limit is valid");
         let poll = self
             .poll_accessibility_until_by_deadline(
-                SEMANTIC_ACTION_STABILITY_MS,
-                std::time::Duration::from_secs(1),
-                bound.deadline,
-                bound.owner.unwrap_or(Whose::Callee),
-                bound.allow_wait,
-                sequence_deadline,
+                a11y_poll::A11yPollCadence {
+                    interval_ms: SEMANTIC_ACTION_STABILITY_MS,
+                    reread_after: std::time::Duration::from_secs(1),
+                },
+                a11y_poll::A11yPollBound {
+                    action_deadline: bound.deadline,
+                    whose: bound.owner.unwrap_or(Whose::Callee),
+                    allow_wait: bound.allow_wait,
+                    sequence_deadline,
+                },
                 "resolve semantic action target",
                 |tree| {
                     let result = tree.semantic_query(&query);
@@ -1105,7 +1117,7 @@ impl Glass {
         max_nodes: Option<usize>,
         sequence_deadline: Deadline,
         bound: ActionDeadline,
-    ) -> std::result::Result<ResolvedPointerTarget, SemanticActionError> {
+    ) -> SemanticActionResult<ResolvedPointerTarget> {
         let coverage = {
             let active = self
                 .active_mut()
@@ -1143,12 +1155,16 @@ impl Glass {
         let mut sample: Option<StabilitySample> = None;
         let poll = self
             .poll_accessibility_until_by_deadline_with_window(
-                SEMANTIC_ACTION_STABILITY_MS,
-                std::time::Duration::from_millis(SEMANTIC_ACTION_STABILITY_MS),
-                bound.deadline,
-                bound.owner.unwrap_or(Whose::Callee),
-                bound.allow_wait,
-                sequence_deadline,
+                a11y_poll::A11yPollCadence {
+                    interval_ms: SEMANTIC_ACTION_STABILITY_MS,
+                    reread_after: std::time::Duration::from_millis(SEMANTIC_ACTION_STABILITY_MS),
+                },
+                a11y_poll::A11yPollBound {
+                    action_deadline: bound.deadline,
+                    whose: bound.owner.unwrap_or(Whose::Callee),
+                    allow_wait: bound.allow_wait,
+                    sequence_deadline,
+                },
                 "stabilize semantic pointer target",
                 |tree, window| {
                     let result = tree.semantic_query(&query);
@@ -1251,8 +1267,10 @@ impl Glass {
             if let Some(candidate) = &poll.observation.candidate {
                 let target = candidate.element.clone();
                 return Err(actionability_error(
-                    SemanticActionFailureKind::UnstableTarget,
-                    "semantic pointer target did not remain stable",
+                    FailureSummary {
+                        kind: SemanticActionFailureKind::UnstableTarget,
+                        summary: "semantic pointer target did not remain stable",
+                    },
                     Some(report),
                     poll.observation
                         .actionability
@@ -1323,7 +1341,7 @@ impl Glass {
     fn dispatch_native_click(
         &mut self,
         resolved: ResolvedSemanticTarget,
-    ) -> std::result::Result<SemanticActionOutcome, SemanticActionError> {
+    ) -> SemanticActionResult<SemanticActionOutcome> {
         let window = {
             let active = self.active.as_ref().ok_or_else(|| {
                 let mut error = source_error(GlassError::NoActiveSession, resolved.bound);
@@ -1344,8 +1362,10 @@ impl Glass {
         );
         if actionability.blocking().is_some() {
             return Err(actionability_error(
-                SemanticActionFailureKind::NotActionable,
-                "semantic target is not actionable",
+                FailureSummary {
+                    kind: SemanticActionFailureKind::NotActionable,
+                    summary: "semantic target is not actionable",
+                },
                 Some(resolved.resolution),
                 actionability,
                 resolved.bound,
@@ -1386,7 +1406,7 @@ impl Glass {
         &mut self,
         resolved: ResolvedPointerTarget,
         native_fallback: Option<String>,
-    ) -> std::result::Result<SemanticActionOutcome, SemanticActionError> {
+    ) -> SemanticActionResult<SemanticActionOutcome> {
         let sample_actionability = ActionabilityReport::evaluate_click(
             &resolved.candidate.element,
             resolved.coverage,
@@ -1422,8 +1442,10 @@ impl Glass {
         }
         if actionability.blocking().is_some() {
             return Err(actionability_error(
-                SemanticActionFailureKind::NotActionable,
-                "semantic pointer target is not actionable",
+                FailureSummary {
+                    kind: SemanticActionFailureKind::NotActionable,
+                    summary: "semantic pointer target is not actionable",
+                },
                 Some(resolved.resolution),
                 actionability,
                 resolved.bound,
@@ -1464,8 +1486,10 @@ impl Glass {
         );
         if actionability.blocking().is_some() {
             return Err(actionability_error(
-                SemanticActionFailureKind::NotActionable,
-                "semantic pointer target is not actionable",
+                FailureSummary {
+                    kind: SemanticActionFailureKind::NotActionable,
+                    summary: "semantic pointer target is not actionable",
+                },
                 Some(resolved.resolution),
                 actionability,
                 resolved.bound,
@@ -1579,7 +1603,7 @@ impl Glass {
         max_nodes: Option<usize>,
         sequence_deadline: Deadline,
         bound: ActionDeadline,
-    ) -> std::result::Result<SemanticActionOutcome, SemanticActionError> {
+    ) -> SemanticActionResult<SemanticActionOutcome> {
         match target {
             ActionTarget::Id(id) => {
                 let actionability = self.legacy_click_actionability(*id, false);
@@ -1632,7 +1656,7 @@ impl Glass {
         sequence_deadline: Deadline,
         bound: ActionDeadline,
         native_fallback: Option<String>,
-    ) -> std::result::Result<SemanticActionOutcome, SemanticActionError> {
+    ) -> SemanticActionResult<SemanticActionOutcome> {
         match target {
             ActionTarget::Id(id) => {
                 let actionability = self.legacy_click_actionability(*id, true);
@@ -1662,7 +1686,7 @@ impl Glass {
     pub fn click_target(
         &mut self,
         params: &ClickTargetParams,
-    ) -> std::result::Result<SemanticActionOutcome, SemanticActionError> {
+    ) -> SemanticActionResult<SemanticActionOutcome> {
         self.click_target_by(params, Deadline::UNBOUNDED)
     }
 
@@ -1670,7 +1694,7 @@ impl Glass {
         &mut self,
         params: &ClickTargetParams,
         sequence_deadline: Deadline,
-    ) -> std::result::Result<SemanticActionOutcome, SemanticActionError> {
+    ) -> SemanticActionResult<SemanticActionOutcome> {
         let started = std::time::Instant::now();
         let result = self.click_target_inner(params.clone(), sequence_deadline);
         let element = match &result {
@@ -1736,7 +1760,7 @@ impl Glass {
         &mut self,
         params: ClickTargetParams,
         sequence_deadline: Deadline,
-    ) -> std::result::Result<SemanticActionOutcome, SemanticActionError> {
+    ) -> SemanticActionResult<SemanticActionOutcome> {
         let bound = target_deadline(
             &params.target,
             params.timeout_ms,
@@ -1799,7 +1823,7 @@ impl Glass {
         text: &str,
         sequence_deadline: Deadline,
         bound: ActionDeadline,
-    ) -> std::result::Result<SemanticActionOutcome, SemanticActionError> {
+    ) -> SemanticActionResult<SemanticActionOutcome> {
         let (element, resolution, coverage, window, legacy_id, execution) = match &params.target {
             ActionTarget::Id(id) => {
                 let before = self.legacy_set_value_snapshot(*id);
@@ -1906,7 +1930,7 @@ impl Glass {
         &mut self,
         params: &SetValueTargetParams,
         text: &str,
-    ) -> std::result::Result<SemanticActionOutcome, SemanticActionError> {
+    ) -> SemanticActionResult<SemanticActionOutcome> {
         self.set_value_target_by(params, text, Deadline::UNBOUNDED)
     }
 
@@ -1915,7 +1939,7 @@ impl Glass {
         params: &SetValueTargetParams,
         text: &str,
         sequence_deadline: Deadline,
-    ) -> std::result::Result<SemanticActionOutcome, SemanticActionError> {
+    ) -> SemanticActionResult<SemanticActionOutcome> {
         let started = std::time::Instant::now();
         let result = match target_deadline(
             &params.target,
@@ -1968,7 +1992,7 @@ impl Glass {
         &mut self,
         target: &AxTarget,
         deadline: ActionDeadline,
-    ) -> std::result::Result<ElementInfo, SemanticActionError> {
+    ) -> SemanticActionResult<ElementInfo> {
         let coverage = self
             .active
             .as_ref()
@@ -2004,12 +2028,16 @@ impl Glass {
         }
         let poll = self
             .poll_accessibility_until_by_deadline(
-                SEMANTIC_ACTION_STABILITY_MS,
-                std::time::Duration::from_secs(1),
-                deadline.deadline,
-                deadline.owner.unwrap_or(Whose::Callee),
-                true,
-                Deadline::UNBOUNDED,
+                a11y_poll::A11yPollCadence {
+                    interval_ms: SEMANTIC_ACTION_STABILITY_MS,
+                    reread_after: std::time::Duration::from_secs(1),
+                },
+                a11y_poll::A11yPollBound {
+                    action_deadline: deadline.deadline,
+                    whose: deadline.owner.unwrap_or(Whose::Callee),
+                    allow_wait: true,
+                    sequence_deadline: Deadline::UNBOUNDED,
+                },
                 "confirm semantic target focus",
                 observe,
                 Option::is_some,
@@ -2055,7 +2083,7 @@ impl Glass {
         params: &TypeTargetParams,
         sequence_deadline: Deadline,
         bound: ActionDeadline,
-    ) -> std::result::Result<ConfirmedFocus, SemanticActionError> {
+    ) -> SemanticActionResult<ConfirmedFocus> {
         let window = self
             .active
             .as_ref()
@@ -2154,7 +2182,7 @@ impl Glass {
         sequence_deadline: Deadline,
         bound: ActionDeadline,
         native_fallback: Option<String>,
-    ) -> std::result::Result<ConfirmedFocus, SemanticActionError> {
+    ) -> SemanticActionResult<ConfirmedFocus> {
         let resolved = self.resolve_stable_pointer_target(
             &params.target,
             params.max_nodes,
@@ -2170,8 +2198,10 @@ impl Glass {
         );
         if pre_dispatch.blocking().is_some() {
             return Err(actionability_error(
-                SemanticActionFailureKind::NotActionable,
-                "semantic target is not eligible for targeted typing",
+                FailureSummary {
+                    kind: SemanticActionFailureKind::NotActionable,
+                    summary: "semantic target is not eligible for targeted typing",
+                },
                 Some(resolved.resolution),
                 pre_dispatch,
                 resolved.bound,
@@ -2242,7 +2272,7 @@ impl Glass {
         params: &TypeTargetParams,
         text: &str,
         sequence_deadline: Deadline,
-    ) -> std::result::Result<SemanticActionOutcome, SemanticActionError> {
+    ) -> SemanticActionResult<SemanticActionOutcome> {
         let bound = target_deadline(
             &ActionTarget::Semantic(params.target.clone()),
             Some(params.timeout_ms),
@@ -2293,7 +2323,7 @@ impl Glass {
         &mut self,
         params: &TypeTargetParams,
         text: &str,
-    ) -> std::result::Result<SemanticActionOutcome, SemanticActionError> {
+    ) -> SemanticActionResult<SemanticActionOutcome> {
         self.type_target_by(params, text, Deadline::UNBOUNDED)
     }
 
@@ -2302,7 +2332,7 @@ impl Glass {
         params: &TypeTargetParams,
         text: &str,
         sequence_deadline: Deadline,
-    ) -> std::result::Result<SemanticActionOutcome, SemanticActionError> {
+    ) -> SemanticActionResult<SemanticActionOutcome> {
         let started = std::time::Instant::now();
         let result = self.type_target_inner(params, text, sequence_deadline);
         let element = match &result {

--- a/crates/glass-core/src/session/semantic_action.rs
+++ b/crates/glass-core/src/session/semantic_action.rs
@@ -1,8 +1,10 @@
 #![allow(dead_code)]
 
+use super::a11y::SetValueExecution;
 use super::*;
 use crate::{
-    ActionabilityReport, AxStateCoverage, ScopeResolution, SemanticMatch, SemanticQuery,
+    ActionabilityCheck, ActionabilityCheckName, ActionabilityReport, ActionabilitySource,
+    ActionabilityVerdict, AxStateCoverage, ScopeResolution, SemanticMatch, SemanticQuery,
     SemanticQueryResult, SemanticSelector, SemanticState, Whose,
 };
 
@@ -590,6 +592,75 @@ fn ax_target(element: &ElementInfo) -> AxTarget {
     }
 }
 
+fn role_supports_set_value(element: &ElementInfo) -> bool {
+    element.states.editable
+        || element.states.checkable
+        || matches!(
+            element.role,
+            AxRole::ComboBox
+                | AxRole::Slider
+                | AxRole::SpinButton
+                | AxRole::ToggleButton
+                | AxRole::CheckBox
+                | AxRole::RadioButton
+        )
+}
+
+fn set_value_eligibility(element: &ElementInfo, coverage: AxStateCoverage) -> ActionabilityVerdict {
+    if matches!(
+        element.role,
+        AxRole::ComboBox
+            | AxRole::Slider
+            | AxRole::SpinButton
+            | AxRole::ToggleButton
+            | AxRole::RadioButton
+            | AxRole::CheckBox
+    ) || (coverage.editable && element.states.editable)
+        || (coverage.checkable && element.states.checkable)
+    {
+        ActionabilityVerdict::Passed
+    } else if coverage.editable && coverage.checkable {
+        ActionabilityVerdict::Failed
+    } else {
+        ActionabilityVerdict::Unproven
+    }
+}
+
+fn set_value_actionability(
+    element: &ElementInfo,
+    coverage: AxStateCoverage,
+    window: (u32, u32),
+    legacy_id: bool,
+) -> ActionabilityReport {
+    let mut report = ActionabilityReport::evaluate_click(
+        element,
+        coverage,
+        None,
+        window,
+        crate::PointerHit::Inconclusive,
+        legacy_id,
+        false,
+    );
+    let source = if legacy_id {
+        ActionabilitySource::LegacyCache
+    } else {
+        ActionabilitySource::NormalizedState
+    };
+    let check = ActionabilityCheck::new(
+        ActionabilityCheckName::FocusEligible,
+        set_value_eligibility(element, coverage),
+        !legacy_id,
+        source,
+    );
+    let insert_at = report
+        .checks
+        .iter()
+        .position(|existing| existing.name == ActionabilityCheckName::Stable)
+        .unwrap_or(report.checks.len());
+    report.checks.insert(insert_at, check);
+    report
+}
+
 fn actionability_error(
     kind: SemanticActionFailureKind,
     summary: &'static str,
@@ -656,6 +727,61 @@ fn action_source_error(
     if dispatch_started && error.action_dispatch != DispatchStatus::NotDispatched {
         error.retry = RetryGuidance::DoNotRetry;
     }
+    error
+}
+
+fn set_value_source_error(
+    source: GlassError,
+    resolution: Option<ResolutionReport>,
+    actionability: ActionabilityReport,
+    bound: ActionDeadline,
+) -> SemanticActionError {
+    let possible_dispatch = source.set_value_failed_after_writing()
+        || source.bound_dispatch() == Some(crate::BoundDispatch::MayHaveDispatched);
+    let cause = source.cause();
+    let proven_pre_dispatch = source.bound_dispatch() == Some(crate::BoundDispatch::NotDispatched)
+        || matches!(
+            cause,
+            GlassError::NoActiveSession
+                | GlassError::NoAxSnapshot
+                | GlassError::AxUnsupported
+                | GlassError::AxElementChanged(_)
+                | GlassError::AxElementGone(_)
+                | GlassError::AxElementNotFound(_)
+                | GlassError::AxElementNotEditable(_)
+                | GlassError::AxValueNotBoolean(_, _)
+        );
+    let retry = if possible_dispatch || !proven_pre_dispatch {
+        RetryGuidance::DoNotRetry
+    } else if matches!(
+        cause,
+        GlassError::NoActiveSession
+            | GlassError::NoAxSnapshot
+            | GlassError::AxElementChanged(_)
+            | GlassError::AxElementGone(_)
+            | GlassError::AxElementNotFound(_)
+    ) {
+        RetryGuidance::Reobserve
+    } else if matches!(
+        cause,
+        GlassError::AxUnsupported
+            | GlassError::AxElementNotEditable(_)
+            | GlassError::AxValueNotBoolean(_, _)
+    ) {
+        RetryGuidance::CorrectRequest
+    } else {
+        RetryGuidance::SafeToRetry
+    };
+    let mut error = source_error(source, bound);
+    error.summary = "semantic set-value action failed";
+    error.resolution = resolution;
+    error.actionability = actionability;
+    error.action_dispatch = if possible_dispatch || !proven_pre_dispatch {
+        DispatchStatus::MayHaveDispatched
+    } else {
+        DispatchStatus::NotDispatched
+    };
+    error.retry = retry;
     error
 }
 
@@ -1449,6 +1575,189 @@ impl Glass {
                 Err(error) => Err(error),
             },
         }
+    }
+
+    fn legacy_set_value_snapshot(
+        &self,
+        id: AxNodeId,
+    ) -> Option<(ElementInfo, AxStateCoverage, (u32, u32))> {
+        let active = self.active.as_ref()?;
+        let node = active.last_ax.as_ref()?.find(id)?;
+        let coverage = active
+            .accessibility
+            .as_ref()
+            .map_or(AxStateCoverage::NONE, |reader| reader.state_coverage());
+        Some((
+            ElementInfo::from_node(node),
+            coverage,
+            (active.geometry.width, active.geometry.height),
+        ))
+    }
+
+    fn set_value_once(
+        &mut self,
+        params: &SetValueTargetParams,
+        text: &str,
+        sequence_deadline: Deadline,
+        bound: ActionDeadline,
+    ) -> std::result::Result<SemanticActionOutcome, SemanticActionError> {
+        let (element, resolution, coverage, window, legacy_id, execution) = match &params.target {
+            ActionTarget::Id(id) => {
+                let before = self.legacy_set_value_snapshot(*id);
+                let actionability = before
+                    .as_ref()
+                    .map(|(element, coverage, window)| {
+                        set_value_actionability(element, *coverage, *window, true)
+                    })
+                    .unwrap_or_default();
+                let execution = self
+                    .set_value_inner(*id, text, bound.deadline)
+                    .map_err(|source| set_value_source_error(source, None, actionability, bound))?;
+                let (element, coverage, window) = self
+                    .legacy_set_value_snapshot(*id)
+                    .or(before)
+                    .expect("a successful ID set-value retained its cached target");
+                (element, None, coverage, window, true, execution)
+            }
+            ActionTarget::Semantic(target) => {
+                let (window, coverage) = self
+                    .active
+                    .as_ref()
+                    .map(|active| {
+                        (
+                            (active.geometry.width, active.geometry.height),
+                            active
+                                .accessibility
+                                .as_ref()
+                                .map_or(AxStateCoverage::NONE, |reader| reader.state_coverage()),
+                        )
+                    })
+                    .unwrap_or_default();
+                let resolved = self
+                    .resolve_semantic_target_by_bound(
+                        target,
+                        params.max_nodes,
+                        sequence_deadline,
+                        bound,
+                        |element, coverage| {
+                            role_supports_set_value(element)
+                                && set_value_actionability(element, coverage, window, false)
+                                    .blocking()
+                                    .is_none()
+                        },
+                    )
+                    .map_err(|mut error| {
+                        if error.kind == SemanticActionFailureKind::NotActionable {
+                            let element = error
+                                .candidates
+                                .first()
+                                .map(|candidate| candidate.element.clone());
+                            if let Some(element) = element {
+                                error.actionability =
+                                    set_value_actionability(&element, coverage, window, false);
+                            }
+                        }
+                        error
+                    })?;
+                let actionability =
+                    set_value_actionability(&resolved.element, resolved.coverage, window, false);
+                let execution = self
+                    .set_value_inner(resolved.element.id, text, resolved.bound.deadline)
+                    .map_err(|source| {
+                        set_value_source_error(
+                            source,
+                            Some(resolved.resolution.clone()),
+                            actionability,
+                            resolved.bound,
+                        )
+                    })?;
+                (
+                    resolved.element,
+                    Some(resolved.resolution),
+                    resolved.coverage,
+                    window,
+                    false,
+                    execution,
+                )
+            }
+        };
+        let mut actionability = set_value_actionability(&element, coverage, window, legacy_id);
+        actionability.pass_backend_fingerprint();
+        Ok(SemanticActionOutcome {
+            target: element,
+            resolution,
+            actionability,
+            focus: None,
+            action: MutationReport {
+                method: ActionMethod::AccessibilityValue,
+                dispatch: match execution {
+                    SetValueExecution::AlreadyApplied => DispatchStatus::NotDispatched,
+                    SetValueExecution::DispatchedAndConfirmed => DispatchStatus::Dispatched,
+                },
+                confirmation: ConfirmationStatus::ValueConfirmed,
+            },
+            bound,
+        })
+    }
+
+    pub fn set_value_target(
+        &mut self,
+        params: &SetValueTargetParams,
+        text: &str,
+    ) -> std::result::Result<SemanticActionOutcome, SemanticActionError> {
+        self.set_value_target_by(params, text, Deadline::UNBOUNDED)
+    }
+
+    pub fn set_value_target_by(
+        &mut self,
+        params: &SetValueTargetParams,
+        text: &str,
+        sequence_deadline: Deadline,
+    ) -> std::result::Result<SemanticActionOutcome, SemanticActionError> {
+        let started = std::time::Instant::now();
+        let result = target_deadline(
+            &params.target,
+            params.timeout_ms,
+            params.max_nodes,
+            sequence_deadline,
+        )
+        .and_then(|bound| self.set_value_once(params, text, sequence_deadline, bound));
+        let element = match &result {
+            Ok(outcome) => crate::audit::ElementRef {
+                id: outcome.target.id.0,
+                role: Some(format!("{:?}", outcome.target.role)),
+                name: outcome.target.name.clone(),
+            },
+            Err(_) => match &params.target {
+                ActionTarget::Id(id) => self.element_ref(*id),
+                ActionTarget::Semantic(target) => crate::audit::ElementRef {
+                    id: 0,
+                    role: target.target.role().map(|role| format!("{role:?}")),
+                    name: target.target.query().map(str::to_owned),
+                },
+            },
+        };
+        let (dispatch, confirmation) = match &result {
+            Ok(outcome) => (
+                outcome.action.dispatch.as_str(),
+                outcome.action.confirmation.as_str(),
+            ),
+            Err(error) => (
+                error.action_dispatch.as_str(),
+                ConfirmationStatus::Unconfirmed.as_str(),
+            ),
+        };
+        self.emit_audit(
+            &crate::audit::Actuation::SetValue {
+                element,
+                text,
+                dispatch,
+                confirmation,
+            },
+            crate::audit::AuditOutcome::from_result(&result),
+            started.elapsed(),
+        );
+        result
     }
 }
 

--- a/crates/glass-core/src/session/semantic_action.rs
+++ b/crates/glass-core/src/session/semantic_action.rs
@@ -221,6 +221,8 @@ pub struct SemanticActionError {
     pub focus: Option<MutationReport>,
     pub action_dispatch: DispatchStatus,
     pub candidates: Vec<SemanticMatch>,
+    /// The resolved element for failures that occur after unique target resolution.
+    pub target: Option<Box<ElementInfo>>,
     pub bound: ActionDeadline,
     pub retry: RetryGuidance,
     pub source: Option<GlassError>,
@@ -235,6 +237,11 @@ impl std::fmt::Display for SemanticActionError {
 impl std::error::Error for SemanticActionError {}
 
 impl SemanticActionError {
+    fn with_target(mut self, target: ElementInfo) -> Self {
+        self.target = Some(Box::new(target));
+        self
+    }
+
     fn proves_pre_dispatch_native_unavailable(&self) -> bool {
         self.action_dispatch == DispatchStatus::NotDispatched
             && self
@@ -383,6 +390,7 @@ fn empty_error(
         focus: None,
         action_dispatch: DispatchStatus::NotDispatched,
         candidates: Vec::new(),
+        target: None,
         bound,
         retry,
         source,
@@ -521,6 +529,7 @@ fn classified_resolution_error(
         focus: None,
         action_dispatch: DispatchStatus::NotDispatched,
         candidates: observation.result.matches,
+        target: None,
         bound,
         retry,
         source: None,
@@ -758,6 +767,7 @@ fn focus_dispatch(source: &GlassError, dispatch_started: bool) -> DispatchStatus
 
 fn focus_source_error(
     source: GlassError,
+    target: ElementInfo,
     resolution: Option<ResolutionReport>,
     actionability: ActionabilityReport,
     method: ActionMethod,
@@ -767,6 +777,7 @@ fn focus_source_error(
     let dispatch = focus_dispatch(&source, dispatch_started);
     let mut error = source_error(source, bound);
     error.summary = "semantic target focus failed";
+    error.target = Some(Box::new(target));
     error.resolution = resolution;
     error.actionability = actionability;
     error.focus = Some(MutationReport {
@@ -783,6 +794,7 @@ fn focus_source_error(
 
 fn focus_unconfirmed_error(
     source: Option<GlassError>,
+    target: ElementInfo,
     resolution: ResolutionReport,
     mut actionability: ActionabilityReport,
     coverage: AxStateCoverage,
@@ -799,7 +811,8 @@ fn focus_unconfirmed_error(
         RetryGuidance::Reobserve,
         source,
         DispatchStatus::NotDispatched,
-    );
+    )
+    .with_target(target);
     error.focus = Some(MutationReport {
         method,
         dispatch: DispatchStatus::Dispatched,
@@ -813,6 +826,7 @@ fn key_source_error(source: GlassError, focused: ConfirmedFocus) -> SemanticActi
         source.bound_dispatch() == Some(crate::BoundDispatch::NotDispatched);
     let mut error = source_error(source, focused.bound);
     error.summary = "semantic targeted typing failed";
+    error.target = Some(Box::new(focused.element.clone()));
     error.resolution = Some(focused.resolution);
     error.actionability = focused.actionability;
     error.focus = Some(focused.focus);
@@ -848,6 +862,7 @@ fn actionability_error(
         focus: None,
         action_dispatch: dispatch,
         candidates: Vec::new(),
+        target: None,
         bound,
         retry,
         source,
@@ -856,6 +871,7 @@ fn actionability_error(
 
 fn action_source_error(
     source: GlassError,
+    target: Option<ElementInfo>,
     resolution: Option<ResolutionReport>,
     actionability: ActionabilityReport,
     bound: ActionDeadline,
@@ -874,6 +890,7 @@ fn action_source_error(
         );
     let mut error = source_error(source, bound);
     error.summary = "semantic action failed";
+    error.target = target.map(Box::new);
     error.resolution = resolution;
     error.actionability = actionability;
     error.action_dispatch = if proves_not_dispatched {
@@ -901,6 +918,7 @@ fn action_source_error(
 
 fn set_value_source_error(
     source: GlassError,
+    target: Option<ElementInfo>,
     resolution: Option<ResolutionReport>,
     actionability: ActionabilityReport,
     bound: ActionDeadline,
@@ -943,6 +961,7 @@ fn set_value_source_error(
     };
     let mut error = source_error(source, bound);
     error.summary = "semantic set-value action failed";
+    error.target = target.map(Box::new);
     error.resolution = resolution;
     error.actionability = actionability;
     error.action_dispatch = if possible_dispatch || !proven_pre_dispatch {
@@ -1229,7 +1248,8 @@ impl Glass {
             poll.timed_out_by,
         );
         if !poll.satisfied {
-            if poll.observation.candidate.is_some() {
+            if let Some(candidate) = &poll.observation.candidate {
+                let target = candidate.element.clone();
                 return Err(actionability_error(
                     SemanticActionFailureKind::UnstableTarget,
                     "semantic pointer target did not remain stable",
@@ -1241,7 +1261,8 @@ impl Glass {
                     RetryGuidance::WaitOrRefine,
                     None,
                     DispatchStatus::NotDispatched,
-                ));
+                )
+                .with_target(target));
             }
             let mut error = classified_resolution_error(poll.observation.resolution, report, bound);
             error.actionability = poll.observation.actionability.unwrap_or_default();
@@ -1304,10 +1325,12 @@ impl Glass {
         resolved: ResolvedSemanticTarget,
     ) -> std::result::Result<SemanticActionOutcome, SemanticActionError> {
         let window = {
-            let active = self
-                .active
-                .as_ref()
-                .ok_or_else(|| source_error(GlassError::NoActiveSession, resolved.bound))?;
+            let active = self.active.as_ref().ok_or_else(|| {
+                let mut error = source_error(GlassError::NoActiveSession, resolved.bound);
+                error.target = Some(Box::new(resolved.element.clone()));
+                error.resolution = Some(resolved.resolution.clone());
+                error
+            })?;
             (active.geometry.width, active.geometry.height)
         };
         let mut actionability = ActionabilityReport::evaluate_click(
@@ -1329,13 +1352,15 @@ impl Glass {
                 RetryGuidance::Reobserve,
                 None,
                 DispatchStatus::NotDispatched,
-            ));
+            )
+            .with_target(resolved.element.clone()));
         }
         let actuated = self
             .try_native_invoke(resolved.element.id, resolved.bound.deadline)
             .map_err(|source| {
                 action_source_error(
                     source,
+                    Some(resolved.element.clone()),
                     Some(resolved.resolution.clone()),
                     actionability.clone(),
                     resolved.bound,
@@ -1376,6 +1401,7 @@ impl Glass {
             .map_err(|source| {
                 action_source_error(
                     source,
+                    Some(resolved.candidate.element.clone()),
                     Some(resolved.resolution.clone()),
                     sample_actionability,
                     resolved.bound,
@@ -1404,7 +1430,8 @@ impl Glass {
                 RetryGuidance::Reobserve,
                 None,
                 DispatchStatus::NotDispatched,
-            ));
+            )
+            .with_target(resolved.candidate.element.clone()));
         }
         let probe_point = match &resolved.candidate.plan {
             PlannedPointerInput::Click { point } => *point,
@@ -1419,6 +1446,7 @@ impl Glass {
             .map_err(|source| {
                 action_source_error(
                     source,
+                    Some(resolved.candidate.element.clone()),
                     Some(resolved.resolution.clone()),
                     actionability.clone(),
                     resolved.bound,
@@ -1444,7 +1472,8 @@ impl Glass {
                 RetryGuidance::Reobserve,
                 None,
                 DispatchStatus::NotDispatched,
-            ));
+            )
+            .with_target(resolved.candidate.element.clone()));
         }
         self.click_element_pointer_only(
             resolved.candidate.element.id,
@@ -1454,6 +1483,7 @@ impl Glass {
         .map_err(|source| {
             action_source_error(
                 source,
+                Some(resolved.candidate.element.clone()),
                 Some(resolved.resolution.clone()),
                 actionability.clone(),
                 resolved.bound,
@@ -1556,7 +1586,7 @@ impl Glass {
                 let actuated = self
                     .try_native_invoke(*id, bound.deadline)
                     .map_err(|source| {
-                        action_source_error(source, None, actionability, bound, true)
+                        action_source_error(source, None, None, actionability, bound, true)
                     })?;
                 Ok(self.legacy_click_outcome(
                     *id,
@@ -1608,7 +1638,7 @@ impl Glass {
                 let actionability = self.legacy_click_actionability(*id, true);
                 self.click_element_pointer_only(*id, None, bound.deadline)
                     .map_err(|source| {
-                        action_source_error(source, None, actionability, bound, true)
+                        action_source_error(source, None, None, actionability, bound, true)
                     })?;
                 Ok(self.legacy_click_outcome(
                     *id,
@@ -1779,9 +1809,11 @@ impl Glass {
                         set_value_actionability(element, *coverage, *window, true)
                     })
                     .unwrap_or_default();
-                let execution = self
-                    .set_value_inner(*id, text, bound.deadline)
-                    .map_err(|source| set_value_source_error(source, None, actionability, bound))?;
+                let execution =
+                    self.set_value_inner(*id, text, bound.deadline)
+                        .map_err(|source| {
+                            set_value_source_error(source, None, None, actionability, bound)
+                        })?;
                 let (element, coverage, window) = self
                     .legacy_set_value_snapshot(*id)
                     .or(before)
@@ -1835,6 +1867,7 @@ impl Glass {
                     .map_err(|source| {
                         set_value_source_error(
                             source,
+                            Some(resolved.element.clone()),
                             Some(resolved.resolution.clone()),
                             actionability,
                             resolved.bound,
@@ -2065,6 +2098,7 @@ impl Glass {
             .map_err(|source| {
                 focus_source_error(
                     source,
+                    resolved.element.clone(),
                     Some(resolved.resolution.clone()),
                     actionability.clone(),
                     ActionMethod::NativeAction { actuated: None },
@@ -2079,6 +2113,7 @@ impl Glass {
             .map_err(|source| {
                 focus_unconfirmed_error(
                     Some(source),
+                    resolved.element.clone(),
                     resolved.resolution.clone(),
                     actionability.clone(),
                     resolved.coverage,
@@ -2091,6 +2126,7 @@ impl Glass {
             .map_err(|error| {
                 focus_unconfirmed_error(
                     error.source,
+                    resolved.element.clone(),
                     resolved.resolution.clone(),
                     actionability.clone(),
                     resolved.coverage,
@@ -2142,7 +2178,8 @@ impl Glass {
                 RetryGuidance::Reobserve,
                 None,
                 DispatchStatus::NotDispatched,
-            ));
+            )
+            .with_target(resolved.candidate.element.clone()));
         }
         let target = resolved.candidate.target.clone();
         let element = resolved.candidate.element.clone();
@@ -2173,6 +2210,7 @@ impl Glass {
             .map_err(|error| {
                 focus_unconfirmed_error(
                     error.source,
+                    focused.target.clone(),
                     focused
                         .resolution
                         .clone()

--- a/crates/glass-core/src/session/semantic_action.rs
+++ b/crates/glass-core/src/session/semantic_action.rs
@@ -270,6 +270,64 @@ struct ResolutionObservation {
     eligible: bool,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct SemanticIdentity {
+    role: AxRole,
+    name: Option<String>,
+    description: Option<String>,
+}
+
+impl From<&ElementInfo> for SemanticIdentity {
+    fn from(element: &ElementInfo) -> Self {
+        Self {
+            role: element.role,
+            name: element.name.clone(),
+            description: element.description.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct StabilitySample {
+    observed_at: std::time::Instant,
+    identity: SemanticIdentity,
+    bounds: AxRect,
+    pointer: PlannedPointerInput,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum PlannedPointerInput {
+    Click {
+        point: (i32, i32),
+    },
+    TrailingToggle {
+        segment: crate::Segment,
+        probe_point: (i32, i32),
+    },
+}
+
+#[derive(Clone, Debug)]
+struct PointerCandidate {
+    element: ElementInfo,
+    target: AxTarget,
+    plan: PlannedPointerInput,
+}
+
+#[derive(Debug)]
+struct PointerResolutionObservation {
+    resolution: ResolutionObservation,
+    candidate: Option<PointerCandidate>,
+    stable: bool,
+}
+
+#[derive(Debug)]
+struct ResolvedPointerTarget {
+    candidate: PointerCandidate,
+    resolution: ResolutionReport,
+    coverage: AxStateCoverage,
+    bound: ActionDeadline,
+}
+
 fn empty_error(
     kind: SemanticActionFailureKind,
     summary: &'static str,
@@ -456,6 +514,122 @@ fn source_error(source: GlassError, bound: ActionDeadline) -> SemanticActionErro
     )
 }
 
+fn pointer_plan(
+    element: &ElementInfo,
+    window: (u32, u32),
+    trailing_toggle_backend: bool,
+) -> Option<PlannedPointerInput> {
+    const ROW_ASPECT: u32 = 4;
+    let bounds = element.bounds?;
+    if element.states.checkable
+        && trailing_toggle_backend
+        && bounds.width > bounds.height.saturating_mul(ROW_ASPECT)
+    {
+        let segment = bounds.trailing_toggle_swipe(window.0, window.1)?;
+        let probe_point = (
+            (segment.from_x + segment.to_x) / 2,
+            (segment.from_y + segment.to_y) / 2,
+        );
+        Some(PlannedPointerInput::TrailingToggle {
+            segment,
+            probe_point,
+        })
+    } else {
+        Some(PlannedPointerInput::Click {
+            point: bounds.clamped_center(window.0, window.1)?,
+        })
+    }
+}
+
+fn ax_target(element: &ElementInfo) -> AxTarget {
+    AxTarget {
+        id: element.id,
+        role: element.role,
+        name: element.name.clone(),
+        bounds: element.bounds,
+        value: element.value.clone(),
+    }
+}
+
+fn actionability_error(
+    kind: SemanticActionFailureKind,
+    summary: &'static str,
+    resolution: Option<ResolutionReport>,
+    actionability: ActionabilityReport,
+    bound: ActionDeadline,
+    retry: RetryGuidance,
+    source: Option<GlassError>,
+    dispatch: DispatchStatus,
+) -> SemanticActionError {
+    SemanticActionError {
+        kind,
+        summary,
+        resolution,
+        actionability,
+        focus: None,
+        action_dispatch: dispatch,
+        candidates: Vec::new(),
+        bound,
+        retry,
+        source,
+    }
+}
+
+fn action_source_error(
+    source: GlassError,
+    resolution: Option<ResolutionReport>,
+    actionability: ActionabilityReport,
+    bound: ActionDeadline,
+    dispatch_started: bool,
+) -> SemanticActionError {
+    let proves_not_dispatched = !dispatch_started
+        || source.invoke_fallback_eligible()
+        || source.bound_dispatch() == Some(crate::BoundDispatch::NotDispatched)
+        || matches!(
+            &source,
+            GlassError::NoAxSnapshot
+                | GlassError::AxElementNotFound(_)
+                | GlassError::AxElementNotClickable(_)
+                | GlassError::AxElementInUnmappedPopover(_)
+                | GlassError::WindowNotFound
+        );
+    let mut error = source_error(source, bound);
+    error.summary = "semantic action failed";
+    error.resolution = resolution;
+    error.actionability = actionability;
+    error.action_dispatch = if proves_not_dispatched {
+        DispatchStatus::NotDispatched
+    } else if dispatch_started {
+        error
+            .source
+            .as_ref()
+            .and_then(GlassError::bound_dispatch)
+            .map_or(
+                DispatchStatus::MayHaveDispatched,
+                |dispatch| match dispatch {
+                    crate::BoundDispatch::NotDispatched => DispatchStatus::NotDispatched,
+                    crate::BoundDispatch::MayHaveDispatched => DispatchStatus::MayHaveDispatched,
+                },
+            )
+    } else {
+        unreachable!("non-dispatching failures are classified above")
+    };
+    if dispatch_started && error.action_dispatch != DispatchStatus::NotDispatched {
+        error.retry = RetryGuidance::DoNotRetry;
+    }
+    error
+}
+
+fn native_fallback_reason(source: &GlassError) -> String {
+    match source {
+        GlassError::AxUnsupported => "native accessibility action is unsupported".into(),
+        GlassError::AxActionUnavailable(_) => {
+            "target exposes no native accessibility action".into()
+        }
+        _ => "native accessibility action did not dispatch".into(),
+    }
+}
+
 impl Glass {
     pub(super) fn resolve_semantic_target(
         &mut self,
@@ -471,6 +645,23 @@ impl Glass {
             max_nodes,
             sequence_deadline,
         )?;
+        self.resolve_semantic_target_by_bound(
+            target,
+            max_nodes,
+            sequence_deadline,
+            bound,
+            eligibility,
+        )
+    }
+
+    fn resolve_semantic_target_by_bound(
+        &mut self,
+        target: &SemanticTarget,
+        max_nodes: Option<usize>,
+        sequence_deadline: Deadline,
+        bound: ActionDeadline,
+        eligibility: impl Fn(&ElementInfo, AxStateCoverage) -> bool,
+    ) -> std::result::Result<ResolvedSemanticTarget, SemanticActionError> {
         let coverage = {
             let active = self
                 .active_mut()
@@ -555,6 +746,644 @@ impl Glass {
             coverage,
             bound,
         })
+    }
+
+    fn resolve_stable_pointer_target(
+        &mut self,
+        target: &SemanticTarget,
+        max_nodes: Option<usize>,
+        sequence_deadline: Deadline,
+        bound: ActionDeadline,
+    ) -> std::result::Result<ResolvedPointerTarget, SemanticActionError> {
+        let coverage = {
+            let active = self
+                .active_mut()
+                .map_err(|source| source_error(source, bound))?;
+            active
+                .accessibility
+                .as_ref()
+                .ok_or_else(|| source_error(GlassError::AxUnsupported, bound))?
+                .state_coverage()
+        };
+        if !target.uncovered_states(coverage).is_empty() {
+            return Err(empty_error(
+                SemanticActionFailureKind::UnprovenSelectorState,
+                "accessibility backend cannot prove a requested selector state",
+                bound,
+                RetryGuidance::CorrectRequest,
+                None,
+            ));
+        }
+        self.set_a11y_limits(max_nodes)
+            .map_err(|source| source_error(source, bound))?;
+        let query = SemanticQuery::new(
+            target.target.clone(),
+            target.within.clone(),
+            SEMANTIC_ACTION_CANDIDATE_LIMIT,
+        )
+        .expect("the fixed candidate limit is valid");
+        let (window, trailing_toggle_backend) = {
+            let active = self
+                .active
+                .as_ref()
+                .ok_or_else(|| source_error(GlassError::NoActiveSession, bound))?;
+            (
+                (active.geometry.width, active.geometry.height),
+                active.platform.a11y_toggle_control_at_trailing_edge(),
+            )
+        };
+        let mut sample: Option<StabilitySample> = None;
+        let poll = self
+            .poll_accessibility_until_by_deadline(
+                SEMANTIC_ACTION_STABILITY_MS,
+                std::time::Duration::from_millis(SEMANTIC_ACTION_STABILITY_MS),
+                bound.deadline,
+                bound.owner.unwrap_or(Whose::Callee),
+                bound.allow_wait,
+                sequence_deadline,
+                "stabilize semantic pointer target",
+                |tree| {
+                    let result = tree.semantic_query(&query);
+                    let complete_unique = matches!(
+                        result.scope,
+                        ScopeResolution::Unscoped | ScopeResolution::Resolved(_)
+                    ) && result.matches_in_walk == 1
+                        && result.search_complete
+                        && result.matches.len() == 1;
+                    let candidate = complete_unique
+                        .then(|| {
+                            let element = result.matches[0].element.clone();
+                            let plan = pointer_plan(&element, window, trailing_toggle_backend)?;
+                            let report = ActionabilityReport::evaluate_click(
+                                &element,
+                                coverage,
+                                Some(true),
+                                window,
+                                crate::PointerHit::Inconclusive,
+                                false,
+                                true,
+                            );
+                            report.blocking().is_none().then(|| PointerCandidate {
+                                target: ax_target(&element),
+                                element,
+                                plan,
+                            })
+                        })
+                        .flatten();
+                    let now = std::time::Instant::now();
+                    let mut stable = false;
+                    if let Some(candidate) = &candidate {
+                        let bounds = candidate
+                            .element
+                            .bounds
+                            .expect("a pointer candidate always has bounds");
+                        let identity = SemanticIdentity::from(&candidate.element);
+                        match &sample {
+                            Some(previous)
+                                if previous.identity == identity
+                                    && previous.bounds == bounds
+                                    && previous.pointer == candidate.plan =>
+                            {
+                                stable = now.duration_since(previous.observed_at)
+                                    >= std::time::Duration::from_millis(
+                                        SEMANTIC_ACTION_STABILITY_MS,
+                                    );
+                            }
+                            _ => {
+                                sample = Some(StabilitySample {
+                                    observed_at: now,
+                                    identity,
+                                    bounds,
+                                    pointer: candidate.plan.clone(),
+                                });
+                            }
+                        }
+                    } else {
+                        sample = None;
+                    }
+                    PointerResolutionObservation {
+                        resolution: ResolutionObservation {
+                            result,
+                            eligible: candidate.is_some(),
+                        },
+                        candidate,
+                        stable,
+                    }
+                },
+                |observation| observation.stable,
+            )
+            .map_err(|source| source_error(source, bound))?;
+        let report = resolution_report(
+            &poll.observation.resolution.result,
+            poll.elapsed_ms,
+            poll.timed_out_by,
+        );
+        if !poll.satisfied {
+            if let Some(candidate) = poll.observation.candidate {
+                let actionability = ActionabilityReport::evaluate_click(
+                    &candidate.element,
+                    coverage,
+                    Some(false),
+                    window,
+                    crate::PointerHit::Inconclusive,
+                    false,
+                    true,
+                );
+                return Err(actionability_error(
+                    SemanticActionFailureKind::UnstableTarget,
+                    "semantic pointer target did not remain stable",
+                    Some(report),
+                    actionability,
+                    bound,
+                    RetryGuidance::WaitOrRefine,
+                    None,
+                    DispatchStatus::NotDispatched,
+                ));
+            }
+            return Err(classified_resolution_error(
+                poll.observation.resolution,
+                report,
+                bound,
+            ));
+        }
+        Ok(ResolvedPointerTarget {
+            candidate: poll
+                .observation
+                .candidate
+                .expect("a satisfied stability observation has a candidate"),
+            resolution: report,
+            coverage,
+            bound,
+        })
+    }
+
+    fn accessibility_context_for_action(&mut self, deadline: Deadline) -> Result<AxContext> {
+        let active = self.active_mut()?;
+        let pids = active.platform.app_pids_by(deadline)?;
+        Ok(AxContext {
+            pids,
+            window: active.geometry.clone(),
+            window_handle: active.platform.active_window_handle(),
+            a11y_bus_addr: active.platform.a11y_bus_addr(),
+            limits: active.a11y_limits,
+            deadline,
+        })
+    }
+
+    fn invoke_semantic_target(
+        &mut self,
+        target: &AxTarget,
+        deadline: Deadline,
+    ) -> Result<Option<AxNodeId>> {
+        if deadline.has_passed() {
+            return Err(GlassError::deadline_not_started(
+                "native accessibility action",
+            ));
+        }
+        let ctx = self.accessibility_context_for_action(deadline)?;
+        let active = self.active_mut()?;
+        let actuated = active
+            .accessibility
+            .as_mut()
+            .ok_or(GlassError::AxUnsupported)?
+            .invoke(&ctx, target)?;
+        active.pump();
+        Ok(actuated)
+    }
+
+    fn probe_semantic_pointer(
+        &mut self,
+        target: &AxTarget,
+        point: (i32, i32),
+        deadline: Deadline,
+    ) -> Result<crate::PointerHit> {
+        if deadline.has_passed() {
+            return Err(GlassError::deadline_not_started("pointer hit probe"));
+        }
+        let ctx = self.accessibility_context_for_action(deadline)?;
+        let active = self.active_mut()?;
+        let hit = active
+            .accessibility
+            .as_mut()
+            .ok_or(GlassError::AxUnsupported)?
+            .pointer_target_at(&ctx, target, point)?;
+        active.pump();
+        Ok(hit)
+    }
+
+    fn dispatch_native_click(
+        &mut self,
+        resolved: ResolvedSemanticTarget,
+    ) -> std::result::Result<SemanticActionOutcome, SemanticActionError> {
+        let window = {
+            let active = self
+                .active
+                .as_ref()
+                .ok_or_else(|| source_error(GlassError::NoActiveSession, resolved.bound))?;
+            (active.geometry.width, active.geometry.height)
+        };
+        let mut actionability = ActionabilityReport::evaluate_click(
+            &resolved.element,
+            resolved.coverage,
+            None,
+            window,
+            crate::PointerHit::Inconclusive,
+            false,
+            false,
+        );
+        if actionability.blocking().is_some() {
+            return Err(actionability_error(
+                SemanticActionFailureKind::NotActionable,
+                "semantic target is not actionable",
+                Some(resolved.resolution),
+                actionability,
+                resolved.bound,
+                RetryGuidance::Reobserve,
+                None,
+                DispatchStatus::NotDispatched,
+            ));
+        }
+        let actuated = self
+            .invoke_semantic_target(&resolved.target, resolved.bound.deadline)
+            .map_err(|source| {
+                action_source_error(
+                    source,
+                    Some(resolved.resolution.clone()),
+                    actionability.clone(),
+                    resolved.bound,
+                    true,
+                )
+            })?;
+        actionability.pass_backend_fingerprint();
+        Ok(SemanticActionOutcome {
+            target: resolved.element,
+            resolution: Some(resolved.resolution),
+            actionability,
+            focus: None,
+            action: MutationReport {
+                method: ActionMethod::NativeAction { actuated },
+                dispatch: DispatchStatus::Dispatched,
+                confirmation: ConfirmationStatus::NotRequested,
+            },
+            bound: resolved.bound,
+        })
+    }
+
+    fn dispatch_pointer_click(
+        &mut self,
+        resolved: ResolvedPointerTarget,
+        native_fallback: Option<String>,
+    ) -> std::result::Result<SemanticActionOutcome, SemanticActionError> {
+        let window = {
+            let active = self
+                .active
+                .as_ref()
+                .ok_or_else(|| source_error(GlassError::NoActiveSession, resolved.bound))?;
+            (active.geometry.width, active.geometry.height)
+        };
+        let probe_point = match &resolved.candidate.plan {
+            PlannedPointerInput::Click { point } => *point,
+            PlannedPointerInput::TrailingToggle { probe_point, .. } => *probe_point,
+        };
+        let hit = self
+            .probe_semantic_pointer(
+                &resolved.candidate.target,
+                probe_point,
+                resolved.bound.deadline,
+            )
+            .map_err(|source| {
+                action_source_error(
+                    source,
+                    Some(resolved.resolution.clone()),
+                    ActionabilityReport::evaluate_click(
+                        &resolved.candidate.element,
+                        resolved.coverage,
+                        Some(true),
+                        window,
+                        crate::PointerHit::Inconclusive,
+                        false,
+                        true,
+                    ),
+                    resolved.bound,
+                    false,
+                )
+            })?;
+        let actionability = ActionabilityReport::evaluate_click(
+            &resolved.candidate.element,
+            resolved.coverage,
+            Some(true),
+            window,
+            hit,
+            false,
+            true,
+        );
+        if actionability.blocking().is_some() {
+            return Err(actionability_error(
+                SemanticActionFailureKind::NotActionable,
+                "semantic pointer target is not actionable",
+                Some(resolved.resolution),
+                actionability,
+                resolved.bound,
+                RetryGuidance::Reobserve,
+                None,
+                DispatchStatus::NotDispatched,
+            ));
+        }
+        self.click_element_pointer_only(
+            resolved.candidate.element.id,
+            Some(&resolved.candidate.plan),
+            resolved.bound.deadline,
+        )
+        .map_err(|source| {
+            action_source_error(
+                source,
+                Some(resolved.resolution.clone()),
+                actionability.clone(),
+                resolved.bound,
+                true,
+            )
+        })?;
+        Ok(SemanticActionOutcome {
+            target: resolved.candidate.element,
+            resolution: Some(resolved.resolution),
+            actionability,
+            focus: None,
+            action: MutationReport {
+                method: ActionMethod::Pointer { native_fallback },
+                dispatch: DispatchStatus::Dispatched,
+                confirmation: ConfirmationStatus::NotRequested,
+            },
+            bound: resolved.bound,
+        })
+    }
+
+    fn legacy_click_target(
+        &mut self,
+        id: AxNodeId,
+        mode: ActionMode,
+        bound: ActionDeadline,
+    ) -> std::result::Result<SemanticActionOutcome, SemanticActionError> {
+        let (element, target, coverage, window) = {
+            let active = self
+                .active
+                .as_ref()
+                .ok_or_else(|| source_error(GlassError::NoActiveSession, bound))?;
+            let tree = active
+                .last_ax
+                .as_ref()
+                .ok_or_else(|| source_error(GlassError::NoAxSnapshot, bound))?;
+            let node = tree
+                .find(id)
+                .ok_or_else(|| source_error(GlassError::AxElementNotFound(id.0), bound))?;
+            let element = ElementInfo::from_node(node);
+            let coverage = active
+                .accessibility
+                .as_ref()
+                .map_or(AxStateCoverage::NONE, |reader| reader.state_coverage());
+            (
+                element.clone(),
+                ax_target(&element),
+                coverage,
+                (active.geometry.width, active.geometry.height),
+            )
+        };
+        let (method, pointer) = match mode {
+            ActionMode::Native => {
+                let actuated = self
+                    .invoke_semantic_target(&target, bound.deadline)
+                    .map_err(|source| {
+                        action_source_error(
+                            source,
+                            None,
+                            ActionabilityReport::evaluate_click(
+                                &element,
+                                coverage,
+                                None,
+                                window,
+                                crate::PointerHit::Inconclusive,
+                                true,
+                                false,
+                            ),
+                            bound,
+                            true,
+                        )
+                    })?;
+                (ActionMethod::NativeAction { actuated }, false)
+            }
+            ActionMode::Pointer => {
+                self.click_element_pointer_only(id, None, bound.deadline)
+                    .map_err(|source| {
+                        action_source_error(
+                            source,
+                            None,
+                            ActionabilityReport::evaluate_click(
+                                &element,
+                                coverage,
+                                None,
+                                window,
+                                crate::PointerHit::Inconclusive,
+                                true,
+                                true,
+                            ),
+                            bound,
+                            true,
+                        )
+                    })?;
+                (
+                    ActionMethod::Pointer {
+                        native_fallback: None,
+                    },
+                    true,
+                )
+            }
+            ActionMode::Auto => {
+                let method = self
+                    .click_element_by(id, bound.deadline)
+                    .map_err(|source| {
+                        action_source_error(
+                            source,
+                            None,
+                            ActionabilityReport::evaluate_click(
+                                &element,
+                                coverage,
+                                None,
+                                window,
+                                crate::PointerHit::Inconclusive,
+                                true,
+                                false,
+                            ),
+                            bound,
+                            true,
+                        )
+                    })?;
+                match method {
+                    ClickMethod::NativeAction { actuated } => {
+                        (ActionMethod::NativeAction { actuated }, false)
+                    }
+                    ClickMethod::Pointer { native_fallback } => (
+                        ActionMethod::Pointer {
+                            native_fallback: Some(native_fallback),
+                        },
+                        true,
+                    ),
+                }
+            }
+        };
+        let mut actionability = ActionabilityReport::evaluate_click(
+            &element,
+            coverage,
+            None,
+            window,
+            crate::PointerHit::Inconclusive,
+            true,
+            pointer,
+        );
+        if !pointer {
+            actionability.pass_backend_fingerprint();
+        }
+        Ok(SemanticActionOutcome {
+            target: element,
+            resolution: None,
+            actionability,
+            focus: None,
+            action: MutationReport {
+                method,
+                dispatch: DispatchStatus::Dispatched,
+                confirmation: ConfirmationStatus::NotRequested,
+            },
+            bound,
+        })
+    }
+
+    pub(super) fn click_target_inner(
+        &mut self,
+        params: ClickTargetParams,
+        sequence_deadline: Deadline,
+    ) -> std::result::Result<SemanticActionOutcome, SemanticActionError> {
+        let bound = target_deadline(
+            &params.target,
+            params.timeout_ms,
+            params.max_nodes,
+            sequence_deadline,
+        )?;
+        match params.target {
+            ActionTarget::Id(id) => self.legacy_click_target(id, params.mode, bound),
+            ActionTarget::Semantic(target) => match params.mode {
+                ActionMode::Native => {
+                    let window = self
+                        .active
+                        .as_ref()
+                        .map(|active| (active.geometry.width, active.geometry.height))
+                        .unwrap_or_default();
+                    let resolved = self.resolve_semantic_target_by_bound(
+                        &target,
+                        params.max_nodes,
+                        sequence_deadline,
+                        bound,
+                        |element, coverage| {
+                            ActionabilityReport::evaluate_click(
+                                element,
+                                coverage,
+                                None,
+                                window,
+                                crate::PointerHit::Inconclusive,
+                                false,
+                                false,
+                            )
+                            .blocking()
+                            .is_none()
+                        },
+                    )?;
+                    self.dispatch_native_click(resolved)
+                }
+                ActionMode::Pointer => {
+                    let resolved = self.resolve_stable_pointer_target(
+                        &target,
+                        params.max_nodes,
+                        sequence_deadline,
+                        bound,
+                    )?;
+                    self.dispatch_pointer_click(resolved, None)
+                }
+                ActionMode::Auto => {
+                    let window = self
+                        .active
+                        .as_ref()
+                        .map(|active| (active.geometry.width, active.geometry.height))
+                        .unwrap_or_default();
+                    let resolved = self.resolve_semantic_target_by_bound(
+                        &target,
+                        params.max_nodes,
+                        sequence_deadline,
+                        bound,
+                        |element, coverage| {
+                            ActionabilityReport::evaluate_click(
+                                element,
+                                coverage,
+                                None,
+                                window,
+                                crate::PointerHit::Inconclusive,
+                                false,
+                                false,
+                            )
+                            .blocking()
+                            .is_none()
+                        },
+                    )?;
+                    match self.invoke_semantic_target(&resolved.target, bound.deadline) {
+                        Ok(actuated) => {
+                            let mut actionability = ActionabilityReport::evaluate_click(
+                                &resolved.element,
+                                resolved.coverage,
+                                None,
+                                window,
+                                crate::PointerHit::Inconclusive,
+                                false,
+                                false,
+                            );
+                            actionability.pass_backend_fingerprint();
+                            Ok(SemanticActionOutcome {
+                                target: resolved.element,
+                                resolution: Some(resolved.resolution),
+                                actionability,
+                                focus: None,
+                                action: MutationReport {
+                                    method: ActionMethod::NativeAction { actuated },
+                                    dispatch: DispatchStatus::Dispatched,
+                                    confirmation: ConfirmationStatus::NotRequested,
+                                },
+                                bound,
+                            })
+                        }
+                        Err(source) if source.invoke_fallback_eligible() => {
+                            let reason = native_fallback_reason(&source);
+                            let resolved = self.resolve_stable_pointer_target(
+                                &target,
+                                params.max_nodes,
+                                sequence_deadline,
+                                bound,
+                            )?;
+                            self.dispatch_pointer_click(resolved, Some(reason))
+                        }
+                        Err(source) => Err(action_source_error(
+                            source,
+                            Some(resolved.resolution),
+                            ActionabilityReport::evaluate_click(
+                                &resolved.element,
+                                resolved.coverage,
+                                None,
+                                window,
+                                crate::PointerHit::Inconclusive,
+                                false,
+                                false,
+                            ),
+                            bound,
+                            true,
+                        )),
+                    }
+                }
+            },
+        }
     }
 }
 

--- a/crates/glass-core/src/session/semantic_action.rs
+++ b/crates/glass-core/src/session/semantic_action.rs
@@ -232,6 +232,24 @@ impl std::fmt::Display for SemanticActionError {
 
 impl std::error::Error for SemanticActionError {}
 
+impl SemanticActionError {
+    fn proves_pre_dispatch_native_unavailable(&self) -> bool {
+        self.action_dispatch == DispatchStatus::NotDispatched
+            && self
+                .source
+                .as_ref()
+                .is_some_and(GlassError::invoke_fallback_eligible)
+    }
+
+    fn safe_fallback_reason(&self) -> String {
+        native_fallback_reason(
+            self.source
+                .as_ref()
+                .expect("native fallback proof always retains its source"),
+        )
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct ClickTargetParams {
     pub target: ActionTarget,
@@ -643,10 +661,8 @@ fn action_source_error(
 
 fn native_fallback_reason(source: &GlassError) -> String {
     match source {
-        GlassError::AxUnsupported => "native accessibility action is unsupported".into(),
-        GlassError::AxActionUnavailable(_) => {
-            "target exposes no native accessibility action".into()
-        }
+        GlassError::AxUnsupported => "backend has no native action path".into(),
+        GlassError::AxActionUnavailable(_) => "element exposes no activation action".into(),
         _ => "native accessibility action did not dispatch".into(),
     }
 }
@@ -968,27 +984,6 @@ impl Glass {
         Ok(dimensions)
     }
 
-    fn invoke_semantic_target(
-        &mut self,
-        target: &AxTarget,
-        deadline: Deadline,
-    ) -> Result<Option<AxNodeId>> {
-        if deadline.has_passed() {
-            return Err(GlassError::deadline_not_started(
-                "native accessibility action",
-            ));
-        }
-        let ctx = self.accessibility_context_for_action(deadline)?;
-        let active = self.active_mut()?;
-        let actuated = active
-            .accessibility
-            .as_mut()
-            .ok_or(GlassError::AxUnsupported)?
-            .invoke(&ctx, target)?;
-        active.pump();
-        Ok(actuated)
-    }
-
     fn probe_semantic_pointer(
         &mut self,
         target: &AxTarget,
@@ -1042,7 +1037,7 @@ impl Glass {
             ));
         }
         let actuated = self
-            .invoke_semantic_target(&resolved.target, resolved.bound.deadline)
+            .try_native_invoke(resolved.element.id, resolved.bound.deadline)
             .map_err(|source| {
                 action_source_error(
                     source,
@@ -1061,7 +1056,7 @@ impl Glass {
             action: MutationReport {
                 method: ActionMethod::NativeAction { actuated },
                 dispatch: DispatchStatus::Dispatched,
-                confirmation: ConfirmationStatus::NotRequested,
+                confirmation: ConfirmationStatus::DispatchConfirmed,
             },
             bound: resolved.bound,
         })
@@ -1178,124 +1173,55 @@ impl Glass {
             action: MutationReport {
                 method: ActionMethod::Pointer { native_fallback },
                 dispatch: DispatchStatus::Dispatched,
-                confirmation: ConfirmationStatus::NotRequested,
+                confirmation: ConfirmationStatus::DispatchConfirmed,
             },
             bound: resolved.bound,
         })
     }
 
-    fn legacy_click_target(
-        &mut self,
+    fn legacy_click_snapshot(
+        &self,
         id: AxNodeId,
-        mode: ActionMode,
-        bound: ActionDeadline,
-    ) -> std::result::Result<SemanticActionOutcome, SemanticActionError> {
-        let (element, target, coverage, window) = {
-            let active = self
-                .active
-                .as_ref()
-                .ok_or_else(|| source_error(GlassError::NoActiveSession, bound))?;
-            let tree = active
-                .last_ax
-                .as_ref()
-                .ok_or_else(|| source_error(GlassError::NoAxSnapshot, bound))?;
-            let node = tree
-                .find(id)
-                .ok_or_else(|| source_error(GlassError::AxElementNotFound(id.0), bound))?;
-            let element = ElementInfo::from_node(node);
-            let coverage = active
-                .accessibility
-                .as_ref()
-                .map_or(AxStateCoverage::NONE, |reader| reader.state_coverage());
-            (
-                element.clone(),
-                ax_target(&element),
-                coverage,
-                (active.geometry.width, active.geometry.height),
-            )
-        };
-        let (method, pointer) = match mode {
-            ActionMode::Native => {
-                let actuated = self
-                    .invoke_semantic_target(&target, bound.deadline)
-                    .map_err(|source| {
-                        action_source_error(
-                            source,
-                            None,
-                            ActionabilityReport::evaluate_click(
-                                &element,
-                                coverage,
-                                None,
-                                window,
-                                crate::PointerHit::Inconclusive,
-                                true,
-                                false,
-                            ),
-                            bound,
-                            true,
-                        )
-                    })?;
-                (ActionMethod::NativeAction { actuated }, false)
-            }
-            ActionMode::Pointer => {
-                self.click_element_pointer_only(id, None, bound.deadline)
-                    .map_err(|source| {
-                        action_source_error(
-                            source,
-                            None,
-                            ActionabilityReport::evaluate_click(
-                                &element,
-                                coverage,
-                                None,
-                                window,
-                                crate::PointerHit::Inconclusive,
-                                true,
-                                true,
-                            ),
-                            bound,
-                            true,
-                        )
-                    })?;
-                (
-                    ActionMethod::Pointer {
-                        native_fallback: None,
-                    },
+    ) -> Option<(ElementInfo, AxStateCoverage, (u32, u32))> {
+        let active = self.active.as_ref()?;
+        let node = active.last_ax.as_ref()?.find(id)?;
+        let coverage = active
+            .accessibility
+            .as_ref()
+            .map_or(AxStateCoverage::NONE, |reader| reader.state_coverage());
+        Some((
+            ElementInfo::from_node(node),
+            coverage,
+            (active.geometry.width, active.geometry.height),
+        ))
+    }
+
+    fn legacy_click_actionability(&self, id: AxNodeId, pointer: bool) -> ActionabilityReport {
+        self.legacy_click_snapshot(id)
+            .map(|(element, coverage, window)| {
+                ActionabilityReport::evaluate_click(
+                    &element,
+                    coverage,
+                    None,
+                    window,
+                    crate::PointerHit::Inconclusive,
                     true,
+                    pointer,
                 )
-            }
-            ActionMode::Auto => {
-                let method = self
-                    .click_element_by(id, bound.deadline)
-                    .map_err(|source| {
-                        action_source_error(
-                            source,
-                            None,
-                            ActionabilityReport::evaluate_click(
-                                &element,
-                                coverage,
-                                None,
-                                window,
-                                crate::PointerHit::Inconclusive,
-                                true,
-                                false,
-                            ),
-                            bound,
-                            true,
-                        )
-                    })?;
-                match method {
-                    ClickMethod::NativeAction { actuated } => {
-                        (ActionMethod::NativeAction { actuated }, false)
-                    }
-                    ClickMethod::Pointer { native_fallback } => (
-                        ActionMethod::Pointer {
-                            native_fallback: Some(native_fallback),
-                        },
-                        true,
-                    ),
-                }
-            }
-        };
+            })
+            .unwrap_or_default()
+    }
+
+    fn legacy_click_outcome(
+        &self,
+        id: AxNodeId,
+        method: ActionMethod,
+        pointer: bool,
+        bound: ActionDeadline,
+    ) -> SemanticActionOutcome {
+        let (element, coverage, window) = self
+            .legacy_click_snapshot(id)
+            .expect("a successful legacy click retains its cached target");
         let mut actionability = ActionabilityReport::evaluate_click(
             &element,
             coverage,
@@ -1308,7 +1234,7 @@ impl Glass {
         if !pointer {
             actionability.pass_backend_fingerprint();
         }
-        Ok(SemanticActionOutcome {
+        SemanticActionOutcome {
             target: element,
             resolution: None,
             actionability,
@@ -1316,10 +1242,169 @@ impl Glass {
             action: MutationReport {
                 method,
                 dispatch: DispatchStatus::Dispatched,
-                confirmation: ConfirmationStatus::NotRequested,
+                confirmation: ConfirmationStatus::DispatchConfirmed,
             },
             bound,
-        })
+        }
+    }
+
+    fn click_native_once(
+        &mut self,
+        target: &ActionTarget,
+        max_nodes: Option<usize>,
+        sequence_deadline: Deadline,
+        bound: ActionDeadline,
+    ) -> std::result::Result<SemanticActionOutcome, SemanticActionError> {
+        match target {
+            ActionTarget::Id(id) => {
+                let actionability = self.legacy_click_actionability(*id, false);
+                let actuated = self
+                    .try_native_invoke(*id, bound.deadline)
+                    .map_err(|source| {
+                        action_source_error(source, None, actionability, bound, true)
+                    })?;
+                Ok(self.legacy_click_outcome(
+                    *id,
+                    ActionMethod::NativeAction { actuated },
+                    false,
+                    bound,
+                ))
+            }
+            ActionTarget::Semantic(target) => {
+                let window = self
+                    .active
+                    .as_ref()
+                    .map(|active| (active.geometry.width, active.geometry.height))
+                    .unwrap_or_default();
+                let resolved = self.resolve_semantic_target_by_bound(
+                    target,
+                    max_nodes,
+                    sequence_deadline,
+                    bound,
+                    |element, coverage| {
+                        ActionabilityReport::evaluate_click(
+                            element,
+                            coverage,
+                            None,
+                            window,
+                            crate::PointerHit::Inconclusive,
+                            false,
+                            false,
+                        )
+                        .blocking()
+                        .is_none()
+                    },
+                )?;
+                self.dispatch_native_click(resolved)
+            }
+        }
+    }
+
+    fn click_pointer_once(
+        &mut self,
+        target: &ActionTarget,
+        max_nodes: Option<usize>,
+        sequence_deadline: Deadline,
+        bound: ActionDeadline,
+        native_fallback: Option<String>,
+    ) -> std::result::Result<SemanticActionOutcome, SemanticActionError> {
+        match target {
+            ActionTarget::Id(id) => {
+                let actionability = self.legacy_click_actionability(*id, true);
+                self.click_element_pointer_only(*id, None, bound.deadline)
+                    .map_err(|source| {
+                        action_source_error(source, None, actionability, bound, true)
+                    })?;
+                Ok(self.legacy_click_outcome(
+                    *id,
+                    ActionMethod::Pointer { native_fallback },
+                    true,
+                    bound,
+                ))
+            }
+            ActionTarget::Semantic(target) => {
+                let resolved = self.resolve_stable_pointer_target(
+                    target,
+                    max_nodes,
+                    sequence_deadline,
+                    bound,
+                )?;
+                self.dispatch_pointer_click(resolved, native_fallback)
+            }
+        }
+    }
+
+    pub fn click_target(
+        &mut self,
+        params: &ClickTargetParams,
+    ) -> std::result::Result<SemanticActionOutcome, SemanticActionError> {
+        self.click_target_by(params, Deadline::UNBOUNDED)
+    }
+
+    pub fn click_target_by(
+        &mut self,
+        params: &ClickTargetParams,
+        sequence_deadline: Deadline,
+    ) -> std::result::Result<SemanticActionOutcome, SemanticActionError> {
+        let started = std::time::Instant::now();
+        let result = self.click_target_inner(params.clone(), sequence_deadline);
+        let element = match &result {
+            Ok(outcome) => crate::audit::ElementRef {
+                id: outcome.target.id.0,
+                role: Some(format!("{:?}", outcome.target.role)),
+                name: outcome.target.name.clone(),
+            },
+            Err(_) => match &params.target {
+                ActionTarget::Id(id) => self.element_ref(*id),
+                ActionTarget::Semantic(target) => crate::audit::ElementRef {
+                    id: 0,
+                    role: target.target.role().map(|role| format!("{role:?}")),
+                    name: target.target.query().map(str::to_owned),
+                },
+            },
+        };
+        let (method, native_fallback, actuated_id, dispatch, confirmation) = match &result {
+            Ok(outcome) => {
+                let (method, native_fallback, actuated_id) = match &outcome.action.method {
+                    ActionMethod::NativeAction { actuated } => {
+                        (Some("native-action"), None, actuated.map(|id| id.0))
+                    }
+                    ActionMethod::Pointer { native_fallback } => {
+                        (Some("pointer"), native_fallback.as_deref(), None)
+                    }
+                    ActionMethod::AccessibilityValue => (Some("accessibility-value"), None, None),
+                    ActionMethod::Keyboard => (Some("keyboard"), None, None),
+                };
+                (
+                    method,
+                    native_fallback,
+                    actuated_id,
+                    outcome.action.dispatch.as_str(),
+                    outcome.action.confirmation.as_str(),
+                )
+            }
+            Err(error) => (
+                None,
+                None,
+                None,
+                error.action_dispatch.as_str(),
+                ConfirmationStatus::Unconfirmed.as_str(),
+            ),
+        };
+        self.emit_audit(
+            &crate::audit::Actuation::ClickElement {
+                element,
+                mode: params.mode.as_str(),
+                method,
+                native_fallback,
+                actuated_id,
+                dispatch,
+                confirmation,
+            },
+            crate::audit::AuditOutcome::from_result(&result),
+            started.elapsed(),
+        );
+        result
     }
 
     pub(super) fn click_target_inner(
@@ -1333,127 +1418,35 @@ impl Glass {
             params.max_nodes,
             sequence_deadline,
         )?;
-        match params.target {
-            ActionTarget::Id(id) => self.legacy_click_target(id, params.mode, bound),
-            ActionTarget::Semantic(target) => match params.mode {
-                ActionMode::Native => {
-                    let window = self
-                        .active
-                        .as_ref()
-                        .map(|active| (active.geometry.width, active.geometry.height))
-                        .unwrap_or_default();
-                    let resolved = self.resolve_semantic_target_by_bound(
-                        &target,
+        match params.mode {
+            ActionMode::Native => {
+                self.click_native_once(&params.target, params.max_nodes, sequence_deadline, bound)
+            }
+            ActionMode::Pointer => self.click_pointer_once(
+                &params.target,
+                params.max_nodes,
+                sequence_deadline,
+                bound,
+                None,
+            ),
+            ActionMode::Auto => match self.click_native_once(
+                &params.target,
+                params.max_nodes,
+                sequence_deadline,
+                bound,
+            ) {
+                Ok(done) => Ok(done),
+                Err(error) if error.proves_pre_dispatch_native_unavailable() => {
+                    let reason = error.safe_fallback_reason();
+                    self.click_pointer_once(
+                        &params.target,
                         params.max_nodes,
                         sequence_deadline,
                         bound,
-                        |element, coverage| {
-                            ActionabilityReport::evaluate_click(
-                                element,
-                                coverage,
-                                None,
-                                window,
-                                crate::PointerHit::Inconclusive,
-                                false,
-                                false,
-                            )
-                            .blocking()
-                            .is_none()
-                        },
-                    )?;
-                    self.dispatch_native_click(resolved)
+                        Some(reason),
+                    )
                 }
-                ActionMode::Pointer => {
-                    let resolved = self.resolve_stable_pointer_target(
-                        &target,
-                        params.max_nodes,
-                        sequence_deadline,
-                        bound,
-                    )?;
-                    self.dispatch_pointer_click(resolved, None)
-                }
-                ActionMode::Auto => {
-                    let eligibility_window = self
-                        .active
-                        .as_ref()
-                        .map(|active| (active.geometry.width, active.geometry.height))
-                        .unwrap_or_default();
-                    let resolved = self.resolve_semantic_target_by_bound(
-                        &target,
-                        params.max_nodes,
-                        sequence_deadline,
-                        bound,
-                        |element, coverage| {
-                            ActionabilityReport::evaluate_click(
-                                element,
-                                coverage,
-                                None,
-                                eligibility_window,
-                                crate::PointerHit::Inconclusive,
-                                false,
-                                false,
-                            )
-                            .blocking()
-                            .is_none()
-                        },
-                    )?;
-                    let window = self
-                        .active
-                        .as_ref()
-                        .map(|active| (active.geometry.width, active.geometry.height))
-                        .ok_or_else(|| source_error(GlassError::NoActiveSession, bound))?;
-                    match self.invoke_semantic_target(&resolved.target, bound.deadline) {
-                        Ok(actuated) => {
-                            let mut actionability = ActionabilityReport::evaluate_click(
-                                &resolved.element,
-                                resolved.coverage,
-                                None,
-                                window,
-                                crate::PointerHit::Inconclusive,
-                                false,
-                                false,
-                            );
-                            actionability.pass_backend_fingerprint();
-                            Ok(SemanticActionOutcome {
-                                target: resolved.element,
-                                resolution: Some(resolved.resolution),
-                                actionability,
-                                focus: None,
-                                action: MutationReport {
-                                    method: ActionMethod::NativeAction { actuated },
-                                    dispatch: DispatchStatus::Dispatched,
-                                    confirmation: ConfirmationStatus::NotRequested,
-                                },
-                                bound,
-                            })
-                        }
-                        Err(source) if source.invoke_fallback_eligible() => {
-                            let reason = native_fallback_reason(&source);
-                            let resolved = self.resolve_stable_pointer_target(
-                                &target,
-                                params.max_nodes,
-                                sequence_deadline,
-                                bound,
-                            )?;
-                            self.dispatch_pointer_click(resolved, Some(reason))
-                        }
-                        Err(source) => Err(action_source_error(
-                            source,
-                            Some(resolved.resolution),
-                            ActionabilityReport::evaluate_click(
-                                &resolved.element,
-                                resolved.coverage,
-                                None,
-                                window,
-                                crate::PointerHit::Inconclusive,
-                                false,
-                                false,
-                            ),
-                            bound,
-                            true,
-                        )),
-                    }
-                }
+                Err(error) => Err(error),
             },
         }
     }

--- a/crates/glass-core/src/session/semantic_action.rs
+++ b/crates/glass-core/src/session/semantic_action.rs
@@ -592,18 +592,8 @@ fn ax_target(element: &ElementInfo) -> AxTarget {
     }
 }
 
-fn role_supports_set_value(element: &ElementInfo) -> bool {
-    element.states.editable
-        || element.states.checkable
-        || matches!(
-            element.role,
-            AxRole::ComboBox
-                | AxRole::Slider
-                | AxRole::SpinButton
-                | AxRole::ToggleButton
-                | AxRole::CheckBox
-                | AxRole::RadioButton
-        )
+fn role_supports_set_value(element: &ElementInfo, coverage: AxStateCoverage) -> bool {
+    set_value_eligibility(element, coverage) == ActionabilityVerdict::Passed
 }
 
 fn set_value_eligibility(element: &ElementInfo, coverage: AxStateCoverage) -> ActionabilityVerdict {
@@ -1640,7 +1630,7 @@ impl Glass {
                         sequence_deadline,
                         bound,
                         |element, coverage| {
-                            role_supports_set_value(element)
+                            role_supports_set_value(element, coverage)
                                 && set_value_actionability(element, coverage, window, false)
                                     .blocking()
                                     .is_none()
@@ -1715,13 +1705,15 @@ impl Glass {
         sequence_deadline: Deadline,
     ) -> std::result::Result<SemanticActionOutcome, SemanticActionError> {
         let started = std::time::Instant::now();
-        let result = target_deadline(
+        let result = match target_deadline(
             &params.target,
             params.timeout_ms,
             params.max_nodes,
             sequence_deadline,
-        )
-        .and_then(|bound| self.set_value_once(params, text, sequence_deadline, bound));
+        ) {
+            Ok(bound) => self.set_value_once(params, text, sequence_deadline, bound),
+            Err(error) => Err(error),
+        };
         let element = match &result {
             Ok(outcome) => crate::audit::ElementRef {
                 id: outcome.target.id.0,

--- a/crates/glass-core/src/session/semantic_action.rs
+++ b/crates/glass-core/src/session/semantic_action.rs
@@ -989,6 +989,41 @@ fn native_fallback_reason(source: &GlassError) -> String {
     }
 }
 
+#[derive(Default)]
+struct ClickAuditContext {
+    method: Option<ActionMethod>,
+}
+
+impl ClickAuditContext {
+    fn selected(&mut self, method: ActionMethod) {
+        self.method = Some(method);
+    }
+}
+
+fn audit_element_ref(element: &ElementInfo) -> crate::audit::ElementRef {
+    crate::audit::ElementRef {
+        id: element.id.0,
+        role: Some(format!("{:?}", element.role)),
+        name: element.name.clone(),
+    }
+}
+
+fn click_audit_fields(
+    method: Option<&ActionMethod>,
+) -> (Option<&'static str>, Option<&str>, Option<u32>) {
+    match method {
+        Some(ActionMethod::NativeAction { actuated }) => {
+            (Some("native-action"), None, actuated.map(|id| id.0))
+        }
+        Some(ActionMethod::Pointer { native_fallback }) => {
+            (Some("pointer"), native_fallback.as_deref(), None)
+        }
+        Some(ActionMethod::AccessibilityValue) => (Some("accessibility-value"), None, None),
+        Some(ActionMethod::Keyboard) => (Some("keyboard"), None, None),
+        None => (None, None, None),
+    }
+}
+
 impl Glass {
     pub(super) fn resolve_semantic_target(
         &mut self,
@@ -1603,10 +1638,12 @@ impl Glass {
         max_nodes: Option<usize>,
         sequence_deadline: Deadline,
         bound: ActionDeadline,
+        audit: &mut ClickAuditContext,
     ) -> SemanticActionResult<SemanticActionOutcome> {
         match target {
             ActionTarget::Id(id) => {
                 let actionability = self.legacy_click_actionability(*id, false);
+                audit.selected(ActionMethod::NativeAction { actuated: None });
                 let actuated = self
                     .try_native_invoke(*id, bound.deadline)
                     .map_err(|source| {
@@ -1644,6 +1681,7 @@ impl Glass {
                         .is_none()
                     },
                 )?;
+                audit.selected(ActionMethod::NativeAction { actuated: None });
                 self.dispatch_native_click(resolved)
             }
         }
@@ -1656,10 +1694,14 @@ impl Glass {
         sequence_deadline: Deadline,
         bound: ActionDeadline,
         native_fallback: Option<String>,
+        audit: &mut ClickAuditContext,
     ) -> SemanticActionResult<SemanticActionOutcome> {
         match target {
             ActionTarget::Id(id) => {
                 let actionability = self.legacy_click_actionability(*id, true);
+                audit.selected(ActionMethod::Pointer {
+                    native_fallback: native_fallback.clone(),
+                });
                 self.click_element_pointer_only(*id, None, bound.deadline)
                     .map_err(|source| {
                         action_source_error(source, None, None, actionability, bound, true)
@@ -1678,6 +1720,9 @@ impl Glass {
                     sequence_deadline,
                     bound,
                 )?;
+                audit.selected(ActionMethod::Pointer {
+                    native_fallback: native_fallback.clone(),
+                });
                 self.dispatch_pointer_click(resolved, native_fallback)
             }
         }
@@ -1690,40 +1735,41 @@ impl Glass {
         self.click_target_by(params, Deadline::UNBOUNDED)
     }
 
+    fn semantic_action_audit_element(
+        &self,
+        result: &SemanticActionResult<SemanticActionOutcome>,
+        target: &ActionTarget,
+    ) -> crate::audit::ElementRef {
+        match result {
+            Ok(outcome) => audit_element_ref(&outcome.target),
+            Err(error) => error.target.as_deref().map_or_else(
+                || match target {
+                    ActionTarget::Id(id) => self.element_ref(*id),
+                    ActionTarget::Semantic(target) => crate::audit::ElementRef {
+                        id: 0,
+                        role: target.target.role().map(|role| format!("{role:?}")),
+                        name: target.target.query().map(str::to_owned),
+                    },
+                },
+                audit_element_ref,
+            ),
+        }
+    }
+
     pub fn click_target_by(
         &mut self,
         params: &ClickTargetParams,
         sequence_deadline: Deadline,
     ) -> SemanticActionResult<SemanticActionOutcome> {
         let started = std::time::Instant::now();
-        let result = self.click_target_inner(params.clone(), sequence_deadline);
-        let element = match &result {
-            Ok(outcome) => crate::audit::ElementRef {
-                id: outcome.target.id.0,
-                role: Some(format!("{:?}", outcome.target.role)),
-                name: outcome.target.name.clone(),
-            },
-            Err(_) => match &params.target {
-                ActionTarget::Id(id) => self.element_ref(*id),
-                ActionTarget::Semantic(target) => crate::audit::ElementRef {
-                    id: 0,
-                    role: target.target.role().map(|role| format!("{role:?}")),
-                    name: target.target.query().map(str::to_owned),
-                },
-            },
-        };
+        let mut audit = ClickAuditContext::default();
+        let result =
+            self.click_target_inner_with_audit(params.clone(), sequence_deadline, &mut audit);
+        let element = self.semantic_action_audit_element(&result, &params.target);
         let (method, native_fallback, actuated_id, dispatch, confirmation) = match &result {
             Ok(outcome) => {
-                let (method, native_fallback, actuated_id) = match &outcome.action.method {
-                    ActionMethod::NativeAction { actuated } => {
-                        (Some("native-action"), None, actuated.map(|id| id.0))
-                    }
-                    ActionMethod::Pointer { native_fallback } => {
-                        (Some("pointer"), native_fallback.as_deref(), None)
-                    }
-                    ActionMethod::AccessibilityValue => (Some("accessibility-value"), None, None),
-                    ActionMethod::Keyboard => (Some("keyboard"), None, None),
-                };
+                let (method, native_fallback, actuated_id) =
+                    click_audit_fields(Some(&outcome.action.method));
                 (
                     method,
                     native_fallback,
@@ -1732,13 +1778,16 @@ impl Glass {
                     outcome.action.confirmation.as_str(),
                 )
             }
-            Err(error) => (
-                None,
-                None,
-                None,
-                error.action_dispatch.as_str(),
-                ConfirmationStatus::Unconfirmed.as_str(),
-            ),
+            Err(error) => {
+                let (method, native_fallback, _) = click_audit_fields(audit.method.as_ref());
+                (
+                    method,
+                    native_fallback,
+                    None,
+                    error.action_dispatch.as_str(),
+                    ConfirmationStatus::Unconfirmed.as_str(),
+                )
+            }
         };
         self.emit_audit(
             &crate::audit::Actuation::ClickElement {
@@ -1761,6 +1810,19 @@ impl Glass {
         params: ClickTargetParams,
         sequence_deadline: Deadline,
     ) -> SemanticActionResult<SemanticActionOutcome> {
+        self.click_target_inner_with_audit(
+            params,
+            sequence_deadline,
+            &mut ClickAuditContext::default(),
+        )
+    }
+
+    fn click_target_inner_with_audit(
+        &mut self,
+        params: ClickTargetParams,
+        sequence_deadline: Deadline,
+        audit: &mut ClickAuditContext,
+    ) -> SemanticActionResult<SemanticActionOutcome> {
         let bound = target_deadline(
             &params.target,
             params.timeout_ms,
@@ -1768,31 +1830,41 @@ impl Glass {
             sequence_deadline,
         )?;
         match params.mode {
-            ActionMode::Native => {
-                self.click_native_once(&params.target, params.max_nodes, sequence_deadline, bound)
-            }
+            ActionMode::Native => self.click_native_once(
+                &params.target,
+                params.max_nodes,
+                sequence_deadline,
+                bound,
+                audit,
+            ),
             ActionMode::Pointer => self.click_pointer_once(
                 &params.target,
                 params.max_nodes,
                 sequence_deadline,
                 bound,
                 None,
+                audit,
             ),
             ActionMode::Auto => match self.click_native_once(
                 &params.target,
                 params.max_nodes,
                 sequence_deadline,
                 bound,
+                audit,
             ) {
                 Ok(done) => Ok(done),
                 Err(error) if error.proves_pre_dispatch_native_unavailable() => {
                     let reason = error.safe_fallback_reason();
+                    audit.selected(ActionMethod::Pointer {
+                        native_fallback: Some(reason.clone()),
+                    });
                     self.click_pointer_once(
                         &params.target,
                         params.max_nodes,
                         sequence_deadline,
                         bound,
                         Some(reason),
+                        audit,
                     )
                 }
                 Err(error) => Err(error),
@@ -1950,21 +2022,7 @@ impl Glass {
             Ok(bound) => self.set_value_once(params, text, sequence_deadline, bound),
             Err(error) => Err(error),
         };
-        let element = match &result {
-            Ok(outcome) => crate::audit::ElementRef {
-                id: outcome.target.id.0,
-                role: Some(format!("{:?}", outcome.target.role)),
-                name: outcome.target.name.clone(),
-            },
-            Err(_) => match &params.target {
-                ActionTarget::Id(id) => self.element_ref(*id),
-                ActionTarget::Semantic(target) => crate::audit::ElementRef {
-                    id: 0,
-                    role: target.target.role().map(|role| format!("{role:?}")),
-                    name: target.target.query().map(str::to_owned),
-                },
-            },
-        };
+        let element = self.semantic_action_audit_element(&result, &params.target);
         let (dispatch, confirmation) = match &result {
             Ok(outcome) => (
                 outcome.action.dispatch.as_str(),
@@ -2335,26 +2393,8 @@ impl Glass {
     ) -> SemanticActionResult<SemanticActionOutcome> {
         let started = std::time::Instant::now();
         let result = self.type_target_inner(params, text, sequence_deadline);
-        let element = match &result {
-            Ok(outcome) => crate::audit::ElementRef {
-                id: outcome.target.id.0,
-                role: Some(format!("{:?}", outcome.target.role)),
-                name: outcome.target.name.clone(),
-            },
-            Err(error) => error
-                .candidates
-                .first()
-                .map(|candidate| crate::audit::ElementRef {
-                    id: candidate.element.id.0,
-                    role: Some(format!("{:?}", candidate.element.role)),
-                    name: candidate.element.name.clone(),
-                })
-                .unwrap_or_else(|| crate::audit::ElementRef {
-                    id: 0,
-                    role: params.target.target.role().map(|role| format!("{role:?}")),
-                    name: params.target.target.query().map(str::to_owned),
-                }),
-        };
+        let audit_target = ActionTarget::Semantic(params.target.clone());
+        let element = self.semantic_action_audit_element(&result, &audit_target);
         let focus = match &result {
             Ok(outcome) => outcome.focus.as_ref(),
             Err(error) => error.focus.as_ref(),

--- a/crates/glass-core/src/session/semantic_action.rs
+++ b/crates/glass-core/src/session/semantic_action.rs
@@ -593,6 +593,15 @@ fn pointer_plan(
     plan.is_inside_window(window).then_some(plan)
 }
 
+fn complete_unique_pointer_result(result: &SemanticQueryResult) -> bool {
+    matches!(
+        result.scope,
+        ScopeResolution::Unscoped | ScopeResolution::Resolved(_)
+    ) && result.matches_in_walk == 1
+        && result.search_complete
+        && result.matches.len() == 1
+}
+
 fn ax_target(element: &ElementInfo) -> AxTarget {
     AxTarget {
         id: element.id,
@@ -1203,12 +1212,7 @@ impl Glass {
                 "stabilize semantic pointer target",
                 |tree, window| {
                     let result = tree.semantic_query(&query);
-                    let complete_unique = matches!(
-                        result.scope,
-                        ScopeResolution::Unscoped | ScopeResolution::Resolved(_)
-                    ) && result.matches_in_walk == 1
-                        && result.search_complete
-                        && result.matches.len() == 1;
+                    let complete_unique = complete_unique_pointer_result(&result);
                     let mut actionability = None;
                     let candidate = if complete_unique {
                         let element = result.matches[0].element.clone();

--- a/crates/glass-core/src/session/semantic_action/tests.rs
+++ b/crates/glass-core/src/session/semantic_action/tests.rs
@@ -1432,6 +1432,27 @@ fn selector_pointer_rejects_a_trailing_toggle_with_a_boundary_endpoint() {
 }
 
 #[test]
+fn exact_trailing_toggle_plan_validates_the_stored_probe_point() {
+    let segment = crate::Segment {
+        from_x: 10,
+        from_y: 20,
+        to_x: 30,
+        to_y: 20,
+    };
+    let valid = PlannedPointerInput::TrailingToggle {
+        segment,
+        probe_point: (20, 20),
+    };
+    let invalid = PlannedPointerInput::TrailingToggle {
+        segment,
+        probe_point: (100, 100),
+    };
+
+    assert!(valid.is_inside_window((100, 100)));
+    assert!(!invalid.is_inside_window((100, 100)));
+}
+
+#[test]
 fn selector_pointer_popover_row_toggle_dispatches_the_translated_planned_segment() {
     let mut tree = fake_tree_with_popover_option();
     let toggle = &mut tree.root.children[0].children[0];

--- a/crates/glass-core/src/session/semantic_action/tests.rs
+++ b/crates/glass-core/src/session/semantic_action/tests.rs
@@ -1622,7 +1622,7 @@ fn pointer_plan_change_resets_stability_when_identity_and_bounds_are_equal() {
 
     glass
         .click_target_inner(
-            pointer_params(ActionTarget::Semantic(semantic_target("Save")), Some(600)),
+            pointer_params(ActionTarget::Semantic(semantic_target("Save")), None),
             Deadline::UNBOUNDED,
         )
         .unwrap();

--- a/crates/glass-core/src/session/semantic_action/tests.rs
+++ b/crates/glass-core/src/session/semantic_action/tests.rs
@@ -116,6 +116,106 @@ fn semantic_set_value_glass_with_coverage(
     )
 }
 
+fn targeted_type_params(query: &str, focus_mode: ActionMode, timeout_ms: u64) -> TypeTargetParams {
+    TypeTargetParams {
+        target: semantic_target(query),
+        focus_mode,
+        timeout_ms,
+        max_nodes: None,
+    }
+}
+
+fn targeted_type_field_tree(name: &str, focused: bool) -> AxTree {
+    let mut tree = editable_field_tree(name, Some("old"), true);
+    tree.root.children[0].id = AxNodeId(1);
+    tree.root.children[0].states.focused = focused;
+    tree
+}
+
+fn renumbered_targeted_type_field_tree(name: &str) -> AxTree {
+    let mut tree = targeted_type_field_tree(name, true);
+    tree.root.children.insert(
+        0,
+        AxNode {
+            id: AxNodeId(1),
+            role: AxRole::Label,
+            raw_role: "label".into(),
+            name: Some("Inserted helper".into()),
+            description: None,
+            value: None,
+            states: AxStates {
+                visible: true,
+                ..AxStates::default()
+            },
+            bounds: Some(AxRect {
+                x: 20,
+                y: 60,
+                width: 160,
+                height: 20,
+            }),
+            children: Vec::new(),
+        },
+    );
+    tree.root.children[1].id = AxNodeId(2);
+    AxTree::new(tree.root)
+}
+
+struct TargetedTypeFixture {
+    glass: Glass,
+    focus_calls: Arc<AtomicUsize>,
+    clicks: Arc<Mutex<Vec<(i32, i32)>>>,
+    key_log: Arc<Mutex<Vec<KeyEvent>>>,
+    walks: Arc<AtomicUsize>,
+    ax_deadlines: AxDeadlineLog,
+    key_deadlines: InputDeadlineLog,
+    hit_calls: Arc<AtomicUsize>,
+    events: Arc<Mutex<Vec<&'static str>>>,
+}
+
+fn targeted_type_glass(
+    trees: Vec<AxTree>,
+    focus_behavior: InvokeBehavior,
+    coverage: AxStateCoverage,
+    fail_key: bool,
+) -> TargetedTypeFixture {
+    let focus_calls = Arc::new(AtomicUsize::new(0));
+    let clicks = Arc::new(Mutex::new(Vec::new()));
+    let key_log = Arc::new(Mutex::new(Vec::new()));
+    let walks = Arc::new(AtomicUsize::new(0));
+    let ax_deadlines = Arc::new(Mutex::new(Vec::new()));
+    let key_deadlines = Arc::new(Mutex::new(Vec::new()));
+    let hit_calls = Arc::new(AtomicUsize::new(0));
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let mut platform = FakePlatform::new(320, 240)
+        .with_click_log(clicks.clone())
+        .with_key_log(key_log.clone())
+        .with_key_deadline_log(key_deadlines.clone())
+        .with_event_log(events.clone());
+    if fail_key {
+        platform = platform.with_failing_key();
+    }
+    let accessibility = SeqAccessibility::new(trees)
+        .with_coverage(coverage)
+        .with_focus_behavior(focus_behavior)
+        .with_focus_calls(focus_calls.clone())
+        .with_hit(PointerHit::Target)
+        .with_hit_calls(hit_calls.clone())
+        .with_walks(walks.clone())
+        .with_deadlines(ax_deadlines.clone())
+        .with_event_log(events.clone());
+    TargetedTypeFixture {
+        glass: glass_with_backend(platform, Box::new(accessibility)),
+        focus_calls,
+        clicks,
+        key_log,
+        walks,
+        ax_deadlines,
+        key_deadlines,
+        hit_calls,
+        events,
+    }
+}
+
 fn named_button_tree(name: &str) -> AxTree {
     let mut tree = fake_tree();
     tree.root.children[0].name = Some(name.into());
@@ -2616,4 +2716,355 @@ fn semantic_public_set_value_audit_emits_one_safe_high_level_record() {
     assert_eq!(audits[0].confirmation, "unconfirmed");
     assert!(!audits[0].ok);
     assert!(!audits[0].error.as_deref().unwrap().contains(secret));
+}
+
+#[test]
+fn targeted_type_zero_timeout_types_only_if_the_first_confirmation_read_is_focused() {
+    for (focused, succeeds) in [(true, true), (false, false)] {
+        let mut fixture = targeted_type_glass(
+            vec![
+                targeted_type_field_tree("Account name", false),
+                targeted_type_field_tree("Account name", focused),
+                targeted_type_field_tree("Account name", true),
+            ],
+            InvokeBehavior::Succeed,
+            full_state_coverage(),
+            false,
+        );
+        fixture.glass.start(&spec()).unwrap();
+
+        let result = fixture.glass.type_target_by(
+            &targeted_type_params("Account name", ActionMode::Native, 0),
+            "typed once",
+            Deadline::UNBOUNDED,
+        );
+
+        assert_eq!(result.is_ok(), succeeds);
+        assert_eq!(fixture.walks.load(Ordering::Relaxed), 2);
+        assert_eq!(fixture.focus_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(fixture.key_log.lock().unwrap().len(), usize::from(succeeds));
+    }
+}
+
+#[test]
+fn targeted_type_native_focuses_confirms_then_types_once() {
+    let secret = "private account text";
+    let mut fixture = targeted_type_glass(
+        vec![
+            targeted_type_field_tree("Account name", false),
+            targeted_type_field_tree("Account name", true),
+        ],
+        InvokeBehavior::Succeed,
+        full_state_coverage(),
+        false,
+    );
+    let sink = RecordingSink::default();
+    fixture.glass.set_audit_sink(Box::new(sink.clone()));
+    fixture.glass.start(&spec()).unwrap();
+    sink.0.lock().unwrap().clear();
+    sink.3.lock().unwrap().clear();
+
+    let outcome = fixture
+        .glass
+        .type_target(
+            &targeted_type_params("Account name", ActionMode::Native, 500),
+            secret,
+        )
+        .unwrap();
+
+    assert_eq!(fixture.focus_calls.load(Ordering::Relaxed), 1);
+    assert!(fixture.clicks.lock().unwrap().is_empty());
+    assert_eq!(
+        fixture.key_log.lock().unwrap().as_slice(),
+        &[KeyEvent::Text(secret.into())]
+    );
+    assert_eq!(
+        fixture.events.lock().unwrap().as_slice(),
+        &["focus", "snapshot focused", "key"]
+    );
+    assert_eq!(
+        outcome.focus,
+        Some(MutationReport {
+            method: ActionMethod::NativeAction { actuated: None },
+            dispatch: DispatchStatus::Dispatched,
+            confirmation: ConfirmationStatus::FocusConfirmed,
+        })
+    );
+    assert_eq!(outcome.action.method, ActionMethod::Keyboard);
+    assert_eq!(outcome.action.dispatch, DispatchStatus::Dispatched);
+    assert_eq!(
+        outcome.action.confirmation,
+        ConfirmationStatus::DispatchConfirmed
+    );
+    assert_eq!(sink.0.lock().unwrap().as_slice(), &["type_target:true"]);
+    let audits = sink.3.lock().unwrap();
+    assert_eq!(audits.len(), 1);
+    assert_eq!(audits[0].text, secret);
+    assert_eq!(audits[0].focus_mode, "native");
+    assert_eq!(audits[0].focus_method.as_deref(), Some("native_action"));
+    assert_eq!(audits[0].focus_dispatch, "dispatched");
+    assert_eq!(audits[0].focus_confirmation, "focus_confirmed");
+    assert_eq!(audits[0].type_dispatch, "dispatched");
+}
+
+#[test]
+fn targeted_type_auto_falls_back_to_pointer_only_after_pre_dispatch_focus_unsupported() {
+    let mut fixture = targeted_type_glass(
+        vec![
+            targeted_type_field_tree("Account name", false),
+            targeted_type_field_tree("Account name", false),
+            targeted_type_field_tree("Account name", false),
+            targeted_type_field_tree("Account name", true),
+        ],
+        InvokeBehavior::Unsupported,
+        full_state_coverage(),
+        false,
+    );
+    fixture.glass.start(&spec()).unwrap();
+
+    let outcome = fixture
+        .glass
+        .type_target(
+            &targeted_type_params("Account name", ActionMode::Auto, 500),
+            "typed once",
+        )
+        .unwrap();
+
+    assert_eq!(fixture.focus_calls.load(Ordering::Relaxed), 1);
+    assert_eq!(fixture.clicks.lock().unwrap().len(), 1);
+    assert_eq!(fixture.hit_calls.load(Ordering::Relaxed), 1);
+    assert_eq!(fixture.key_log.lock().unwrap().len(), 1);
+    assert!(matches!(
+        outcome.focus,
+        Some(MutationReport {
+            method: ActionMethod::Pointer {
+                native_fallback: Some(_)
+            },
+            dispatch: DispatchStatus::Dispatched,
+            confirmation: ConfirmationStatus::FocusConfirmed,
+        })
+    ));
+}
+
+#[test]
+fn targeted_type_does_not_try_pointer_after_native_focus_may_have_dispatched() {
+    let mut fixture = targeted_type_glass(
+        vec![targeted_type_field_tree("Account name", false)],
+        InvokeBehavior::MayHaveDispatched,
+        full_state_coverage(),
+        false,
+    );
+    fixture.glass.start(&spec()).unwrap();
+
+    let error = fixture
+        .glass
+        .type_target(
+            &targeted_type_params("Account name", ActionMode::Auto, 0),
+            "must not type",
+        )
+        .unwrap_err();
+
+    assert_eq!(fixture.focus_calls.load(Ordering::Relaxed), 1);
+    assert!(fixture.clicks.lock().unwrap().is_empty());
+    assert!(fixture.key_log.lock().unwrap().is_empty());
+    assert_eq!(error.action_dispatch, DispatchStatus::NotDispatched);
+    assert_eq!(error.retry, RetryGuidance::DoNotRetry);
+    assert_eq!(
+        error.focus.as_ref().map(|focus| focus.dispatch),
+        Some(DispatchStatus::MayHaveDispatched)
+    );
+}
+
+#[test]
+fn targeted_type_never_types_when_focus_cannot_be_confirmed() {
+    let secret = "never expose this text";
+    let mut fixture = targeted_type_glass(
+        vec![
+            targeted_type_field_tree("Account name", false),
+            targeted_type_field_tree("Account name", true),
+        ],
+        InvokeBehavior::Succeed,
+        AxStateCoverage {
+            focused: false,
+            ..full_state_coverage()
+        },
+        false,
+    );
+    let sink = RecordingSink::default();
+    fixture.glass.set_audit_sink(Box::new(sink.clone()));
+    fixture.glass.start(&spec()).unwrap();
+    sink.0.lock().unwrap().clear();
+    sink.3.lock().unwrap().clear();
+
+    let error = fixture
+        .glass
+        .type_target(
+            &targeted_type_params("Account name", ActionMode::Native, 0),
+            secret,
+        )
+        .unwrap_err();
+
+    assert_eq!(fixture.focus_calls.load(Ordering::Relaxed), 1);
+    assert!(fixture.key_log.lock().unwrap().is_empty());
+    assert_eq!(error.kind, SemanticActionFailureKind::FocusUnconfirmed);
+    assert_eq!(error.action_dispatch, DispatchStatus::NotDispatched);
+    assert_eq!(error.retry, RetryGuidance::Reobserve);
+    assert_eq!(
+        error.focus,
+        Some(MutationReport {
+            method: ActionMethod::NativeAction { actuated: None },
+            dispatch: DispatchStatus::Dispatched,
+            confirmation: ConfirmationStatus::Unconfirmed,
+        })
+    );
+    assert!(!error.to_string().contains(secret));
+    assert!(!format!("{:?}", error.source).contains(secret));
+    assert!(!format!("{:?}", error.candidates).contains(secret));
+    assert!(!format!("{:?}", error.actionability).contains(secret));
+    assert_eq!(sink.0.lock().unwrap().as_slice(), &["type_target:false"]);
+    let audits = sink.3.lock().unwrap();
+    assert_eq!(audits.len(), 1);
+    assert_eq!(audits[0].text, secret);
+    assert!(!audits[0].error.as_deref().unwrap().contains(secret));
+}
+
+#[test]
+fn targeted_type_never_dispatches_a_second_text_batch_after_possible_key_delivery() {
+    let mut fixture = targeted_type_glass(
+        vec![
+            targeted_type_field_tree("Account name", false),
+            targeted_type_field_tree("Account name", true),
+        ],
+        InvokeBehavior::Succeed,
+        full_state_coverage(),
+        true,
+    );
+    let sink = RecordingSink::default();
+    fixture.glass.set_audit_sink(Box::new(sink.clone()));
+    fixture.glass.start(&spec()).unwrap();
+    sink.0.lock().unwrap().clear();
+
+    let error = fixture
+        .glass
+        .type_target(
+            &targeted_type_params("Account name", ActionMode::Native, 500),
+            "one batch",
+        )
+        .unwrap_err();
+
+    assert_eq!(fixture.key_log.lock().unwrap().len(), 1);
+    assert_eq!(error.action_dispatch, DispatchStatus::MayHaveDispatched);
+    assert_eq!(error.retry, RetryGuidance::DoNotRetry);
+    assert_eq!(
+        error.focus.as_ref().map(|focus| focus.confirmation),
+        Some(ConfirmationStatus::FocusConfirmed)
+    );
+    assert_eq!(sink.0.lock().unwrap().as_slice(), &["type_target:false"]);
+}
+
+#[test]
+fn targeted_type_reacquires_a_renumbered_focused_field_by_identity() {
+    let initial = targeted_type_field_tree("Account name", false);
+    let initial_id = initial.root.children[0].id;
+    let focused = renumbered_targeted_type_field_tree("Account name");
+    let focused_id = focused.root.children[1].id;
+    assert_ne!(initial_id, focused_id);
+    let mut fixture = targeted_type_glass(
+        vec![initial, focused],
+        InvokeBehavior::Succeed,
+        full_state_coverage(),
+        false,
+    );
+    fixture.glass.start(&spec()).unwrap();
+
+    let outcome = fixture
+        .glass
+        .type_target(
+            &targeted_type_params("Account name", ActionMode::Native, 500),
+            "typed after renumber",
+        )
+        .unwrap();
+
+    assert_eq!(outcome.target.id, focused_id);
+    assert_eq!(fixture.key_log.lock().unwrap().len(), 1);
+    assert!(
+        fixture
+            .glass
+            .active
+            .as_ref()
+            .and_then(|active| active.last_ax.as_ref())
+            .and_then(|tree| tree.find(focused_id))
+            .is_some_and(|node| node.states.focused)
+    );
+}
+
+#[test]
+fn targeted_type_rejects_a_button_even_when_the_backend_can_focus_it() {
+    let tree = value_control_tree(
+        "Save",
+        AxRole::Button,
+        None,
+        AxStates {
+            enabled: true,
+            visible: true,
+            focusable: true,
+            ..AxStates::default()
+        },
+    );
+    let mut fixture = targeted_type_glass(
+        vec![tree],
+        InvokeBehavior::Succeed,
+        full_state_coverage(),
+        false,
+    );
+    fixture.glass.start(&spec()).unwrap();
+
+    let error = fixture
+        .glass
+        .type_target(
+            &targeted_type_params("Save", ActionMode::Native, 0),
+            "must not type",
+        )
+        .unwrap_err();
+
+    assert_eq!(error.kind, SemanticActionFailureKind::NotActionable);
+    assert_eq!(error.action_dispatch, DispatchStatus::NotDispatched);
+    assert_eq!(fixture.focus_calls.load(Ordering::Relaxed), 0);
+    assert!(fixture.clicks.lock().unwrap().is_empty());
+    assert!(fixture.key_log.lock().unwrap().is_empty());
+}
+
+#[test]
+fn targeted_type_uses_the_same_absolute_deadline_for_focus_confirmation_and_typing() {
+    let mut fixture = targeted_type_glass(
+        vec![
+            targeted_type_field_tree("Account name", false),
+            targeted_type_field_tree("Account name", true),
+        ],
+        InvokeBehavior::Succeed,
+        full_state_coverage(),
+        false,
+    );
+    fixture.glass.start(&spec()).unwrap();
+
+    let outcome = fixture
+        .glass
+        .type_target_by(
+            &targeted_type_params("Account name", ActionMode::Native, 500),
+            "one deadline",
+            Deadline::from_millis(1_000),
+        )
+        .unwrap();
+
+    let ax_deadlines = fixture.ax_deadlines.lock().unwrap();
+    assert_eq!(ax_deadlines.len(), 3);
+    assert!(
+        ax_deadlines
+            .iter()
+            .all(|deadline| *deadline == outcome.bound.deadline)
+    );
+    assert_eq!(
+        fixture.key_deadlines.lock().unwrap().as_slice(),
+        &[outcome.bound.deadline]
+    );
 }

--- a/crates/glass-core/src/session/semantic_action/tests.rs
+++ b/crates/glass-core/src/session/semantic_action/tests.rs
@@ -1665,3 +1665,474 @@ fn legacy_id_missing_bounds_preserves_the_primitive_error_before_dispatch() {
     ));
     assert_eq!(error.action_dispatch, DispatchStatus::NotDispatched);
 }
+
+fn click_mode_glass(
+    trees: Vec<AxTree>,
+    behavior: InvokeBehavior,
+) -> (
+    Glass,
+    Arc<AtomicUsize>,
+    Arc<Mutex<Vec<(i32, i32)>>>,
+    AxDeadlineLog,
+) {
+    let native_calls = Arc::new(AtomicUsize::new(0));
+    let clicks = Arc::new(Mutex::new(Vec::new()));
+    let deadlines = Arc::new(Mutex::new(Vec::new()));
+    let accessibility = SeqAccessibility::new(trees)
+        .with_coverage(full_state_coverage())
+        .with_invoke_behavior(behavior)
+        .with_invoke_calls(native_calls.clone())
+        .with_deadlines(deadlines.clone())
+        .with_hit(PointerHit::Target);
+    let platform = FakePlatform::new(100, 100).with_click_log(clicks.clone());
+    (
+        glass_with_backend(platform, Box::new(accessibility)),
+        native_calls,
+        clicks,
+        deadlines,
+    )
+}
+
+fn semantic_click_params(mode: ActionMode, timeout_ms: u64) -> ClickTargetParams {
+    ClickTargetParams {
+        target: ActionTarget::Semantic(semantic_target("Save")),
+        mode,
+        timeout_ms: Some(timeout_ms),
+        max_nodes: None,
+    }
+}
+
+#[test]
+fn semantic_auto_click_uses_native_action_first() {
+    let tree = actionable_button_tree(
+        "Save",
+        AxRect {
+            x: 10,
+            y: 10,
+            width: 20,
+            height: 20,
+        },
+    );
+    let (mut glass, native_calls, clicks, _) =
+        click_mode_glass(vec![tree], InvokeBehavior::Succeed);
+    glass.start(&spec()).unwrap();
+
+    let outcome = glass
+        .click_target_by(
+            &semantic_click_params(ActionMode::Auto, 500),
+            Deadline::UNBOUNDED,
+        )
+        .unwrap();
+
+    assert_eq!(native_calls.load(Ordering::Relaxed), 1);
+    assert!(clicks.lock().unwrap().is_empty());
+    assert!(matches!(
+        outcome.action.method,
+        ActionMethod::NativeAction { actuated: None }
+    ));
+    assert_eq!(outcome.action.dispatch, DispatchStatus::Dispatched);
+    assert_eq!(
+        outcome.action.confirmation,
+        ConfirmationStatus::DispatchConfirmed
+    );
+}
+
+#[test]
+fn semantic_auto_click_falls_back_only_after_proven_pre_dispatch_unavailable() {
+    let tree = actionable_button_tree(
+        "Save",
+        AxRect {
+            x: 10,
+            y: 10,
+            width: 20,
+            height: 20,
+        },
+    );
+    let (mut glass, native_calls, clicks, deadlines) =
+        click_mode_glass(vec![tree.clone(), tree], InvokeBehavior::NoAction);
+    glass.start(&spec()).unwrap();
+
+    let outcome = glass
+        .click_target_by(
+            &semantic_click_params(ActionMode::Auto, 500),
+            Deadline::UNBOUNDED,
+        )
+        .unwrap();
+
+    assert_eq!(native_calls.load(Ordering::Relaxed), 1);
+    assert_eq!(clicks.lock().unwrap().len(), 1);
+    assert!(matches!(
+        outcome.action.method,
+        ActionMethod::Pointer {
+            native_fallback: Some(ref reason)
+        } if reason == "element exposes no activation action"
+    ));
+    assert_eq!(outcome.action.dispatch, DispatchStatus::Dispatched);
+    assert!(
+        deadlines
+            .lock()
+            .unwrap()
+            .iter()
+            .all(|deadline| *deadline == outcome.bound.deadline),
+        "auto fallback must keep the original action deadline"
+    );
+    assert_eq!(
+        outcome.action.confirmation,
+        ConfirmationStatus::DispatchConfirmed
+    );
+}
+
+#[test]
+fn semantic_auto_click_never_falls_back_after_possible_native_dispatch() {
+    let tree = actionable_button_tree(
+        "Save",
+        AxRect {
+            x: 10,
+            y: 10,
+            width: 20,
+            height: 20,
+        },
+    );
+    let (mut glass, native_calls, clicks, _) =
+        click_mode_glass(vec![tree], InvokeBehavior::MayHaveDispatched);
+    glass.start(&spec()).unwrap();
+
+    let error = glass
+        .click_target_by(
+            &semantic_click_params(ActionMode::Auto, 500),
+            Deadline::UNBOUNDED,
+        )
+        .unwrap_err();
+
+    assert_eq!(native_calls.load(Ordering::Relaxed), 1);
+    assert_eq!(native_calls.load(Ordering::Relaxed).saturating_sub(1), 0);
+    assert!(clicks.lock().unwrap().is_empty());
+    assert_eq!(error.action_dispatch, DispatchStatus::MayHaveDispatched);
+    assert_eq!(error.retry, RetryGuidance::DoNotRetry);
+}
+
+#[test]
+fn semantic_native_mode_never_dispatches_pointer() {
+    let tree = actionable_button_tree(
+        "Save",
+        AxRect {
+            x: 10,
+            y: 10,
+            width: 20,
+            height: 20,
+        },
+    );
+    let (mut glass, native_calls, clicks, _) =
+        click_mode_glass(vec![tree], InvokeBehavior::Unsupported);
+    glass.start(&spec()).unwrap();
+
+    let error = glass
+        .click_target_by(
+            &semantic_click_params(ActionMode::Native, 500),
+            Deadline::UNBOUNDED,
+        )
+        .unwrap_err();
+
+    assert_eq!(native_calls.load(Ordering::Relaxed), 1);
+    assert!(clicks.lock().unwrap().is_empty());
+    assert_eq!(error.action_dispatch, DispatchStatus::NotDispatched);
+}
+
+#[test]
+fn semantic_pointer_mode_never_attempts_native_invoke() {
+    let tree = actionable_button_tree(
+        "Save",
+        AxRect {
+            x: 10,
+            y: 10,
+            width: 20,
+            height: 20,
+        },
+    );
+    let (mut glass, native_calls, clicks, _) =
+        click_mode_glass(vec![tree.clone(), tree], InvokeBehavior::Succeed);
+    let sink = RecordingSink::default();
+    glass.set_audit_sink(Box::new(sink.clone()));
+    glass.start(&spec()).unwrap();
+
+    let outcome = glass
+        .click_target_by(
+            &semantic_click_params(ActionMode::Pointer, 500),
+            Deadline::UNBOUNDED,
+        )
+        .unwrap();
+
+    assert_eq!(native_calls.load(Ordering::Relaxed), 0);
+    assert_eq!(clicks.lock().unwrap().len(), 1);
+    assert_eq!(
+        outcome.action.method,
+        ActionMethod::Pointer {
+            native_fallback: None
+        }
+    );
+    let audits = sink.1.lock().unwrap();
+    assert_eq!(audits.len(), 1);
+    assert_eq!(audits[0].mode, "pointer");
+    assert_eq!(audits[0].method.as_deref(), Some("pointer"));
+    assert_eq!(audits[0].native_fallback, None);
+    assert_eq!(audits[0].dispatch, "dispatched");
+    assert_eq!(audits[0].confirmation, "dispatch_confirmed");
+}
+
+#[test]
+fn semantic_native_click_can_actuate_a_known_hidden_target_and_discloses_visibility_failure_as_optional()
+ {
+    let mut tree = actionable_button_tree(
+        "Save",
+        AxRect {
+            x: 10,
+            y: 10,
+            width: 20,
+            height: 20,
+        },
+    );
+    tree.root.children[0].states.visible = false;
+    let (mut glass, native_calls, clicks, _) =
+        click_mode_glass(vec![tree], InvokeBehavior::Succeed);
+    glass.start(&spec()).unwrap();
+
+    let outcome = glass
+        .click_target_by(
+            &semantic_click_params(ActionMode::Native, 500),
+            Deadline::UNBOUNDED,
+        )
+        .unwrap();
+
+    assert_eq!(native_calls.load(Ordering::Relaxed), 1);
+    assert!(clicks.lock().unwrap().is_empty());
+    let visible = outcome
+        .actionability
+        .checks
+        .iter()
+        .find(|check| check.name == ActionabilityCheckName::Visible)
+        .unwrap();
+    assert_eq!(visible.verdict, ActionabilityVerdict::Failed);
+    assert!(!visible.required);
+}
+
+#[test]
+fn semantic_pointer_click_refuses_the_same_known_hidden_target() {
+    let mut tree = actionable_button_tree(
+        "Save",
+        AxRect {
+            x: 10,
+            y: 10,
+            width: 20,
+            height: 20,
+        },
+    );
+    tree.root.children[0].states.visible = false;
+    let (mut glass, native_calls, clicks, _) =
+        click_mode_glass(vec![tree], InvokeBehavior::Succeed);
+    glass.start(&spec()).unwrap();
+
+    let error = glass
+        .click_target_by(
+            &semantic_click_params(ActionMode::Pointer, 0),
+            Deadline::UNBOUNDED,
+        )
+        .unwrap_err();
+
+    assert_eq!(native_calls.load(Ordering::Relaxed), 0);
+    assert!(clicks.lock().unwrap().is_empty());
+    assert_eq!(error.kind, SemanticActionFailureKind::NotActionable);
+    assert_eq!(
+        error.actionability.blocking().unwrap().name,
+        ActionabilityCheckName::Visible
+    );
+    assert_eq!(error.action_dispatch, DispatchStatus::NotDispatched);
+}
+
+#[test]
+fn duplicate_semantic_click_dispatches_neither_native_nor_pointer() {
+    let tree = duplicate_button_tree("Save", 2);
+    let (mut glass, native_calls, clicks, _) =
+        click_mode_glass(vec![tree], InvokeBehavior::Succeed);
+    glass.start(&spec()).unwrap();
+
+    let error = glass
+        .click_target_by(
+            &semantic_click_params(ActionMode::Auto, 0),
+            Deadline::UNBOUNDED,
+        )
+        .unwrap_err();
+
+    assert_eq!(native_calls.load(Ordering::Relaxed), 0);
+    assert!(clicks.lock().unwrap().is_empty());
+    assert_eq!(error.kind, SemanticActionFailureKind::AmbiguousTarget);
+    assert_eq!(error.action_dispatch, DispatchStatus::NotDispatched);
+}
+
+#[test]
+fn legacy_click_element_fields_and_native_first_behavior_are_unchanged() {
+    let tree = actionable_button_tree(
+        "Save",
+        AxRect {
+            x: 10,
+            y: 10,
+            width: 20,
+            height: 20,
+        },
+    );
+    let id = tree.root.children[0].id;
+    let (mut legacy, legacy_native_calls, legacy_clicks, _) =
+        click_mode_glass(vec![tree.clone()], InvokeBehavior::SucceedOnAnother(7));
+    let legacy_sink = RecordingSink::default();
+    legacy.set_audit_sink(Box::new(legacy_sink.clone()));
+    legacy.start(&spec()).unwrap();
+    legacy.a11y_snapshot(None).unwrap();
+
+    let legacy_method = legacy.click_element(id).unwrap();
+
+    assert_eq!(legacy_method.label(), "native-action");
+    assert_eq!(legacy_method.native_fallback(), None);
+    assert_eq!(legacy_method.actuated(), Some(AxNodeId(7)));
+    assert_eq!(legacy_native_calls.load(Ordering::Relaxed), 1);
+    assert!(legacy_clicks.lock().unwrap().is_empty());
+    let legacy_audits = legacy_sink.1.lock().unwrap();
+    assert_eq!(legacy_audits.len(), 1);
+    assert_eq!(legacy_audits[0].mode, "auto");
+    assert_eq!(legacy_audits[0].method.as_deref(), Some("native-action"));
+    assert_eq!(legacy_audits[0].actuated_id, Some(7));
+    drop(legacy_audits);
+
+    let (mut semantic, semantic_native_calls, semantic_clicks, _) =
+        click_mode_glass(vec![tree], InvokeBehavior::NoAction);
+    let semantic_sink = RecordingSink::default();
+    semantic.set_audit_sink(Box::new(semantic_sink.clone()));
+    semantic.start(&spec()).unwrap();
+    semantic.a11y_snapshot(None).unwrap();
+    let outcome = semantic
+        .click_target_by(
+            &ClickTargetParams {
+                target: ActionTarget::Id(id),
+                mode: ActionMode::Auto,
+                timeout_ms: None,
+                max_nodes: None,
+            },
+            Deadline::UNBOUNDED,
+        )
+        .unwrap();
+    let legacy_pointer = semantic.click_element(id).unwrap();
+
+    assert!(matches!(
+        outcome.action.method,
+        ActionMethod::Pointer {
+            native_fallback: Some(_)
+        }
+    ));
+    assert_eq!(legacy_pointer.label(), "pointer");
+    assert_eq!(
+        legacy_pointer.native_fallback(),
+        Some("element exposes no activation action")
+    );
+    assert_eq!(legacy_pointer.actuated(), None);
+    assert_eq!(semantic_native_calls.load(Ordering::Relaxed), 2);
+    assert_eq!(semantic_clicks.lock().unwrap().len(), 2);
+    let semantic_audits = semantic_sink.1.lock().unwrap();
+    assert_eq!(semantic_audits.len(), 2);
+    assert!(semantic_audits.iter().all(|audit| {
+        audit.mode == "auto"
+            && audit.method.as_deref() == Some("pointer")
+            && audit.native_fallback.as_deref() == Some("element exposes no activation action")
+            && audit.actuated_id.is_none()
+    }));
+}
+
+#[test]
+fn semantic_public_click_audit_emits_exactly_one_record_on_native_fallback_and_failure() {
+    let tree = actionable_button_tree(
+        "Save",
+        AxRect {
+            x: 10,
+            y: 10,
+            width: 20,
+            height: 20,
+        },
+    );
+    let cases = [
+        (
+            vec![tree.clone()],
+            InvokeBehavior::Succeed,
+            500,
+            true,
+            Some("native-action"),
+            None,
+            "dispatched",
+            "dispatch_confirmed",
+        ),
+        (
+            vec![tree.clone(), tree.clone()],
+            InvokeBehavior::Unsupported,
+            500,
+            true,
+            Some("pointer"),
+            Some("backend has no native action path"),
+            "dispatched",
+            "dispatch_confirmed",
+        ),
+        (
+            vec![duplicate_button_tree("Save", 2)],
+            InvokeBehavior::Succeed,
+            0,
+            false,
+            None,
+            None,
+            "not_dispatched",
+            "unconfirmed",
+        ),
+    ];
+
+    for (
+        trees,
+        behavior,
+        timeout_ms,
+        succeeds,
+        expected_method,
+        expected_fallback,
+        expected_dispatch,
+        expected_confirmation,
+    ) in cases
+    {
+        let (mut glass, _, _, _) = click_mode_glass(trees, behavior);
+        let sink = RecordingSink::default();
+        glass.set_audit_sink(Box::new(sink.clone()));
+        glass.start(&spec()).unwrap();
+
+        let result = glass.click_target_by(
+            &semantic_click_params(ActionMode::Auto, timeout_ms),
+            Deadline::UNBOUNDED,
+        );
+
+        assert_eq!(result.is_ok(), succeeds);
+        let records = sink.0.lock().unwrap();
+        let click_records = records
+            .iter()
+            .filter(|record| record.starts_with("click_element:"))
+            .collect::<Vec<_>>();
+        assert_eq!(click_records.len(), 1, "records: {records:?}");
+        assert_eq!(
+            click_records[0].as_str(),
+            if succeeds {
+                "click_element:true"
+            } else {
+                "click_element:false"
+            }
+        );
+        drop(records);
+        let audits = sink.1.lock().unwrap();
+        assert_eq!(audits.len(), 1);
+        assert_eq!(audits[0].element.name.as_deref(), Some("Save"));
+        assert_eq!(audits[0].mode, "auto");
+        assert_eq!(audits[0].method.as_deref(), expected_method);
+        assert_eq!(audits[0].native_fallback.as_deref(), expected_fallback);
+        assert_eq!(audits[0].dispatch, expected_dispatch);
+        assert_eq!(audits[0].confirmation, expected_confirmation);
+        assert_eq!(audits[0].ok, succeeds);
+    }
+}

--- a/crates/glass-core/src/session/semantic_action/tests.rs
+++ b/crates/glass-core/src/session/semantic_action/tests.rs
@@ -1,8 +1,9 @@
 use super::*;
 use crate::session::test_support::*;
 use crate::{
-    Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxStateCoverage, AxStates, AxTree,
-    ChangeSignal, SemanticSelector, SemanticState, Truncation, TruncationLimit, WalkLimits,
+    Accessibility, ActionabilityCheckName, ActionabilityVerdict, AxContext, AxNode, AxNodeId,
+    AxRect, AxRole, AxStateCoverage, AxStates, AxTree, ChangeSignal, PointerHit, SemanticSelector,
+    SemanticState, Truncation, TruncationLimit, WalkLimits,
 };
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -22,6 +23,68 @@ fn named_button_tree(name: &str) -> AxTree {
     let mut tree = fake_tree();
     tree.root.children[0].name = Some(name.into());
     tree
+}
+
+fn actionable_button_tree(name: &str, bounds: AxRect) -> AxTree {
+    let mut tree = named_button_tree(name);
+    let button = &mut tree.root.children[0];
+    button.bounds = Some(bounds);
+    button.states.enabled = true;
+    button.states.visible = true;
+    tree
+}
+
+fn pointer_params(target: ActionTarget, timeout_ms: Option<u64>) -> ClickTargetParams {
+    ClickTargetParams {
+        target,
+        mode: ActionMode::Pointer,
+        timeout_ms,
+        max_nodes: None,
+    }
+}
+
+fn pointer_glass(
+    platform: FakePlatform,
+    trees: Vec<AxTree>,
+    hit: PointerHit,
+    hit_error: bool,
+) -> (
+    Glass,
+    Arc<AtomicUsize>,
+    Arc<AtomicUsize>,
+    Arc<Mutex<Vec<(i32, i32)>>>,
+) {
+    let walks = Arc::new(AtomicUsize::new(0));
+    let hit_calls = Arc::new(AtomicUsize::new(0));
+    let hit_points = Arc::new(Mutex::new(Vec::new()));
+    let mut accessibility = SeqAccessibility::new(trees)
+        .with_coverage(full_state_coverage())
+        .with_hit(hit)
+        .with_walks(walks.clone())
+        .with_hit_calls(hit_calls.clone())
+        .with_hit_points(hit_points.clone());
+    if hit_error {
+        accessibility = accessibility.with_hit_error();
+    }
+    (
+        glass_with_backend(platform, Box::new(accessibility)),
+        walks,
+        hit_calls,
+        hit_points,
+    )
+}
+
+fn report_verdict(
+    outcome: &SemanticActionOutcome,
+    name: ActionabilityCheckName,
+) -> ActionabilityVerdict {
+    outcome
+        .actionability
+        .checks
+        .iter()
+        .find(|check| check.name == name)
+        .expect("missing actionability check")
+        .verdict
 }
 
 fn duplicate_button_tree(name: &str, count: usize) -> AxTree {
@@ -712,4 +775,542 @@ fn target_deadlines_preserve_id_and_selector_bound_ownership() {
     assert_eq!(sequence_limited.deadline, sequence);
     assert_eq!(sequence_limited.owner, Some(Whose::Caller));
     assert!(sequence_limited.allow_wait);
+}
+
+#[test]
+fn selector_pointer_waits_for_two_identical_samples_at_least_one_hundred_ms_apart() {
+    let bounds = AxRect {
+        x: 10,
+        y: 10,
+        width: 20,
+        height: 20,
+    };
+    let clicks = Arc::new(Mutex::new(Vec::new()));
+    let platform = FakePlatform::new(100, 100).with_click_log(clicks.clone());
+    let (mut glass, walks, hit_calls, _) = pointer_glass(
+        platform,
+        vec![
+            actionable_button_tree("Save", bounds),
+            actionable_button_tree("Save", bounds),
+        ],
+        PointerHit::Target,
+        false,
+    );
+    glass.start(&spec()).unwrap();
+
+    let started = std::time::Instant::now();
+    let outcome = glass
+        .click_target_inner(
+            pointer_params(ActionTarget::Semantic(semantic_target("Save")), Some(500)),
+            Deadline::UNBOUNDED,
+        )
+        .unwrap();
+
+    assert!(started.elapsed() >= std::time::Duration::from_millis(100));
+    assert_eq!(walks.load(Ordering::Relaxed), 2);
+    assert_eq!(hit_calls.load(Ordering::Relaxed), 1);
+    assert_eq!(clicks.lock().unwrap().as_slice(), &[(20, 20)]);
+    assert_eq!(
+        report_verdict(&outcome, ActionabilityCheckName::Stable),
+        ActionabilityVerdict::Passed
+    );
+}
+
+#[test]
+fn moving_bounds_reset_the_stability_sample_until_the_target_stops() {
+    let first = AxRect {
+        x: 10,
+        y: 10,
+        width: 20,
+        height: 20,
+    };
+    let final_bounds = AxRect { x: 40, ..first };
+    let clicks = Arc::new(Mutex::new(Vec::new()));
+    let platform = FakePlatform::new(100, 100).with_click_log(clicks.clone());
+    let (mut glass, walks, _, _) = pointer_glass(
+        platform,
+        vec![
+            actionable_button_tree("Save", first),
+            actionable_button_tree("Save", final_bounds),
+            actionable_button_tree("Save", final_bounds),
+        ],
+        PointerHit::Target,
+        false,
+    );
+    glass.start(&spec()).unwrap();
+
+    let started = std::time::Instant::now();
+    glass
+        .click_target_inner(
+            pointer_params(ActionTarget::Semantic(semantic_target("Save")), Some(600)),
+            Deadline::UNBOUNDED,
+        )
+        .unwrap();
+
+    assert!(started.elapsed() >= std::time::Duration::from_millis(200));
+    assert_eq!(walks.load(Ordering::Relaxed), 3);
+    assert_eq!(clicks.lock().unwrap().as_slice(), &[(50, 20)]);
+}
+
+#[test]
+fn identity_change_resets_stability_even_when_bounds_are_equal() {
+    let bounds = AxRect {
+        x: 10,
+        y: 10,
+        width: 20,
+        height: 20,
+    };
+    let mut first = actionable_button_tree("Save", bounds);
+    first.root.children[0].description = Some("old identity".into());
+    let mut final_tree = actionable_button_tree("Save", bounds);
+    final_tree.root.children[0].description = Some("new identity".into());
+    let clicks = Arc::new(Mutex::new(Vec::new()));
+    let platform = FakePlatform::new(100, 100).with_click_log(clicks.clone());
+    let (mut glass, walks, _, _) = pointer_glass(
+        platform,
+        vec![first, final_tree.clone(), final_tree],
+        PointerHit::Target,
+        false,
+    );
+    glass.start(&spec()).unwrap();
+
+    glass
+        .click_target_inner(
+            pointer_params(ActionTarget::Semantic(semantic_target("Save")), Some(600)),
+            Deadline::UNBOUNDED,
+        )
+        .unwrap();
+
+    assert_eq!(walks.load(Ordering::Relaxed), 3);
+    assert_eq!(clicks.lock().unwrap().len(), 1);
+}
+
+#[test]
+fn zero_timeout_native_action_dispatches_after_one_fresh_read() {
+    let tree = actionable_button_tree(
+        "Save",
+        AxRect {
+            x: 10,
+            y: 10,
+            width: 20,
+            height: 20,
+        },
+    );
+    let (mut glass, walks, _, invoke_log) =
+        semantic_glass(vec![tree], None, InvokeBehavior::Succeed);
+    glass.start(&spec()).unwrap();
+
+    let outcome = glass
+        .click_target_inner(
+            ClickTargetParams {
+                target: ActionTarget::Semantic(semantic_target("Save")),
+                mode: ActionMode::Native,
+                timeout_ms: Some(0),
+                max_nodes: None,
+            },
+            Deadline::UNBOUNDED,
+        )
+        .unwrap();
+
+    assert_eq!(walks.load(Ordering::Relaxed), 1);
+    assert_eq!(invoke_log.lock().unwrap().len(), 1);
+    assert!(matches!(
+        outcome.action.method,
+        ActionMethod::NativeAction { .. }
+    ));
+}
+
+#[test]
+fn zero_timeout_pointer_action_returns_unstable_without_dispatch() {
+    let tree = actionable_button_tree(
+        "Save",
+        AxRect {
+            x: 10,
+            y: 10,
+            width: 20,
+            height: 20,
+        },
+    );
+    let clicks = Arc::new(Mutex::new(Vec::new()));
+    let platform = FakePlatform::new(100, 100).with_click_log(clicks.clone());
+    let (mut glass, walks, hit_calls, _) =
+        pointer_glass(platform, vec![tree], PointerHit::Target, false);
+    glass.start(&spec()).unwrap();
+
+    let error = glass
+        .click_target_inner(
+            pointer_params(ActionTarget::Semantic(semantic_target("Save")), Some(0)),
+            Deadline::UNBOUNDED,
+        )
+        .unwrap_err();
+
+    assert_eq!(error.kind, SemanticActionFailureKind::UnstableTarget);
+    assert_eq!(error.action_dispatch, DispatchStatus::NotDispatched);
+    assert_eq!(walks.load(Ordering::Relaxed), 1);
+    assert_eq!(hit_calls.load(Ordering::Relaxed), 0);
+    assert!(clicks.lock().unwrap().is_empty());
+}
+
+#[test]
+fn selector_pointer_known_occlusion_blocks_before_pointer_dispatch() {
+    let tree = actionable_button_tree(
+        "Save",
+        AxRect {
+            x: 10,
+            y: 10,
+            width: 20,
+            height: 20,
+        },
+    );
+    let clicks = Arc::new(Mutex::new(Vec::new()));
+    let platform = FakePlatform::new(100, 100).with_click_log(clicks.clone());
+    let (mut glass, _, hit_calls, _) =
+        pointer_glass(platform, vec![tree.clone(), tree], PointerHit::Other, false);
+    glass.start(&spec()).unwrap();
+
+    let error = glass
+        .click_target_inner(
+            pointer_params(ActionTarget::Semantic(semantic_target("Save")), Some(500)),
+            Deadline::UNBOUNDED,
+        )
+        .unwrap_err();
+
+    assert_eq!(error.kind, SemanticActionFailureKind::NotActionable);
+    assert_eq!(error.action_dispatch, DispatchStatus::NotDispatched);
+    assert_eq!(hit_calls.load(Ordering::Relaxed), 1);
+    assert!(clicks.lock().unwrap().is_empty());
+}
+
+#[test]
+fn selector_pointer_inconclusive_occlusion_dispatches_once_and_discloses_unproven() {
+    let tree = actionable_button_tree(
+        "Save",
+        AxRect {
+            x: 10,
+            y: 10,
+            width: 20,
+            height: 20,
+        },
+    );
+    let clicks = Arc::new(Mutex::new(Vec::new()));
+    let platform = FakePlatform::new(100, 100).with_click_log(clicks.clone());
+    let (mut glass, _, hit_calls, _) = pointer_glass(
+        platform,
+        vec![tree.clone(), tree],
+        PointerHit::Inconclusive,
+        false,
+    );
+    glass.start(&spec()).unwrap();
+
+    let outcome = glass
+        .click_target_inner(
+            pointer_params(ActionTarget::Semantic(semantic_target("Save")), Some(500)),
+            Deadline::UNBOUNDED,
+        )
+        .unwrap();
+
+    assert_eq!(hit_calls.load(Ordering::Relaxed), 1);
+    assert_eq!(clicks.lock().unwrap().len(), 1);
+    assert_eq!(
+        report_verdict(&outcome, ActionabilityCheckName::NonOccluded),
+        ActionabilityVerdict::Unproven
+    );
+}
+
+#[test]
+fn selector_pointer_hit_probe_and_dispatch_use_the_same_planned_point() {
+    let tree = actionable_button_tree(
+        "Save",
+        AxRect {
+            x: -10,
+            y: 10,
+            width: 30,
+            height: 20,
+        },
+    );
+    let clicks = Arc::new(Mutex::new(Vec::new()));
+    let platform = FakePlatform::new(100, 100).with_click_log(clicks.clone());
+    let (mut glass, _, _, hit_points) = pointer_glass(
+        platform,
+        vec![tree.clone(), tree],
+        PointerHit::Target,
+        false,
+    );
+    glass.start(&spec()).unwrap();
+
+    glass
+        .click_target_inner(
+            pointer_params(ActionTarget::Semantic(semantic_target("Save")), Some(500)),
+            Deadline::UNBOUNDED,
+        )
+        .unwrap();
+
+    assert_eq!(hit_points.lock().unwrap().as_slice(), &[(10, 20)]);
+    assert_eq!(clicks.lock().unwrap().as_slice(), &[(10, 20)]);
+}
+
+#[test]
+fn selector_pointer_row_toggle_probes_and_dispatches_the_same_trailing_control() {
+    let bounds = AxRect {
+        x: 10,
+        y: 10,
+        width: 80,
+        height: 15,
+    };
+    let mut tree = actionable_button_tree("Wi-Fi", bounds);
+    let toggle = &mut tree.root.children[0];
+    toggle.role = AxRole::CheckBox;
+    toggle.states.checkable = true;
+    let drags = Arc::new(Mutex::new(Vec::new()));
+    let platform = FakePlatform::new(100, 100)
+        .with_drag_log(drags.clone())
+        .with_trailing_toggle_backend();
+    let (mut glass, _, _, hit_points) = pointer_glass(
+        platform,
+        vec![tree.clone(), tree],
+        PointerHit::Target,
+        false,
+    );
+    glass.start(&spec()).unwrap();
+
+    glass
+        .click_target_inner(
+            pointer_params(ActionTarget::Semantic(semantic_target("Wi-Fi")), Some(500)),
+            Deadline::UNBOUNDED,
+        )
+        .unwrap();
+
+    let segment = bounds.trailing_toggle_swipe(100, 100).unwrap();
+    let midpoint = (
+        (segment.from_x + segment.to_x) / 2,
+        (segment.from_y + segment.to_y) / 2,
+    );
+    assert_eq!(hit_points.lock().unwrap().as_slice(), &[midpoint]);
+    let drags = drags.lock().unwrap();
+    assert_eq!(drags.len(), 1);
+    assert!(matches!(
+        drags[0],
+        PointerEvent::Drag {
+            from_x,
+            from_y,
+            to_x,
+            to_y,
+            ..
+        } if (from_x, from_y, to_x, to_y)
+            == (segment.from_x, segment.from_y, segment.to_x, segment.to_y)
+    ));
+}
+
+#[test]
+fn selector_pointer_popover_row_toggle_dispatches_the_translated_planned_segment() {
+    let mut tree = fake_tree_with_popover_option();
+    let toggle = &mut tree.root.children[0].children[0];
+    toggle.role = AxRole::CheckBox;
+    toggle.states.enabled = true;
+    toggle.states.visible = true;
+    toggle.states.checkable = true;
+    toggle.bounds.as_mut().unwrap().width = 200;
+    let bounds = toggle.bounds.unwrap();
+    let active = window_info(
+        1,
+        WindowGeometry {
+            x: 0,
+            y: 0,
+            width: 340,
+            height: 300,
+        },
+        true,
+    );
+    let popover = window_info(
+        2,
+        WindowGeometry {
+            x: -3,
+            y: 220,
+            width: 326,
+            height: 135,
+        },
+        false,
+    );
+    let clicks = Arc::new(Mutex::new(Vec::new()));
+    let drags = Arc::new(Mutex::new(Vec::new()));
+    let platform = FakePlatform::new(340, 300)
+        .with_windows(vec![active, popover])
+        .with_click_log(clicks.clone())
+        .with_drag_log(drags.clone())
+        .with_trailing_toggle_backend();
+    let (mut glass, _, _, hit_points) = pointer_glass(
+        platform,
+        vec![tree.clone(), tree],
+        PointerHit::Target,
+        false,
+    );
+    glass.start(&spec()).unwrap();
+
+    glass
+        .click_target_inner(
+            pointer_params(ActionTarget::Semantic(semantic_target("Globex")), Some(500)),
+            Deadline::UNBOUNDED,
+        )
+        .unwrap();
+
+    let segment = bounds.trailing_toggle_swipe(340, 300).unwrap();
+    let probe_point = (
+        (segment.from_x + segment.to_x) / 2,
+        (segment.from_y + segment.to_y) / 2,
+    );
+    assert_eq!(hit_points.lock().unwrap().as_slice(), &[probe_point]);
+    assert!(clicks.lock().unwrap().is_empty());
+    let drags = drags.lock().unwrap();
+    assert_eq!(drags.len(), 1);
+    assert!(matches!(
+        drags[0],
+        PointerEvent::Drag {
+            from_x,
+            from_y,
+            to_x,
+            to_y,
+            ..
+        } if (from_x, from_y, to_x, to_y)
+            == (
+                segment.from_x,
+                segment.from_y - 194,
+                segment.to_x,
+                segment.to_y - 194,
+            )
+    ));
+}
+
+#[test]
+fn legacy_id_forced_pointer_dispatches_without_a_fresh_read_or_stability_sleep() {
+    let tree = fake_tree();
+    let clicks = Arc::new(Mutex::new(Vec::new()));
+    let platform = FakePlatform::new(100, 100).with_click_log(clicks.clone());
+    let (mut glass, walks, hit_calls, _) =
+        pointer_glass(platform, vec![tree], PointerHit::Other, false);
+    glass.start(&spec()).unwrap();
+    glass.a11y_snapshot(None).unwrap();
+    walks.store(0, Ordering::Relaxed);
+    hit_calls.store(0, Ordering::Relaxed);
+    clicks.lock().unwrap().clear();
+
+    let started = std::time::Instant::now();
+    let outcome = glass
+        .click_target_inner(
+            pointer_params(ActionTarget::Id(AxNodeId(1)), None),
+            Deadline::UNBOUNDED,
+        )
+        .unwrap();
+
+    assert!(started.elapsed() < std::time::Duration::from_millis(75));
+    assert_eq!(walks.load(Ordering::Relaxed), 0);
+    assert_eq!(hit_calls.load(Ordering::Relaxed), 0);
+    assert_eq!(clicks.lock().unwrap().len(), 1);
+    for name in [
+        ActionabilityCheckName::Unique,
+        ActionabilityCheckName::Stable,
+        ActionabilityCheckName::NonOccluded,
+    ] {
+        let check = outcome
+            .actionability
+            .checks
+            .iter()
+            .find(|check| check.name == name)
+            .unwrap();
+        assert_eq!(check.verdict, ActionabilityVerdict::Unproven);
+        assert!(!check.required);
+    }
+}
+
+#[test]
+fn selector_pointer_hit_probe_errors_are_action_failed_before_dispatch() {
+    let tree = actionable_button_tree(
+        "Save",
+        AxRect {
+            x: 10,
+            y: 10,
+            width: 20,
+            height: 20,
+        },
+    );
+    let clicks = Arc::new(Mutex::new(Vec::new()));
+    let platform = FakePlatform::new(100, 100).with_click_log(clicks.clone());
+    let (mut glass, _, hit_calls, _) = pointer_glass(
+        platform,
+        vec![tree.clone(), tree],
+        PointerHit::Inconclusive,
+        true,
+    );
+    glass.start(&spec()).unwrap();
+
+    let error = glass
+        .click_target_inner(
+            pointer_params(ActionTarget::Semantic(semantic_target("Save")), Some(500)),
+            Deadline::UNBOUNDED,
+        )
+        .unwrap_err();
+
+    assert_eq!(error.kind, SemanticActionFailureKind::ActionFailed);
+    assert_eq!(error.action_dispatch, DispatchStatus::NotDispatched);
+    assert_eq!(hit_calls.load(Ordering::Relaxed), 1);
+    assert!(clicks.lock().unwrap().is_empty());
+}
+
+#[test]
+fn native_mode_unsupported_is_proven_not_dispatched() {
+    let tree = actionable_button_tree(
+        "Save",
+        AxRect {
+            x: 10,
+            y: 10,
+            width: 20,
+            height: 20,
+        },
+    );
+    let clicks = Arc::new(Mutex::new(Vec::new()));
+    let platform = FakePlatform::new(100, 100).with_click_log(clicks.clone());
+    let (mut glass, _, _, _) = pointer_glass(platform, vec![tree], PointerHit::Inconclusive, false);
+    glass.start(&spec()).unwrap();
+
+    let error = glass
+        .click_target_inner(
+            ClickTargetParams {
+                target: ActionTarget::Semantic(semantic_target("Save")),
+                mode: ActionMode::Native,
+                timeout_ms: Some(0),
+                max_nodes: None,
+            },
+            Deadline::UNBOUNDED,
+        )
+        .unwrap_err();
+
+    assert!(matches!(error.source, Some(GlassError::AxUnsupported)));
+    assert_eq!(error.action_dispatch, DispatchStatus::NotDispatched);
+    assert!(clicks.lock().unwrap().is_empty());
+}
+
+#[test]
+fn legacy_id_missing_bounds_preserves_the_primitive_error_before_dispatch() {
+    let mut tree = fake_tree();
+    tree.root.children[0].bounds = None;
+    let (mut glass, _, _, _) = pointer_glass(
+        FakePlatform::new(100, 100),
+        vec![tree],
+        PointerHit::Other,
+        false,
+    );
+    glass.start(&spec()).unwrap();
+    glass.a11y_snapshot(None).unwrap();
+
+    let error = glass
+        .click_target_inner(
+            pointer_params(ActionTarget::Id(AxNodeId(1)), None),
+            Deadline::UNBOUNDED,
+        )
+        .unwrap_err();
+
+    assert!(matches!(
+        error.source,
+        Some(GlassError::AxElementNotClickable(1))
+    ));
+    assert_eq!(error.action_dispatch, DispatchStatus::NotDispatched);
 }

--- a/crates/glass-core/src/session/semantic_action/tests.rs
+++ b/crates/glass-core/src/session/semantic_action/tests.rs
@@ -9,6 +9,37 @@ use crate::{
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
+type SemanticSetValueFixture = (
+    Glass,
+    Arc<AtomicUsize>,
+    Arc<Mutex<Vec<(AxNodeId, String)>>>,
+    AxDeadlineLog,
+);
+type PointerFixture = (
+    Glass,
+    Arc<AtomicUsize>,
+    Arc<AtomicUsize>,
+    Arc<Mutex<Vec<(i32, i32)>>>,
+);
+type SemanticFixture = (
+    Glass,
+    Arc<AtomicUsize>,
+    Arc<AtomicUsize>,
+    Arc<Mutex<Vec<AxTarget>>>,
+);
+type DeadlineRecordingFixture = (
+    Glass,
+    Arc<Mutex<Option<std::time::Instant>>>,
+    Arc<Mutex<Vec<Deadline>>>,
+    Arc<Mutex<Vec<Deadline>>>,
+);
+type ClickModeFixture = (
+    Glass,
+    Arc<AtomicUsize>,
+    Arc<Mutex<Vec<(i32, i32)>>>,
+    AxDeadlineLog,
+);
+
 fn selector(query: &str) -> SemanticSelector {
     SemanticSelector::new(Some(query.into()), None, Vec::new()).unwrap()
 }
@@ -80,12 +111,7 @@ fn semantic_set_value_params(query: &str, timeout_ms: u64) -> SetValueTargetPara
 fn semantic_set_value_glass(
     trees: Vec<AxTree>,
     set_results: Vec<crate::Result<()>>,
-) -> (
-    Glass,
-    Arc<AtomicUsize>,
-    Arc<Mutex<Vec<(AxNodeId, String)>>>,
-    AxDeadlineLog,
-) {
+) -> SemanticSetValueFixture {
     semantic_set_value_glass_with_coverage(trees, set_results, full_state_coverage())
 }
 
@@ -93,12 +119,7 @@ fn semantic_set_value_glass_with_coverage(
     trees: Vec<AxTree>,
     set_results: Vec<crate::Result<()>>,
     coverage: AxStateCoverage,
-) -> (
-    Glass,
-    Arc<AtomicUsize>,
-    Arc<Mutex<Vec<(AxNodeId, String)>>>,
-    AxDeadlineLog,
-) {
+) -> SemanticSetValueFixture {
     let walks = Arc::new(AtomicUsize::new(0));
     let set_log = Arc::new(Mutex::new(Vec::new()));
     let deadlines = Arc::new(Mutex::new(Vec::new()));
@@ -245,12 +266,7 @@ fn pointer_glass(
     trees: Vec<AxTree>,
     hit: PointerHit,
     hit_error: bool,
-) -> (
-    Glass,
-    Arc<AtomicUsize>,
-    Arc<AtomicUsize>,
-    Arc<Mutex<Vec<(i32, i32)>>>,
-) {
+) -> PointerFixture {
     let walks = Arc::new(AtomicUsize::new(0));
     let hit_calls = Arc::new(AtomicUsize::new(0));
     let hit_points = Arc::new(Mutex::new(Vec::new()));
@@ -374,12 +390,7 @@ fn semantic_glass(
     trees: Vec<AxTree>,
     signal: Option<fn() -> Box<dyn ChangeSignal>>,
     behavior: InvokeBehavior,
-) -> (
-    Glass,
-    Arc<AtomicUsize>,
-    Arc<AtomicUsize>,
-    Arc<Mutex<Vec<AxTarget>>>,
-) {
+) -> SemanticFixture {
     let walks = Arc::new(AtomicUsize::new(0));
     let focus_calls = Arc::new(AtomicUsize::new(0));
     let invoke_log = Arc::new(Mutex::new(Vec::new()));
@@ -423,14 +434,7 @@ impl Accessibility for DeadlineRecordingAccessibility {
     }
 }
 
-fn deadline_recording_glass(
-    coverage_delay: std::time::Duration,
-) -> (
-    Glass,
-    Arc<Mutex<Option<std::time::Instant>>>,
-    Arc<Mutex<Vec<Deadline>>>,
-    Arc<Mutex<Vec<Deadline>>>,
-) {
+fn deadline_recording_glass(coverage_delay: std::time::Duration) -> DeadlineRecordingFixture {
     let coverage_finished = Arc::new(Mutex::new(None));
     let subscription_deadlines = Arc::new(Mutex::new(Vec::new()));
     let snapshot_deadlines = Arc::new(Mutex::new(Vec::new()));
@@ -1870,15 +1874,7 @@ fn legacy_id_missing_bounds_preserves_the_primitive_error_before_dispatch() {
     assert_eq!(error.action_dispatch, DispatchStatus::NotDispatched);
 }
 
-fn click_mode_glass(
-    trees: Vec<AxTree>,
-    behavior: InvokeBehavior,
-) -> (
-    Glass,
-    Arc<AtomicUsize>,
-    Arc<Mutex<Vec<(i32, i32)>>>,
-    AxDeadlineLog,
-) {
+fn click_mode_glass(trees: Vec<AxTree>, behavior: InvokeBehavior) -> ClickModeFixture {
     let native_calls = Arc::new(AtomicUsize::new(0));
     let clicks = Arc::new(Mutex::new(Vec::new()));
     let deadlines = Arc::new(Mutex::new(Vec::new()));
@@ -2034,7 +2030,7 @@ fn generated_trees(count: usize) -> Vec<GeneratedTreeCase> {
 fn run_generated_click(
     tree: AxTree,
     dispatches: Arc<AtomicUsize>,
-) -> std::result::Result<SemanticActionOutcome, SemanticActionError> {
+) -> SemanticActionResult<SemanticActionOutcome> {
     let accessibility = SeqAccessibility::new(vec![tree])
         .with_coverage(full_state_coverage())
         .with_invoke_behavior(InvokeBehavior::Succeed)

--- a/crates/glass-core/src/session/semantic_action/tests.rs
+++ b/crates/glass-core/src/session/semantic_action/tests.rs
@@ -313,6 +313,26 @@ fn error_report_check(
         .expect("missing actionability check")
 }
 
+fn test_element(role: AxRole, states: AxStates, bounds: AxRect) -> ElementInfo {
+    ElementInfo {
+        id: AxNodeId(7),
+        role,
+        name: Some("Target".into()),
+        description: Some("test target".into()),
+        value: None,
+        bounds: Some(bounds),
+        states,
+    }
+}
+
+fn unbounded_action_deadline(owner: Option<Whose>) -> ActionDeadline {
+    ActionDeadline {
+        deadline: Deadline::UNBOUNDED,
+        owner,
+        allow_wait: true,
+    }
+}
+
 fn assert_pointer_report_order(error: &SemanticActionError) {
     assert_eq!(
         error
@@ -579,6 +599,427 @@ fn semantic_action_error_display_never_exposes_retained_payloads() {
 
     assert_eq!(error.to_string(), "semantic action failed");
     assert!(std::error::Error::source(&error).is_none());
+}
+
+#[test]
+fn source_errors_preserve_deadline_owner_in_kind_and_summary() {
+    let cases = [
+        (
+            GlassError::caller_deadline_elapsed("resolve"),
+            unbounded_action_deadline(None),
+            SemanticActionFailureKind::SequenceDeadlineExceeded,
+            "semantic action sequence deadline exceeded",
+        ),
+        (
+            GlassError::Bounded {
+                kind: crate::BoundKind::TimedOut,
+                whose: Whose::Callee,
+                dispatch: crate::BoundDispatch::NotDispatched,
+                message: "resolver ceiling elapsed".into(),
+            },
+            unbounded_action_deadline(None),
+            SemanticActionFailureKind::ActionDeadlineExceeded,
+            "semantic action deadline exceeded",
+        ),
+        (
+            GlassError::Backend("reader failed".into()),
+            unbounded_action_deadline(None),
+            SemanticActionFailureKind::ActionFailed,
+            "semantic action target resolution failed",
+        ),
+    ];
+
+    for (source, bound, kind, summary) in cases {
+        let error = source_error(source, bound);
+        assert_eq!(error.kind, kind);
+        assert_eq!(error.summary, summary);
+        assert!(error.source.is_some());
+    }
+}
+
+#[test]
+fn pointer_plan_requires_every_trailing_toggle_fact_and_uses_the_segment_midpoint() {
+    let bounds = AxRect {
+        x: 11,
+        y: 7,
+        width: 81,
+        height: 15,
+    };
+    let mut element = test_element(
+        AxRole::CheckBox,
+        AxStates {
+            checkable: true,
+            ..AxStates::default()
+        },
+        bounds,
+    );
+    let segment = bounds.trailing_toggle_swipe(120, 80).unwrap();
+    assert_eq!(
+        pointer_plan(&element, (120, 80), true),
+        Some(PlannedPointerInput::TrailingToggle {
+            segment,
+            probe_point: (
+                segment.from_x + (segment.to_x - segment.from_x) / 2,
+                segment.from_y + (segment.to_y - segment.from_y) / 2,
+            ),
+        })
+    );
+
+    element.states.checkable = false;
+    assert!(matches!(
+        pointer_plan(&element, (120, 80), true),
+        Some(PlannedPointerInput::Click { .. })
+    ));
+    element.states.checkable = true;
+    assert!(matches!(
+        pointer_plan(&element, (120, 80), false),
+        Some(PlannedPointerInput::Click { .. })
+    ));
+    element.bounds = Some(AxRect {
+        width: 60,
+        ..bounds
+    });
+    assert!(matches!(
+        pointer_plan(&element, (120, 80), true),
+        Some(PlannedPointerInput::Click { .. })
+    ));
+}
+
+#[test]
+fn pointer_candidate_requires_one_retained_match_from_a_complete_resolved_query() {
+    let tree = actionable_button_tree(
+        "Save",
+        AxRect {
+            x: 10,
+            y: 10,
+            width: 20,
+            height: 20,
+        },
+    );
+    let query = SemanticQuery::new(selector("Save"), None, SEMANTIC_ACTION_CANDIDATE_LIMIT)
+        .expect("valid query");
+    let complete = tree.semantic_query(&query);
+    assert!(complete_unique_pointer_result(&complete));
+
+    let mut unresolved_scope = complete.clone();
+    unresolved_scope.scope = ScopeResolution::NotFound;
+    let mut duplicate_walk = complete.clone();
+    duplicate_walk.matches_in_walk = 2;
+    let mut incomplete = complete.clone();
+    incomplete.search_complete = false;
+    let mut omitted_match = complete;
+    omitted_match.matches.clear();
+
+    for result in [unresolved_scope, duplicate_walk, incomplete, omitted_match] {
+        assert!(!complete_unique_pointer_result(&result), "{result:?}");
+    }
+}
+
+#[test]
+fn pointer_resolution_reports_partial_query_evidence_without_hit_testing_or_dispatch() {
+    let bounds = AxRect {
+        x: 10,
+        y: 10,
+        width: 20,
+        height: 20,
+    };
+    let mut incomplete = actionable_button_tree("Save", bounds);
+    incomplete.truncated = Some(Truncation {
+        limit: TruncationLimit::Nodes,
+        limit_value: 2,
+        nodes_walked: 2,
+    });
+    let cases = [
+        (
+            duplicate_button_tree("Save", 2),
+            SemanticTarget {
+                target: selector("Save"),
+                within: None,
+            },
+            SemanticActionFailureKind::AmbiguousTarget,
+        ),
+        (
+            incomplete,
+            SemanticTarget {
+                target: selector("Save"),
+                within: None,
+            },
+            SemanticActionFailureKind::IncompleteTree,
+        ),
+        (
+            scoped_tree(),
+            SemanticTarget {
+                target: selector("Save account"),
+                within: Some(selector("Account panel")),
+            },
+            SemanticActionFailureKind::AmbiguousScope,
+        ),
+    ];
+
+    for (tree, target, expected_kind) in cases {
+        let clicks = Arc::new(Mutex::new(Vec::new()));
+        let platform = FakePlatform::new(100, 100).with_click_log(clicks.clone());
+        let (mut glass, walks, hit_calls, _) =
+            pointer_glass(platform, vec![tree], PointerHit::Target, false);
+        glass.start(&spec()).unwrap();
+
+        let error = glass
+            .click_target_inner(
+                pointer_params(ActionTarget::Semantic(target), Some(0)),
+                Deadline::UNBOUNDED,
+            )
+            .expect_err("partial query evidence cannot choose a pointer target");
+
+        assert_eq!(error.kind, expected_kind);
+        assert_eq!(error.action_dispatch, DispatchStatus::NotDispatched);
+        assert_eq!(walks.load(Ordering::Relaxed), 1);
+        assert_eq!(hit_calls.load(Ordering::Relaxed), 0);
+        assert!(clicks.lock().unwrap().is_empty());
+    }
+}
+
+#[test]
+fn planned_pointer_input_requires_every_coordinate_to_be_strictly_inside_the_window() {
+    for point in [(0, 0), (99, 99)] {
+        assert!(PlannedPointerInput::Click { point }.is_inside_window((100, 100)));
+    }
+    for point in [(-1, 0), (0, -1), (100, 0), (0, 100)] {
+        assert!(!PlannedPointerInput::Click { point }.is_inside_window((100, 100)));
+    }
+
+    let segment = crate::Segment {
+        from_x: 1,
+        from_y: 2,
+        to_x: 98,
+        to_y: 97,
+    };
+    assert!(
+        PlannedPointerInput::TrailingToggle {
+            segment,
+            probe_point: (50, 50),
+        }
+        .is_inside_window((100, 100))
+    );
+    for plan in [
+        PlannedPointerInput::TrailingToggle {
+            segment: crate::Segment {
+                from_x: 100,
+                ..segment
+            },
+            probe_point: (50, 50),
+        },
+        PlannedPointerInput::TrailingToggle {
+            segment: crate::Segment {
+                to_y: 100,
+                ..segment
+            },
+            probe_point: (50, 50),
+        },
+        PlannedPointerInput::TrailingToggle {
+            segment,
+            probe_point: (-1, 50),
+        },
+    ] {
+        assert!(!plan.is_inside_window((100, 100)), "{plan:?}");
+    }
+}
+
+#[test]
+fn value_and_type_actionability_insert_one_exact_eligibility_check_before_stability() {
+    let bounds = AxRect {
+        x: 10,
+        y: 10,
+        width: 80,
+        height: 20,
+    };
+    let editable = test_element(
+        AxRole::Button,
+        AxStates {
+            enabled: true,
+            visible: true,
+            editable: true,
+            ..AxStates::default()
+        },
+        bounds,
+    );
+    let coverage = AxStateCoverage {
+        enabled: true,
+        visible: true,
+        editable: true,
+        checkable: true,
+        ..AxStateCoverage::NONE
+    };
+
+    let semantic = set_value_actionability(&editable, coverage, (100, 100), false);
+    let legacy = set_value_actionability(&editable, coverage, (100, 100), true);
+    let targeted = targeted_type_actionability(&editable, coverage, Some(true), (100, 100), true);
+    for (report, required, source) in [
+        (&semantic, true, ActionabilitySource::NormalizedState),
+        (&legacy, false, ActionabilitySource::LegacyCache),
+        (&targeted, true, ActionabilitySource::NormalizedState),
+    ] {
+        let positions = report
+            .checks
+            .iter()
+            .enumerate()
+            .filter(|(_, check)| check.name == ActionabilityCheckName::FocusEligible)
+            .collect::<Vec<_>>();
+        assert_eq!(positions.len(), 1);
+        let (position, check) = positions[0];
+        assert_eq!(
+            report.checks[position + 1].name,
+            ActionabilityCheckName::Stable
+        );
+        assert_eq!(check.verdict, ActionabilityVerdict::Passed);
+        assert_eq!(check.required, required);
+        assert_eq!(check.source, source);
+    }
+
+    let unsupported = test_element(AxRole::Button, AxStates::default(), bounds);
+    assert_eq!(
+        targeted_type_eligibility(&unsupported, AxStateCoverage::NONE),
+        ActionabilityVerdict::Unproven
+    );
+    assert_eq!(
+        targeted_type_eligibility(
+            &unsupported,
+            AxStateCoverage {
+                editable: true,
+                ..AxStateCoverage::NONE
+            }
+        ),
+        ActionabilityVerdict::Failed
+    );
+    assert_eq!(
+        targeted_type_eligibility(
+            &test_element(AxRole::TextArea, AxStates::default(), bounds),
+            AxStateCoverage::NONE
+        ),
+        ActionabilityVerdict::Passed
+    );
+}
+
+#[test]
+fn focus_confirmation_discloses_coverage_and_observation_independently() {
+    for (covered, confirmed, expected) in [
+        (false, false, ActionabilityVerdict::Unproven),
+        (false, true, ActionabilityVerdict::Unproven),
+        (true, false, ActionabilityVerdict::Failed),
+        (true, true, ActionabilityVerdict::Passed),
+    ] {
+        let mut report = ActionabilityReport::default();
+        record_focus_confirmation(
+            &mut report,
+            AxStateCoverage {
+                focused: covered,
+                ..AxStateCoverage::NONE
+            },
+            confirmed,
+        );
+        assert_eq!(
+            report.checks,
+            vec![ActionabilityCheck::new(
+                ActionabilityCheckName::Focused,
+                expected,
+                true,
+                ActionabilitySource::ConfirmationPoll,
+            )],
+            "covered={covered}, confirmed={confirmed}"
+        );
+    }
+}
+
+#[test]
+fn dispatch_and_retry_provenance_distinguish_pre_dispatch_from_uncertain_effects() {
+    let may_have = GlassError::Backend("focus transport failed".into());
+    assert_eq!(
+        focus_dispatch(&may_have, true),
+        DispatchStatus::MayHaveDispatched
+    );
+    assert_eq!(
+        focus_dispatch(&may_have, false),
+        DispatchStatus::NotDispatched
+    );
+    assert_eq!(
+        focus_dispatch(&GlassError::AxUnsupported, true),
+        DispatchStatus::NotDispatched
+    );
+    assert_eq!(
+        focus_dispatch(&GlassError::NoAxSnapshot, true),
+        DispatchStatus::NotDispatched
+    );
+    assert_eq!(
+        focus_dispatch(
+            &GlassError::Backend("pre-dispatch".into()).before_dispatch(),
+            true
+        ),
+        DispatchStatus::NotDispatched
+    );
+
+    let uncertain = action_source_error(
+        GlassError::Backend("click transport failed".into()),
+        None,
+        None,
+        ActionabilityReport::default(),
+        unbounded_action_deadline(None),
+        true,
+    );
+    assert_eq!(uncertain.action_dispatch, DispatchStatus::MayHaveDispatched);
+    assert_eq!(uncertain.retry, RetryGuidance::DoNotRetry);
+    let pre_dispatch = action_source_error(
+        GlassError::NoAxSnapshot,
+        None,
+        None,
+        ActionabilityReport::default(),
+        unbounded_action_deadline(None),
+        true,
+    );
+    assert_eq!(pre_dispatch.action_dispatch, DispatchStatus::NotDispatched);
+    assert_eq!(pre_dispatch.retry, RetryGuidance::SafeToRetry);
+}
+
+#[test]
+fn set_value_error_provenance_requires_proof_before_reporting_safe_non_dispatch() {
+    let cases = [
+        (
+            GlassError::NoAxSnapshot,
+            DispatchStatus::NotDispatched,
+            RetryGuidance::Reobserve,
+        ),
+        (
+            GlassError::AxUnsupported,
+            DispatchStatus::NotDispatched,
+            RetryGuidance::CorrectRequest,
+        ),
+        (
+            GlassError::Backend("refused before write".into()).before_dispatch(),
+            DispatchStatus::NotDispatched,
+            RetryGuidance::SafeToRetry,
+        ),
+        (
+            GlassError::Backend("unknown transport outcome".into()),
+            DispatchStatus::MayHaveDispatched,
+            RetryGuidance::DoNotRetry,
+        ),
+        (
+            GlassError::AxWriteUnconfirmed(7, "read-back failed".into()),
+            DispatchStatus::MayHaveDispatched,
+            RetryGuidance::DoNotRetry,
+        ),
+    ];
+
+    for (source, dispatch, retry) in cases {
+        let error = set_value_source_error(
+            source,
+            None,
+            None,
+            ActionabilityReport::default(),
+            unbounded_action_deadline(None),
+        );
+        assert_eq!(error.action_dispatch, dispatch);
+        assert_eq!(error.retry, retry);
+        assert_eq!(error.summary, "semantic set-value action failed");
+    }
 }
 
 #[test]
@@ -954,6 +1395,16 @@ fn target_deadlines_validate_id_options_and_selector_timeout_ceiling() {
         DispatchStatus::NotDispatched
     );
     assert_eq!(selector_error.retry, RetryGuidance::CorrectRequest);
+
+    let exact_maximum = target_deadline(
+        &ActionTarget::Semantic(semantic_target("save")),
+        Some(SEMANTIC_ACTION_MAX_TIMEOUT_MS),
+        None,
+        Deadline::UNBOUNDED,
+    )
+    .expect("the documented maximum remains a valid action timeout");
+    assert_eq!(exact_maximum.owner, Some(Whose::Callee));
+    assert!(exact_maximum.allow_wait);
 }
 
 #[test]
@@ -1118,6 +1569,40 @@ fn identity_change_resets_stability_even_when_bounds_are_equal() {
 
     assert_eq!(walks.load(Ordering::Relaxed), 3);
     assert_eq!(clicks.lock().unwrap().len(), 1);
+}
+
+#[test]
+fn pointer_plan_change_resets_stability_when_identity_and_bounds_are_equal() {
+    let bounds = AxRect {
+        x: 10,
+        y: 10,
+        width: 81,
+        height: 15,
+    };
+    let first = actionable_button_tree("Save", bounds);
+    let mut final_tree = first.clone();
+    final_tree.root.children[0].states.checkable = true;
+    let drags = Arc::new(Mutex::new(Vec::new()));
+    let platform = FakePlatform::new(120, 80)
+        .with_drag_log(drags.clone())
+        .with_trailing_toggle_backend();
+    let (mut glass, walks, _, _) = pointer_glass(
+        platform,
+        vec![first, final_tree.clone(), final_tree],
+        PointerHit::Target,
+        false,
+    );
+    glass.start(&spec()).unwrap();
+
+    glass
+        .click_target_inner(
+            pointer_params(ActionTarget::Semantic(semantic_target("Save")), Some(600)),
+            Deadline::UNBOUNDED,
+        )
+        .unwrap();
+
+    assert_eq!(walks.load(Ordering::Relaxed), 3);
+    assert_eq!(drags.lock().unwrap().len(), 1);
 }
 
 #[test]
@@ -2405,6 +2890,37 @@ fn legacy_click_element_fields_and_native_first_behavior_are_unchanged() {
             native_fallback: Some(_)
         }
     ));
+    assert!(!outcome.actionability.checks.is_empty());
+    assert!(
+        outcome
+            .actionability
+            .checks
+            .iter()
+            .all(|check| !check.required && check.source == ActionabilitySource::LegacyCache)
+    );
+    assert_eq!(
+        report_verdict(&outcome, ActionabilityCheckName::BackendFingerprint),
+        ActionabilityVerdict::Unproven,
+        "a legacy pointer fallback cannot claim native fingerprint validation"
+    );
+    let native_report = legacy.legacy_click_actionability(id, false);
+    assert!(!native_report.checks.is_empty());
+    assert!(
+        native_report
+            .checks
+            .iter()
+            .all(|check| !check.required && check.source == ActionabilitySource::LegacyCache)
+    );
+    let native_outcome = legacy.legacy_click_outcome(
+        id,
+        ActionMethod::NativeAction { actuated: None },
+        false,
+        unbounded_action_deadline(None),
+    );
+    assert_eq!(
+        report_verdict(&native_outcome, ActionabilityCheckName::BackendFingerprint),
+        ActionabilityVerdict::Passed
+    );
     assert_eq!(legacy_pointer.label(), "pointer");
     assert_eq!(
         legacy_pointer.native_fallback(),
@@ -3155,6 +3671,75 @@ fn targeted_type_does_not_try_pointer_after_native_focus_may_have_dispatched() {
 }
 
 #[test]
+fn targeted_type_keeps_retry_safe_when_pointer_focus_proves_no_dispatch() {
+    let tree = value_control_tree(
+        "Account name",
+        AxRole::TextField,
+        Some("old"),
+        AxStates {
+            enabled: true,
+            visible: true,
+            focusable: true,
+            editable: true,
+            ..AxStates::default()
+        },
+    );
+    let mut tree = tree;
+    tree.root.children[0].bounds = Some(AxRect {
+        x: 70,
+        y: 248,
+        width: 80,
+        height: 27,
+    });
+    let active = window_info(
+        1,
+        WindowGeometry {
+            x: 0,
+            y: 0,
+            width: 340,
+            height: 300,
+        },
+        true,
+    );
+    let popover = window_info(
+        2,
+        WindowGeometry {
+            x: -3,
+            y: 220,
+            width: 326,
+            height: 135,
+        },
+        false,
+    );
+    let keys = Arc::new(Mutex::new(Vec::new()));
+    let platform = FakePlatform::new(340, 300)
+        .with_windows(vec![active, popover])
+        .with_key_log(keys.clone());
+    let (mut glass, _, _, _) = pointer_glass(
+        platform,
+        vec![tree.clone(), tree.clone(), tree],
+        PointerHit::Target,
+        false,
+    );
+    glass.start(&spec()).unwrap();
+
+    let error = glass
+        .type_target(
+            &targeted_type_params("Account name", ActionMode::Auto, 600),
+            "must not type",
+        )
+        .expect_err("an unmappable popover target cannot receive pointer focus");
+
+    assert_eq!(error.action_dispatch, DispatchStatus::NotDispatched);
+    assert_eq!(error.retry, RetryGuidance::SafeToRetry);
+    assert_eq!(
+        error.focus.as_ref().map(|focus| focus.dispatch),
+        Some(DispatchStatus::NotDispatched)
+    );
+    assert!(keys.lock().unwrap().is_empty());
+}
+
+#[test]
 fn targeted_type_never_types_when_focus_cannot_be_confirmed() {
     let secret = "never expose this text";
     let mut fixture = targeted_type_glass(
@@ -3412,6 +3997,10 @@ fn targeted_type_rejects_a_button_even_when_the_backend_can_focus_it() {
 
     assert_eq!(error.kind, SemanticActionFailureKind::NotActionable);
     assert_eq!(error.action_dispatch, DispatchStatus::NotDispatched);
+    let eligibility = error_report_check(&error, ActionabilityCheckName::FocusEligible);
+    assert_eq!(eligibility.verdict, ActionabilityVerdict::Failed);
+    assert!(eligibility.required);
+    assert_eq!(eligibility.source, ActionabilitySource::NormalizedState);
     assert_eq!(fixture.focus_calls.load(Ordering::Relaxed), 0);
     assert!(fixture.clicks.lock().unwrap().is_empty());
     assert!(fixture.key_log.lock().unwrap().is_empty());

--- a/crates/glass-core/src/session/semantic_action/tests.rs
+++ b/crates/glass-core/src/session/semantic_action/tests.rs
@@ -2517,6 +2517,65 @@ fn semantic_public_click_audit_emits_exactly_one_record_on_native_fallback_and_f
 }
 
 #[test]
+fn failure_audit_auto_pointer_fallback_retains_the_resolved_target_and_selected_path() {
+    let tree = actionable_button_tree(
+        "Save account",
+        AxRect {
+            x: 10,
+            y: 10,
+            width: 20,
+            height: 20,
+        },
+    );
+    let native_calls = Arc::new(AtomicUsize::new(0));
+    let clicks = Arc::new(Mutex::new(Vec::new()));
+    let accessibility = SeqAccessibility::new(vec![tree.clone(), tree.clone(), tree])
+        .with_coverage(full_state_coverage())
+        .with_invoke_behavior(InvokeBehavior::Unsupported)
+        .with_invoke_calls(native_calls.clone())
+        .with_hit(PointerHit::Target);
+    let platform = FakePlatform::new(100, 100)
+        .with_click_log(clicks.clone())
+        .with_failing_pointer();
+    let mut glass = glass_with_backend(platform, Box::new(accessibility));
+    let sink = RecordingSink::default();
+    glass.set_audit_sink(Box::new(sink.clone()));
+    glass.start(&spec()).unwrap();
+
+    let error = glass
+        .click_target(&semantic_click_params(ActionMode::Auto, 500))
+        .unwrap_err();
+
+    assert_eq!(native_calls.load(Ordering::Relaxed), 1);
+    assert_eq!(clicks.lock().unwrap().len(), 1);
+    assert_eq!(error.action_dispatch, DispatchStatus::MayHaveDispatched);
+    assert_eq!(
+        error.target.as_ref().map(|target| target.id),
+        Some(AxNodeId(1))
+    );
+    let audits = sink.1.lock().unwrap();
+    assert_eq!(audits.len(), 1);
+    assert_eq!(
+        (
+            audits[0].element.id,
+            audits[0].method.as_deref(),
+            audits[0].native_fallback.as_deref(),
+        ),
+        (
+            1,
+            Some("pointer"),
+            Some("backend has no native action path"),
+        )
+    );
+    assert_eq!(audits[0].element.role.as_deref(), Some("Button"));
+    assert_eq!(audits[0].element.name.as_deref(), Some("Save account"));
+    assert_eq!(audits[0].actuated_id, None);
+    assert_eq!(audits[0].dispatch, "may_have_dispatched");
+    assert_eq!(audits[0].confirmation, "unconfirmed");
+    assert!(!audits[0].ok);
+}
+
+#[test]
 fn semantic_set_value_resolves_fresh_and_calls_the_backend_once() {
     let cached = editable_field_tree("Former account name", Some("old"), true);
     let fresh = editable_field_tree("Account name", Some("old"), true);
@@ -2902,6 +2961,43 @@ fn semantic_public_set_value_audit_emits_one_safe_high_level_record() {
 }
 
 #[test]
+fn failure_audit_set_value_retains_the_resolved_target_instead_of_the_selector_query() {
+    let secret = "audit secret text";
+    let tree = editable_field_tree("Primary account name", Some("old"), true);
+    let (mut glass, walks, set_log, _) = semantic_set_value_glass(
+        vec![tree],
+        vec![Err(GlassError::AxWriteUnconfirmed(1, secret.into()))],
+    );
+    let sink = RecordingSink::default();
+    glass.set_audit_sink(Box::new(sink.clone()));
+    glass.start(&spec()).unwrap();
+
+    let error = glass
+        .set_value_target(&semantic_set_value_params("account", 0), secret)
+        .unwrap_err();
+
+    assert_eq!(walks.load(Ordering::Relaxed), 1);
+    assert_eq!(set_log.lock().unwrap().len(), 1);
+    assert_eq!(error.action_dispatch, DispatchStatus::MayHaveDispatched);
+    assert_eq!(
+        error.target.as_ref().map(|target| target.id),
+        Some(AxNodeId(1))
+    );
+    let audits = sink.2.lock().unwrap();
+    assert_eq!(audits.len(), 1);
+    assert_eq!(audits[0].element.id, 1);
+    assert_eq!(audits[0].element.role.as_deref(), Some("TextField"));
+    assert_eq!(
+        audits[0].element.name.as_deref(),
+        Some("Primary account name")
+    );
+    assert_eq!(audits[0].dispatch, "may_have_dispatched");
+    assert_eq!(audits[0].confirmation, "unconfirmed");
+    assert!(!audits[0].ok);
+    assert!(!audits[0].error.as_deref().unwrap().contains(secret));
+}
+
+#[test]
 fn targeted_type_zero_timeout_types_only_if_the_first_confirmation_read_is_focused() {
     for (focused, succeeds) in [(true, true), (false, false)] {
         let mut fixture = targeted_type_glass(
@@ -3150,6 +3246,103 @@ fn targeted_type_never_dispatches_a_second_text_batch_after_possible_key_deliver
         Some(ConfirmationStatus::FocusConfirmed)
     );
     assert_eq!(sink.0.lock().unwrap().as_slice(), &["type_target:false"]);
+}
+
+#[test]
+fn failure_audit_post_focus_type_retains_the_resolved_target_and_dispatch_evidence() {
+    let secret = "one private batch";
+    let mut fixture = targeted_type_glass(
+        vec![
+            targeted_type_field_tree("Primary account name", false),
+            targeted_type_field_tree("Primary account name", true),
+        ],
+        InvokeBehavior::Succeed,
+        full_state_coverage(),
+        true,
+    );
+    let sink = RecordingSink::default();
+    fixture.glass.set_audit_sink(Box::new(sink.clone()));
+    fixture.glass.start(&spec()).unwrap();
+    sink.0.lock().unwrap().clear();
+    sink.3.lock().unwrap().clear();
+
+    let error = fixture
+        .glass
+        .type_target(
+            &targeted_type_params("account", ActionMode::Native, 500),
+            secret,
+        )
+        .unwrap_err();
+
+    assert_eq!(fixture.focus_calls.load(Ordering::Relaxed), 1);
+    assert!(fixture.clicks.lock().unwrap().is_empty());
+    assert_eq!(fixture.key_log.lock().unwrap().len(), 1);
+    assert_eq!(error.action_dispatch, DispatchStatus::MayHaveDispatched);
+    assert_eq!(
+        error.target.as_ref().map(|target| target.id),
+        Some(AxNodeId(1))
+    );
+    assert_eq!(sink.0.lock().unwrap().as_slice(), &["type_target:false"]);
+    let audits = sink.3.lock().unwrap();
+    assert_eq!(audits.len(), 1);
+    assert_eq!(audits[0].element.id, 1);
+    assert_eq!(audits[0].element.role.as_deref(), Some("TextField"));
+    assert_eq!(
+        audits[0].element.name.as_deref(),
+        Some("Primary account name")
+    );
+    assert_eq!(audits[0].focus_method.as_deref(), Some("native_action"));
+    assert_eq!(audits[0].focus_dispatch, "dispatched");
+    assert_eq!(audits[0].focus_confirmation, "focus_confirmed");
+    assert_eq!(audits[0].type_dispatch, "may_have_dispatched");
+    assert!(!audits[0].ok);
+    assert!(!audits[0].error.as_deref().unwrap().contains(secret));
+}
+
+#[test]
+fn failure_audit_ambiguity_stays_unresolved_and_dispatches_nothing() {
+    let mut tree = targeted_type_field_tree("Primary account name", false);
+    let mut duplicate = tree.root.children[0].clone();
+    duplicate.id = AxNodeId(2);
+    duplicate.name = Some("Backup account name".into());
+    tree.root.children.push(duplicate);
+    let tree = AxTree::new(tree.root);
+    let mut fixture = targeted_type_glass(
+        vec![tree],
+        InvokeBehavior::Succeed,
+        full_state_coverage(),
+        false,
+    );
+    let sink = RecordingSink::default();
+    fixture.glass.set_audit_sink(Box::new(sink.clone()));
+    fixture.glass.start(&spec()).unwrap();
+    sink.0.lock().unwrap().clear();
+    sink.3.lock().unwrap().clear();
+
+    let error = fixture
+        .glass
+        .type_target(
+            &targeted_type_params("account", ActionMode::Native, 0),
+            "must not type",
+        )
+        .unwrap_err();
+
+    assert_eq!(error.kind, SemanticActionFailureKind::AmbiguousTarget);
+    assert_eq!(error.candidates.len(), 2);
+    assert!(error.target.is_none());
+    assert_eq!(fixture.focus_calls.load(Ordering::Relaxed), 0);
+    assert!(fixture.clicks.lock().unwrap().is_empty());
+    assert!(fixture.key_log.lock().unwrap().is_empty());
+    assert_eq!(sink.0.lock().unwrap().as_slice(), &["type_target:false"]);
+    let audits = sink.3.lock().unwrap();
+    assert_eq!(audits.len(), 1);
+    assert_eq!(audits[0].element.id, 0);
+    assert_eq!(audits[0].element.role, None);
+    assert_eq!(audits[0].element.name.as_deref(), Some("account"));
+    assert_eq!(audits[0].focus_method, None);
+    assert_eq!(audits[0].focus_dispatch, "not_dispatched");
+    assert_eq!(audits[0].type_dispatch, "not_dispatched");
+    assert!(!audits[0].ok);
 }
 
 #[test]

--- a/crates/glass-core/src/session/semantic_action/tests.rs
+++ b/crates/glass-core/src/session/semantic_action/tests.rs
@@ -1,8 +1,8 @@
 use super::*;
 use crate::session::test_support::*;
 use crate::{
-    AxNode, AxNodeId, AxRect, AxRole, AxStateCoverage, AxStates, AxTree, ChangeSignal,
-    SemanticSelector, SemanticState, Truncation, TruncationLimit, WalkLimits,
+    Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxStateCoverage, AxStates, AxTree,
+    ChangeSignal, SemanticSelector, SemanticState, Truncation, TruncationLimit, WalkLimits,
 };
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -99,6 +99,61 @@ fn semantic_glass(
         .with_focus_calls(focus_calls.clone());
     let glass = glass_with_backend(FakePlatform::new(100, 100), Box::new(accessibility));
     (glass, walks, focus_calls, invoke_log)
+}
+
+struct DeadlineRecordingAccessibility {
+    tree: AxTree,
+    coverage_delay: std::time::Duration,
+    coverage_finished: Arc<Mutex<Option<std::time::Instant>>>,
+    subscription_deadlines: Arc<Mutex<Vec<Deadline>>>,
+    snapshot_deadlines: Arc<Mutex<Vec<Deadline>>>,
+}
+
+impl Accessibility for DeadlineRecordingAccessibility {
+    fn snapshot(&mut self, ctx: &AxContext) -> crate::Result<AxTree> {
+        self.snapshot_deadlines.lock().unwrap().push(ctx.deadline);
+        Ok(self.tree.clone())
+    }
+
+    fn subscribe_changes(&mut self, ctx: &AxContext) -> Option<Box<dyn ChangeSignal>> {
+        self.subscription_deadlines
+            .lock()
+            .unwrap()
+            .push(ctx.deadline);
+        None
+    }
+
+    fn state_coverage(&self) -> AxStateCoverage {
+        std::thread::sleep(self.coverage_delay);
+        *self.coverage_finished.lock().unwrap() = Some(std::time::Instant::now());
+        full_state_coverage()
+    }
+}
+
+fn deadline_recording_glass(
+    coverage_delay: std::time::Duration,
+) -> (
+    Glass,
+    Arc<Mutex<Option<std::time::Instant>>>,
+    Arc<Mutex<Vec<Deadline>>>,
+    Arc<Mutex<Vec<Deadline>>>,
+) {
+    let coverage_finished = Arc::new(Mutex::new(None));
+    let subscription_deadlines = Arc::new(Mutex::new(Vec::new()));
+    let snapshot_deadlines = Arc::new(Mutex::new(Vec::new()));
+    let accessibility = DeadlineRecordingAccessibility {
+        tree: named_button_tree("Save account"),
+        coverage_delay,
+        coverage_finished: coverage_finished.clone(),
+        subscription_deadlines: subscription_deadlines.clone(),
+        snapshot_deadlines: snapshot_deadlines.clone(),
+    };
+    (
+        glass_with_backend(FakePlatform::new(100, 100), Box::new(accessibility)),
+        coverage_finished,
+        subscription_deadlines,
+        snapshot_deadlines,
+    )
 }
 
 #[test]
@@ -292,6 +347,70 @@ fn selector_resolution_waits_for_delayed_publication() {
     assert_eq!(walks.load(Ordering::Relaxed), 2);
     assert_eq!(resolved.element.name.as_deref(), Some("Save account"));
     assert!(resolved.bound.allow_wait);
+}
+
+#[test]
+fn selector_resolution_uses_the_reported_deadline_for_subscription_and_snapshot() {
+    let (mut glass, _, subscription_deadlines, snapshot_deadlines) =
+        deadline_recording_glass(std::time::Duration::ZERO);
+    glass.start(&spec()).unwrap();
+
+    let resolved = glass
+        .resolve_semantic_target(
+            &semantic_target("Save account"),
+            None,
+            500,
+            Deadline::UNBOUNDED,
+            |_, _| true,
+        )
+        .unwrap();
+
+    assert_eq!(
+        subscription_deadlines.lock().unwrap().as_slice(),
+        &[resolved.bound.deadline]
+    );
+    assert_eq!(
+        snapshot_deadlines.lock().unwrap().as_slice(),
+        &[resolved.bound.deadline]
+    );
+}
+
+#[test]
+fn selector_resolution_setup_consumes_the_reported_action_budget() {
+    let timeout = std::time::Duration::from_millis(300);
+    let (mut glass, coverage_finished, subscription_deadlines, snapshot_deadlines) =
+        deadline_recording_glass(std::time::Duration::from_millis(150));
+    glass.start(&spec()).unwrap();
+
+    let resolved = glass
+        .resolve_semantic_target(
+            &semantic_target("Save account"),
+            None,
+            timeout.as_millis() as u64,
+            Deadline::UNBOUNDED,
+            |_, _| true,
+        )
+        .unwrap();
+
+    let coverage_finished = coverage_finished.lock().unwrap().unwrap();
+    let remaining_after_setup = resolved
+        .bound
+        .deadline
+        .instant()
+        .unwrap()
+        .saturating_duration_since(coverage_finished);
+    assert!(
+        remaining_after_setup < std::time::Duration::from_millis(225),
+        "pre-poll setup did not consume the action budget: {remaining_after_setup:?} remained"
+    );
+    assert_eq!(
+        subscription_deadlines.lock().unwrap().as_slice(),
+        &[resolved.bound.deadline]
+    );
+    assert_eq!(
+        snapshot_deadlines.lock().unwrap().as_slice(),
+        &[resolved.bound.deadline]
+    );
 }
 
 #[test]

--- a/crates/glass-core/src/session/semantic_action/tests.rs
+++ b/crates/glass-core/src/session/semantic_action/tests.rs
@@ -653,17 +653,38 @@ fn pointer_plan_requires_every_trailing_toggle_fact_and_uses_the_segment_midpoin
         },
         bounds,
     );
-    let segment = bounds.trailing_toggle_swipe(120, 80).unwrap();
     assert_eq!(
         pointer_plan(&element, (120, 80), true),
         Some(PlannedPointerInput::TrailingToggle {
-            segment,
-            probe_point: (
-                segment.from_x + (segment.to_x - segment.from_x) / 2,
-                segment.from_y + (segment.to_y - segment.from_y) / 2,
-            ),
+            segment: Segment {
+                from_x: 66,
+                from_y: 14,
+                to_x: 88,
+                to_y: 14,
+            },
+            probe_point: (77, 14),
         })
     );
+
+    element.bounds = Some(AxRect {
+        x: 10,
+        y: 0,
+        width: 20,
+        height: 1,
+    });
+    assert_eq!(
+        pointer_plan(&element, (120, 80), true),
+        Some(PlannedPointerInput::TrailingToggle {
+            segment: Segment {
+                from_x: 28,
+                from_y: 0,
+                to_x: 30,
+                to_y: 0,
+            },
+            probe_point: (29, 0),
+        })
+    );
+    element.bounds = Some(bounds);
 
     element.states.checkable = false;
     assert!(matches!(
@@ -998,6 +1019,12 @@ fn set_value_error_provenance_requires_proof_before_reporting_safe_non_dispatch(
         ),
         (
             GlassError::Backend("unknown transport outcome".into()),
+            DispatchStatus::MayHaveDispatched,
+            RetryGuidance::DoNotRetry,
+        ),
+        (
+            GlassError::Backend("dispatch completed before transport failure".into())
+                .after_dispatch(),
             DispatchStatus::MayHaveDispatched,
             RetryGuidance::DoNotRetry,
         ),
@@ -4001,6 +4028,39 @@ fn targeted_type_rejects_a_button_even_when_the_backend_can_focus_it() {
     assert_eq!(eligibility.verdict, ActionabilityVerdict::Failed);
     assert!(eligibility.required);
     assert_eq!(eligibility.source, ActionabilitySource::NormalizedState);
+    assert_eq!(fixture.focus_calls.load(Ordering::Relaxed), 0);
+    assert!(fixture.clicks.lock().unwrap().is_empty());
+    assert!(fixture.key_log.lock().unwrap().is_empty());
+}
+
+#[test]
+fn targeted_type_incomplete_query_keeps_resolution_error_actionability_unselected() {
+    let mut tree = targeted_type_field_tree("Account name", false);
+    tree.truncated = Some(Truncation {
+        limit: TruncationLimit::Nodes,
+        limit_value: 2,
+        nodes_walked: 2,
+    });
+    let mut fixture = targeted_type_glass(
+        vec![tree],
+        InvokeBehavior::Succeed,
+        full_state_coverage(),
+        false,
+    );
+    fixture.glass.start(&spec()).unwrap();
+
+    let error = fixture
+        .glass
+        .type_target(
+            &targeted_type_params("Account name", ActionMode::Native, 0),
+            "must not type",
+        )
+        .unwrap_err();
+
+    assert_eq!(error.kind, SemanticActionFailureKind::IncompleteTree);
+    assert_eq!(error.candidates.len(), 1);
+    assert!(error.actionability.checks.is_empty());
+    assert!(error.target.is_none());
     assert_eq!(fixture.focus_calls.load(Ordering::Relaxed), 0);
     assert!(fixture.clicks.lock().unwrap().is_empty());
     assert!(fixture.key_log.lock().unwrap().is_empty());

--- a/crates/glass-core/src/session/semantic_action/tests.rs
+++ b/crates/glass-core/src/session/semantic_action/tests.rs
@@ -20,6 +20,89 @@ fn semantic_target(query: &str) -> SemanticTarget {
     }
 }
 
+fn value_control_tree(name: &str, role: AxRole, value: Option<&str>, states: AxStates) -> AxTree {
+    AxTree::new(AxNode {
+        id: AxNodeId(0),
+        role: AxRole::Window,
+        raw_role: "window".into(),
+        name: Some("App".into()),
+        description: None,
+        value: None,
+        states: AxStates::default(),
+        bounds: Some(AxRect {
+            x: 0,
+            y: 0,
+            width: 320,
+            height: 240,
+        }),
+        children: vec![AxNode {
+            id: AxNodeId(0),
+            role,
+            raw_role: format!("{role:?}"),
+            name: Some(name.into()),
+            description: None,
+            value: value.map(str::to_owned),
+            states,
+            bounds: Some(AxRect {
+                x: 20,
+                y: 20,
+                width: 160,
+                height: 30,
+            }),
+            children: Vec::new(),
+        }],
+    })
+}
+
+fn editable_field_tree(name: &str, value: Option<&str>, enabled: bool) -> AxTree {
+    value_control_tree(
+        name,
+        AxRole::TextField,
+        value,
+        AxStates {
+            enabled,
+            visible: true,
+            focusable: true,
+            editable: true,
+            ..AxStates::default()
+        },
+    )
+}
+
+fn semantic_set_value_params(query: &str, timeout_ms: u64) -> SetValueTargetParams {
+    SetValueTargetParams {
+        target: ActionTarget::Semantic(semantic_target(query)),
+        timeout_ms: Some(timeout_ms),
+        max_nodes: None,
+    }
+}
+
+fn semantic_set_value_glass(
+    trees: Vec<AxTree>,
+    set_results: Vec<crate::Result<()>>,
+) -> (
+    Glass,
+    Arc<AtomicUsize>,
+    Arc<Mutex<Vec<(AxNodeId, String)>>>,
+    AxDeadlineLog,
+) {
+    let walks = Arc::new(AtomicUsize::new(0));
+    let set_log = Arc::new(Mutex::new(Vec::new()));
+    let deadlines = Arc::new(Mutex::new(Vec::new()));
+    let accessibility = SeqAccessibility::new(trees)
+        .with_coverage(full_state_coverage())
+        .with_walks(walks.clone())
+        .with_deadlines(deadlines.clone())
+        .with_set_log(set_log.clone())
+        .with_set_results(set_results);
+    (
+        glass_with_backend(FakePlatform::new(320, 240), Box::new(accessibility)),
+        walks,
+        set_log,
+        deadlines,
+    )
+}
+
 fn named_button_tree(name: &str) -> AxTree {
     let mut tree = fake_tree();
     tree.root.children[0].name = Some(name.into());
@@ -2135,4 +2218,285 @@ fn semantic_public_click_audit_emits_exactly_one_record_on_native_fallback_and_f
         assert_eq!(audits[0].confirmation, expected_confirmation);
         assert_eq!(audits[0].ok, succeeds);
     }
+}
+
+#[test]
+fn semantic_set_value_resolves_fresh_and_calls_the_backend_once() {
+    let cached = editable_field_tree("Former account name", Some("old"), true);
+    let fresh = editable_field_tree("Account name", Some("old"), true);
+    let (mut glass, walks, set_log, deadlines) =
+        semantic_set_value_glass(vec![cached, fresh], Vec::new());
+    glass.start(&spec()).unwrap();
+    glass.a11y_snapshot(None).unwrap();
+
+    let outcome = glass
+        .set_value_target_by(
+            &semantic_set_value_params("Account name", 500),
+            "updated",
+            Deadline::UNBOUNDED,
+        )
+        .unwrap();
+
+    assert_eq!(walks.load(Ordering::Relaxed), 2);
+    assert_eq!(
+        set_log.lock().unwrap().as_slice(),
+        &[(outcome.target.id, "updated".into())]
+    );
+    assert_eq!(outcome.target.name.as_deref(), Some("Account name"));
+    assert_eq!(outcome.action.method, ActionMethod::AccessibilityValue);
+    assert_eq!(outcome.action.dispatch, DispatchStatus::Dispatched);
+    assert_eq!(
+        outcome.action.confirmation,
+        ConfirmationStatus::ValueConfirmed
+    );
+    let deadlines = deadlines.lock().unwrap();
+    assert_eq!(deadlines.len(), 3);
+    assert!(
+        deadlines[1..]
+            .iter()
+            .all(|deadline| *deadline == outcome.bound.deadline)
+    );
+}
+
+#[test]
+fn semantic_set_value_waits_for_a_known_disabled_field_to_become_enabled() {
+    let disabled = editable_field_tree("Account name", Some("old"), false);
+    let enabled = editable_field_tree("Account name", Some("old"), true);
+    let (mut glass, walks, set_log, _) =
+        semantic_set_value_glass(vec![disabled, enabled], Vec::new());
+    glass.start(&spec()).unwrap();
+
+    let outcome = glass
+        .set_value_target(&semantic_set_value_params("Account name", 500), "updated")
+        .unwrap();
+
+    assert_eq!(walks.load(Ordering::Relaxed), 2);
+    assert_eq!(set_log.lock().unwrap().len(), 1);
+    assert_eq!(outcome.action.dispatch, DispatchStatus::Dispatched);
+    assert_eq!(
+        outcome.action.confirmation,
+        ConfirmationStatus::ValueConfirmed
+    );
+}
+
+#[test]
+fn semantic_set_value_refuses_a_known_non_value_role_before_backend_dispatch() {
+    let tree = value_control_tree(
+        "Save",
+        AxRole::Button,
+        None,
+        AxStates {
+            enabled: true,
+            visible: true,
+            focusable: true,
+            ..AxStates::default()
+        },
+    );
+    let (mut glass, walks, set_log, _) = semantic_set_value_glass(vec![tree], Vec::new());
+    glass.start(&spec()).unwrap();
+
+    let error = glass
+        .set_value_target(&semantic_set_value_params("Save", 0), "not-a-value")
+        .unwrap_err();
+
+    assert_eq!(error.kind, SemanticActionFailureKind::NotActionable);
+    assert_eq!(error.action_dispatch, DispatchStatus::NotDispatched);
+    assert_eq!(error.retry, RetryGuidance::Reobserve);
+    assert_eq!(
+        error.actionability.blocking().unwrap().name,
+        ActionabilityCheckName::FocusEligible
+    );
+    assert_eq!(walks.load(Ordering::Relaxed), 1);
+    assert!(set_log.lock().unwrap().is_empty());
+}
+
+#[test]
+fn semantic_set_value_preserves_backend_value_confirmation() {
+    let tree = editable_field_tree("Account name", Some("old"), true);
+    let (mut glass, walks, set_log, _) = semantic_set_value_glass(vec![tree], Vec::new());
+    glass.start(&spec()).unwrap();
+    glass.a11y_snapshot(None).unwrap();
+    let id = glass
+        .active
+        .as_ref()
+        .unwrap()
+        .last_ax
+        .as_ref()
+        .unwrap()
+        .root
+        .children[0]
+        .id;
+
+    let outcome = glass
+        .set_value_target(
+            &SetValueTargetParams {
+                target: ActionTarget::Id(id),
+                timeout_ms: None,
+                max_nodes: None,
+            },
+            "updated",
+        )
+        .unwrap();
+
+    assert_eq!(walks.load(Ordering::Relaxed), 1);
+    assert_eq!(
+        set_log.lock().unwrap().as_slice(),
+        &[(id, "updated".into())]
+    );
+    assert_eq!(outcome.action.method, ActionMethod::AccessibilityValue);
+    assert_eq!(outcome.action.dispatch, DispatchStatus::Dispatched);
+    assert_eq!(
+        outcome.action.confirmation,
+        ConfirmationStatus::ValueConfirmed
+    );
+}
+
+#[test]
+fn unconfirmed_semantic_write_is_terminal_and_clears_the_cached_value() {
+    let secret = "requested secret text";
+    let tree = editable_field_tree("Account name", Some("old"), true);
+    let (mut glass, _, set_log, _) = semantic_set_value_glass(
+        vec![tree],
+        vec![Err(GlassError::AxWriteUnconfirmed(1, secret.into()))],
+    );
+    glass.start(&spec()).unwrap();
+
+    let error = glass
+        .set_value_target(&semantic_set_value_params("Account name", 0), secret)
+        .unwrap_err();
+
+    let calls = set_log.lock().unwrap();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].1, secret);
+    let id = calls[0].0;
+    drop(calls);
+    assert_eq!(error.action_dispatch, DispatchStatus::MayHaveDispatched);
+    assert_eq!(error.retry, RetryGuidance::DoNotRetry);
+    assert!(!error.to_string().contains(secret));
+    assert!(!error.summary.contains(secret));
+    assert!(!format!("{:?}", error.candidates).contains(secret));
+    assert!(!format!("{:?}", error.actionability).contains(secret));
+    assert_eq!(
+        glass
+            .active
+            .as_ref()
+            .and_then(|active| active.last_ax.as_ref())
+            .and_then(|tree| tree.find(id))
+            .and_then(|node| node.value.as_deref()),
+        None
+    );
+}
+
+#[test]
+fn semantic_set_value_does_not_retry_after_a_may_have_dispatched_transport_failure() {
+    let tree = editable_field_tree("Account name", Some("old"), true);
+    let (mut glass, walks, set_log, _) = semantic_set_value_glass(
+        vec![tree],
+        vec![Err(GlassError::AccessibilityUnavailable(
+            "scripted transport failure".into(),
+        ))],
+    );
+    glass.start(&spec()).unwrap();
+
+    let error = glass
+        .set_value_target(&semantic_set_value_params("Account name", 500), "updated")
+        .unwrap_err();
+
+    assert_eq!(walks.load(Ordering::Relaxed), 1);
+    assert_eq!(set_log.lock().unwrap().len(), 1);
+    assert_eq!(error.action_dispatch, DispatchStatus::MayHaveDispatched);
+    assert_eq!(error.retry, RetryGuidance::DoNotRetry);
+}
+
+#[test]
+fn legacy_set_value_uses_the_cached_id_without_a_fresh_read() {
+    let cached = editable_field_tree("Cached account name", Some("old"), true);
+    let fresh = editable_field_tree("Different field", Some("other"), true);
+    let (mut glass, walks, set_log, _) = semantic_set_value_glass(vec![cached, fresh], Vec::new());
+    glass.start(&spec()).unwrap();
+    glass.a11y_snapshot(None).unwrap();
+    let cached_id = glass
+        .active
+        .as_ref()
+        .unwrap()
+        .last_ax
+        .as_ref()
+        .unwrap()
+        .root
+        .children[0]
+        .id;
+
+    glass.set_value(cached_id, "updated").unwrap();
+
+    assert_eq!(walks.load(Ordering::Relaxed), 1);
+    assert_eq!(
+        set_log.lock().unwrap().as_slice(),
+        &[(cached_id, "updated".into())]
+    );
+}
+
+#[test]
+fn semantic_set_value_already_applied_reports_a_truthful_no_op() {
+    let tree = value_control_tree(
+        "Beta",
+        AxRole::ComboBox,
+        Some("Beta"),
+        AxStates {
+            enabled: true,
+            visible: true,
+            focusable: true,
+            ..AxStates::default()
+        },
+    );
+    let (mut glass, walks, set_log, _) = semantic_set_value_glass(vec![tree], Vec::new());
+    glass.start(&spec()).unwrap();
+
+    let outcome = glass
+        .set_value_target(&semantic_set_value_params("Beta", 0), "Beta")
+        .unwrap();
+
+    assert_eq!(walks.load(Ordering::Relaxed), 1);
+    assert!(set_log.lock().unwrap().is_empty());
+    assert_eq!(outcome.action.method, ActionMethod::AccessibilityValue);
+    assert_eq!(outcome.action.dispatch, DispatchStatus::NotDispatched);
+    assert_eq!(
+        outcome.action.confirmation,
+        ConfirmationStatus::ValueConfirmed
+    );
+}
+
+#[test]
+fn semantic_public_set_value_audit_emits_one_safe_high_level_record() {
+    let secret = "audit secret text";
+    let tree = editable_field_tree("Account name", Some("old"), true);
+    let (mut glass, _, set_log, _) = semantic_set_value_glass(
+        vec![tree],
+        vec![Err(GlassError::AxWriteUnconfirmed(1, secret.into()))],
+    );
+    let sink = RecordingSink::default();
+    glass.set_audit_sink(Box::new(sink.clone()));
+    glass.start(&spec()).unwrap();
+
+    let result = glass.set_value_target(&semantic_set_value_params("Account name", 0), secret);
+
+    assert!(result.is_err());
+    assert_eq!(set_log.lock().unwrap().len(), 1);
+    let records = sink.0.lock().unwrap();
+    assert_eq!(
+        records
+            .iter()
+            .filter(|record| record.starts_with("set_value:"))
+            .count(),
+        1,
+        "records: {records:?}"
+    );
+    drop(records);
+    let audits = sink.2.lock().unwrap();
+    assert_eq!(audits.len(), 1);
+    assert_eq!(audits[0].element.name.as_deref(), Some("Account name"));
+    assert_eq!(audits[0].text, secret);
+    assert_eq!(audits[0].dispatch, "may_have_dispatched");
+    assert_eq!(audits[0].confirmation, "unconfirmed");
+    assert!(!audits[0].ok);
+    assert!(!audits[0].error.as_deref().unwrap().contains(secret));
 }

--- a/crates/glass-core/src/session/semantic_action/tests.rs
+++ b/crates/glass-core/src/session/semantic_action/tests.rs
@@ -1,0 +1,596 @@
+use super::*;
+use crate::session::test_support::*;
+use crate::{
+    AxNode, AxNodeId, AxRect, AxRole, AxStateCoverage, AxStates, AxTree, ChangeSignal,
+    SemanticSelector, SemanticState, Truncation, TruncationLimit, WalkLimits,
+};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+fn selector(query: &str) -> SemanticSelector {
+    SemanticSelector::new(Some(query.into()), None, Vec::new()).unwrap()
+}
+
+fn semantic_target(query: &str) -> SemanticTarget {
+    SemanticTarget {
+        target: selector(query),
+        within: None,
+    }
+}
+
+fn named_button_tree(name: &str) -> AxTree {
+    let mut tree = fake_tree();
+    tree.root.children[0].name = Some(name.into());
+    tree
+}
+
+fn duplicate_button_tree(name: &str, count: usize) -> AxTree {
+    let mut tree = named_button_tree(name);
+    let button = tree.root.children[0].clone();
+    tree.root.children = vec![button; count];
+    tree
+}
+
+fn scoped_tree() -> AxTree {
+    fn node(role: AxRole, name: &str, children: Vec<AxNode>) -> AxNode {
+        AxNode {
+            id: AxNodeId(0),
+            role,
+            raw_role: format!("{role:?}"),
+            name: Some(name.into()),
+            description: None,
+            value: None,
+            states: AxStates::default(),
+            bounds: Some(AxRect {
+                x: 0,
+                y: 0,
+                width: 20,
+                height: 20,
+            }),
+            children,
+        }
+    }
+
+    AxTree::new(node(
+        AxRole::Window,
+        "App",
+        vec![
+            node(
+                AxRole::Group,
+                "Account panel",
+                vec![node(AxRole::Button, "Save account", Vec::new())],
+            ),
+            node(
+                AxRole::Group,
+                "Account panel",
+                vec![node(AxRole::Button, "Save other", Vec::new())],
+            ),
+        ],
+    ))
+}
+
+fn signals_once() -> Box<dyn ChangeSignal> {
+    Box::new(SignalsOnce(true))
+}
+
+fn never_signals() -> Box<dyn ChangeSignal> {
+    Box::new(NeverSignals)
+}
+
+fn semantic_glass(
+    trees: Vec<AxTree>,
+    signal: Option<fn() -> Box<dyn ChangeSignal>>,
+    behavior: InvokeBehavior,
+) -> (
+    Glass,
+    Arc<AtomicUsize>,
+    Arc<AtomicUsize>,
+    Arc<Mutex<Vec<AxTarget>>>,
+) {
+    let walks = Arc::new(AtomicUsize::new(0));
+    let focus_calls = Arc::new(AtomicUsize::new(0));
+    let invoke_log = Arc::new(Mutex::new(Vec::new()));
+    let accessibility = SeqAccessibility::new(trees)
+        .with_coverage(full_state_coverage())
+        .with_signal(signal)
+        .with_invoke_behavior(behavior)
+        .with_invoke_log(invoke_log.clone())
+        .with_walks(walks.clone())
+        .with_focus_calls(focus_calls.clone());
+    let glass = glass_with_backend(FakePlatform::new(100, 100), Box::new(accessibility));
+    (glass, walks, focus_calls, invoke_log)
+}
+
+#[test]
+fn public_semantic_action_enums_have_stable_snake_case_labels() {
+    assert_eq!(ActionTarget::Id(AxNodeId(7)).as_str(), "id");
+    assert_eq!(
+        ActionTarget::Semantic(semantic_target("save")).as_str(),
+        "semantic"
+    );
+    assert_eq!(ActionMode::Auto.as_str(), "auto");
+    assert_eq!(ActionMode::Native.as_str(), "native");
+    assert_eq!(ActionMode::Pointer.as_str(), "pointer");
+    assert_eq!(
+        ActionMethod::NativeAction { actuated: None }.as_str(),
+        "native_action"
+    );
+    assert_eq!(
+        ActionMethod::Pointer {
+            native_fallback: None
+        }
+        .as_str(),
+        "pointer"
+    );
+    assert_eq!(
+        ActionMethod::AccessibilityValue.as_str(),
+        "accessibility_value"
+    );
+    assert_eq!(ActionMethod::Keyboard.as_str(), "keyboard");
+    assert_eq!(DispatchStatus::NotDispatched.as_str(), "not_dispatched");
+    assert_eq!(DispatchStatus::Dispatched.as_str(), "dispatched");
+    assert_eq!(
+        DispatchStatus::MayHaveDispatched.as_str(),
+        "may_have_dispatched"
+    );
+    assert_eq!(ConfirmationStatus::NotRequested.as_str(), "not_requested");
+    assert_eq!(
+        ConfirmationStatus::DispatchConfirmed.as_str(),
+        "dispatch_confirmed"
+    );
+    assert_eq!(
+        ConfirmationStatus::FocusConfirmed.as_str(),
+        "focus_confirmed"
+    );
+    assert_eq!(
+        ConfirmationStatus::ValueConfirmed.as_str(),
+        "value_confirmed"
+    );
+    assert_eq!(ConfirmationStatus::Unconfirmed.as_str(), "unconfirmed");
+    assert_eq!(SemanticActionFailureKind::NoMatch.as_str(), "no_match");
+    assert_eq!(
+        SemanticActionFailureKind::AmbiguousTarget.as_str(),
+        "ambiguous_target"
+    );
+    assert_eq!(
+        SemanticActionFailureKind::AmbiguousScope.as_str(),
+        "ambiguous_scope"
+    );
+    assert_eq!(
+        SemanticActionFailureKind::IncompleteTree.as_str(),
+        "incomplete_tree"
+    );
+    assert_eq!(
+        SemanticActionFailureKind::UnprovenSelectorState.as_str(),
+        "unproven_selector_state"
+    );
+    assert_eq!(
+        SemanticActionFailureKind::NotActionable.as_str(),
+        "not_actionable"
+    );
+    assert_eq!(
+        SemanticActionFailureKind::UnstableTarget.as_str(),
+        "unstable_target"
+    );
+    assert_eq!(
+        SemanticActionFailureKind::FocusUnconfirmed.as_str(),
+        "focus_unconfirmed"
+    );
+    assert_eq!(
+        SemanticActionFailureKind::UnsupportedMode.as_str(),
+        "unsupported_mode"
+    );
+    assert_eq!(
+        SemanticActionFailureKind::ActionDeadlineExceeded.as_str(),
+        "action_deadline_exceeded"
+    );
+    assert_eq!(
+        SemanticActionFailureKind::SequenceDeadlineExceeded.as_str(),
+        "sequence_deadline_exceeded"
+    );
+    assert_eq!(
+        SemanticActionFailureKind::ActionFailed.as_str(),
+        "action_failed"
+    );
+    assert_eq!(RetryGuidance::CorrectRequest.as_str(), "correct_request");
+    assert_eq!(RetryGuidance::WaitOrRefine.as_str(), "wait_or_refine");
+    assert_eq!(RetryGuidance::Reobserve.as_str(), "reobserve");
+    assert_eq!(RetryGuidance::SafeToRetry.as_str(), "safe_to_retry");
+    assert_eq!(RetryGuidance::DoNotRetry.as_str(), "do_not_retry");
+}
+
+#[test]
+fn semantic_action_error_display_never_exposes_retained_payloads() {
+    let error = SemanticActionError {
+        kind: SemanticActionFailureKind::ActionFailed,
+        summary: "semantic action failed",
+        resolution: None,
+        actionability: ActionabilityReport::default(),
+        focus: Some(MutationReport {
+            method: ActionMethod::Pointer {
+                native_fallback: Some("mutation-secret".into()),
+            },
+            dispatch: DispatchStatus::MayHaveDispatched,
+            confirmation: ConfirmationStatus::Unconfirmed,
+        }),
+        action_dispatch: DispatchStatus::MayHaveDispatched,
+        candidates: Vec::new(),
+        bound: ActionDeadline {
+            deadline: Deadline::UNBOUNDED,
+            owner: None,
+            allow_wait: true,
+        },
+        retry: RetryGuidance::DoNotRetry,
+        source: Some(GlassError::Backend("source-secret".into())),
+    };
+
+    assert_eq!(error.to_string(), "semantic action failed");
+    assert!(std::error::Error::source(&error).is_none());
+}
+
+#[test]
+fn selector_resolution_reads_fresh_and_caches_the_unique_complete_tree() {
+    let stale = named_button_tree("Save old");
+    let fresh = named_button_tree("Save account");
+    let (mut glass, walks, _, _) =
+        semantic_glass(vec![stale, fresh], None, InvokeBehavior::Unsupported);
+    glass.start(&spec()).unwrap();
+    glass.a11y_snapshot(None).unwrap();
+
+    let resolved = glass
+        .resolve_semantic_target(
+            &semantic_target("Save account"),
+            None,
+            0,
+            Deadline::UNBOUNDED,
+            |_, _| true,
+        )
+        .unwrap();
+
+    assert_eq!(walks.load(Ordering::Relaxed), 2);
+    assert_eq!(resolved.element.id, AxNodeId(1));
+    assert_eq!(resolved.element.name.as_deref(), Some("Save account"));
+    assert_eq!(resolved.target.id, AxNodeId(1));
+    assert_eq!(resolved.target.name.as_deref(), Some("Save account"));
+    assert_eq!(
+        glass
+            .active
+            .as_ref()
+            .unwrap()
+            .last_ax
+            .as_ref()
+            .unwrap()
+            .root
+            .children[0]
+            .name
+            .as_deref(),
+        Some("Save account")
+    );
+}
+
+#[test]
+fn selector_resolution_waits_for_delayed_publication() {
+    let first = named_button_tree("Save old");
+    let second = named_button_tree("Save account");
+    let (mut glass, walks, _, _) = semantic_glass(
+        vec![first, second],
+        Some(signals_once),
+        InvokeBehavior::Unsupported,
+    );
+    glass.start(&spec()).unwrap();
+
+    let resolved = glass
+        .resolve_semantic_target(
+            &semantic_target("Save account"),
+            None,
+            500,
+            Deadline::UNBOUNDED,
+            |_, _| true,
+        )
+        .unwrap();
+
+    assert_eq!(walks.load(Ordering::Relaxed), 2);
+    assert_eq!(resolved.element.name.as_deref(), Some("Save account"));
+    assert!(resolved.bound.allow_wait);
+}
+
+#[test]
+fn duplicate_targets_never_resolve_to_the_first_ranked_match() {
+    let tree = duplicate_button_tree("Save account", 7);
+    let (mut glass, walks, mutation_calls, _) =
+        semantic_glass(vec![tree], Some(never_signals), InvokeBehavior::Unsupported);
+    glass.start(&spec()).unwrap();
+
+    let error = glass
+        .resolve_semantic_target(
+            &semantic_target("Save account"),
+            None,
+            0,
+            Deadline::UNBOUNDED,
+            |_, _| true,
+        )
+        .unwrap_err();
+
+    assert_eq!(error.kind, SemanticActionFailureKind::AmbiguousTarget);
+    assert_eq!(error.resolution.as_ref().unwrap().matches_in_walk, 7);
+    assert_eq!(error.candidates.len(), SEMANTIC_ACTION_CANDIDATE_LIMIT);
+    assert_eq!(walks.load(Ordering::Relaxed), 1);
+    assert_eq!(mutation_calls.load(Ordering::Relaxed), 0);
+}
+
+#[test]
+fn ambiguous_scope_never_falls_back_to_the_whole_window() {
+    let target = SemanticTarget {
+        target: selector("Save account"),
+        within: Some(selector("Account panel")),
+    };
+    let (mut glass, walks, mutation_calls, _) =
+        semantic_glass(vec![scoped_tree()], None, InvokeBehavior::Unsupported);
+    glass.start(&spec()).unwrap();
+
+    let error = glass
+        .resolve_semantic_target(&target, None, 0, Deadline::UNBOUNDED, |_, _| true)
+        .unwrap_err();
+
+    assert_eq!(error.kind, SemanticActionFailureKind::AmbiguousScope);
+    assert!(error.candidates.is_empty());
+    assert_eq!(walks.load(Ordering::Relaxed), 1);
+    assert_eq!(mutation_calls.load(Ordering::Relaxed), 0);
+}
+
+#[test]
+fn one_match_in_an_incomplete_tree_does_not_prove_uniqueness() {
+    let mut tree = named_button_tree("Save account");
+    tree.truncated = Some(Truncation {
+        limit: TruncationLimit::Nodes,
+        limit_value: 2,
+        nodes_walked: 2,
+    });
+    let (mut glass, walks, mutation_calls, _) =
+        semantic_glass(vec![tree], None, InvokeBehavior::Unsupported);
+    glass.start(&spec()).unwrap();
+
+    let error = glass
+        .resolve_semantic_target(
+            &semantic_target("Save account"),
+            None,
+            0,
+            Deadline::UNBOUNDED,
+            |_, _| true,
+        )
+        .unwrap_err();
+
+    assert_eq!(error.kind, SemanticActionFailureKind::IncompleteTree);
+    let report = error.resolution.unwrap();
+    assert_eq!(report.matches_in_walk, 1);
+    assert!(!report.search_complete);
+    assert!(report.tree_truncated);
+    assert_eq!(walks.load(Ordering::Relaxed), 1);
+    assert_eq!(mutation_calls.load(Ordering::Relaxed), 0);
+}
+
+#[test]
+fn uncovered_requested_state_fails_before_the_first_tree_read() {
+    let walks = Arc::new(AtomicUsize::new(0));
+    let accessibility = SeqAccessibility::new(vec![named_button_tree("Save account")])
+        .with_coverage(AxStateCoverage::NONE)
+        .with_walks(walks.clone());
+    let mut glass = glass_with_backend(FakePlatform::new(100, 100), Box::new(accessibility));
+    glass.start(&spec()).unwrap();
+    let target = SemanticTarget {
+        target: SemanticSelector::new(
+            Some("Save account".into()),
+            None,
+            vec![SemanticState::Visible],
+        )
+        .unwrap(),
+        within: None,
+    };
+
+    let error = glass
+        .resolve_semantic_target(&target, None, 0, Deadline::UNBOUNDED, |_, _| true)
+        .unwrap_err();
+
+    assert_eq!(error.kind, SemanticActionFailureKind::UnprovenSelectorState);
+    assert_eq!(error.action_dispatch, DispatchStatus::NotDispatched);
+    assert_eq!(walks.load(Ordering::Relaxed), 0);
+}
+
+#[test]
+fn zero_timeout_performs_exactly_one_fresh_read() {
+    let (mut glass, walks, _, _) = semantic_glass(
+        vec![
+            named_button_tree("Save old"),
+            named_button_tree("Save account"),
+        ],
+        Some(signals_once),
+        InvokeBehavior::Unsupported,
+    );
+    glass.start(&spec()).unwrap();
+
+    let error = glass
+        .resolve_semantic_target(
+            &semantic_target("missing"),
+            None,
+            0,
+            Deadline::UNBOUNDED,
+            |_, _| true,
+        )
+        .unwrap_err();
+
+    assert_eq!(error.kind, SemanticActionFailureKind::NoMatch);
+    assert!(!error.bound.allow_wait);
+    assert_eq!(walks.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn zero_timeout_native_click_can_dispatch_without_starting_a_wait() {
+    let (mut glass, walks, _, invoke_log) = semantic_glass(
+        vec![named_button_tree("Save account")],
+        Some(never_signals),
+        InvokeBehavior::Succeed,
+    );
+    glass.start(&spec()).unwrap();
+
+    let resolved = glass
+        .resolve_semantic_target(
+            &semantic_target("Save account"),
+            None,
+            0,
+            Deadline::UNBOUNDED,
+            |_, _| true,
+        )
+        .unwrap();
+    assert!(!resolved.bound.allow_wait);
+    assert_eq!(walks.load(Ordering::Relaxed), 1);
+
+    glass.click_element(resolved.target.id).unwrap();
+
+    assert_eq!(invoke_log.lock().unwrap().len(), 1);
+    assert_eq!(walks.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn omitted_max_nodes_installs_walk_limits_default_instead_of_reusing_the_session_cap() {
+    let (mut glass, walks, _, _) = semantic_glass(
+        vec![
+            named_button_tree("Save old"),
+            named_button_tree("Save account"),
+        ],
+        None,
+        InvokeBehavior::Unsupported,
+    );
+    glass.start(&spec()).unwrap();
+    glass.a11y_snapshot(Some(1)).unwrap();
+    assert_eq!(
+        glass.active.as_ref().unwrap().a11y_limits,
+        WalkLimits::from_max_nodes(Some(1))
+    );
+
+    glass
+        .resolve_semantic_target(
+            &semantic_target("Save account"),
+            None,
+            0,
+            Deadline::UNBOUNDED,
+            |_, _| true,
+        )
+        .unwrap();
+
+    assert_eq!(
+        glass.active.as_ref().unwrap().a11y_limits,
+        WalkLimits::DEFAULT
+    );
+    assert_eq!(walks.load(Ordering::Relaxed), 2);
+}
+
+#[test]
+fn known_ineligible_target_is_classified_after_unique_complete_resolution() {
+    let (mut glass, walks, _, _) = semantic_glass(
+        vec![named_button_tree("Save account")],
+        None,
+        InvokeBehavior::Unsupported,
+    );
+    glass.start(&spec()).unwrap();
+
+    let error = glass
+        .resolve_semantic_target(
+            &semantic_target("Save account"),
+            None,
+            0,
+            Deadline::UNBOUNDED,
+            |_, _| false,
+        )
+        .unwrap_err();
+
+    assert_eq!(error.kind, SemanticActionFailureKind::NotActionable);
+    assert_eq!(error.candidates.len(), 1);
+    assert_eq!(walks.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn target_deadlines_validate_id_options_and_selector_timeout_ceiling() {
+    let id_error = target_deadline(
+        &ActionTarget::Id(AxNodeId(1)),
+        Some(1),
+        None,
+        Deadline::UNBOUNDED,
+    )
+    .unwrap_err();
+    assert_eq!(id_error.kind, SemanticActionFailureKind::UnsupportedMode);
+    assert_eq!(id_error.action_dispatch, DispatchStatus::NotDispatched);
+    assert_eq!(id_error.retry, RetryGuidance::CorrectRequest);
+
+    let selector_error = target_deadline(
+        &ActionTarget::Semantic(semantic_target("save")),
+        Some(SEMANTIC_ACTION_MAX_TIMEOUT_MS + 1),
+        None,
+        Deadline::UNBOUNDED,
+    )
+    .unwrap_err();
+    assert_eq!(
+        selector_error.kind,
+        SemanticActionFailureKind::UnsupportedMode
+    );
+    assert_eq!(
+        selector_error.action_dispatch,
+        DispatchStatus::NotDispatched
+    );
+    assert_eq!(selector_error.retry, RetryGuidance::CorrectRequest);
+}
+
+#[test]
+fn target_deadlines_preserve_id_and_selector_bound_ownership() {
+    let standalone = target_deadline(
+        &ActionTarget::Id(AxNodeId(1)),
+        None,
+        None,
+        Deadline::UNBOUNDED,
+    )
+    .unwrap();
+    assert_eq!(standalone.deadline, Deadline::UNBOUNDED);
+    assert_eq!(standalone.owner, None);
+    assert!(standalone.allow_wait);
+
+    let sequence = Deadline::from_millis(500);
+    let batched = target_deadline(&ActionTarget::Id(AxNodeId(1)), None, None, sequence).unwrap();
+    assert_eq!(batched.deadline, sequence);
+    assert_eq!(batched.owner, Some(Whose::Caller));
+    assert!(batched.allow_wait);
+
+    let defaulted = target_deadline(
+        &ActionTarget::Semantic(semantic_target("save")),
+        None,
+        None,
+        Deadline::UNBOUNDED,
+    )
+    .unwrap();
+    let remaining = defaulted.deadline.remaining().unwrap();
+    assert!(remaining <= std::time::Duration::from_millis(SEMANTIC_ACTION_DEFAULT_TIMEOUT_MS));
+    assert!(remaining > std::time::Duration::from_millis(SEMANTIC_ACTION_DEFAULT_TIMEOUT_MS - 100));
+    assert_eq!(defaulted.owner, Some(Whose::Callee));
+    assert!(defaulted.allow_wait);
+
+    let zero = target_deadline(
+        &ActionTarget::Semantic(semantic_target("save")),
+        Some(0),
+        None,
+        Deadline::UNBOUNDED,
+    )
+    .unwrap();
+    assert_eq!(zero.deadline, Deadline::UNBOUNDED);
+    assert_eq!(zero.owner, None);
+    assert!(!zero.allow_wait);
+
+    let sequence = Deadline::from_millis(500);
+    let sequence_limited = target_deadline(
+        &ActionTarget::Semantic(semantic_target("save")),
+        Some(1_000),
+        None,
+        sequence,
+    )
+    .unwrap();
+    assert_eq!(sequence_limited.deadline, sequence);
+    assert_eq!(sequence_limited.owner, Some(Whose::Caller));
+    assert!(sequence_limited.allow_wait);
+}

--- a/crates/glass-core/src/session/semantic_action/tests.rs
+++ b/crates/glass-core/src/session/semantic_action/tests.rs
@@ -1,9 +1,10 @@
 use super::*;
 use crate::session::test_support::*;
 use crate::{
-    Accessibility, ActionabilityCheckName, ActionabilityVerdict, AxContext, AxNode, AxNodeId,
-    AxRect, AxRole, AxStateCoverage, AxStates, AxTree, ChangeSignal, PointerHit, SemanticSelector,
-    SemanticState, Truncation, TruncationLimit, WalkLimits,
+    Accessibility, ActionabilityCheck, ActionabilityCheckName, ActionabilitySource,
+    ActionabilityVerdict, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxStateCoverage, AxStates,
+    AxTree, ChangeSignal, PointerHit, SemanticSelector, SemanticState, Truncation, TruncationLimit,
+    WalkLimits,
 };
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -85,6 +86,39 @@ fn report_verdict(
         .find(|check| check.name == name)
         .expect("missing actionability check")
         .verdict
+}
+
+fn error_report_check(
+    error: &SemanticActionError,
+    name: ActionabilityCheckName,
+) -> ActionabilityCheck {
+    error
+        .actionability
+        .checks
+        .iter()
+        .copied()
+        .find(|check| check.name == name)
+        .expect("missing actionability check")
+}
+
+fn assert_pointer_report_order(error: &SemanticActionError) {
+    assert_eq!(
+        error
+            .actionability
+            .checks
+            .iter()
+            .map(|check| check.name)
+            .collect::<Vec<_>>(),
+        vec![
+            ActionabilityCheckName::Unique,
+            ActionabilityCheckName::Enabled,
+            ActionabilityCheckName::Visible,
+            ActionabilityCheckName::Stable,
+            ActionabilityCheckName::InWindow,
+            ActionabilityCheckName::NonOccluded,
+            ActionabilityCheckName::BackendFingerprint,
+        ]
+    );
 }
 
 fn duplicate_button_tree(name: &str, count: usize) -> AxTree {
@@ -886,6 +920,261 @@ fn identity_change_resets_stability_even_when_bounds_are_equal() {
 }
 
 #[test]
+fn selector_pointer_builds_each_stability_sample_from_its_refreshed_window() {
+    let bounds = AxRect {
+        x: 10,
+        y: 10,
+        width: 20,
+        height: 20,
+    };
+    let clicks = Arc::new(Mutex::new(Vec::new()));
+    let narrow = WindowGeometry {
+        x: 0,
+        y: 0,
+        width: 15,
+        height: 100,
+    };
+    let full = WindowGeometry {
+        width: 100,
+        ..narrow.clone()
+    };
+    let platform = FakePlatform::new(100, 100)
+        .with_click_log(clicks.clone())
+        .resized_to(narrow)
+        .resized_to(full.clone())
+        .resized_to(full);
+    let tree = actionable_button_tree("Save", bounds);
+    let (mut glass, walks, _, hit_points) = pointer_glass(
+        platform,
+        vec![tree.clone(), tree.clone(), tree],
+        PointerHit::Target,
+        false,
+    );
+    glass.start(&spec()).unwrap();
+
+    glass
+        .click_target_inner(
+            pointer_params(ActionTarget::Semantic(semantic_target("Save")), Some(600)),
+            Deadline::UNBOUNDED,
+        )
+        .unwrap();
+
+    assert_eq!(walks.load(Ordering::Relaxed), 3);
+    assert_eq!(hit_points.lock().unwrap().as_slice(), &[(20, 20)]);
+    assert_eq!(clicks.lock().unwrap().as_slice(), &[(20, 20)]);
+}
+
+#[test]
+fn selector_pointer_revalidates_the_exact_plan_against_the_dispatch_window() {
+    let bounds = AxRect {
+        x: 80,
+        y: 10,
+        width: 20,
+        height: 20,
+    };
+    let clicks = Arc::new(Mutex::new(Vec::new()));
+    let full = WindowGeometry {
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 100,
+    };
+    let narrow = WindowGeometry {
+        width: 15,
+        ..full.clone()
+    };
+    let platform = FakePlatform::new(100, 100)
+        .with_click_log(clicks.clone())
+        .resized_to(full.clone())
+        .resized_to(full)
+        .resized_to(narrow);
+    let tree = actionable_button_tree("Save", bounds);
+    let (mut glass, _, hit_calls, _) = pointer_glass(
+        platform,
+        vec![tree.clone(), tree],
+        PointerHit::Target,
+        false,
+    );
+    glass.start(&spec()).unwrap();
+
+    let error = glass
+        .click_target_inner(
+            pointer_params(ActionTarget::Semantic(semantic_target("Save")), Some(500)),
+            Deadline::UNBOUNDED,
+        )
+        .unwrap_err();
+
+    assert_eq!(error.kind, SemanticActionFailureKind::NotActionable);
+    assert_eq!(error.action_dispatch, DispatchStatus::NotDispatched);
+    assert_eq!(
+        error_report_check(&error, ActionabilityCheckName::InWindow).verdict,
+        ActionabilityVerdict::Failed
+    );
+    assert_eq!(hit_calls.load(Ordering::Relaxed), 0);
+    assert!(clicks.lock().unwrap().is_empty());
+}
+
+#[test]
+fn auto_native_discloses_the_post_resolution_window_geometry() {
+    let tree = actionable_button_tree(
+        "Save",
+        AxRect {
+            x: 80,
+            y: 10,
+            width: 20,
+            height: 20,
+        },
+    );
+    let platform = FakePlatform::new(100, 100).resized_to(WindowGeometry {
+        x: 0,
+        y: 0,
+        width: 15,
+        height: 100,
+    });
+    let invoke_log = Arc::new(Mutex::new(Vec::new()));
+    let accessibility = SeqAccessibility::new(vec![tree])
+        .with_coverage(full_state_coverage())
+        .with_invoke_behavior(InvokeBehavior::Succeed)
+        .with_invoke_log(invoke_log.clone());
+    let mut glass = glass_with_backend(platform, Box::new(accessibility));
+    glass.start(&spec()).unwrap();
+
+    let outcome = glass
+        .click_target_inner(
+            ClickTargetParams {
+                target: ActionTarget::Semantic(semantic_target("Save")),
+                mode: ActionMode::Auto,
+                timeout_ms: Some(0),
+                max_nodes: None,
+            },
+            Deadline::UNBOUNDED,
+        )
+        .unwrap();
+
+    assert_eq!(invoke_log.lock().unwrap().len(), 1);
+    let in_window = outcome
+        .actionability
+        .checks
+        .iter()
+        .find(|check| check.name == ActionabilityCheckName::InWindow)
+        .unwrap();
+    assert_eq!(in_window.verdict, ActionabilityVerdict::Failed);
+    assert!(!in_window.required);
+}
+
+#[test]
+fn selector_pointer_disabled_target_preserves_the_ordered_blocking_report() {
+    let mut tree = actionable_button_tree(
+        "Save",
+        AxRect {
+            x: 10,
+            y: 10,
+            width: 20,
+            height: 20,
+        },
+    );
+    tree.root.children[0].states.enabled = false;
+    let (mut glass, _, hit_calls, _) = pointer_glass(
+        FakePlatform::new(100, 100),
+        vec![tree],
+        PointerHit::Target,
+        false,
+    );
+    glass.start(&spec()).unwrap();
+
+    let error = glass
+        .click_target_inner(
+            pointer_params(ActionTarget::Semantic(semantic_target("Save")), Some(0)),
+            Deadline::UNBOUNDED,
+        )
+        .unwrap_err();
+
+    assert_pointer_report_order(&error);
+    assert_eq!(
+        error.actionability.blocking().unwrap().name,
+        ActionabilityCheckName::Enabled
+    );
+    let stable = error_report_check(&error, ActionabilityCheckName::Stable);
+    assert_eq!(stable.verdict, ActionabilityVerdict::Unproven);
+    assert!(stable.required);
+    assert_eq!(stable.source, ActionabilitySource::GeometrySamples);
+    assert_eq!(hit_calls.load(Ordering::Relaxed), 0);
+}
+
+#[test]
+fn selector_pointer_hidden_target_preserves_the_ordered_blocking_report() {
+    let mut tree = actionable_button_tree(
+        "Save",
+        AxRect {
+            x: 10,
+            y: 10,
+            width: 20,
+            height: 20,
+        },
+    );
+    tree.root.children[0].states.visible = false;
+    let (mut glass, _, hit_calls, _) = pointer_glass(
+        FakePlatform::new(100, 100),
+        vec![tree],
+        PointerHit::Target,
+        false,
+    );
+    glass.start(&spec()).unwrap();
+
+    let error = glass
+        .click_target_inner(
+            pointer_params(ActionTarget::Semantic(semantic_target("Save")), Some(0)),
+            Deadline::UNBOUNDED,
+        )
+        .unwrap_err();
+
+    assert_pointer_report_order(&error);
+    assert_eq!(
+        error.actionability.blocking().unwrap().name,
+        ActionabilityCheckName::Visible
+    );
+    assert_eq!(hit_calls.load(Ordering::Relaxed), 0);
+}
+
+#[test]
+fn selector_pointer_off_window_target_preserves_the_ordered_blocking_report() {
+    let tree = actionable_button_tree(
+        "Save",
+        AxRect {
+            x: 100,
+            y: 10,
+            width: 20,
+            height: 20,
+        },
+    );
+    let (mut glass, _, hit_calls, _) = pointer_glass(
+        FakePlatform::new(100, 100),
+        vec![tree],
+        PointerHit::Target,
+        false,
+    );
+    glass.start(&spec()).unwrap();
+
+    let error = glass
+        .click_target_inner(
+            pointer_params(ActionTarget::Semantic(semantic_target("Save")), Some(0)),
+            Deadline::UNBOUNDED,
+        )
+        .unwrap_err();
+
+    assert_pointer_report_order(&error);
+    assert_eq!(
+        error.actionability.blocking().unwrap().name,
+        ActionabilityCheckName::InWindow
+    );
+    let in_window = error_report_check(&error, ActionabilityCheckName::InWindow);
+    assert_eq!(in_window.verdict, ActionabilityVerdict::Failed);
+    assert!(in_window.required);
+    assert_eq!(in_window.source, ActionabilitySource::WindowGeometry);
+    assert_eq!(hit_calls.load(Ordering::Relaxed), 0);
+}
+
+#[test]
 fn zero_timeout_native_action_dispatches_after_one_fresh_read() {
     let tree = actionable_button_tree(
         "Save",
@@ -1099,6 +1388,47 @@ fn selector_pointer_row_toggle_probes_and_dispatches_the_same_trailing_control()
         } if (from_x, from_y, to_x, to_y)
             == (segment.from_x, segment.from_y, segment.to_x, segment.to_y)
     ));
+}
+
+#[test]
+fn selector_pointer_rejects_a_trailing_toggle_with_a_boundary_endpoint() {
+    let bounds = AxRect {
+        x: 99,
+        y: 99,
+        width: 80,
+        height: 15,
+    };
+    let mut tree = actionable_button_tree("Wi-Fi", bounds);
+    let toggle = &mut tree.root.children[0];
+    toggle.role = AxRole::CheckBox;
+    toggle.states.checkable = true;
+    let drags = Arc::new(Mutex::new(Vec::new()));
+    let platform = FakePlatform::new(100, 100)
+        .with_drag_log(drags.clone())
+        .with_trailing_toggle_backend();
+    let (mut glass, _, hit_calls, _) = pointer_glass(
+        platform,
+        vec![tree.clone(), tree],
+        PointerHit::Target,
+        false,
+    );
+    glass.start(&spec()).unwrap();
+
+    let error = glass
+        .click_target_inner(
+            pointer_params(ActionTarget::Semantic(semantic_target("Wi-Fi")), Some(500)),
+            Deadline::UNBOUNDED,
+        )
+        .unwrap_err();
+
+    assert_eq!(error.kind, SemanticActionFailureKind::NotActionable);
+    assert_eq!(error.action_dispatch, DispatchStatus::NotDispatched);
+    assert_eq!(
+        error.actionability.blocking().unwrap().name,
+        ActionabilityCheckName::InWindow
+    );
+    assert_eq!(hit_calls.load(Ordering::Relaxed), 0);
+    assert!(drags.lock().unwrap().is_empty());
 }
 
 #[test]

--- a/crates/glass-core/src/session/semantic_action/tests.rs
+++ b/crates/glass-core/src/session/semantic_action/tests.rs
@@ -1023,8 +1023,7 @@ fn set_value_error_provenance_requires_proof_before_reporting_safe_non_dispatch(
             RetryGuidance::DoNotRetry,
         ),
         (
-            GlassError::Backend("dispatch completed before transport failure".into())
-                .after_dispatch(),
+            GlassError::AxElementGone(7).after_dispatch(),
             DispatchStatus::MayHaveDispatched,
             RetryGuidance::DoNotRetry,
         ),
@@ -4028,6 +4027,36 @@ fn targeted_type_rejects_a_button_even_when_the_backend_can_focus_it() {
     assert_eq!(eligibility.verdict, ActionabilityVerdict::Failed);
     assert!(eligibility.required);
     assert_eq!(eligibility.source, ActionabilitySource::NormalizedState);
+    assert_eq!(fixture.focus_calls.load(Ordering::Relaxed), 0);
+    assert!(fixture.clicks.lock().unwrap().is_empty());
+    assert!(fixture.key_log.lock().unwrap().is_empty());
+}
+
+#[test]
+fn targeted_type_rejects_a_disabled_field_before_native_focus_dispatch() {
+    let mut tree = targeted_type_field_tree("Account name", false);
+    tree.root.children[0].states.enabled = false;
+    let mut fixture = targeted_type_glass(
+        vec![tree],
+        InvokeBehavior::Succeed,
+        full_state_coverage(),
+        false,
+    );
+    fixture.glass.start(&spec()).unwrap();
+
+    let error = fixture
+        .glass
+        .type_target(
+            &targeted_type_params("Account name", ActionMode::Native, 0),
+            "must not type",
+        )
+        .unwrap_err();
+
+    assert_eq!(error.kind, SemanticActionFailureKind::NotActionable);
+    let enabled = error_report_check(&error, ActionabilityCheckName::Enabled);
+    assert_eq!(enabled.verdict, ActionabilityVerdict::Failed);
+    assert!(enabled.required);
+    assert_eq!(enabled.source, ActionabilitySource::NormalizedState);
     assert_eq!(fixture.focus_calls.load(Ordering::Relaxed), 0);
     assert!(fixture.clicks.lock().unwrap().is_empty());
     assert!(fixture.key_log.lock().unwrap().is_empty());

--- a/crates/glass-core/src/session/semantic_action/tests.rs
+++ b/crates/glass-core/src/session/semantic_action/tests.rs
@@ -86,11 +86,24 @@ fn semantic_set_value_glass(
     Arc<Mutex<Vec<(AxNodeId, String)>>>,
     AxDeadlineLog,
 ) {
+    semantic_set_value_glass_with_coverage(trees, set_results, full_state_coverage())
+}
+
+fn semantic_set_value_glass_with_coverage(
+    trees: Vec<AxTree>,
+    set_results: Vec<crate::Result<()>>,
+    coverage: AxStateCoverage,
+) -> (
+    Glass,
+    Arc<AtomicUsize>,
+    Arc<Mutex<Vec<(AxNodeId, String)>>>,
+    AxDeadlineLog,
+) {
     let walks = Arc::new(AtomicUsize::new(0));
     let set_log = Arc::new(Mutex::new(Vec::new()));
     let deadlines = Arc::new(Mutex::new(Vec::new()));
     let accessibility = SeqAccessibility::new(trees)
-        .with_coverage(full_state_coverage())
+        .with_coverage(coverage)
         .with_walks(walks.clone())
         .with_deadlines(deadlines.clone())
         .with_set_log(set_log.clone())
@@ -2306,6 +2319,110 @@ fn semantic_set_value_refuses_a_known_non_value_role_before_backend_dispatch() {
         error.actionability.blocking().unwrap().name,
         ActionabilityCheckName::FocusEligible
     );
+    assert_eq!(walks.load(Ordering::Relaxed), 1);
+    assert!(set_log.lock().unwrap().is_empty());
+}
+
+#[test]
+fn semantic_set_value_refuses_uncovered_editable_bit_on_unsupported_role() {
+    let tree = value_control_tree(
+        "Save",
+        AxRole::Button,
+        None,
+        AxStates {
+            enabled: true,
+            visible: true,
+            focusable: true,
+            editable: true,
+            ..AxStates::default()
+        },
+    );
+    let mut coverage = full_state_coverage();
+    coverage.editable = false;
+    let (mut glass, walks, set_log, _) =
+        semantic_set_value_glass_with_coverage(vec![tree], Vec::new(), coverage);
+    glass.start(&spec()).unwrap();
+
+    let error = glass
+        .set_value_target(&semantic_set_value_params("Save", 0), "not-a-value")
+        .unwrap_err();
+
+    assert_eq!(error.kind, SemanticActionFailureKind::NotActionable);
+    assert_eq!(error.action_dispatch, DispatchStatus::NotDispatched);
+    assert_eq!(error.retry, RetryGuidance::Reobserve);
+    let eligibility = error
+        .actionability
+        .checks
+        .iter()
+        .find(|check| check.name == ActionabilityCheckName::FocusEligible)
+        .unwrap();
+    assert_eq!(eligibility.verdict, ActionabilityVerdict::Unproven);
+    assert!(eligibility.required);
+    assert_eq!(walks.load(Ordering::Relaxed), 1);
+    assert!(set_log.lock().unwrap().is_empty());
+}
+
+#[test]
+fn semantic_set_value_refuses_uncovered_checkable_bit_on_unsupported_role() {
+    let tree = value_control_tree(
+        "Save",
+        AxRole::Button,
+        None,
+        AxStates {
+            enabled: true,
+            visible: true,
+            focusable: true,
+            checkable: true,
+            ..AxStates::default()
+        },
+    );
+    let (mut glass, walks, set_log, _) =
+        semantic_set_value_glass_with_coverage(vec![tree], Vec::new(), AxStateCoverage::NONE);
+    glass.start(&spec()).unwrap();
+
+    let error = glass
+        .set_value_target(&semantic_set_value_params("Save", 0), "not-a-value")
+        .unwrap_err();
+
+    assert_eq!(error.kind, SemanticActionFailureKind::NotActionable);
+    assert_eq!(error.action_dispatch, DispatchStatus::NotDispatched);
+    assert_eq!(error.retry, RetryGuidance::Reobserve);
+    let eligibility = error
+        .actionability
+        .checks
+        .iter()
+        .find(|check| check.name == ActionabilityCheckName::FocusEligible)
+        .unwrap();
+    assert_eq!(eligibility.verdict, ActionabilityVerdict::Unproven);
+    assert!(eligibility.required);
+    assert_eq!(walks.load(Ordering::Relaxed), 1);
+    assert!(set_log.lock().unwrap().is_empty());
+}
+
+#[test]
+fn semantic_set_value_refuses_uncovered_editable_support_on_text_field() {
+    let tree = editable_field_tree("Account name", Some("old"), true);
+    let mut coverage = full_state_coverage();
+    coverage.editable = false;
+    let (mut glass, walks, set_log, _) =
+        semantic_set_value_glass_with_coverage(vec![tree], Vec::new(), coverage);
+    glass.start(&spec()).unwrap();
+
+    let error = glass
+        .set_value_target(&semantic_set_value_params("Account name", 0), "updated")
+        .unwrap_err();
+
+    assert_eq!(error.kind, SemanticActionFailureKind::NotActionable);
+    assert_eq!(error.action_dispatch, DispatchStatus::NotDispatched);
+    assert_eq!(error.retry, RetryGuidance::Reobserve);
+    let eligibility = error
+        .actionability
+        .checks
+        .iter()
+        .find(|check| check.name == ActionabilityCheckName::FocusEligible)
+        .unwrap();
+    assert_eq!(eligibility.verdict, ActionabilityVerdict::Unproven);
+    assert!(eligibility.required);
     assert_eq!(walks.load(Ordering::Relaxed), 1);
     assert!(set_log.lock().unwrap().is_empty());
 }

--- a/crates/glass-core/src/session/semantic_action/tests.rs
+++ b/crates/glass-core/src/session/semantic_action/tests.rs
@@ -1906,6 +1906,185 @@ fn semantic_click_params(mode: ActionMode, timeout_ms: u64) -> ClickTargetParams
     }
 }
 
+#[derive(Debug)]
+struct GeneratedTreeCase {
+    tree: AxTree,
+    match_count: usize,
+    complete: bool,
+    summary: String,
+}
+
+struct FixedLcg(u64);
+
+impl FixedLcg {
+    fn next(&mut self) -> u64 {
+        self.0 = self
+            .0
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        self.0
+    }
+
+    fn below(&mut self, upper: usize) -> usize {
+        (self.next() % upper as u64) as usize
+    }
+}
+
+fn generated_trees(count: usize) -> Vec<GeneratedTreeCase> {
+    let mut rng = FixedLcg(0x676c_6173_735f_7077);
+    (0..count)
+        .map(|case_index| {
+            let match_count = rng.below(7);
+            let sibling_count = rng.below(13);
+            let mut children = Vec::with_capacity(match_count + sibling_count);
+            for index in 0..match_count {
+                children.push(AxNode {
+                    id: AxNodeId(0),
+                    role: AxRole::Button,
+                    raw_role: "button".into(),
+                    name: Some("Generated target".into()),
+                    description: None,
+                    value: None,
+                    states: AxStates {
+                        enabled: true,
+                        visible: true,
+                        focusable: true,
+                        ..AxStates::default()
+                    },
+                    bounds: Some(AxRect {
+                        x: 10,
+                        y: 10 + index as i32 * 20,
+                        width: 80,
+                        height: 18,
+                    }),
+                    children: Vec::new(),
+                });
+            }
+            for index in 0..sibling_count {
+                children.push(AxNode {
+                    id: AxNodeId(0),
+                    role: if rng.below(2) == 0 {
+                        AxRole::Button
+                    } else {
+                        AxRole::Label
+                    },
+                    raw_role: "generated sibling".into(),
+                    name: Some(format!("Unrelated sibling {case_index}-{index}")),
+                    description: None,
+                    value: None,
+                    states: AxStates {
+                        enabled: true,
+                        visible: true,
+                        ..AxStates::default()
+                    },
+                    bounds: Some(AxRect {
+                        x: 110,
+                        y: 10 + index as i32 * 12,
+                        width: 80,
+                        height: 10,
+                    }),
+                    children: Vec::new(),
+                });
+            }
+            let mut tree = AxTree::new(AxNode {
+                id: AxNodeId(0),
+                role: AxRole::Window,
+                raw_role: "window".into(),
+                name: Some("Generated app".into()),
+                description: None,
+                value: None,
+                states: AxStates::default(),
+                bounds: Some(AxRect {
+                    x: 0,
+                    y: 0,
+                    width: 320,
+                    height: 240,
+                }),
+                children,
+            });
+            if rng.below(4) == 0 {
+                tree.truncated = Some(Truncation {
+                    limit: match rng.below(3) {
+                        0 => TruncationLimit::Nodes,
+                        1 => TruncationLimit::Depth,
+                        _ => TruncationLimit::Siblings,
+                    },
+                    limit_value: 32,
+                    nodes_walked: tree.root.children.len() + 1,
+                });
+            }
+            tree.unexposed = rng.below(4);
+            let complete = tree.can_prove_absence();
+            let summary = format!(
+                "index={case_index} matches={match_count} siblings={sibling_count} \
+                 truncated={:?} withheld={} complete={complete}",
+                tree.truncated.map(|value| value.limit),
+                tree.unexposed,
+            );
+            GeneratedTreeCase {
+                tree,
+                match_count,
+                complete,
+                summary,
+            }
+        })
+        .collect()
+}
+
+fn run_generated_click(
+    tree: AxTree,
+    dispatches: Arc<AtomicUsize>,
+) -> std::result::Result<SemanticActionOutcome, SemanticActionError> {
+    let accessibility = SeqAccessibility::new(vec![tree])
+        .with_coverage(full_state_coverage())
+        .with_invoke_behavior(InvokeBehavior::Succeed)
+        .with_invoke_calls(dispatches);
+    let mut glass = glass_with_backend(FakePlatform::new(320, 240), Box::new(accessibility));
+    glass.start(&spec()).unwrap();
+    glass.click_target(&ClickTargetParams {
+        target: ActionTarget::Semantic(SemanticTarget {
+            target: SemanticSelector::new(
+                Some("Generated target".into()),
+                Some(AxRole::Button),
+                vec![SemanticState::Enabled, SemanticState::Visible],
+            )
+            .unwrap(),
+            within: None,
+        }),
+        mode: ActionMode::Native,
+        timeout_ms: Some(0),
+        max_nodes: None,
+    })
+}
+
+#[test]
+fn generated_selector_actions_dispatch_only_for_one_match_in_a_complete_tree() {
+    let mut seen = [[false; 2]; 7];
+    for case in generated_trees(512) {
+        seen[case.match_count][usize::from(case.complete)] = true;
+        let expected = case.match_count == 1 && case.complete;
+        let dispatches = Arc::new(AtomicUsize::new(0));
+        let result = run_generated_click(case.tree, Arc::clone(&dispatches));
+        assert_eq!(result.is_ok(), expected, "case={:?}", case.summary);
+        assert_eq!(dispatches.load(Ordering::SeqCst), usize::from(expected));
+        if let Err(error) = result {
+            assert_eq!(
+                error.action_dispatch,
+                DispatchStatus::NotDispatched,
+                "case={:?}",
+                case.summary
+            );
+        }
+    }
+    for (match_count, completeness) in seen.into_iter().enumerate() {
+        assert_eq!(
+            completeness,
+            [true, true],
+            "generator did not cover complete and incomplete trees for match_count={match_count}"
+        );
+    }
+}
+
 #[test]
 fn semantic_auto_click_uses_native_action_first() {
     let tree = actionable_button_tree(

--- a/crates/glass-core/src/session/semantic_action/tests.rs
+++ b/crates/glass-core/src/session/semantic_action/tests.rs
@@ -563,6 +563,7 @@ fn semantic_action_error_display_never_exposes_retained_payloads() {
         }),
         action_dispatch: DispatchStatus::MayHaveDispatched,
         candidates: Vec::new(),
+        target: None,
         bound: ActionDeadline {
             deadline: Deadline::UNBOUNDED,
             owner: None,
@@ -1419,7 +1420,7 @@ fn zero_timeout_pointer_action_returns_unstable_without_dispatch() {
     let clicks = Arc::new(Mutex::new(Vec::new()));
     let platform = FakePlatform::new(100, 100).with_click_log(clicks.clone());
     let (mut glass, walks, hit_calls, _) =
-        pointer_glass(platform, vec![tree], PointerHit::Target, false);
+        pointer_glass(platform, vec![tree.clone()], PointerHit::Target, false);
     glass.start(&spec()).unwrap();
 
     let error = glass
@@ -1431,6 +1432,13 @@ fn zero_timeout_pointer_action_returns_unstable_without_dispatch() {
 
     assert_eq!(error.kind, SemanticActionFailureKind::UnstableTarget);
     assert_eq!(error.action_dispatch, DispatchStatus::NotDispatched);
+    let target = error
+        .target
+        .as_ref()
+        .expect("unstable known target retained");
+    assert_eq!(target.id, AxNodeId(1));
+    assert_eq!(target.name.as_deref(), Some("Save"));
+    assert_eq!(target.bounds, tree.root.children[0].bounds);
     assert_eq!(walks.load(Ordering::Relaxed), 1);
     assert_eq!(hit_calls.load(Ordering::Relaxed), 0);
     assert!(clicks.lock().unwrap().is_empty());
@@ -2917,6 +2925,13 @@ fn targeted_type_never_types_when_focus_cannot_be_confirmed() {
             confirmation: ConfirmationStatus::Unconfirmed,
         })
     );
+    let target = error
+        .target
+        .as_ref()
+        .expect("focus-unconfirmed target retained");
+    assert_eq!(target.id, AxNodeId(1));
+    assert_eq!(target.name.as_deref(), Some("Account name"));
+    assert_eq!(target.role, AxRole::TextField);
     assert!(!error.to_string().contains(secret));
     assert!(!format!("{:?}", error.source).contains(secret));
     assert!(!format!("{:?}", error.candidates).contains(secret));

--- a/crates/glass-core/src/session/semantic_action/tests.rs
+++ b/crates/glass-core/src/session/semantic_action/tests.rs
@@ -3068,3 +3068,116 @@ fn targeted_type_uses_the_same_absolute_deadline_for_focus_confirmation_and_typi
         &[outcome.bound.deadline]
     );
 }
+
+#[test]
+fn targeted_type_sanitizes_a_secret_bearing_key_backend_error_after_classification() {
+    let secret = "scripted key failure";
+    let mut fixture = targeted_type_glass(
+        vec![
+            targeted_type_field_tree("Account name", false),
+            targeted_type_field_tree("Account name", true),
+        ],
+        InvokeBehavior::Succeed,
+        full_state_coverage(),
+        true,
+    );
+    let sink = RecordingSink::default();
+    fixture.glass.set_audit_sink(Box::new(sink.clone()));
+    fixture.glass.start(&spec()).unwrap();
+    sink.0.lock().unwrap().clear();
+    sink.3.lock().unwrap().clear();
+
+    let error = fixture
+        .glass
+        .type_target(
+            &targeted_type_params("Account name", ActionMode::Native, 500),
+            secret,
+        )
+        .unwrap_err();
+
+    assert_eq!(fixture.key_log.lock().unwrap().len(), 1);
+    assert_eq!(error.action_dispatch, DispatchStatus::MayHaveDispatched);
+    assert_eq!(error.retry, RetryGuidance::DoNotRetry);
+    assert!(!error.to_string().contains(secret));
+    assert!(!format!("{error:?}").contains(secret));
+    assert!(!format!("{:?}", error.source).contains(secret));
+    assert!(error.source.is_none());
+    assert!(!format!("{:?}", error.candidates).contains(secret));
+    assert!(!format!("{:?}", error.actionability).contains(secret));
+    assert_eq!(sink.0.lock().unwrap().as_slice(), &["type_target:false"]);
+    let audits = sink.3.lock().unwrap();
+    assert_eq!(audits.len(), 1);
+    assert!(!audits[0].error.as_deref().unwrap().contains(secret));
+}
+
+#[test]
+fn targeted_type_confirms_and_reports_a_substituted_native_focus_target() {
+    let mut before = targeted_type_field_tree("Account name", false);
+    before.root.children.push(AxNode {
+        id: AxNodeId(2),
+        role: AxRole::TextArea,
+        raw_role: "text area".into(),
+        name: Some("Actual editor".into()),
+        description: None,
+        value: Some("old".into()),
+        states: AxStates {
+            enabled: true,
+            visible: true,
+            focusable: true,
+            editable: true,
+            ..AxStates::default()
+        },
+        bounds: Some(AxRect {
+            x: 20,
+            y: 70,
+            width: 160,
+            height: 60,
+        }),
+        children: Vec::new(),
+    });
+    let mut after = before.clone();
+    after.root.children[1].states.focused = true;
+    let mut fixture = targeted_type_glass(
+        vec![before, after],
+        InvokeBehavior::SucceedOnAnother(2),
+        full_state_coverage(),
+        false,
+    );
+    fixture.glass.start(&spec()).unwrap();
+
+    let outcome = fixture
+        .glass
+        .type_target(
+            &targeted_type_params("Account name", ActionMode::Native, 0),
+            "typed once",
+        )
+        .unwrap();
+
+    assert_eq!(fixture.focus_calls.load(Ordering::Relaxed), 1);
+    assert!(fixture.clicks.lock().unwrap().is_empty());
+    assert_eq!(fixture.key_log.lock().unwrap().len(), 1);
+    assert_eq!(outcome.target.id, AxNodeId(2));
+    assert_eq!(outcome.target.role, AxRole::TextArea);
+    assert_eq!(outcome.target.name.as_deref(), Some("Actual editor"));
+    assert_eq!(
+        outcome.focus,
+        Some(MutationReport {
+            method: ActionMethod::NativeAction {
+                actuated: Some(AxNodeId(2)),
+            },
+            dispatch: DispatchStatus::Dispatched,
+            confirmation: ConfirmationStatus::FocusConfirmed,
+        })
+    );
+    let deadlines = fixture.ax_deadlines.lock().unwrap();
+    assert_eq!(deadlines.len(), 3);
+    assert!(
+        deadlines
+            .iter()
+            .all(|deadline| *deadline == outcome.bound.deadline)
+    );
+    assert_eq!(
+        fixture.key_deadlines.lock().unwrap().as_slice(),
+        &[outcome.bound.deadline]
+    );
+}

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -701,8 +701,10 @@ pub(crate) struct FakeAccessibility {
     coverage: AxStateCoverage,
     focus_behavior: InvokeBehavior,
     hit: PointerHit,
+    hit_error: bool,
     focus_calls: Arc<AtomicUsize>,
     hit_calls: Arc<AtomicUsize>,
+    hit_points: Arc<Mutex<Vec<(i32, i32)>>>,
 }
 
 #[allow(dead_code)]
@@ -718,8 +720,10 @@ impl FakeAccessibility {
             coverage: AxStateCoverage::NONE,
             focus_behavior: InvokeBehavior::Unsupported,
             hit: PointerHit::Inconclusive,
+            hit_error: false,
             focus_calls: Arc::new(AtomicUsize::new(0)),
             hit_calls: Arc::new(AtomicUsize::new(0)),
+            hit_points: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -738,6 +742,11 @@ impl FakeAccessibility {
         self
     }
 
+    pub(crate) fn with_hit_error(mut self) -> Self {
+        self.hit_error = true;
+        self
+    }
+
     pub(crate) fn with_focus_calls(mut self, calls: Arc<AtomicUsize>) -> Self {
         self.focus_calls = calls;
         self
@@ -745,6 +754,11 @@ impl FakeAccessibility {
 
     pub(crate) fn with_hit_calls(mut self, calls: Arc<AtomicUsize>) -> Self {
         self.hit_calls = calls;
+        self
+    }
+
+    pub(crate) fn with_hit_points(mut self, points: Arc<Mutex<Vec<(i32, i32)>>>) -> Self {
+        self.hit_points = points;
         self
     }
 }
@@ -772,10 +786,16 @@ impl Accessibility for FakeAccessibility {
         &mut self,
         ctx: &AxContext,
         _target: &AxTarget,
-        _point: (i32, i32),
+        point: (i32, i32),
     ) -> Result<PointerHit> {
         *self.ctx_log.lock().unwrap() = Some(ctx.clone());
         self.hit_calls.fetch_add(1, Ordering::Relaxed);
+        self.hit_points.lock().unwrap().push(point);
+        if self.hit_error {
+            return Err(GlassError::AccessibilityUnavailable(
+                "scripted pointer hit probe failure".into(),
+            ));
+        }
         Ok(self.hit)
     }
     fn set_value(&mut self, ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
@@ -985,8 +1005,10 @@ pub(crate) struct SeqAccessibility {
     coverage: AxStateCoverage,
     focus_behavior: InvokeBehavior,
     hit: PointerHit,
+    hit_error: bool,
     focus_calls: Arc<AtomicUsize>,
     hit_calls: Arc<AtomicUsize>,
+    hit_points: Arc<Mutex<Vec<(i32, i32)>>>,
 }
 
 #[allow(dead_code)]
@@ -1009,8 +1031,10 @@ impl SeqAccessibility {
             coverage: AxStateCoverage::NONE,
             focus_behavior: InvokeBehavior::Unsupported,
             hit: PointerHit::Inconclusive,
+            hit_error: false,
             focus_calls: Arc::new(AtomicUsize::new(0)),
             hit_calls: Arc::new(AtomicUsize::new(0)),
+            hit_points: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -1029,6 +1053,11 @@ impl SeqAccessibility {
         self
     }
 
+    pub(crate) fn with_hit_error(mut self) -> Self {
+        self.hit_error = true;
+        self
+    }
+
     pub(crate) fn with_focus_calls(mut self, calls: Arc<AtomicUsize>) -> Self {
         self.focus_calls = calls;
         self
@@ -1036,6 +1065,11 @@ impl SeqAccessibility {
 
     pub(crate) fn with_hit_calls(mut self, calls: Arc<AtomicUsize>) -> Self {
         self.hit_calls = calls;
+        self
+    }
+
+    pub(crate) fn with_hit_points(mut self, points: Arc<Mutex<Vec<(i32, i32)>>>) -> Self {
+        self.hit_points = points;
         self
     }
 
@@ -1088,10 +1122,16 @@ impl Accessibility for SeqAccessibility {
         &mut self,
         ctx: &AxContext,
         _target: &AxTarget,
-        _point: (i32, i32),
+        point: (i32, i32),
     ) -> Result<PointerHit> {
         self.deadlines.lock().unwrap().push(ctx.deadline);
         self.hit_calls.fetch_add(1, Ordering::Relaxed);
+        self.hit_points.lock().unwrap().push(point);
+        if self.hit_error {
+            return Err(GlassError::AccessibilityUnavailable(
+                "scripted pointer hit probe failure".into(),
+            ));
+        }
         Ok(self.hit)
     }
     fn set_value(&mut self, ctx: &AxContext, _t: &AxTarget, _s: &str) -> Result<()> {

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -4,7 +4,8 @@
 
 pub(crate) use super::*;
 pub(crate) use crate::accessibility::{
-    AxNode, AxRect, AxRole, AxStates, AxTarget, ChangeSignal, ChangeWait, ElementCondition,
+    AxNode, AxRect, AxRole, AxStateCoverage, AxStates, AxTarget, ChangeSignal, ChangeWait,
+    ElementCondition, PointerHit,
 };
 pub(crate) use crate::audit::{Actuation, ActuationContext, AuditOutcome, AuditSink};
 pub(crate) use crate::platform::{SandboxLevel, Segment};
@@ -651,6 +652,34 @@ fn scripted_invoke(
     }
 }
 
+fn scripted_focus(behavior: InvokeBehavior, target: &AxTarget) -> Result<Option<AxNodeId>> {
+    match behavior {
+        InvokeBehavior::Unsupported => Err(GlassError::AxUnsupported),
+        InvokeBehavior::Succeed => Ok(None),
+        InvokeBehavior::SucceedOnAnother(actuated) => Ok(Some(AxNodeId(actuated))),
+        InvokeBehavior::NoAction => Err(GlassError::AxActionUnavailable(target.id.0)),
+        InvokeBehavior::Fail => Err(GlassError::AxActionFailed(
+            target.id.0,
+            "focus reported failure".into(),
+        )),
+        InvokeBehavior::Drifted => Err(GlassError::AxElementChanged(target.id.0)),
+    }
+}
+
+pub fn full_state_coverage() -> AxStateCoverage {
+    AxStateCoverage {
+        enabled: true,
+        visible: true,
+        checkable: true,
+        checked: true,
+        selected: true,
+        expanded: true,
+        focused: true,
+        focusable: true,
+        editable: true,
+    }
+}
+
 /// A scriptable `Accessibility` returning a fixed tree.
 pub(crate) struct FakeAccessibility {
     pub(crate) tree: AxTree,
@@ -669,6 +698,55 @@ pub(crate) struct FakeAccessibility {
     /// Succeed`) — lets a test prove the native path fired instead of / in addition to the
     /// pointer path.
     pub(crate) invoke_log: Arc<Mutex<Vec<AxTarget>>>,
+    coverage: AxStateCoverage,
+    focus_behavior: InvokeBehavior,
+    hit: PointerHit,
+    focus_calls: Arc<AtomicUsize>,
+    hit_calls: Arc<AtomicUsize>,
+}
+
+#[allow(dead_code)]
+impl FakeAccessibility {
+    pub(crate) fn new(tree: AxTree) -> Self {
+        Self {
+            tree,
+            set_log: Arc::new(Mutex::new(Vec::new())),
+            set_fail: false,
+            ctx_log: Arc::new(Mutex::new(None)),
+            invoke_behavior: InvokeBehavior::Unsupported,
+            invoke_log: Arc::new(Mutex::new(Vec::new())),
+            coverage: AxStateCoverage::NONE,
+            focus_behavior: InvokeBehavior::Unsupported,
+            hit: PointerHit::Inconclusive,
+            focus_calls: Arc::new(AtomicUsize::new(0)),
+            hit_calls: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    pub(crate) fn with_coverage(mut self, coverage: AxStateCoverage) -> Self {
+        self.coverage = coverage;
+        self
+    }
+
+    pub(crate) fn with_focus_behavior(mut self, behavior: InvokeBehavior) -> Self {
+        self.focus_behavior = behavior;
+        self
+    }
+
+    pub(crate) fn with_hit(mut self, hit: PointerHit) -> Self {
+        self.hit = hit;
+        self
+    }
+
+    pub(crate) fn with_focus_calls(mut self, calls: Arc<AtomicUsize>) -> Self {
+        self.focus_calls = calls;
+        self
+    }
+
+    pub(crate) fn with_hit_calls(mut self, calls: Arc<AtomicUsize>) -> Self {
+        self.hit_calls = calls;
+        self
+    }
 }
 
 impl Accessibility for FakeAccessibility {
@@ -681,6 +759,24 @@ impl Accessibility for FakeAccessibility {
     fn subscribe_changes(&mut self, ctx: &AxContext) -> Option<Box<dyn ChangeSignal>> {
         *self.ctx_log.lock().unwrap() = Some(ctx.clone());
         None
+    }
+    fn state_coverage(&self) -> AxStateCoverage {
+        self.coverage
+    }
+    fn focus(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<Option<AxNodeId>> {
+        *self.ctx_log.lock().unwrap() = Some(ctx.clone());
+        self.focus_calls.fetch_add(1, Ordering::Relaxed);
+        scripted_focus(self.focus_behavior, target)
+    }
+    fn pointer_target_at(
+        &mut self,
+        ctx: &AxContext,
+        _target: &AxTarget,
+        _point: (i32, i32),
+    ) -> Result<PointerHit> {
+        *self.ctx_log.lock().unwrap() = Some(ctx.clone());
+        self.hit_calls.fetch_add(1, Ordering::Relaxed);
+        Ok(self.hit)
     }
     fn set_value(&mut self, ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
         *self.ctx_log.lock().unwrap() = Some(ctx.clone());
@@ -826,17 +922,7 @@ pub(crate) fn glass_with_backend(
 }
 
 pub(crate) fn glass_with_a11y(platform: FakePlatform, tree: AxTree) -> Glass {
-    glass_with_backend(
-        platform,
-        Box::new(FakeAccessibility {
-            tree,
-            set_log: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
-            set_fail: false,
-            ctx_log: Arc::new(Mutex::new(None)),
-            invoke_behavior: InvokeBehavior::Unsupported,
-            invoke_log: Arc::new(Mutex::new(Vec::new())),
-        }),
-    )
+    glass_with_backend(platform, Box::new(FakeAccessibility::new(tree)))
 }
 
 /// [`glass_with_a11y`] plus the ctx log — for a test that must prove what reached the backend
@@ -868,17 +954,11 @@ pub(crate) fn glass_with_a11y_invoke_ctx(
 ) -> (Glass, Arc<Mutex<Vec<AxTarget>>>, CtxLog) {
     let invoke_log = Arc::new(Mutex::new(Vec::new()));
     let ctx_log: CtxLog = Arc::new(Mutex::new(None));
-    let g = glass_with_backend(
-        platform,
-        Box::new(FakeAccessibility {
-            tree,
-            set_log: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
-            set_fail: false,
-            ctx_log: ctx_log.clone(),
-            invoke_behavior: behavior,
-            invoke_log: invoke_log.clone(),
-        }),
-    );
+    let mut accessibility = FakeAccessibility::new(tree);
+    accessibility.ctx_log = ctx_log.clone();
+    accessibility.invoke_behavior = behavior;
+    accessibility.invoke_log = invoke_log.clone();
+    let g = glass_with_backend(platform, Box::new(accessibility));
     (g, invoke_log, ctx_log)
 }
 
@@ -902,6 +982,82 @@ pub(crate) struct SeqAccessibility {
     subscribes: Arc<AtomicUsize>,
     deadlines: AxDeadlineLog,
     read_starts: AxReadStartLog,
+    coverage: AxStateCoverage,
+    focus_behavior: InvokeBehavior,
+    hit: PointerHit,
+    focus_calls: Arc<AtomicUsize>,
+    hit_calls: Arc<AtomicUsize>,
+}
+
+#[allow(dead_code)]
+impl SeqAccessibility {
+    pub(crate) fn new(trees: Vec<AxTree>) -> Self {
+        assert!(
+            !trees.is_empty(),
+            "SeqAccessibility needs at least one tree"
+        );
+        Self {
+            trees,
+            idx: 0,
+            invoke_behavior: InvokeBehavior::Unsupported,
+            invoke_log: Arc::new(Mutex::new(Vec::new())),
+            walks: Arc::new(AtomicUsize::new(0)),
+            signal: None,
+            subscribes: Arc::new(AtomicUsize::new(0)),
+            deadlines: Arc::new(Mutex::new(Vec::new())),
+            read_starts: Arc::new(Mutex::new(Vec::new())),
+            coverage: AxStateCoverage::NONE,
+            focus_behavior: InvokeBehavior::Unsupported,
+            hit: PointerHit::Inconclusive,
+            focus_calls: Arc::new(AtomicUsize::new(0)),
+            hit_calls: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    pub(crate) fn with_coverage(mut self, coverage: AxStateCoverage) -> Self {
+        self.coverage = coverage;
+        self
+    }
+
+    pub(crate) fn with_focus_behavior(mut self, behavior: InvokeBehavior) -> Self {
+        self.focus_behavior = behavior;
+        self
+    }
+
+    pub(crate) fn with_hit(mut self, hit: PointerHit) -> Self {
+        self.hit = hit;
+        self
+    }
+
+    pub(crate) fn with_focus_calls(mut self, calls: Arc<AtomicUsize>) -> Self {
+        self.focus_calls = calls;
+        self
+    }
+
+    pub(crate) fn with_hit_calls(mut self, calls: Arc<AtomicUsize>) -> Self {
+        self.hit_calls = calls;
+        self
+    }
+
+    pub(crate) fn with_invoke_behavior(mut self, behavior: InvokeBehavior) -> Self {
+        self.invoke_behavior = behavior;
+        self
+    }
+
+    pub(crate) fn with_invoke_log(mut self, log: Arc<Mutex<Vec<AxTarget>>>) -> Self {
+        self.invoke_log = log;
+        self
+    }
+
+    pub(crate) fn with_walks(mut self, walks: Arc<AtomicUsize>) -> Self {
+        self.walks = walks;
+        self
+    }
+
+    pub(crate) fn with_signal(mut self, signal: Option<fn() -> Box<dyn ChangeSignal>>) -> Self {
+        self.signal = signal;
+        self
+    }
 }
 
 impl Accessibility for SeqAccessibility {
@@ -919,6 +1075,24 @@ impl Accessibility for SeqAccessibility {
     fn subscribe_changes(&mut self, _ctx: &AxContext) -> Option<Box<dyn ChangeSignal>> {
         self.subscribes.fetch_add(1, Ordering::Relaxed);
         self.signal.map(|make| make())
+    }
+    fn state_coverage(&self) -> AxStateCoverage {
+        self.coverage
+    }
+    fn focus(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<Option<AxNodeId>> {
+        self.deadlines.lock().unwrap().push(ctx.deadline);
+        self.focus_calls.fetch_add(1, Ordering::Relaxed);
+        scripted_focus(self.focus_behavior, target)
+    }
+    fn pointer_target_at(
+        &mut self,
+        ctx: &AxContext,
+        _target: &AxTarget,
+        _point: (i32, i32),
+    ) -> Result<PointerHit> {
+        self.deadlines.lock().unwrap().push(ctx.deadline);
+        self.hit_calls.fetch_add(1, Ordering::Relaxed);
+        Ok(self.hit)
     }
     fn set_value(&mut self, ctx: &AxContext, _t: &AxTarget, _s: &str) -> Result<()> {
         self.deadlines.lock().unwrap().push(ctx.deadline);
@@ -972,20 +1146,12 @@ pub(crate) fn glass_with_a11y_seq_observed(
     let invoke_log = Arc::new(Mutex::new(Vec::new()));
     let deadlines = Arc::new(Mutex::new(Vec::new()));
     let read_starts = Arc::new(Mutex::new(Vec::new()));
-    let g = glass_with_backend(
-        platform,
-        Box::new(SeqAccessibility {
-            trees,
-            idx: 0,
-            invoke_behavior: behavior,
-            invoke_log: invoke_log.clone(),
-            walks: Arc::new(AtomicUsize::new(0)),
-            signal: None,
-            subscribes: Arc::new(AtomicUsize::new(0)),
-            deadlines: deadlines.clone(),
-            read_starts: read_starts.clone(),
-        }),
-    );
+    let mut accessibility = SeqAccessibility::new(trees);
+    accessibility.invoke_behavior = behavior;
+    accessibility.invoke_log = invoke_log.clone();
+    accessibility.deadlines = deadlines.clone();
+    accessibility.read_starts = read_starts.clone();
+    let g = glass_with_backend(platform, Box::new(accessibility));
     (g, invoke_log, deadlines, read_starts)
 }
 
@@ -1010,20 +1176,11 @@ pub(crate) fn glass_with_a11y_counted_subs(
 ) -> (Glass, Arc<AtomicUsize>, Arc<AtomicUsize>) {
     let walks = Arc::new(AtomicUsize::new(0));
     let subscribes = Arc::new(AtomicUsize::new(0));
-    let g = glass_with_backend(
-        platform,
-        Box::new(SeqAccessibility {
-            trees,
-            idx: 0,
-            invoke_behavior: InvokeBehavior::Unsupported,
-            invoke_log: Arc::new(Mutex::new(Vec::new())),
-            walks: walks.clone(),
-            signal,
-            subscribes: subscribes.clone(),
-            deadlines: Arc::new(Mutex::new(Vec::new())),
-            read_starts: Arc::new(Mutex::new(Vec::new())),
-        }),
-    );
+    let mut accessibility = SeqAccessibility::new(trees);
+    accessibility.walks = walks.clone();
+    accessibility.signal = signal;
+    accessibility.subscribes = subscribes.clone();
+    let g = glass_with_backend(platform, Box::new(accessibility));
     (g, walks, subscribes)
 }
 

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -39,6 +39,8 @@ pub(crate) struct FakePlatform {
     pointer_events: Vec<PointerEvent>,
     fail_pointer: bool,
     key_events: Vec<KeyEvent>,
+    fail_key: bool,
+    event_log: Option<Arc<Mutex<Vec<&'static str>>>>,
     started: bool,
     capture_log: Arc<Mutex<Vec<Option<Region>>>>,
     capture_deadline_log: Option<CaptureDeadlineLog>,
@@ -158,6 +160,14 @@ impl FakePlatform {
     }
     pub(crate) fn with_failing_pointer(mut self) -> Self {
         self.fail_pointer = true;
+        self
+    }
+    pub(crate) fn with_failing_key(mut self) -> Self {
+        self.fail_key = true;
+        self
+    }
+    pub(crate) fn with_event_log(mut self, log: Arc<Mutex<Vec<&'static str>>>) -> Self {
+        self.event_log = Some(log);
         self
     }
     pub(crate) fn with_key_deadline_log(mut self, log: InputDeadlineLog) -> Self {
@@ -444,6 +454,9 @@ impl Platform for FakePlatform {
         }
         if let PointerEvent::Click { x, y, .. } = event {
             self.click_log.lock().unwrap().push((*x, *y));
+            if let Some(log) = &self.event_log {
+                log.lock().unwrap().push("pointer");
+            }
         }
         if let PointerEvent::Scroll { .. } = event {
             self.scroll_log.lock().unwrap().push(event.clone());
@@ -485,7 +498,14 @@ impl Platform for FakePlatform {
         }
         self.key_events.push(event.clone());
         self.key_log.lock().unwrap().push(event.clone());
-        Ok(())
+        if let Some(log) = &self.event_log {
+            log.lock().unwrap().push("key");
+        }
+        if self.fail_key {
+            Err(GlassError::Backend("scripted key failure".into()))
+        } else {
+            Ok(())
+        }
     }
     fn window_by(&mut self, op: &WindowOp, deadline: Deadline) -> Result<WindowGeometry> {
         if deadline.has_passed() {
@@ -1020,6 +1040,7 @@ pub(crate) struct SeqAccessibility {
     hit_points: Arc<Mutex<Vec<(i32, i32)>>>,
     set_log: Arc<Mutex<Vec<(AxNodeId, String)>>>,
     set_results: VecDeque<Result<()>>,
+    event_log: Option<Arc<Mutex<Vec<&'static str>>>>,
 }
 
 #[allow(dead_code)]
@@ -1049,6 +1070,7 @@ impl SeqAccessibility {
             hit_points: Arc::new(Mutex::new(Vec::new())),
             set_log: Arc::new(Mutex::new(Vec::new())),
             set_results: VecDeque::new(),
+            event_log: None,
         }
     }
 
@@ -1126,6 +1148,11 @@ impl SeqAccessibility {
         self.signal = signal;
         self
     }
+
+    pub(crate) fn with_event_log(mut self, log: Arc<Mutex<Vec<&'static str>>>) -> Self {
+        self.event_log = Some(log);
+        self
+    }
 }
 
 impl Accessibility for SeqAccessibility {
@@ -1138,6 +1165,14 @@ impl Accessibility for SeqAccessibility {
         self.walks.fetch_add(1, Ordering::Relaxed);
         let t = self.trees[self.idx.min(self.trees.len() - 1)].clone();
         self.idx += 1;
+        fn contains_focused(node: &AxNode) -> bool {
+            node.states.focused || node.children.iter().any(contains_focused)
+        }
+        if contains_focused(&t.root)
+            && let Some(log) = &self.event_log
+        {
+            log.lock().unwrap().push("snapshot focused");
+        }
         Ok(t)
     }
     fn subscribe_changes(&mut self, _ctx: &AxContext) -> Option<Box<dyn ChangeSignal>> {
@@ -1150,6 +1185,9 @@ impl Accessibility for SeqAccessibility {
     fn focus(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<Option<AxNodeId>> {
         self.deadlines.lock().unwrap().push(ctx.deadline);
         self.focus_calls.fetch_add(1, Ordering::Relaxed);
+        if let Some(log) = &self.event_log {
+            log.lock().unwrap().push("focus");
+        }
         scripted_focus(self.focus_behavior, target)
     }
     fn pointer_target_at(
@@ -1546,12 +1584,26 @@ pub(crate) struct RecordedSetValueAudit {
     pub(crate) error: Option<String>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct RecordedTypeTargetAudit {
+    pub(crate) element: crate::audit::ElementRef,
+    pub(crate) text: String,
+    pub(crate) focus_mode: String,
+    pub(crate) focus_method: Option<String>,
+    pub(crate) focus_dispatch: String,
+    pub(crate) focus_confirmation: String,
+    pub(crate) type_dispatch: String,
+    pub(crate) ok: bool,
+    pub(crate) error: Option<String>,
+}
+
 /// Records `"action:ok"` for each actuation plus structured click metadata.
 #[derive(Clone, Default)]
 pub(crate) struct RecordingSink(
     pub(crate) Arc<Mutex<Vec<String>>>,
     pub(crate) Arc<Mutex<Vec<RecordedClickAudit>>>,
     pub(crate) Arc<Mutex<Vec<RecordedSetValueAudit>>>,
+    pub(crate) Arc<Mutex<Vec<RecordedTypeTargetAudit>>>,
 );
 impl AuditSink for RecordingSink {
     fn record(&self, act: &Actuation, _ctx: &ActuationContext, o: &AuditOutcome, _d: Duration) {
@@ -1573,6 +1625,7 @@ impl AuditSink for RecordingSink {
             Actuation::Window { .. } => "window",
             Actuation::ClickElement { .. } => "click_element",
             Actuation::SetValue { .. } => "set_value",
+            Actuation::TypeTarget { .. } => "type_target",
         };
         self.0.lock().unwrap().push(format!("{action}:{}", o.ok));
         if let Actuation::ClickElement {
@@ -1608,6 +1661,28 @@ impl AuditSink for RecordingSink {
                 text: (*text).into(),
                 dispatch: (*dispatch).into(),
                 confirmation: (*confirmation).into(),
+                ok: o.ok,
+                error: o.error.clone(),
+            });
+        }
+        if let Actuation::TypeTarget {
+            element,
+            text,
+            focus_mode,
+            focus_method,
+            focus_dispatch,
+            focus_confirmation,
+            type_dispatch,
+        } = act
+        {
+            self.3.lock().unwrap().push(RecordedTypeTargetAudit {
+                element: element.clone(),
+                text: (*text).into(),
+                focus_mode: (*focus_mode).into(),
+                focus_method: focus_method.map(Into::into),
+                focus_dispatch: (*focus_dispatch).into(),
+                focus_confirmation: (*focus_confirmation).into(),
+                type_dispatch: (*type_dispatch).into(),
                 ok: o.ok,
                 error: o.error.clone(),
             });

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -1018,6 +1018,8 @@ pub(crate) struct SeqAccessibility {
     invoke_calls: Arc<AtomicUsize>,
     hit_calls: Arc<AtomicUsize>,
     hit_points: Arc<Mutex<Vec<(i32, i32)>>>,
+    set_log: Arc<Mutex<Vec<(AxNodeId, String)>>>,
+    set_results: VecDeque<Result<()>>,
 }
 
 #[allow(dead_code)]
@@ -1045,6 +1047,8 @@ impl SeqAccessibility {
             invoke_calls: Arc::new(AtomicUsize::new(0)),
             hit_calls: Arc::new(AtomicUsize::new(0)),
             hit_points: Arc::new(Mutex::new(Vec::new())),
+            set_log: Arc::new(Mutex::new(Vec::new())),
+            set_results: VecDeque::new(),
         }
     }
 
@@ -1090,6 +1094,16 @@ impl SeqAccessibility {
 
     pub(crate) fn with_hit_points(mut self, points: Arc<Mutex<Vec<(i32, i32)>>>) -> Self {
         self.hit_points = points;
+        self
+    }
+
+    pub(crate) fn with_set_log(mut self, log: Arc<Mutex<Vec<(AxNodeId, String)>>>) -> Self {
+        self.set_log = log;
+        self
+    }
+
+    pub(crate) fn with_set_results(mut self, results: Vec<Result<()>>) -> Self {
+        self.set_results = results.into();
         self
     }
 
@@ -1154,9 +1168,13 @@ impl Accessibility for SeqAccessibility {
         }
         Ok(self.hit)
     }
-    fn set_value(&mut self, ctx: &AxContext, _t: &AxTarget, _s: &str) -> Result<()> {
+    fn set_value(&mut self, ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
         self.deadlines.lock().unwrap().push(ctx.deadline);
-        Ok(())
+        self.set_log
+            .lock()
+            .unwrap()
+            .push((target.id, text.to_string()));
+        self.set_results.pop_front().unwrap_or(Ok(()))
     }
     fn invoke(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<Option<AxNodeId>> {
         self.deadlines.lock().unwrap().push(ctx.deadline);
@@ -1518,11 +1536,22 @@ pub(crate) struct RecordedClickAudit {
     pub(crate) ok: bool,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct RecordedSetValueAudit {
+    pub(crate) element: crate::audit::ElementRef,
+    pub(crate) text: String,
+    pub(crate) dispatch: String,
+    pub(crate) confirmation: String,
+    pub(crate) ok: bool,
+    pub(crate) error: Option<String>,
+}
+
 /// Records `"action:ok"` for each actuation plus structured click metadata.
 #[derive(Clone, Default)]
 pub(crate) struct RecordingSink(
     pub(crate) Arc<Mutex<Vec<String>>>,
     pub(crate) Arc<Mutex<Vec<RecordedClickAudit>>>,
+    pub(crate) Arc<Mutex<Vec<RecordedSetValueAudit>>>,
 );
 impl AuditSink for RecordingSink {
     fn record(&self, act: &Actuation, _ctx: &ActuationContext, o: &AuditOutcome, _d: Duration) {
@@ -1565,6 +1594,22 @@ impl AuditSink for RecordingSink {
                 dispatch: (*dispatch).into(),
                 confirmation: (*confirmation).into(),
                 ok: o.ok,
+            });
+        }
+        if let Actuation::SetValue {
+            element,
+            text,
+            dispatch,
+            confirmation,
+        } = act
+        {
+            self.2.lock().unwrap().push(RecordedSetValueAudit {
+                element: element.clone(),
+                text: (*text).into(),
+                dispatch: (*dispatch).into(),
+                confirmation: (*confirmation).into(),
+                ok: o.ok,
+                error: o.error.clone(),
             });
         }
     }

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -622,6 +622,8 @@ pub(crate) enum InvokeBehavior {
     NoAction,
     /// Action fired but the toolkit reported failure.
     Fail,
+    /// The caller's bound elapsed after the backend may have dispatched the action.
+    MayHaveDispatched,
     /// Fingerprint mismatch — tree drifted since the snapshot.
     Drifted,
 }
@@ -648,6 +650,9 @@ fn scripted_invoke(
             target.id.0,
             "action reported failure".into(),
         )),
+        InvokeBehavior::MayHaveDispatched => Err(GlassError::caller_deadline_elapsed(
+            "scripted native accessibility action",
+        )),
         InvokeBehavior::Drifted => Err(GlassError::AxElementChanged(target.id.0)),
     }
 }
@@ -661,6 +666,9 @@ fn scripted_focus(behavior: InvokeBehavior, target: &AxTarget) -> Result<Option<
         InvokeBehavior::Fail => Err(GlassError::AxActionFailed(
             target.id.0,
             "focus reported failure".into(),
+        )),
+        InvokeBehavior::MayHaveDispatched => Err(GlassError::caller_deadline_elapsed(
+            "scripted native accessibility focus",
         )),
         InvokeBehavior::Drifted => Err(GlassError::AxElementChanged(target.id.0)),
     }
@@ -1007,6 +1015,7 @@ pub(crate) struct SeqAccessibility {
     hit: PointerHit,
     hit_error: bool,
     focus_calls: Arc<AtomicUsize>,
+    invoke_calls: Arc<AtomicUsize>,
     hit_calls: Arc<AtomicUsize>,
     hit_points: Arc<Mutex<Vec<(i32, i32)>>>,
 }
@@ -1033,6 +1042,7 @@ impl SeqAccessibility {
             hit: PointerHit::Inconclusive,
             hit_error: false,
             focus_calls: Arc::new(AtomicUsize::new(0)),
+            invoke_calls: Arc::new(AtomicUsize::new(0)),
             hit_calls: Arc::new(AtomicUsize::new(0)),
             hit_points: Arc::new(Mutex::new(Vec::new())),
         }
@@ -1060,6 +1070,16 @@ impl SeqAccessibility {
 
     pub(crate) fn with_focus_calls(mut self, calls: Arc<AtomicUsize>) -> Self {
         self.focus_calls = calls;
+        self
+    }
+
+    pub(crate) fn with_invoke_calls(mut self, calls: Arc<AtomicUsize>) -> Self {
+        self.invoke_calls = calls;
+        self
+    }
+
+    pub(crate) fn with_deadlines(mut self, deadlines: AxDeadlineLog) -> Self {
+        self.deadlines = deadlines;
         self
     }
 
@@ -1140,6 +1160,7 @@ impl Accessibility for SeqAccessibility {
     }
     fn invoke(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<Option<AxNodeId>> {
         self.deadlines.lock().unwrap().push(ctx.deadline);
+        self.invoke_calls.fetch_add(1, Ordering::Relaxed);
         scripted_invoke(self.invoke_behavior, &self.invoke_log, target)
     }
 }
@@ -1485,9 +1506,24 @@ impl Platform for BareMinPlatform {
     }
 }
 
-/// Records `"action:ok"` for each actuation the seam reports.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct RecordedClickAudit {
+    pub(crate) element: crate::audit::ElementRef,
+    pub(crate) mode: String,
+    pub(crate) method: Option<String>,
+    pub(crate) native_fallback: Option<String>,
+    pub(crate) actuated_id: Option<u32>,
+    pub(crate) dispatch: String,
+    pub(crate) confirmation: String,
+    pub(crate) ok: bool,
+}
+
+/// Records `"action:ok"` for each actuation plus structured click metadata.
 #[derive(Clone, Default)]
-pub(crate) struct RecordingSink(pub(crate) Arc<Mutex<Vec<String>>>);
+pub(crate) struct RecordingSink(
+    pub(crate) Arc<Mutex<Vec<String>>>,
+    pub(crate) Arc<Mutex<Vec<RecordedClickAudit>>>,
+);
 impl AuditSink for RecordingSink {
     fn record(&self, act: &Actuation, _ctx: &ActuationContext, o: &AuditOutcome, _d: Duration) {
         let action = match act {
@@ -1510,6 +1546,27 @@ impl AuditSink for RecordingSink {
             Actuation::SetValue { .. } => "set_value",
         };
         self.0.lock().unwrap().push(format!("{action}:{}", o.ok));
+        if let Actuation::ClickElement {
+            element,
+            mode,
+            method,
+            native_fallback,
+            actuated_id,
+            dispatch,
+            confirmation,
+        } = act
+        {
+            self.1.lock().unwrap().push(RecordedClickAudit {
+                element: element.clone(),
+                mode: (*mode).into(),
+                method: method.map(|value| (*value).into()),
+                native_fallback: native_fallback.map(Into::into),
+                actuated_id: *actuated_id,
+                dispatch: (*dispatch).into(),
+                confirmation: (*confirmation).into(),
+                ok: o.ok,
+            });
+        }
     }
 }
 

--- a/crates/glass-fixture-egui/src/main.rs
+++ b/crates/glass-fixture-egui/src/main.rs
@@ -7,6 +7,39 @@ use std::time::{Duration, Instant};
 
 use eframe::egui;
 
+const DEFAULT_MOVEMENT_DURATION: Duration = Duration::from_millis(300);
+
+fn parse_movement_duration(value: Option<&str>) -> Result<Duration, &'static str> {
+    let Some(value) = value else {
+        return Ok(DEFAULT_MOVEMENT_DURATION);
+    };
+    let invalid = "--movement-duration-ms must be an integer from 1 to 5000";
+    if value.is_empty() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(invalid);
+    }
+    let millis = value.parse::<u64>().map_err(|_| invalid)?;
+    if !(1..=5000).contains(&millis) {
+        return Err(invalid);
+    }
+    Ok(Duration::from_millis(millis))
+}
+
+fn movement_duration_from_args<'a>(
+    args: impl IntoIterator<Item = &'a str>,
+) -> Result<Duration, &'static str> {
+    let mut args = args.into_iter();
+    let Some(arg) = args.next() else {
+        return parse_movement_duration(None);
+    };
+    let value = arg
+        .strip_prefix("--movement-duration-ms=")
+        .ok_or("expected --movement-duration-ms=<milliseconds>")?;
+    if args.next().is_some() {
+        return Err("only one movement duration option is allowed");
+    }
+    parse_movement_duration(Some(value))
+}
+
 fn log(line: &str) {
     println!("{line}");
     let _ = std::io::stdout().flush();
@@ -32,6 +65,30 @@ fn wrap_in_pane<R>(ui: &mut egui::Ui, add_contents: impl FnOnce(&mut egui::Ui) -
     ret
 }
 
+fn wrap_in_semantic_button<R>(
+    ui: &mut egui::Ui,
+    label: &str,
+    add_contents: impl FnOnce(&mut egui::Ui) -> R,
+) -> R {
+    let mut prepared = egui::Frame::group(ui.style()).begin(ui);
+    let id = prepared.content_ui.unique_id();
+    ui.ctx().accesskit_node_builder(id, |node| {
+        node.set_role(egui::accesskit::Role::Button);
+        node.set_label(label);
+    });
+    let ret = add_contents(&mut prepared.content_ui);
+    let rect = prepared.end(ui).rect;
+    ui.ctx().accesskit_node_builder(id, |node| {
+        node.set_bounds(egui::accesskit::Rect {
+            x0: f64::from(rect.left()),
+            y0: f64::from(rect.top()),
+            x1: f64::from(rect.right()),
+            y1: f64::from(rect.bottom()),
+        });
+    });
+    ret
+}
+
 #[derive(Default)]
 struct Fixture {
     text: String,
@@ -40,6 +97,7 @@ struct Fixture {
     frames: u32,
     copied: bool,
     movement_started: Option<Instant>,
+    movement_duration: Option<Duration>,
     logs: Vec<&'static str>,
 }
 
@@ -116,6 +174,10 @@ impl eframe::App for Fixture {
                 self.movement_started = Some(Instant::now());
                 self.logs.push("[fixture] semantic_save");
             }
+            if ui.button("Restart movement").clicked() {
+                self.movement_started = Some(Instant::now());
+                self.logs.push("[fixture] movement_restart");
+            }
             if ui
                 .add_enabled(false, egui::Button::new("Disabled semantic"))
                 .clicked()
@@ -131,11 +193,12 @@ impl eframe::App for Fixture {
             });
 
             let movement = self.movement_started.map_or(0.0, |started| {
-                let elapsed = started.elapsed().min(Duration::from_millis(300));
-                if elapsed < Duration::from_millis(300) {
+                let duration = self.movement_duration.unwrap_or(DEFAULT_MOVEMENT_DURATION);
+                let elapsed = started.elapsed().min(duration);
+                if elapsed < duration {
                     ui.ctx().request_repaint();
                 }
-                elapsed.as_secs_f32() * 1_500.0
+                450.0 * elapsed.as_secs_f32() / duration.as_secs_f32()
             });
             ui.horizontal(|ui| {
                 ui.add_space(movement);
@@ -159,6 +222,21 @@ impl eframe::App for Fixture {
                         self.logs.push("[fixture] occluder");
                     }
                 });
+            wrap_in_semantic_button(ui, "Composite semantic", |ui| {
+                if ui.button("Nested semantic").clicked() {
+                    self.logs.push("[fixture] nested_semantic");
+                }
+            });
+            let hidden = ui.place(
+                egui::Rect::from_min_size(
+                    egui::pos2(20.0, ui.ctx().content_rect().bottom() + 150.0),
+                    egui::vec2(160.0, 32.0),
+                ),
+                egui::Button::new("Hidden semantic"),
+            );
+            if hidden.clicked() {
+                self.logs.push("[fixture] hidden_semantic");
+            }
             // Nest Apply inside a pair of unnamed, single-child panes (see `wrap_in_pane`) —
             // this fixture's accessibility tree is otherwise flat, so on-box a11y tests that
             // assert the outline's compact render is smaller than its full render need this
@@ -178,7 +256,19 @@ impl eframe::App for Fixture {
     }
 }
 
-fn main() -> eframe::Result {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = std::env::args_os()
+        .skip(1)
+        .map(|arg| {
+            arg.into_string()
+                .map_err(|_| "fixture arguments must be UTF-8")
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let movement_duration = movement_duration_from_args(args.iter().map(String::as_str))?;
+    log(&format!(
+        "[fixture] movement_duration_ms={}",
+        movement_duration.as_millis()
+    ));
     let native_options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()
             .with_inner_size([700.0, 500.0])
@@ -188,6 +278,221 @@ fn main() -> eframe::Result {
     eframe::run_native(
         "glass-fixture-egui",
         native_options,
-        Box::new(|_cc| Ok(Box::new(Fixture::default()))),
-    )
+        Box::new(move |_cc| {
+            Ok(Box::new(Fixture {
+                movement_duration: Some(movement_duration),
+                ..Default::default()
+            }))
+        }),
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn movement_arguments_default_or_select_an_explicit_duration() {
+        assert_eq!(
+            movement_duration_from_args([]).unwrap(),
+            Duration::from_millis(300)
+        );
+        assert_eq!(
+            movement_duration_from_args(["--movement-duration-ms=3000"]).unwrap(),
+            Duration::from_millis(3000)
+        );
+    }
+
+    #[test]
+    fn movement_arguments_reject_unknown_duplicate_or_malformed_options() {
+        for args in [
+            vec!["--unknown=3000"],
+            vec!["--movement-duration-ms"],
+            vec!["--movement-duration-ms="],
+            vec!["--movement-duration-ms=no"],
+            vec!["--movement-duration-ms=3000", "--movement-duration-ms=3000"],
+        ] {
+            assert!(movement_duration_from_args(args).is_err());
+        }
+    }
+
+    #[test]
+    fn movement_duration_defaults_to_three_hundred_milliseconds() {
+        assert_eq!(
+            parse_movement_duration(None).unwrap(),
+            Duration::from_millis(300)
+        );
+    }
+
+    #[test]
+    fn movement_duration_accepts_bounded_explicit_milliseconds() {
+        for millis in [1, 300, 3000, 5000] {
+            assert_eq!(
+                parse_movement_duration(Some(&millis.to_string())).unwrap(),
+                Duration::from_millis(millis)
+            );
+        }
+    }
+
+    #[test]
+    fn movement_duration_rejects_malformed_zero_and_excessive_values() {
+        for value in [
+            "",
+            "0",
+            "5001",
+            "-1",
+            "+3000",
+            " 3000",
+            "3000 ",
+            "3s",
+            "3.0",
+            "999999999999999999999999999",
+        ] {
+            assert!(
+                parse_movement_duration(Some(value)).is_err(),
+                "must reject {value:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn movement_duration_override_moves_longer_without_leaving_the_viewport() {
+        let ctx = egui::Context::default();
+        ctx.enable_accesskit();
+        let mut fixture = Fixture {
+            movement_duration: Some(parse_movement_duration(Some("3000")).unwrap()),
+            ..Default::default()
+        };
+        let mut frame = eframe::Frame::_new_kittest();
+        let mut bounds_at = |elapsed| {
+            fixture.movement_started = Some(Instant::now() - elapsed);
+            let output = ctx.run_ui(
+                egui::RawInput {
+                    screen_rect: Some(egui::Rect::from_min_size(
+                        egui::Pos2::ZERO,
+                        egui::vec2(700.0, 500.0),
+                    )),
+                    ..Default::default()
+                },
+                |ui| eframe::App::ui(&mut fixture, ui, &mut frame),
+            );
+            output
+                .platform_output
+                .accesskit_update
+                .unwrap()
+                .nodes
+                .iter()
+                .find(|(_, node)| node.label() == Some("Moving semantic"))
+                .unwrap()
+                .1
+                .bounds()
+                .unwrap()
+        };
+        let early = bounds_at(Duration::from_millis(350));
+        let later = bounds_at(Duration::from_millis(1000));
+        let final_bounds = bounds_at(Duration::from_millis(3100));
+        assert!(early.x0 < later.x0 && later.x0 < final_bounds.x0);
+        assert!(final_bounds.x1 <= 700.0);
+        assert_eq!(final_bounds, bounds_at(Duration::from_millis(4000)));
+    }
+
+    #[test]
+    fn moving_semantic_holds_fixed_after_three_hundred_milliseconds() {
+        let ctx = egui::Context::default();
+        ctx.enable_accesskit();
+        let mut fixture = Fixture::default();
+        let mut frame = eframe::Frame::_new_kittest();
+        let mut bounds_at = |elapsed| {
+            fixture.movement_started = Some(Instant::now() - elapsed);
+            let output = ctx.run_ui(
+                egui::RawInput {
+                    screen_rect: Some(egui::Rect::from_min_size(
+                        egui::Pos2::ZERO,
+                        egui::vec2(700.0, 500.0),
+                    )),
+                    ..Default::default()
+                },
+                |ui| eframe::App::ui(&mut fixture, ui, &mut frame),
+            );
+            output
+                .platform_output
+                .accesskit_update
+                .expect("AccessKit update")
+                .nodes
+                .iter()
+                .find(|(_, node)| node.label() == Some("Moving semantic"))
+                .expect("moving control")
+                .1
+                .bounds()
+                .expect("moving bounds")
+        };
+        assert_eq!(
+            bounds_at(Duration::from_millis(350)),
+            bounds_at(Duration::from_secs(1))
+        );
+    }
+
+    #[test]
+    fn hidden_semantic_is_physically_outside_the_viewport() {
+        let ctx = egui::Context::default();
+        ctx.enable_accesskit();
+        let mut fixture = Fixture::default();
+        let mut frame = eframe::Frame::_new_kittest();
+        let viewport = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(700.0, 500.0));
+        let output = ctx.run_ui(
+            egui::RawInput {
+                screen_rect: Some(viewport),
+                ..Default::default()
+            },
+            |ui| eframe::App::ui(&mut fixture, ui, &mut frame),
+        );
+        let update = output
+            .platform_output
+            .accesskit_update
+            .expect("AccessKit update");
+        let (id, node) = update
+            .nodes
+            .iter()
+            .find(|(_, node)| node.label() == Some("Hidden semantic"))
+            .expect("hidden control remains discoverable");
+        // SAFETY: this ID came directly from egui's AccessKit update, which preserves Id bits.
+        let widget_id = unsafe { egui::Id::from_high_entropy_bits(id.0) };
+        let response = ctx.read_response(widget_id).expect("real widget response");
+        assert!(
+            !viewport.intersects(response.rect),
+            "hidden widget is actually drawn at {:?}",
+            response.rect
+        );
+        let bounds = node.bounds().expect("hidden control has bounds");
+        assert_eq!(bounds.y0, f64::from(response.rect.top()));
+    }
+
+    #[test]
+    fn composite_accesskit_bounds_enclose_the_nested_button_center() {
+        let ctx = egui::Context::default();
+        ctx.enable_accesskit();
+        let mut nested = egui::Rect::NOTHING;
+        let output = ctx.run_ui(egui::RawInput::default(), |ui| {
+            wrap_in_semantic_button(ui, "Composite semantic", |ui| {
+                nested = ui.button("Nested semantic").rect;
+            });
+        });
+        let update = output
+            .platform_output
+            .accesskit_update
+            .expect("AccessKit update");
+        let composite = update
+            .nodes
+            .iter()
+            .find(|(_, node)| node.label() == Some("Composite semantic"))
+            .expect("composite node");
+        let bounds = composite
+            .1
+            .bounds()
+            .expect("composite exposes actual hit geometry");
+        let center = nested.center();
+        assert!(bounds.x0 <= f64::from(center.x) && f64::from(center.x) < bounds.x1);
+        assert!(bounds.y0 <= f64::from(center.y) && f64::from(center.y) < bounds.y1);
+    }
 }

--- a/crates/glass-fixture-egui/src/main.rs
+++ b/crates/glass-fixture-egui/src/main.rs
@@ -3,6 +3,7 @@
 //! Excluded from the workspace build (heavy egui deps; on-box-test-only).
 
 use std::io::Write;
+use std::time::{Duration, Instant};
 
 use eframe::egui;
 
@@ -38,6 +39,8 @@ struct Fixture {
     announced: bool,
     frames: u32,
     copied: bool,
+    movement_started: Option<Instant>,
+    logs: Vec<&'static str>,
 }
 
 impl eframe::App for Fixture {
@@ -109,6 +112,53 @@ impl eframe::App for Fixture {
             {
                 log(&format!("[fixture] value={}", self.value));
             }
+            if ui.button("Semantic Save").clicked() {
+                self.movement_started = Some(Instant::now());
+                self.logs.push("[fixture] semantic_save");
+            }
+            if ui
+                .add_enabled(false, egui::Button::new("Disabled semantic"))
+                .clicked()
+            {
+                self.logs.push("[fixture] disabled_semantic");
+            }
+            ui.horizontal(|ui| {
+                for _ in 0..2 {
+                    if ui.button("Duplicate semantic").clicked() {
+                        self.logs.push("[fixture] duplicate_semantic");
+                    }
+                }
+            });
+
+            let movement = self.movement_started.map_or(0.0, |started| {
+                let elapsed = started.elapsed().min(Duration::from_millis(300));
+                if elapsed < Duration::from_millis(300) {
+                    ui.ctx().request_repaint();
+                }
+                elapsed.as_secs_f32() * 1_500.0
+            });
+            ui.horizontal(|ui| {
+                ui.add_space(movement);
+                if ui.button("Moving semantic").clicked() {
+                    self.logs.push("[fixture] moving_semantic");
+                }
+            });
+
+            let occluded = ui.add_sized([180.0, 32.0], egui::Button::new("Occluded semantic"));
+            if occluded.clicked() {
+                self.logs.push("[fixture] occluded_semantic");
+            }
+            egui::Area::new(egui::Id::new("semantic-occluder"))
+                .order(egui::Order::Foreground)
+                .fixed_pos(occluded.rect.min)
+                .show(ui.ctx(), |ui| {
+                    if ui
+                        .add_sized(occluded.rect.size(), egui::Button::new("Occluder"))
+                        .clicked()
+                    {
+                        self.logs.push("[fixture] occluder");
+                    }
+                });
             // Nest Apply inside a pair of unnamed, single-child panes (see `wrap_in_pane`) —
             // this fixture's accessibility tree is otherwise flat, so on-box a11y tests that
             // assert the outline's compact render is smaller than its full render need this
@@ -122,13 +172,16 @@ impl eframe::App for Fixture {
                 });
             });
         });
+        for line in self.logs.drain(..) {
+            log(line);
+        }
     }
 }
 
 fn main() -> eframe::Result {
     let native_options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()
-            .with_inner_size([400.0, 300.0])
+            .with_inner_size([700.0, 500.0])
             .with_title("glass-fixture-egui"),
         ..Default::default()
     };

--- a/crates/glass-ios/src/a11y.rs
+++ b/crates/glass-ios/src/a11y.rs
@@ -4,7 +4,7 @@
 //! input, and finally reads the element back and reports the write as not applied if it does not
 //! hold the text.
 use glass_core::accessibility::{
-    Accessibility, AxContext, AxNodeId, AxRect, AxTarget, AxTree, Located,
+    Accessibility, AxContext, AxNodeId, AxRect, AxTarget, AxTree, Located, PointerHit,
 };
 use std::time::Duration;
 
@@ -299,6 +299,10 @@ fn post_write_error(target: &AxTarget, error: GlassError) -> GlassError {
 }
 
 impl Accessibility for IosA11y {
+    fn state_coverage(&self) -> glass_core::AxStateCoverage {
+        crate::axmap::STATE_COVERAGE
+    }
+
     fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
         Ok(self
             .describe(ctx, SemanticPhase::Snapshot { dispatched: false })?
@@ -379,6 +383,19 @@ impl Accessibility for IosA11y {
     fn invoke(&mut self, ctx: &AxContext, _target: &AxTarget) -> Result<Option<AxNodeId>> {
         SemanticPhase::Invoke.run(ctx.deadline, || Err(GlassError::AxUnsupported))
     }
+
+    fn focus(&mut self, _ctx: &AxContext, _target: &AxTarget) -> Result<Option<AxNodeId>> {
+        Err(GlassError::AxUnsupported)
+    }
+
+    fn pointer_target_at(
+        &mut self,
+        _ctx: &AxContext,
+        _target: &AxTarget,
+        _point: (i32, i32),
+    ) -> Result<PointerHit> {
+        Ok(PointerHit::Inconclusive)
+    }
 }
 
 #[cfg(test)]
@@ -397,6 +414,7 @@ mod tests {
     struct ScriptedClient {
         scale: Mutex<VecDeque<ScaleRpc>>,
         tree: Mutex<VecDeque<TreeRpc>>,
+        hid: Option<Arc<Mutex<Vec<Vec<proto::HidEvent>>>>>,
     }
 
     #[derive(Debug)]
@@ -441,6 +459,19 @@ mod tests {
             Self {
                 scale: Mutex::new(scale.into()),
                 tree: Mutex::new(tree.into()),
+                hid: None,
+            }
+        }
+
+        fn with_hid_log(
+            scale: Vec<ScaleRpc>,
+            tree: Vec<TreeRpc>,
+            hid: Arc<Mutex<Vec<Vec<proto::HidEvent>>>>,
+        ) -> Self {
+            Self {
+                scale: Mutex::new(scale.into()),
+                tree: Mutex::new(tree.into()),
+                hid: Some(hid),
             }
         }
     }
@@ -462,8 +493,12 @@ mod tests {
                 .expect("one scripted tree RPC")(deadline)
         }
 
-        fn hid_by(&self, _events: Vec<proto::HidEvent>, _deadline: Deadline) -> Result<()> {
-            panic!("snapshot deadline tests never send HID")
+        fn hid_by(&self, events: Vec<proto::HidEvent>, _deadline: Deadline) -> Result<()> {
+            let Some(hid) = &self.hid else {
+                panic!("snapshot deadline tests never send HID");
+            };
+            hid.lock().expect("HID log lock").push(events);
+            Ok(())
         }
     }
 
@@ -538,6 +573,285 @@ mod tests {
             a11y_bus_addr: None,
             limits: glass_core::WalkLimits::DEFAULT,
             deadline,
+        }
+    }
+
+    fn successful_tree_replies(json: &str, count: usize) -> Vec<TreeRpc> {
+        (0..count)
+            .map(|_| {
+                let json = json.to_owned();
+                Box::new(move |_deadline| SnapshotRpc::dispatched(Ok(json))) as TreeRpc
+            })
+            .collect()
+    }
+
+    fn field_json(value: &str) -> String {
+        format!(
+            r#"[{{"role":"AXApplication","AXLabel":"Fixture","enabled":true,
+                "frame":{{"x":0,"y":0,"width":200,"height":200}},"children":[{{
+                  "role":"AXTextField","AXUniqueId":"inputField","AXValue":"{value}",
+                  "enabled":true,"frame":{{"x":10,"y":10,"width":80,"height":30}},
+                  "children":[]
+                }}]}}]"#
+        )
+    }
+
+    #[derive(Default)]
+    struct HidPlatform {
+        pointer_batches: Arc<Mutex<Vec<Vec<proto::HidEvent>>>>,
+        key_batches: Arc<Mutex<Vec<Vec<proto::HidEvent>>>>,
+    }
+
+    impl glass_core::Platform for HidPlatform {
+        fn start_app(&mut self, _spec: &glass_core::AppSpec) -> Result<glass_core::WindowGeometry> {
+            Ok(glass_core::WindowGeometry {
+                x: 0,
+                y: 0,
+                width: 200,
+                height: 200,
+            })
+        }
+
+        fn stop_app_by(&mut self, _deadline: Deadline) -> Result<()> {
+            Ok(())
+        }
+
+        fn capture_frame_by(
+            &mut self,
+            _region: Option<&glass_core::Region>,
+            _deadline: Deadline,
+        ) -> Result<glass_core::Frame> {
+            Err(GlassError::CaptureFailed("scripted iOS platform".into()))
+        }
+
+        fn capture_window_by(
+            &mut self,
+            _id: glass_core::WindowId,
+            _region: Option<&glass_core::Region>,
+            _deadline: Deadline,
+        ) -> Result<glass_core::Frame> {
+            Err(GlassError::Unsupported(
+                "scripted iOS window capture".into(),
+            ))
+        }
+
+        fn send_pointer_by(&mut self, event: &PointerEvent, _deadline: Deadline) -> Result<()> {
+            self.pointer_batches
+                .lock()
+                .expect("pointer HID log lock")
+                .push(IdbInjector::new(1.0).pointer_events(event)?);
+            Ok(())
+        }
+
+        fn send_key_by(&mut self, event: &KeyEvent, _deadline: Deadline) -> Result<()> {
+            self.key_batches
+                .lock()
+                .expect("key HID log lock")
+                .push(IdbInjector::new(1.0).key_events(event)?);
+            Ok(())
+        }
+
+        fn window_by(
+            &mut self,
+            _op: &glass_core::WindowOp,
+            _deadline: Deadline,
+        ) -> Result<glass_core::WindowGeometry> {
+            Ok(glass_core::WindowGeometry {
+                x: 0,
+                y: 0,
+                width: 200,
+                height: 200,
+            })
+        }
+
+        fn list_windows_by(&mut self, _deadline: Deadline) -> Result<Vec<glass_core::WindowInfo>> {
+            Ok(Vec::new())
+        }
+
+        fn select_window_by(
+            &mut self,
+            _id: glass_core::WindowId,
+            _deadline: Deadline,
+        ) -> Result<glass_core::WindowGeometry> {
+            Err(GlassError::WindowNotFound)
+        }
+
+        fn drain_logs(&mut self) -> Vec<(glass_core::Stream, String)> {
+            Vec::new()
+        }
+    }
+
+    fn selector_target(
+        query: &str,
+        states: Vec<glass_core::SemanticState>,
+    ) -> glass_core::SemanticTarget {
+        glass_core::SemanticTarget {
+            target: glass_core::SemanticSelector::new(
+                Some(query.to_owned()),
+                Some(AxRole::TextField),
+                states,
+            )
+            .expect("valid semantic selector"),
+            within: None,
+        }
+    }
+
+    fn scripted_glass(
+        trees: Vec<TreeRpc>,
+        reader_hid: Arc<Mutex<Vec<Vec<proto::HidEvent>>>>,
+        platform: HidPlatform,
+    ) -> glass_core::Glass {
+        let a11y = IosA11y {
+            client: Box::new(ScriptedClient::with_hid_log(Vec::new(), trees, reader_hid)),
+            scale: Some(1.0),
+        };
+        let mut backend = Some(glass_core::Backend {
+            platform: Box::new(platform),
+            accessibility: Some(Box::new(a11y)),
+        });
+        glass_core::Glass::new(
+            Box::new(move |_| {
+                backend
+                    .take()
+                    .ok_or_else(|| GlassError::Backend("scripted backend already used".into()))
+            }),
+            "ios".into(),
+            glass_core::BaselineStore::new(std::env::temp_dir().join("glass-ios-semantic-tests")),
+            16,
+        )
+    }
+
+    fn test_spec() -> glass_core::AppSpec {
+        glass_core::AppSpec {
+            build: None,
+            run: vec!["fixture".into()],
+            cwd: None,
+            env: Vec::new(),
+            window_hint: None,
+            timeout_ms: 1_000,
+            sandbox: glass_core::SandboxLevel::Off,
+            a11y: true,
+        }
+    }
+
+    #[test]
+    fn targeted_type_pointer_focus_without_focused_state_never_sends_text() {
+        let reader_hid = Arc::new(Mutex::new(Vec::new()));
+        let pointer_batches = Arc::new(Mutex::new(Vec::new()));
+        let key_batches = Arc::new(Mutex::new(Vec::new()));
+        let platform = HidPlatform {
+            pointer_batches: Arc::clone(&pointer_batches),
+            key_batches: Arc::clone(&key_batches),
+        };
+        let replies = successful_tree_replies(&field_json("old"), 32);
+        let mut glass = scripted_glass(replies, Arc::clone(&reader_hid), platform);
+        glass.start(&test_spec()).expect("start scripted session");
+
+        let error = glass
+            .type_target(
+                &glass_core::TypeTargetParams {
+                    target: selector_target("inputField", Vec::new()),
+                    focus_mode: glass_core::ActionMode::Pointer,
+                    timeout_ms: 350,
+                    max_nodes: None,
+                },
+                "must not dispatch",
+            )
+            .expect_err("idb publishes no focused state, so typing must be refused");
+
+        assert_eq!(pointer_batches.lock().unwrap().len(), 1);
+        assert!(key_batches.lock().unwrap().is_empty());
+        assert!(reader_hid.lock().unwrap().is_empty());
+        assert_eq!(
+            error.kind,
+            glass_core::SemanticActionFailureKind::FocusUnconfirmed
+        );
+        assert_eq!(
+            error.action_dispatch,
+            glass_core::DispatchStatus::NotDispatched
+        );
+        assert_eq!(
+            error.focus,
+            Some(glass_core::MutationReport {
+                method: glass_core::ActionMethod::Pointer {
+                    native_fallback: None,
+                },
+                dispatch: glass_core::DispatchStatus::Dispatched,
+                confirmation: glass_core::ConfirmationStatus::Unconfirmed,
+            })
+        );
+    }
+
+    #[test]
+    fn semantic_set_value_resolves_fresh_input_field_and_keeps_two_hid_calls() {
+        let reader_hid = Arc::new(Mutex::new(Vec::new()));
+        let platform = HidPlatform::default();
+        let mut replies = successful_tree_replies(&field_json("old"), 2);
+        replies.extend(successful_tree_replies(&field_json("updated"), 4));
+        let mut glass = scripted_glass(replies, Arc::clone(&reader_hid), platform);
+        glass.start(&test_spec()).expect("start scripted session");
+
+        let outcome = glass
+            .set_value_target(
+                &glass_core::SetValueTargetParams {
+                    target: glass_core::ActionTarget::Semantic(selector_target(
+                        "inputField",
+                        Vec::new(),
+                    )),
+                    timeout_ms: Some(1_000),
+                    max_nodes: None,
+                },
+                "updated",
+            )
+            .expect("semantic set-value confirms the fresh field value");
+
+        assert_eq!(reader_hid.lock().unwrap().len(), 2);
+        assert_eq!(outcome.target.name.as_deref(), Some("inputField"));
+        assert_eq!(
+            outcome.action.dispatch,
+            glass_core::DispatchStatus::Dispatched
+        );
+        assert_eq!(
+            outcome.action.confirmation,
+            glass_core::ConfirmationStatus::ValueConfirmed
+        );
+    }
+
+    #[test]
+    fn visible_and_hidden_selectors_are_refused_before_idb_read_or_dispatch() {
+        for state in [
+            glass_core::SemanticState::Visible,
+            glass_core::SemanticState::Hidden,
+        ] {
+            let reader_hid = Arc::new(Mutex::new(Vec::new()));
+            let pointer_batches = Arc::new(Mutex::new(Vec::new()));
+            let key_batches = Arc::new(Mutex::new(Vec::new()));
+            let platform = HidPlatform {
+                pointer_batches: Arc::clone(&pointer_batches),
+                key_batches: Arc::clone(&key_batches),
+            };
+            let mut glass = scripted_glass(Vec::new(), Arc::clone(&reader_hid), platform);
+            glass.start(&test_spec()).expect("start scripted session");
+
+            let error = glass
+                .click_target(&glass_core::ClickTargetParams {
+                    target: glass_core::ActionTarget::Semantic(selector_target(
+                        "inputField",
+                        vec![state],
+                    )),
+                    mode: glass_core::ActionMode::Pointer,
+                    timeout_ms: Some(0),
+                    max_nodes: None,
+                })
+                .expect_err("iOS has no truthful visible/hidden state coverage");
+
+            assert_eq!(
+                error.kind,
+                glass_core::SemanticActionFailureKind::UnprovenSelectorState
+            );
+            assert!(pointer_batches.lock().unwrap().is_empty());
+            assert!(key_batches.lock().unwrap().is_empty());
+            assert!(reader_hid.lock().unwrap().is_empty());
         }
     }
 

--- a/crates/glass-ios/src/axmap.rs
+++ b/crates/glass-ios/src/axmap.rs
@@ -20,11 +20,28 @@
 //! key anywhere in the output), so [`AxStates::focused`] is always false from this
 //! backend — a known limitation.
 use glass_core::accessibility::{
-    AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTree, WalkBudget, WalkLimits,
+    AxNode, AxNodeId, AxRect, AxRole, AxStateCoverage, AxStates, AxTree, WalkBudget, WalkLimits,
     normalize_description, normalize_name,
 };
 use glass_core::{GlassError, Result, WindowGeometry};
 use serde_json::Value;
+
+/// State facts the idb schema can establish for every mapped node.
+///
+/// `AxStates::visible` remains true as a legacy outline approximation, but it is deliberately not
+/// covered: idb publishes off-window nodes without a visibility field, so that bit cannot prove a
+/// `visible`/`hidden` selector or pointer actionability.
+pub const STATE_COVERAGE: AxStateCoverage = AxStateCoverage {
+    enabled: true,
+    visible: false,
+    checkable: true,
+    checked: true,
+    selected: false,
+    expanded: false,
+    focused: false,
+    focusable: false,
+    editable: true,
+};
 
 /// Every iOS role string glass maps, as reported through `idb`.
 pub const ROLE_TOKENS: &[(&str, AxRole)] = &[
@@ -325,6 +342,42 @@ mod tests {
         // The checkable roles the toggle-state derivation depends on.
         assert_eq!(ax_role("AXCheckBox"), AxRole::CheckBox);
         assert_eq!(ax_role("AXWhatever"), AxRole::Other);
+    }
+
+    #[test]
+    fn ios_mapping_never_claims_focus_coverage_idb_does_not_publish() {
+        assert_eq!(
+            STATE_COVERAGE,
+            AxStateCoverage {
+                enabled: true,
+                visible: false,
+                checkable: true,
+                checked: true,
+                selected: false,
+                expanded: false,
+                focused: false,
+                focusable: false,
+                editable: true,
+            }
+        );
+    }
+
+    #[test]
+    fn idb_fixture_has_no_key_interpreted_as_focused_or_focusable() {
+        fn contains_key(value: &Value, sought: &str) -> bool {
+            match value {
+                Value::Object(fields) => {
+                    fields.contains_key(sought)
+                        || fields.values().any(|value| contains_key(value, sought))
+                }
+                Value::Array(values) => values.iter().any(|value| contains_key(value, sought)),
+                _ => false,
+            }
+        }
+
+        let fixture: Value = serde_json::from_str(FIXTURE).expect("fixture JSON");
+        assert!(!contains_key(&fixture, "focused"));
+        assert!(!contains_key(&fixture, "focusable"));
     }
 
     /// Read on the iOS 26.5 Simulator (2026-08-24, companions 1.5.0b3 and 1.1.8): a WKWebView

--- a/crates/glass-ios/tests/drive_integration.rs
+++ b/crates/glass-ios/tests/drive_integration.rs
@@ -38,11 +38,17 @@
 
 #![cfg(unix)]
 
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use glass_core::Deadline;
 use glass_core::accessibility::{
     Accessibility, AxContext, AxNode, AxRole, AxTarget, AxTree, WalkLimits,
+};
+use glass_core::{
+    ActionMethod, ActionMode, ActionTarget, ActionabilityCheckName, ActionabilityVerdict, Backend,
+    BaselineStore, ClickTargetParams, ConfirmationStatus, Deadline, DispatchStatus, Glass,
+    MutationReport, SemanticActionFailureKind, SemanticSelector, SemanticTarget,
+    SetValueTargetParams, TypeTargetParams,
 };
 use glass_core::{AppSpec, KeyEvent, MouseButton, Platform, PointerEvent, SandboxLevel};
 use glass_ios::{IosA11y, IosPlatform, SimulatorRegistry};
@@ -106,6 +112,190 @@ fn tap(x: i32, y: i32) -> PointerEvent {
         count: 1,
         modifiers: vec![],
     }
+}
+
+fn semantic_target(query: &str, role: AxRole) -> SemanticTarget {
+    SemanticTarget {
+        target: SemanticSelector::new(Some(query.to_owned()), Some(role), Vec::new())
+            .expect("valid semantic selector"),
+        within: None,
+    }
+}
+
+fn pointer_click(query: &str, role: AxRole, timeout_ms: u64) -> ClickTargetParams {
+    ClickTargetParams {
+        target: ActionTarget::Semantic(semantic_target(query, role)),
+        mode: ActionMode::Pointer,
+        timeout_ms: Some(timeout_ms),
+        max_nodes: None,
+    }
+}
+
+fn semantic_fixture_spec(app: String) -> AppSpec {
+    AppSpec {
+        build: None,
+        run: vec![app],
+        cwd: None,
+        env: vec![],
+        window_hint: None,
+        timeout_ms: 30_000,
+        sandbox: SandboxLevel::Off,
+        a11y: true,
+    }
+}
+
+struct CountingIosPlatform {
+    inner: IosPlatform,
+    pointer_events: Arc<Mutex<Vec<PointerEvent>>>,
+    key_events: Arc<Mutex<Vec<KeyEvent>>>,
+}
+
+impl Platform for CountingIosPlatform {
+    fn start_app(&mut self, spec: &AppSpec) -> glass_core::Result<glass_core::WindowGeometry> {
+        self.inner.start_app(spec)
+    }
+
+    fn stop_app_by(&mut self, deadline: Deadline) -> glass_core::Result<()> {
+        self.inner.stop_app_by(deadline)
+    }
+
+    fn capture_frame_by(
+        &mut self,
+        region: Option<&glass_core::Region>,
+        deadline: Deadline,
+    ) -> glass_core::Result<glass_core::Frame> {
+        self.inner.capture_frame_by(region, deadline)
+    }
+
+    fn capture_window_by(
+        &mut self,
+        id: glass_core::WindowId,
+        region: Option<&glass_core::Region>,
+        deadline: Deadline,
+    ) -> glass_core::Result<glass_core::Frame> {
+        self.inner.capture_window_by(id, region, deadline)
+    }
+
+    fn send_pointer_by(
+        &mut self,
+        event: &PointerEvent,
+        deadline: Deadline,
+    ) -> glass_core::Result<()> {
+        let result = self.inner.send_pointer_by(event, deadline);
+        if result.is_ok() {
+            self.pointer_events.lock().unwrap().push(event.clone());
+        }
+        result
+    }
+
+    fn send_key_by(&mut self, event: &KeyEvent, deadline: Deadline) -> glass_core::Result<()> {
+        let result = self.inner.send_key_by(event, deadline);
+        if result.is_ok() {
+            self.key_events.lock().unwrap().push(event.clone());
+        }
+        result
+    }
+
+    fn window_by(
+        &mut self,
+        op: &glass_core::WindowOp,
+        deadline: Deadline,
+    ) -> glass_core::Result<glass_core::WindowGeometry> {
+        self.inner.window_by(op, deadline)
+    }
+
+    fn list_windows_by(
+        &mut self,
+        deadline: Deadline,
+    ) -> glass_core::Result<Vec<glass_core::WindowInfo>> {
+        self.inner.list_windows_by(deadline)
+    }
+
+    fn select_window_by(
+        &mut self,
+        id: glass_core::WindowId,
+        deadline: Deadline,
+    ) -> glass_core::Result<glass_core::WindowGeometry> {
+        self.inner.select_window_by(id, deadline)
+    }
+
+    fn drain_logs(&mut self) -> Vec<(glass_core::Stream, String)> {
+        self.inner.drain_logs()
+    }
+
+    fn app_pid(&self) -> Option<u32> {
+        self.inner.app_pid()
+    }
+
+    fn a11y_toggle_control_at_trailing_edge(&self) -> bool {
+        self.inner.a11y_toggle_control_at_trailing_edge()
+    }
+}
+
+type SemanticFixtureSession = (
+    Glass,
+    IosA11y,
+    Arc<Mutex<Vec<PointerEvent>>>,
+    Arc<Mutex<Vec<KeyEvent>>>,
+);
+
+fn semantic_fixture_session() -> SemanticFixtureSession {
+    let registry = Box::new(SimulatorRegistry::new());
+    let platform = IosPlatform::from_env(&registry)
+        .expect("from_env: resolve/boot a Simulator and open the idb_companion input client");
+    let session_reader = platform
+        .accessibility()
+        .expect("connect the session accessibility reader")
+        .expect("companion is required for this on-box test");
+    let independent_reader = platform
+        .accessibility()
+        .expect("connect the independent stale-target reader")
+        .expect("companion is required for this on-box test");
+    let pointer_events = Arc::new(Mutex::new(Vec::new()));
+    let key_events = Arc::new(Mutex::new(Vec::new()));
+    let mut backend = Some(Backend {
+        platform: Box::new(CountingIosPlatform {
+            inner: platform,
+            pointer_events: Arc::clone(&pointer_events),
+            key_events: Arc::clone(&key_events),
+        }),
+        accessibility: Some(Box::new(session_reader)),
+    });
+    let factory: glass_core::PlatformFactory = Box::new(move |_: &str| {
+        let _keep_registry_alive = &registry;
+        backend.take().ok_or_else(|| {
+            glass_core::GlassError::Backend("iOS backend already constructed".into())
+        })
+    });
+    let baselines = std::env::temp_dir().join(format!(
+        "glass-ios-semantic-integration-{}",
+        std::process::id()
+    ));
+    let glass = Glass::new(factory, "ios".into(), BaselineStore::new(baselines), 64);
+    (glass, independent_reader, pointer_events, key_events)
+}
+
+fn fresh_until(glass: &mut Glass, attempts: usize, pred: impl Fn(&AxTree) -> bool) -> AxTree {
+    let mut tree = glass.a11y_snapshot(None).expect("fresh semantic snapshot");
+    for _ in 0..attempts {
+        if pred(&tree) {
+            return tree;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+        tree = glass.a11y_snapshot(None).expect("fresh semantic snapshot");
+    }
+    tree
+}
+
+fn check_verdict(
+    checks: &[glass_core::ActionabilityCheck],
+    name: ActionabilityCheckName,
+) -> ActionabilityVerdict {
+    checks
+        .iter()
+        .find(|check| check.name == name)
+        .unwrap_or_else(|| panic!("missing {name:?} actionability check: {checks:?}"))
+        .verdict
 }
 
 #[test]
@@ -231,6 +421,244 @@ fn drive_fixture_snapshot_tap_and_type_end_to_end() {
     );
 
     platform.stop_app().expect("stop_app");
+}
+
+#[test]
+#[ignore = "on-box only: needs a macOS host with Xcode + idb_companion + a booted iOS \
+            Simulator, and GLASS_IOS_APP pointing at the examples/ios-fixture .app"]
+fn semantic_actions_refuse_unproven_ios_state_and_dispatch_once() {
+    let app = std::env::var("GLASS_IOS_APP")
+        .expect("GLASS_IOS_APP must be set to the examples/ios-fixture GlassFixture.app path");
+    let (mut glass, mut independent_reader, pointer_events, key_events) =
+        semantic_fixture_session();
+    let window = glass
+        .start(&semantic_fixture_spec(app))
+        .expect("start semantic fixture through Glass");
+
+    let initial = fresh_until(&mut glass, 20, |tree| {
+        named_value(tree, "statusLabel").as_deref() == Some("READY")
+            && find_named(&tree.root, "movingSemantic").is_some()
+    });
+    assert_eq!(
+        named_value(&initial, "statusLabel").as_deref(),
+        Some("READY")
+    );
+    let initial_moving = find_named(&initial.root, "movingSemantic")
+        .and_then(|node| node.bounds)
+        .expect("movingSemantic has initial bounds");
+
+    let pointers_before_save = pointer_events.lock().unwrap().len();
+    let save = glass
+        .click_target(&pointer_click("semanticSave", AxRole::Button, 2_000))
+        .expect("semantic save pointer action");
+    assert_eq!(save.action.dispatch, DispatchStatus::Dispatched);
+    assert_eq!(
+        check_verdict(
+            &save.actionability.checks,
+            ActionabilityCheckName::NonOccluded
+        ),
+        ActionabilityVerdict::Unproven
+    );
+    assert_eq!(
+        check_verdict(&save.actionability.checks, ActionabilityCheckName::Visible),
+        ActionabilityVerdict::Unproven
+    );
+    assert_eq!(
+        check_verdict(&save.actionability.checks, ActionabilityCheckName::InWindow),
+        ActionabilityVerdict::Passed
+    );
+    assert_eq!(
+        pointer_events.lock().unwrap().len(),
+        pointers_before_save + 1,
+        "semanticSave sends one pointer submission"
+    );
+
+    let mut observed_bounds = Vec::new();
+    let motion_deadline = std::time::Instant::now() + Duration::from_secs(2);
+    loop {
+        let tree = glass
+            .a11y_snapshot(None)
+            .expect("motion observation snapshot");
+        let bounds = find_named(&tree.root, "movingSemantic")
+            .and_then(|node| node.bounds)
+            .expect("movingSemantic stays published while moving");
+        let save_counted = named_value(&tree, "statusLabel").as_deref() == Some("SAVED:1 MOVED:0");
+        if observed_bounds.last().copied() != Some(bounds) {
+            observed_bounds.push(bounds);
+        }
+        if observed_bounds.len() >= 2 && save_counted {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < motion_deadline,
+            "movingSemantic never published two changing bounds with the exact save count: \
+             {observed_bounds:?}"
+        );
+        std::thread::sleep(Duration::from_millis(30));
+    }
+    println!("movingSemantic initial={initial_moving:?}, changing bounds={observed_bounds:?}");
+
+    let pointers_before_moving = pointer_events.lock().unwrap().len();
+    let moving = glass
+        .click_target(&pointer_click("movingSemantic", AxRole::Button, 2_000))
+        .expect("moving target waits for stable bounds then dispatches");
+    assert_eq!(moving.action.dispatch, DispatchStatus::Dispatched);
+    assert_eq!(
+        check_verdict(&moving.actionability.checks, ActionabilityCheckName::Stable),
+        ActionabilityVerdict::Passed
+    );
+    assert_eq!(
+        pointer_events.lock().unwrap().len(),
+        pointers_before_moving + 1,
+        "movingSemantic sends one pointer submission after stability"
+    );
+    std::thread::sleep(Duration::from_millis(350));
+    let after_moving = glass.a11y_snapshot(None).expect("quiet moving observation");
+    assert_eq!(
+        named_value(&after_moving, "statusLabel").as_deref(),
+        Some("SAVED:1 MOVED:1"),
+        "both semantic controls must remain at exactly one dispatch through the quiet window"
+    );
+
+    let pointers_before_refusals = pointer_events.lock().unwrap().len();
+    let duplicate = glass
+        .click_target(&pointer_click("duplicateSemantic", AxRole::Button, 0))
+        .expect_err("duplicate selector must refuse without a tap");
+    assert_eq!(duplicate.kind, SemanticActionFailureKind::AmbiguousTarget);
+    assert_eq!(duplicate.action_dispatch, DispatchStatus::NotDispatched);
+    let disabled = glass
+        .click_target(&pointer_click("disabledSemantic", AxRole::Button, 0))
+        .expect_err("known disabled selector must refuse without a tap");
+    assert_eq!(disabled.kind, SemanticActionFailureKind::NotActionable);
+    assert_eq!(disabled.action_dispatch, DispatchStatus::NotDispatched);
+    assert_eq!(
+        check_verdict(
+            &disabled.actionability.checks,
+            ActionabilityCheckName::Enabled
+        ),
+        ActionabilityVerdict::Failed
+    );
+    std::thread::sleep(Duration::from_millis(350));
+    let after_refusals = glass
+        .a11y_snapshot(None)
+        .expect("quiet refusal observation");
+    assert_eq!(
+        named_value(&after_refusals, "statusLabel").as_deref(),
+        Some("SAVED:1 MOVED:1"),
+        "duplicate and disabled refusals must deliver no fixture tap"
+    );
+    assert_eq!(
+        pointer_events.lock().unwrap().len(),
+        pointers_before_refusals,
+        "duplicate and disabled refusals submit zero pointer events"
+    );
+
+    let stale_ctx = AxContext {
+        pids: vec![],
+        window: window.clone(),
+        window_handle: None,
+        a11y_bus_addr: None,
+        limits: WalkLimits::DEFAULT,
+        deadline: Deadline::UNBOUNDED,
+    };
+    let stale_tree = independent_reader
+        .snapshot(&stale_ctx)
+        .expect("capture stale inputField identity before semantic write");
+    let stale_field = find_named(&stale_tree.root, "inputField").expect("inputField present");
+    let stale_target = AxTarget {
+        id: stale_field.id,
+        role: stale_field.role,
+        name: stale_field.name.clone(),
+        bounds: stale_field.bounds,
+        value: stale_field.value.clone(),
+    };
+
+    let set_value = glass
+        .set_value_target(
+            &SetValueTargetParams {
+                target: ActionTarget::Semantic(semantic_target("inputField", AxRole::TextField)),
+                timeout_ms: Some(3_000),
+                max_nodes: None,
+            },
+            "semantic-value",
+        )
+        .expect("semantic set-value resolves fresh and confirms its value");
+    assert_eq!(set_value.action.dispatch, DispatchStatus::Dispatched);
+    assert_eq!(
+        set_value.action.confirmation,
+        ConfirmationStatus::ValueConfirmed
+    );
+    let written = fresh_until(&mut glass, 12, |tree| {
+        named_value(tree, "echoLabel").as_deref() == Some("semantic-value")
+    });
+    assert_eq!(
+        named_value(&written, "echoLabel").as_deref(),
+        Some("semantic-value")
+    );
+
+    let stale_error = independent_reader
+        .set_value(&stale_ctx, &stale_target, "stale-write")
+        .expect_err("stale value identity must refuse before dispatch");
+    assert!(
+        matches!(stale_error, glass_core::GlassError::AxElementChanged(_)),
+        "{stale_error}"
+    );
+    std::thread::sleep(Duration::from_millis(350));
+    let after_stale = glass
+        .a11y_snapshot(None)
+        .expect("quiet stale refusal observation");
+    assert_eq!(
+        named_value(&after_stale, "echoLabel").as_deref(),
+        Some("semantic-value"),
+        "stale identity refusal must not deliver text"
+    );
+
+    let pointers_before_type = pointer_events.lock().unwrap().len();
+    let keys_before_type = key_events.lock().unwrap().len();
+    let type_error = glass
+        .type_target(
+            &TypeTargetParams {
+                target: semantic_target("inputField", AxRole::TextField),
+                focus_mode: ActionMode::Pointer,
+                timeout_ms: 500,
+                max_nodes: None,
+            },
+            "forbidden-text",
+        )
+        .expect_err("idb cannot confirm focus, so targeted typing must stop after the focus tap");
+    assert_eq!(type_error.kind, SemanticActionFailureKind::FocusUnconfirmed);
+    assert_eq!(type_error.action_dispatch, DispatchStatus::NotDispatched);
+    assert_eq!(
+        type_error.focus,
+        Some(MutationReport {
+            method: ActionMethod::Pointer {
+                native_fallback: None,
+            },
+            dispatch: DispatchStatus::Dispatched,
+            confirmation: ConfirmationStatus::Unconfirmed,
+        })
+    );
+    assert_eq!(
+        pointer_events.lock().unwrap().len(),
+        pointers_before_type + 1,
+        "targeted type sends exactly one focus tap"
+    );
+    assert_eq!(
+        key_events.lock().unwrap().len(),
+        keys_before_type,
+        "unconfirmed focus sends zero text key submissions"
+    );
+    std::thread::sleep(Duration::from_millis(350));
+    let after_type = glass
+        .a11y_snapshot(None)
+        .expect("quiet targeted-type observation");
+    assert_eq!(
+        named_value(&after_type, "echoLabel").as_deref(),
+        Some("semantic-value"),
+        "unconfirmed focus must dispatch zero text to the field"
+    );
+
+    glass.stop().expect("stop semantic fixture");
 }
 
 /// The page's own elements, by the accessible name each carries on a platform that exposes web

--- a/crates/glass-macos/fixture/a11y_fixture.swift
+++ b/crates/glass-macos/fixture/a11y_fixture.swift
@@ -1,6 +1,6 @@
 // a11y_fixture.swift — glass-macos accessibility-tree test fixture.
 //
-// A minimal Cocoa app whose window exposes a real NSAccessibility tree with five controls, for
+// A minimal Cocoa app whose window exposes a real NSAccessibility tree with known controls, for
 // the macOS a11y reader's on-box tests to drive by name:
 //
 //   - an NSButton titled "Save" — prints `SAVE_CLICKED` to stdout (flushed) when its action
@@ -35,8 +35,12 @@ import AppKit
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
     let window = NSWindow(
-        contentRect: NSRect(x: 0, y: 0, width: 400, height: 200),
+        contentRect: NSRect(x: 0, y: 0, width: 500, height: 440),
         styleMask: [.titled], backing: .buffered, defer: false)
+    var movingSemantic: NSButton?
+    var movementTicks = 0
+    var movementTimer: Timer?
+    var movementStep: CGFloat = 20
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         let save = NSButton(title: "Save", target: self, action: #selector(onSave))
@@ -79,6 +83,40 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // same string twice on one outline line.
         status.setAccessibilityHelp("Status")
 
+        let semanticSave = NSButton(
+            title: "Semantic Save", target: self, action: #selector(onSemanticSave))
+        semanticSave.frame = NSRect(x: 20, y: 380, width: 130, height: 32)
+        semanticSave.setAccessibilityLabel("Semantic Save")
+
+        let disabledSemantic = NSButton(
+            title: "Disabled semantic", target: self, action: #selector(onDisabledSemantic))
+        disabledSemantic.frame = NSRect(x: 170, y: 380, width: 150, height: 32)
+        disabledSemantic.setAccessibilityLabel("Disabled semantic")
+        disabledSemantic.isEnabled = false
+
+        let duplicateOne = NSButton(
+            title: "Duplicate semantic", target: self, action: #selector(onDuplicateSemantic))
+        duplicateOne.frame = NSRect(x: 20, y: 340, width: 160, height: 32)
+        duplicateOne.setAccessibilityLabel("Duplicate semantic")
+        let duplicateTwo = NSButton(
+            title: "Duplicate semantic", target: self, action: #selector(onDuplicateSemantic))
+        duplicateTwo.frame = NSRect(x: 200, y: 340, width: 160, height: 32)
+        duplicateTwo.setAccessibilityLabel("Duplicate semantic")
+
+        let moving = NSButton(
+            title: "Moving semantic", target: self, action: #selector(onMovingSemantic))
+        moving.frame = NSRect(x: 20, y: 300, width: 150, height: 32)
+        moving.setAccessibilityLabel("Moving semantic")
+        movingSemantic = moving
+
+        let occluded = NSButton(
+            title: "Occluded semantic", target: self, action: #selector(onOccludedSemantic))
+        occluded.frame = NSRect(x: 20, y: 250, width: 160, height: 32)
+        occluded.setAccessibilityLabel("Occluded semantic")
+        let occluder = NSButton(title: "Occluder", target: self, action: #selector(onOccluder))
+        occluder.frame = NSRect(x: 60, y: 250, width: 90, height: 32)
+        occluder.setAccessibilityLabel("Occluder")
+
         let contentView = NSView(frame: window.contentView!.bounds)
         contentView.addSubview(save)
         contentView.addSubview(enable)
@@ -86,10 +124,48 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         contentView.addSubview(bold)
         contentView.addSubview(note)
         contentView.addSubview(status)
+        contentView.addSubview(semanticSave)
+        contentView.addSubview(disabledSemantic)
+        contentView.addSubview(duplicateOne)
+        contentView.addSubview(duplicateTwo)
+        contentView.addSubview(moving)
+        contentView.addSubview(occluded)
+        contentView.addSubview(occluder)
         window.contentView = contentView
         window.title = "glass a11y fixture"
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
+        window.makeFirstResponder(note)
+        if let editor = note.currentEditor() as? NSTextView {
+            editor.setSelectedRange(NSRange(location: note.stringValue.utf16.count, length: 0))
+        }
+        restartMovement()
+    }
+
+    func restartMovement() {
+        movementTimer?.invalidate()
+        movementTicks = 0
+        if let moving = movingSemantic {
+            let previousX = moving.frame.origin.x
+            if previousX > 140 {
+                moving.frame.origin.x = 180
+                movementStep = -16
+            } else {
+                moving.frame.origin.x = 60
+                movementStep = 20
+            }
+            if abs(previousX - moving.frame.origin.x) > 12 {
+                emit("MOVING_RESET")
+            }
+        }
+        let timer = Timer(
+            timeInterval: 0.03,
+            target: self,
+            selector: #selector(moveSemantic),
+            userInfo: nil,
+            repeats: true)
+        movementTimer = timer
+        RunLoop.main.add(timer, forMode: .common)
     }
 
     // `print` is fully buffered (not line-buffered) once stdout is a pipe rather than a
@@ -101,8 +177,39 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // process — on a non-seekable fd such as a pipe. `fflush(stdout)`, the convention
     // already used throughout `quadrants.swift`, is the safe equivalent here.
     @objc func onSave() {
-        print("SAVE_CLICKED")
+        emit("SAVE_CLICKED")
+    }
+
+    func emit(_ marker: String) {
+        print(marker)
         fflush(stdout)
+    }
+
+    @objc func onSemanticSave() {
+        restartMovement()
+        emit("SEMANTIC_SAVE")
+    }
+    @objc func onDisabledSemantic() { emit("DISABLED_SEMANTIC") }
+    @objc func onDuplicateSemantic() { emit("DUPLICATE_SEMANTIC") }
+    @objc func onMovingSemantic() {
+        emit(movementTimer == nil ? "MOVING_CLICKED_SETTLED" : "MOVING_CLICKED_MOVING")
+        emit("MOVING_CLICKED")
+    }
+    @objc func onOccludedSemantic() { emit("OCCLUDED_CLICKED") }
+    @objc func onOccluder() { emit("OCCLUDER_CLICKED") }
+
+    @objc func moveSemantic() {
+        guard let moving = movingSemantic else { return }
+        movementTicks += 1
+        moving.frame.origin.x += movementStep
+        if movementTicks == 1 {
+            emit("MOVING_STARTED")
+        }
+        if movementTicks >= 10 {
+            movementTimer?.invalidate()
+            movementTimer = nil
+            emit("MOVING_SETTLED")
+        }
     }
 }
 

--- a/crates/glass-macos/tests/a11y.rs
+++ b/crates/glass-macos/tests/a11y.rs
@@ -58,16 +58,16 @@ fn main() {
 #[cfg(target_os = "macos")]
 mod macos_main {
     use std::path::PathBuf;
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
     use glass_core::platform::{MouseButton, PointerEvent};
     use glass_core::{
-        Accessibility, AppSpec, AxContext, AxNode, AxRole, AxTarget, Deadline, GlassError,
-        Platform, SandboxLevel, Stream, WalkLimits,
+        Accessibility, AppSpec, AxContext, AxNode, AxRole, AxTarget, Backend, BaselineStore,
+        Deadline, Glass, GlassError, Platform, PlatformFactory, SandboxLevel, Stream, WalkLimits,
     };
     use glass_macos::MacosPlatform;
 
-    use crate::common::{build_fixture, expect, fail, swiftc_available, try_expect};
+    use crate::common::{build_fixture, fail, swiftc_available, try_expect};
 
     /// Settle after an action that should print `SAVE_CLICKED` — native `invoke` or the
     /// a11y-bounds pointer click — before draining logs, mirroring `input.rs`'s
@@ -119,6 +119,106 @@ mod macos_main {
         lines
             .iter()
             .any(|(stream, line)| *stream == Stream::Stdout && line.contains(needle))
+    }
+
+    fn semantic_target(
+        role: AxRole,
+        name: &str,
+        states: Vec<glass_core::SemanticState>,
+    ) -> glass_core::SemanticTarget {
+        glass_core::SemanticTarget {
+            target: glass_core::SemanticSelector::new(Some(name.into()), Some(role), states)
+                .expect("valid semantic selector"),
+            within: None,
+        }
+    }
+
+    fn actionability_verdict(
+        report: &glass_core::ActionabilityReport,
+        name: glass_core::ActionabilityCheckName,
+    ) -> glass_core::ActionabilityVerdict {
+        report
+            .checks
+            .iter()
+            .find(|check| check.name == name)
+            .unwrap_or_else(|| panic!("missing {name:?} check in {:?}", report.checks))
+            .verdict
+    }
+
+    fn log_cursor(glass: &mut Glass) -> Result<u64, String> {
+        glass
+            .logs(0, 1_000, None, None)
+            .map(|(_, cursor)| cursor)
+            .map_err(|error| format!("read fixture log cursor: {error}"))
+    }
+
+    fn exact_log_count_since(
+        glass: &mut Glass,
+        cursor: u64,
+        expected: &str,
+    ) -> Result<usize, String> {
+        glass
+            .logs(cursor, 1_000, None, None)
+            .map(|(lines, _)| lines.iter().filter(|line| line.text == expected).count())
+            .map_err(|error| format!("read fixture logs: {error}"))
+    }
+
+    fn await_exact_log_arrival(
+        glass: &mut Glass,
+        cursor: u64,
+        expected: &str,
+        count: usize,
+    ) -> Result<(), String> {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let observed = exact_log_count_since(glass, cursor, expected)?;
+            if observed == count {
+                return Ok(());
+            }
+            if observed > count || Instant::now() >= deadline {
+                return Err(format!(
+                    "expected exactly {count} {expected:?} logs, got {observed}"
+                ));
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+    }
+
+    fn await_exact_log_count(
+        glass: &mut Glass,
+        cursor: u64,
+        expected: &str,
+        count: usize,
+    ) -> Result<(), String> {
+        if count != 0 {
+            await_exact_log_arrival(glass, cursor, expected, count)?;
+        }
+        let quiet_until = Instant::now() + Duration::from_millis(400);
+        loop {
+            let observed = exact_log_count_since(glass, cursor, expected)?;
+            if observed != count {
+                return Err(format!(
+                    "expected {count} exact {expected:?} logs throughout the quiet window, got {observed}"
+                ));
+            }
+            if Instant::now() >= quiet_until {
+                return Ok(());
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+    }
+
+    fn glass_with_a11y() -> Glass {
+        let factory: PlatformFactory = Box::new(|_backend| {
+            Ok(Backend {
+                platform: Box::new(MacosPlatform::new()?),
+                accessibility: Some(Box::new(glass_a11y_macos::MacosA11y::new())),
+            })
+        });
+        let dir = tempfile::tempdir().expect("semantic baseline tempdir");
+        let root = dir.path().join("baselines");
+        std::mem::forget(dir);
+        Glass::new(factory, "macos".into(), BaselineStore::new(root), 100)
     }
 
     /// Launch the fixture, snapshot its accessibility tree, and assert the outline contains
@@ -357,6 +457,298 @@ mod macos_main {
         Ok(())
     }
 
+    fn run_semantic_checks(fixture_bin: &std::path::Path) -> Result<(), String> {
+        use glass_core::{
+            ActionMethod, ActionMode, ActionTarget, ActionabilityCheckName, ActionabilityVerdict,
+            ConfirmationStatus, DispatchStatus, SemanticActionFailureKind, SemanticState,
+        };
+
+        let mut glass = glass_with_a11y();
+        glass
+            .start(&AppSpec {
+                build: None,
+                run: vec![fixture_bin.to_string_lossy().into_owned()],
+                cwd: None,
+                env: vec![],
+                window_hint: None,
+                timeout_ms: 8_000,
+                sandbox: SandboxLevel::Off,
+                a11y: false,
+            })
+            .map_err(|error| format!("semantic fixture start: {error}"))?;
+
+        let result = (|| {
+            await_exact_log_arrival(&mut glass, 0, "MOVING_SETTLED", 1)?;
+            let initial = glass
+                .a11y_snapshot(None)
+                .map_err(|error| format!("initial semantic snapshot: {error}"))?;
+            let initial_moving = find_by_name(&initial.root, "Moving semantic")
+                .ok_or_else(|| "initial snapshot has no Moving semantic button".to_string())?;
+            let moving_id = initial_moving.id;
+            let stale_cached_bounds = initial_moving.bounds;
+            let coverage =
+                glass_core::Accessibility::state_coverage(&glass_a11y_macos::MacosA11y::new());
+            if coverage != glass_a11y_macos::mapping::STATE_COVERAGE {
+                return Err(format!("unexpected macOS state coverage: {coverage:?}"));
+            }
+
+            let save_cursor = log_cursor(&mut glass)?;
+            let native_save = glass
+                .click_target(&glass_core::ClickTargetParams {
+                    target: ActionTarget::Semantic(semantic_target(
+                        AxRole::Button,
+                        "Semantic Save",
+                        vec![SemanticState::Enabled],
+                    )),
+                    mode: ActionMode::Native,
+                    timeout_ms: Some(5_000),
+                    max_nodes: None,
+                })
+                .map_err(|error| format!("native semantic save: {error}"))?;
+            if native_save.action.method != (ActionMethod::NativeAction { actuated: None })
+                || native_save.action.dispatch != DispatchStatus::Dispatched
+            {
+                return Err(format!("unexpected native action report: {native_save:?}"));
+            }
+            await_exact_log_arrival(&mut glass, save_cursor, "SEMANTIC_SAVE", 1)?;
+            await_exact_log_arrival(&mut glass, save_cursor, "MOVING_RESET", 1)?;
+            let stale_cursor = log_cursor(&mut glass)?;
+            let stale = glass
+                .click_element(moving_id)
+                .expect_err("moving bounds must stale the cached backend target");
+            if !matches!(stale.cause(), GlassError::AxElementChanged(_)) {
+                return Err(format!("stale backend rewalk returned {stale}"));
+            }
+            let stale_current = glass
+                .a11y_snapshot(None)
+                .map_err(|error| format!("stale rejection evidence snapshot: {error}"))?;
+            let stale_current_bounds = find_by_name(&stale_current.root, "Moving semantic")
+                .ok_or_else(|| "stale evidence has no Moving semantic button".to_string())?
+                .bounds;
+            if stale_current_bounds == stale_cached_bounds {
+                return Err(format!(
+                    "stale rejection did not observe changed bounds: cached={stale_cached_bounds:?}, current={stale_current_bounds:?}"
+                ));
+            }
+            await_exact_log_count(&mut glass, stale_cursor, "MOVING_CLICKED", 0)?;
+            await_exact_log_count(&mut glass, save_cursor, "SEMANTIC_SAVE", 1)?;
+            await_exact_log_count(&mut glass, save_cursor, "MOVING_RESET", 1)?;
+
+            await_exact_log_arrival(&mut glass, save_cursor, "MOVING_SETTLED", 1)?;
+            let pointer_baseline = glass
+                .a11y_snapshot(None)
+                .map_err(|error| format!("settled pointer baseline snapshot: {error}"))?;
+            let pointer_baseline_bounds = find_by_name(&pointer_baseline.root, "Moving semantic")
+                .ok_or_else(|| "pointer baseline has no Moving semantic button".to_string())?
+                .bounds;
+
+            let moving_cursor = log_cursor(&mut glass)?;
+            glass
+                .click_target(&glass_core::ClickTargetParams {
+                    target: ActionTarget::Semantic(semantic_target(
+                        AxRole::Button,
+                        "Semantic Save",
+                        vec![SemanticState::Enabled],
+                    )),
+                    mode: ActionMode::Native,
+                    timeout_ms: Some(5_000),
+                    max_nodes: None,
+                })
+                .map_err(|error| format!("restart movement through native save: {error}"))?;
+            await_exact_log_arrival(&mut glass, moving_cursor, "MOVING_STARTED", 1)?;
+            let changing_sample = glass
+                .a11y_snapshot(None)
+                .map_err(|error| format!("changing pointer sample snapshot: {error}"))?;
+            let changing_bounds = find_by_name(&changing_sample.root, "Moving semantic")
+                .ok_or_else(|| "changing sample has no Moving semantic button".to_string())?
+                .bounds;
+            if changing_bounds == pointer_baseline_bounds {
+                return Err(format!(
+                    "moving bounds did not change after restart: {changing_bounds:?}"
+                ));
+            }
+            let moving_started = std::time::Instant::now();
+            let moving = glass
+                .click_target(&glass_core::ClickTargetParams {
+                    target: ActionTarget::Semantic(semantic_target(
+                        AxRole::Button,
+                        "Moving semantic",
+                        vec![SemanticState::Enabled],
+                    )),
+                    mode: ActionMode::Pointer,
+                    timeout_ms: Some(5_000),
+                    max_nodes: None,
+                })
+                .map_err(|error| format!("forced pointer moving semantic: {error}"))?;
+            if moving_started.elapsed() < Duration::from_millis(300)
+                || moving.action.method
+                    != (ActionMethod::Pointer {
+                        native_fallback: None,
+                    })
+                || actionability_verdict(&moving.actionability, ActionabilityCheckName::Stable)
+                    != ActionabilityVerdict::Passed
+                || actionability_verdict(&moving.actionability, ActionabilityCheckName::NonOccluded)
+                    != ActionabilityVerdict::Passed
+            {
+                return Err(format!("unexpected moving pointer report: {moving:?}"));
+            }
+            await_exact_log_count(&mut glass, moving_cursor, "MOVING_SETTLED", 1)?;
+            await_exact_log_count(&mut glass, moving_cursor, "MOVING_CLICKED", 1)?;
+            await_exact_log_count(&mut glass, moving_cursor, "MOVING_CLICKED_SETTLED", 1)?;
+            await_exact_log_count(&mut glass, moving_cursor, "MOVING_CLICKED_MOVING", 0)?;
+            await_exact_log_count(&mut glass, moving_cursor, "SEMANTIC_SAVE", 1)?;
+            let settled_sample = glass
+                .a11y_snapshot(None)
+                .map_err(|error| format!("settled pointer sample snapshot: {error}"))?;
+            let settled_bounds = find_by_name(&settled_sample.root, "Moving semantic")
+                .ok_or_else(|| "settled sample has no Moving semantic button".to_string())?
+                .bounds;
+            if settled_bounds == changing_bounds {
+                return Err(format!(
+                    "pointer samples never changed before settling: {changing_bounds:?}"
+                ));
+            }
+
+            let before_type = glass
+                .a11y_snapshot(None)
+                .map_err(|error| format!("before targeted type snapshot: {error}"))?;
+            let before_value = find_by_name(&before_type.root, "Note")
+                .and_then(|node| node.value.clone())
+                .ok_or_else(|| "before targeted type snapshot has no Note value".to_string())?;
+            let typed = glass
+                .type_target(
+                    &glass_core::TypeTargetParams {
+                        target: semantic_target(
+                            AxRole::TextField,
+                            "Note",
+                            vec![SemanticState::Enabled],
+                        ),
+                        focus_mode: ActionMode::Native,
+                        timeout_ms: 5_000,
+                        max_nodes: None,
+                    },
+                    "Z",
+                )
+                .map_err(|error| format!("native targeted type: {error}"))?;
+            let Some(ref focus) = typed.focus else {
+                return Err("targeted type returned no focus report".into());
+            };
+            if focus.confirmation != ConfirmationStatus::FocusConfirmed
+                || focus.dispatch != DispatchStatus::Dispatched
+                || typed.action.method != ActionMethod::Keyboard
+            {
+                return Err(format!("unexpected targeted type report: {typed:?}"));
+            }
+            let typed_tree = glass
+                .a11y_snapshot(None)
+                .map_err(|error| format!("targeted type snapshot: {error}"))?;
+            let typed_note = find_by_name(&typed_tree.root, "Note")
+                .ok_or_else(|| "typed snapshot has no Note field".to_string())?;
+            let after_value = typed_note
+                .value
+                .as_deref()
+                .ok_or_else(|| "typed Note has no value".to_string())?;
+            let inserted_once = after_value.len() == before_value.len() + 1
+                && after_value.matches('Z').count() == before_value.matches('Z').count() + 1
+                && after_value.replacen('Z', "", 1) == before_value;
+            if !typed_note.states.focused || !inserted_once {
+                return Err(format!(
+                    "targeted type did not insert exactly one Z: before={before_value:?}, after={after_value:?}, node={typed_note:?}"
+                ));
+            }
+            let typed_value = after_value.to_string();
+            std::thread::sleep(Duration::from_millis(400));
+            let quiet_typed_tree = glass
+                .a11y_snapshot(None)
+                .map_err(|error| format!("quiet targeted type snapshot: {error}"))?;
+            let quiet_typed_note = find_by_name(&quiet_typed_tree.root, "Note")
+                .ok_or_else(|| "quiet typed snapshot has no Note field".to_string())?;
+            if quiet_typed_note.value.as_deref() != Some(typed_value.as_str()) {
+                return Err(format!(
+                    "targeted type changed again during the quiet interval: first={typed_value:?}, quiet={:?}",
+                    quiet_typed_note.value
+                ));
+            }
+
+            let disabled_cursor = log_cursor(&mut glass)?;
+            let disabled = glass
+                .click_target(&glass_core::ClickTargetParams {
+                    target: ActionTarget::Semantic(semantic_target(
+                        AxRole::Button,
+                        "Disabled semantic",
+                        vec![],
+                    )),
+                    mode: ActionMode::Pointer,
+                    timeout_ms: Some(0),
+                    max_nodes: None,
+                })
+                .expect_err("disabled semantic target must be refused");
+            if disabled.kind != SemanticActionFailureKind::NotActionable
+                || disabled.action_dispatch != DispatchStatus::NotDispatched
+                || actionability_verdict(&disabled.actionability, ActionabilityCheckName::Enabled)
+                    != ActionabilityVerdict::Failed
+            {
+                return Err(format!("unexpected disabled refusal: {disabled:?}"));
+            }
+            await_exact_log_count(&mut glass, disabled_cursor, "DISABLED_SEMANTIC", 0)?;
+
+            let duplicate_cursor = log_cursor(&mut glass)?;
+            let duplicate = glass
+                .click_target(&glass_core::ClickTargetParams {
+                    target: ActionTarget::Semantic(semantic_target(
+                        AxRole::Button,
+                        "Duplicate semantic",
+                        vec![],
+                    )),
+                    mode: ActionMode::Native,
+                    timeout_ms: Some(0),
+                    max_nodes: None,
+                })
+                .expect_err("duplicate semantic target must be refused");
+            if duplicate.kind != SemanticActionFailureKind::AmbiguousTarget
+                || duplicate.action_dispatch != DispatchStatus::NotDispatched
+            {
+                return Err(format!("unexpected duplicate refusal: {duplicate:?}"));
+            }
+            await_exact_log_count(&mut glass, duplicate_cursor, "DUPLICATE_SEMANTIC", 0)?;
+
+            let occluded_cursor = log_cursor(&mut glass)?;
+            let occluded = glass
+                .click_target(&glass_core::ClickTargetParams {
+                    target: ActionTarget::Semantic(semantic_target(
+                        AxRole::Button,
+                        "Occluded semantic",
+                        vec![SemanticState::Enabled],
+                    )),
+                    mode: ActionMode::Pointer,
+                    timeout_ms: Some(5_000),
+                    max_nodes: None,
+                })
+                .expect_err("AX hit testing must prove the foreground occluder");
+            if occluded.kind != SemanticActionFailureKind::NotActionable
+                || occluded.action_dispatch != DispatchStatus::NotDispatched
+                || actionability_verdict(
+                    &occluded.actionability,
+                    ActionabilityCheckName::NonOccluded,
+                ) != ActionabilityVerdict::Failed
+            {
+                return Err(format!("unexpected occlusion refusal: {occluded:?}"));
+            }
+            await_exact_log_count(&mut glass, occluded_cursor, "OCCLUDED_CLICKED", 0)?;
+            await_exact_log_count(&mut glass, occluded_cursor, "OCCLUDER_CLICKED", 0)?;
+
+            println!("A11Y_SEMANTIC_PASS");
+            Ok(())
+        })();
+
+        let stop_result = glass.stop();
+        match (result, stop_result) {
+            (Ok(()), Ok(())) => Ok(()),
+            (Err(error), _) => Err(error),
+            (Ok(()), Err(error)) => Err(format!("semantic fixture stop: {error}")),
+        }
+    }
+
     pub(super) fn run() {
         // Prefer a pre-built fixture (the granted run supplies `GLASS_A11Y_FIXTURE_BIN`);
         // otherwise build it here, skipping cleanly if `swiftc` is unavailable.
@@ -403,11 +795,18 @@ mod macos_main {
         // Reached on every path and BEFORE any process::exit below: stop_app is idempotent,
         // so this guarantees the fixture process never survives a failed run.
         let stop_result = platform.stop_app();
-        cleanup_dir(&fixture_dir);
 
         match result {
             Ok(()) => {
-                expect(stop_result, "stop_app");
+                if let Err(error) = stop_result {
+                    cleanup_dir(&fixture_dir);
+                    fail(format!("stop_app: {error}"));
+                }
+                if let Err(error) = run_semantic_checks(&fixture_bin) {
+                    cleanup_dir(&fixture_dir);
+                    fail(error);
+                }
+                cleanup_dir(&fixture_dir);
                 println!("A11Y_SNAPSHOT_PASS");
                 std::process::exit(0);
             }
@@ -415,6 +814,7 @@ mod macos_main {
                 if let Err(e) = stop_result {
                     eprintln!("(additionally) stop_app failed: {e}");
                 }
+                cleanup_dir(&fixture_dir);
                 fail(msg);
             }
         }

--- a/crates/glass-mcp/src/audit.rs
+++ b/crates/glass-mcp/src/audit.rs
@@ -730,6 +730,8 @@ mod tests {
             &Actuation::SetValue {
                 element: el,
                 text: "v",
+                dispatch: "dispatched",
+                confirmation: "value_confirmed",
             },
             &ActuationContext::default(),
             &ok(),
@@ -739,6 +741,7 @@ mod tests {
         assert_eq!(r["action"], "set_value");
         assert_eq!(r["target"]["element"]["id"], 5);
         assert_eq!(r["target"]["element"]["role"], "PasswordField");
+        assert_eq!(r["args"], json!({}));
         assert_eq!(r["content"]["len"], 1);
     }
 

--- a/crates/glass-mcp/src/audit.rs
+++ b/crates/glass-mcp/src/audit.rs
@@ -200,32 +200,60 @@ fn describe(act: &Actuation) -> Option<(&'static str, Value, Option<String>)> {
             ("window", args, None)
         }
         Actuation::ClickElement {
+            mode,
             method,
             native_fallback,
             actuated_id,
+            dispatch,
+            confirmation,
             ..
         } => {
-            // A failed click has no method: omit the key rather than writing a null, so a
-            // reader never has to distinguish "no method recorded" from "method: null".
-            let args = match method {
-                Some(m) => {
-                    let mut args = json!({ "method": m });
-                    if let Some(reason) = native_fallback {
-                        args["native_fallback"] = json!(reason);
-                    }
-                    // Without this, "clicked the Save label" and "clicked the card around it,
-                    // which navigated away" are indistinguishable in the record.
-                    if let Some(actuated) = actuated_id {
-                        args["actuated_id"] = json!(actuated);
-                    }
-                    args
-                }
-                None => json!({}),
-            };
+            let mut args = json!({
+                "mode": mode,
+                "dispatch": dispatch,
+                "confirmation": confirmation,
+            });
+            if let Some(method) = method {
+                args["method"] = json!(method);
+            }
+            if let Some(reason) = native_fallback {
+                args["native_fallback"] = json!(reason);
+            }
+            if let Some(actuated) = actuated_id {
+                args["actuated_id"] = json!(actuated);
+            }
             ("click_element", args, None)
         }
-        Actuation::SetValue { text, .. } => ("set_value", json!({}), Some((*text).to_string())),
-        Actuation::TypeTarget { text, .. } => ("type", json!({}), Some((*text).to_string())),
+        Actuation::SetValue {
+            text,
+            dispatch,
+            confirmation,
+            ..
+        } => (
+            "set_value",
+            json!({ "dispatch": dispatch, "confirmation": confirmation }),
+            Some((*text).to_string()),
+        ),
+        Actuation::TypeTarget {
+            text,
+            focus_mode,
+            focus_method,
+            focus_dispatch,
+            focus_confirmation,
+            type_dispatch,
+            ..
+        } => {
+            let mut args = json!({
+                "focus_mode": focus_mode,
+                "focus_dispatch": focus_dispatch,
+                "focus_confirmation": focus_confirmation,
+                "type_dispatch": type_dispatch,
+            });
+            if let Some(method) = focus_method {
+                args["focus_method"] = json!(method);
+            }
+            ("type", args, Some((*text).to_string()))
+        }
     })
 }
 
@@ -342,10 +370,13 @@ impl AuditSink for JsonlSink {
             content: raw.as_deref().and_then(|r| render_content(r, &self.cfg)),
             result: ResultRecord {
                 ok: outcome.ok,
-                // `error` is recorded verbatim and is NOT run through content redaction.
-                // Invariant: backend error messages must never embed actuation content
-                // (e.g. the typed text), or it would leak here regardless of content mode.
-                error: outcome.error.clone(),
+                error: outcome.error.as_ref().map(|error| {
+                    if raw.is_some() {
+                        "action failed".into()
+                    } else {
+                        error.clone()
+                    }
+                }),
                 duration_ms: u64::try_from(dur.as_millis()).unwrap_or(u64::MAX),
             },
         };
@@ -749,7 +780,13 @@ mod tests {
         assert_eq!(r["action"], "set_value");
         assert_eq!(r["target"]["element"]["id"], 5);
         assert_eq!(r["target"]["element"]["role"], "PasswordField");
-        assert_eq!(r["args"], json!({}));
+        assert_eq!(
+            r["args"],
+            json!({
+                "dispatch": "dispatched",
+                "confirmation": "value_confirmed",
+            })
+        );
         assert_eq!(r["content"]["len"], 1);
     }
 
@@ -779,6 +816,11 @@ mod tests {
         assert_eq!(r["action"], "type");
         assert_eq!(r["target"]["element"]["id"], 9);
         assert_eq!(r["target"]["element"]["role"], "TextField");
+        assert_eq!(r["args"]["focus_mode"], "auto");
+        assert_eq!(r["args"]["focus_method"], "native-action");
+        assert_eq!(r["args"]["focus_dispatch"], "dispatched");
+        assert_eq!(r["args"]["focus_confirmation"], "focus_confirmed");
+        assert_eq!(r["args"]["type_dispatch"], "dispatched");
         assert_eq!(r["content"]["len"], 3);
         assert!(r["content"].get("text").is_none());
     }
@@ -850,7 +892,10 @@ mod tests {
         );
         let r = &lines(&buf)[0];
         assert_eq!(r["action"], "click_element");
+        assert_eq!(r["args"]["mode"], "auto");
         assert_eq!(r["args"]["method"], "pointer");
+        assert_eq!(r["args"]["dispatch"], "dispatched");
+        assert_eq!(r["args"]["confirmation"], "dispatch_confirmed");
         assert_eq!(
             r["args"]["native_fallback"], "element exposes no activation action",
             "the pointer path records WHY the native action wasn't used: {r}"
@@ -876,7 +921,10 @@ mod tests {
             Duration::from_millis(1),
         );
         let r = &lines(&buf)[0];
+        assert_eq!(r["args"]["mode"], "native");
         assert_eq!(r["args"]["method"], "native-action");
+        assert_eq!(r["args"]["dispatch"], "dispatched");
+        assert_eq!(r["args"]["confirmation"], "dispatch_confirmed");
         assert!(
             r["args"].get("native_fallback").is_none(),
             "nothing fell back: {r}"
@@ -931,8 +979,83 @@ mod tests {
         let r = &lines(&buf)[0];
         assert_eq!(r["action"], "click_element");
         assert_eq!(r["result"]["ok"], false);
+        assert_eq!(r["args"]["mode"], "auto");
+        assert_eq!(r["args"]["dispatch"], "not_dispatched");
+        assert_eq!(r["args"]["confirmation"], "unconfirmed");
         assert!(r["args"].get("method").is_none(), "no null method: {r}");
         assert!(r["args"].get("native_fallback").is_none(), "{r}");
+    }
+
+    #[test]
+    fn semantic_content_modes_never_let_typed_or_set_text_bypass_result_error_policy() {
+        const SENTINEL: &str = "AUDIT_PAYLOAD_SENTINEL_4f937e";
+        let record = |content: ContentMode, act: Actuation<'_>| {
+            let buf = Arc::new(Mutex::new(Vec::new()));
+            let sink = JsonlSink::with_writer(
+                Box::new(Buf(buf.clone())),
+                AuditConfig {
+                    content,
+                    prefix_len: 5,
+                },
+            );
+            sink.record(
+                &act,
+                &ActuationContext::default(),
+                &AuditOutcome {
+                    ok: false,
+                    error: Some(format!("backend echoed {SENTINEL}")),
+                },
+                Duration::from_millis(1),
+            );
+            lines(&buf).remove(0)
+        };
+        let element = ElementRef {
+            id: 9,
+            role: Some("TextField".into()),
+            name: Some("Account".into()),
+        };
+        let make = |targeted_type: bool| {
+            if targeted_type {
+                Actuation::TypeTarget {
+                    element: element.clone(),
+                    text: SENTINEL,
+                    focus_mode: "auto",
+                    focus_method: Some("native-action"),
+                    focus_dispatch: "dispatched",
+                    focus_confirmation: "focus_confirmed",
+                    type_dispatch: "may_have_dispatched",
+                }
+            } else {
+                Actuation::SetValue {
+                    element: element.clone(),
+                    text: SENTINEL,
+                    dispatch: "may_have_dispatched",
+                    confirmation: "unconfirmed",
+                }
+            }
+        };
+
+        for targeted_type in [false, true] {
+            let none = record(ContentMode::None, make(targeted_type));
+            assert!(none.get("content").is_none());
+            assert!(!none["result"]["error"].as_str().unwrap().contains(SENTINEL));
+
+            let redacted = record(ContentMode::Redacted, make(targeted_type));
+            assert_eq!(redacted["content"]["len"], SENTINEL.len());
+            assert!(redacted["content"]["sha256"].as_str().is_some());
+            assert_eq!(redacted["content"]["prefix"], &SENTINEL[..5]);
+            assert!(
+                !redacted["result"]["error"]
+                    .as_str()
+                    .unwrap()
+                    .contains(SENTINEL)
+            );
+
+            let full = record(ContentMode::Full, make(targeted_type));
+            assert_eq!(full["content"]["text"], SENTINEL);
+            assert!(!full["result"]["error"].as_str().unwrap().contains(SENTINEL));
+            assert_eq!(full.to_string().matches(SENTINEL).count(), 1);
+        }
     }
 
     #[test]

--- a/crates/glass-mcp/src/audit.rs
+++ b/crates/glass-mcp/src/audit.rs
@@ -1248,7 +1248,7 @@ mod tests {
                         modifiers: None,
                     }),
                     Action::Settle(SettleArgs {
-                        interval_ms: Some(0),
+                        interval_ms: Some(1),
                         settle_frames: Some(1),
                         tolerance: None,
                         timeout_ms: Some(500),

--- a/crates/glass-mcp/src/audit.rs
+++ b/crates/glass-mcp/src/audit.rs
@@ -199,19 +199,24 @@ fn describe(act: &Actuation) -> Option<(&'static str, Value, Option<String>)> {
             };
             ("window", args, None)
         }
-        Actuation::ClickElement { method, .. } => {
+        Actuation::ClickElement {
+            method,
+            native_fallback,
+            actuated_id,
+            ..
+        } => {
             // A failed click has no method: omit the key rather than writing a null, so a
             // reader never has to distinguish "no method recorded" from "method: null".
             let args = match method {
                 Some(m) => {
-                    let mut args = json!({ "method": m.label() });
-                    if let Some(reason) = m.native_fallback() {
+                    let mut args = json!({ "method": m });
+                    if let Some(reason) = native_fallback {
                         args["native_fallback"] = json!(reason);
                     }
                     // Without this, "clicked the Save label" and "clicked the card around it,
                     // which navigated away" are indistinguishable in the record.
-                    if let Some(actuated) = m.actuated() {
-                        args["actuated_id"] = json!(actuated.0);
+                    if let Some(actuated) = actuated_id {
+                        args["actuated_id"] = json!(actuated);
                     }
                     args
                 }
@@ -220,12 +225,15 @@ fn describe(act: &Actuation) -> Option<(&'static str, Value, Option<String>)> {
             ("click_element", args, None)
         }
         Actuation::SetValue { text, .. } => ("set_value", json!({}), Some((*text).to_string())),
+        Actuation::TypeTarget { text, .. } => ("type", json!({}), Some((*text).to_string())),
     })
 }
 
 fn target_json(act: &Actuation, ctx: &ActuationContext) -> Value {
     match act {
-        Actuation::ClickElement { element, .. } | Actuation::SetValue { element, .. } => {
+        Actuation::ClickElement { element, .. }
+        | Actuation::SetValue { element, .. }
+        | Actuation::TypeTarget { element, .. } => {
             json!({ "element": { "id": element.id, "role": element.role, "name": element.name } })
         }
         _ => match &ctx.window {
@@ -458,8 +466,8 @@ pub fn resolve(
 mod tests {
     use super::*;
     use glass_core::{
-        Actuation, ActuationContext, AuditOutcome, ClickMethod, ElementRef, KeyEvent, MouseButton,
-        PointerEvent, WindowRef,
+        Actuation, ActuationContext, AuditOutcome, ElementRef, KeyEvent, MouseButton, PointerEvent,
+        WindowRef,
     };
     use std::io::Write;
     use std::sync::{Arc, Mutex};
@@ -745,6 +753,75 @@ mod tests {
         assert_eq!(r["content"]["len"], 1);
     }
 
+    #[test]
+    fn targeted_type_targets_element_and_uses_redacted_content_policy() {
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let s = JsonlSink::with_writer(Box::new(Buf(buf.clone())), AuditConfig::default());
+        s.record(
+            &Actuation::TypeTarget {
+                element: ElementRef {
+                    id: 9,
+                    role: Some("TextField".into()),
+                    name: Some("Account name".into()),
+                },
+                text: "Ada",
+                focus_mode: "auto",
+                focus_method: Some("native-action"),
+                focus_dispatch: "dispatched",
+                focus_confirmation: "focus_confirmed",
+                type_dispatch: "dispatched",
+            },
+            &ActuationContext::default(),
+            &ok(),
+            Duration::from_millis(1),
+        );
+        let r = &lines(&buf)[0];
+        assert_eq!(r["action"], "type");
+        assert_eq!(r["target"]["element"]["id"], 9);
+        assert_eq!(r["target"]["element"]["role"], "TextField");
+        assert_eq!(r["content"]["len"], 3);
+        assert!(r["content"].get("text").is_none());
+    }
+
+    #[test]
+    fn targeted_type_honors_full_and_none_content_modes() {
+        let element = ElementRef {
+            id: 9,
+            role: Some("TextField".into()),
+            name: Some("Account name".into()),
+        };
+        let record = |content| {
+            let buf = Arc::new(Mutex::new(Vec::new()));
+            let s = JsonlSink::with_writer(
+                Box::new(Buf(buf.clone())),
+                AuditConfig {
+                    content,
+                    prefix_len: 8,
+                },
+            );
+            s.record(
+                &Actuation::TypeTarget {
+                    element: element.clone(),
+                    text: "Ada",
+                    focus_mode: "auto",
+                    focus_method: Some("native-action"),
+                    focus_dispatch: "dispatched",
+                    focus_confirmation: "focus_confirmed",
+                    type_dispatch: "dispatched",
+                },
+                &ActuationContext::default(),
+                &ok(),
+                Duration::from_millis(1),
+            );
+            lines(&buf).remove(0)
+        };
+
+        let full = record(ContentMode::Full);
+        assert_eq!(full["content"]["text"], "Ada");
+        let none = record(ContentMode::None);
+        assert!(none.get("content").is_none());
+    }
+
     fn click_el() -> ElementRef {
         ElementRef {
             id: 1,
@@ -757,13 +834,15 @@ mod tests {
     fn click_element_carries_the_actuating_method_and_its_fallback_reason() {
         let buf = Arc::new(Mutex::new(Vec::new()));
         let s = JsonlSink::with_writer(Box::new(Buf(buf.clone())), AuditConfig::default());
-        let method = ClickMethod::Pointer {
-            native_fallback: "element exposes no activation action".into(),
-        };
         s.record(
             &Actuation::ClickElement {
                 element: click_el(),
-                method: Some(&method),
+                mode: "auto",
+                method: Some("pointer"),
+                native_fallback: Some("element exposes no activation action"),
+                actuated_id: None,
+                dispatch: "dispatched",
+                confirmation: "dispatch_confirmed",
             },
             &ActuationContext::default(),
             &ok(),
@@ -771,7 +850,7 @@ mod tests {
         );
         let r = &lines(&buf)[0];
         assert_eq!(r["action"], "click_element");
-        assert_eq!(r["args"]["method"], method.label());
+        assert_eq!(r["args"]["method"], "pointer");
         assert_eq!(
             r["args"]["native_fallback"], "element exposes no activation action",
             "the pointer path records WHY the native action wasn't used: {r}"
@@ -782,18 +861,22 @@ mod tests {
     fn click_element_native_action_records_no_fallback_reason() {
         let buf = Arc::new(Mutex::new(Vec::new()));
         let s = JsonlSink::with_writer(Box::new(Buf(buf.clone())), AuditConfig::default());
-        let method = ClickMethod::NativeAction { actuated: None };
         s.record(
             &Actuation::ClickElement {
                 element: click_el(),
-                method: Some(&method),
+                mode: "native",
+                method: Some("native-action"),
+                native_fallback: None,
+                actuated_id: None,
+                dispatch: "dispatched",
+                confirmation: "dispatch_confirmed",
             },
             &ActuationContext::default(),
             &ok(),
             Duration::from_millis(1),
         );
         let r = &lines(&buf)[0];
-        assert_eq!(r["args"]["method"], method.label());
+        assert_eq!(r["args"]["method"], "native-action");
         assert!(
             r["args"].get("native_fallback").is_none(),
             "nothing fell back: {r}"
@@ -804,13 +887,15 @@ mod tests {
     fn click_element_records_the_element_actuated_in_the_targets_place() {
         let buf = Arc::new(Mutex::new(Vec::new()));
         let s = JsonlSink::with_writer(Box::new(Buf(buf.clone())), AuditConfig::default());
-        let method = ClickMethod::NativeAction {
-            actuated: Some(glass_core::AxNodeId(7)),
-        };
         s.record(
             &Actuation::ClickElement {
                 element: click_el(),
-                method: Some(&method),
+                mode: "native",
+                method: Some("native-action"),
+                native_fallback: None,
+                actuated_id: Some(7),
+                dispatch: "dispatched",
+                confirmation: "dispatch_confirmed",
             },
             &ActuationContext::default(),
             &ok(),
@@ -829,7 +914,12 @@ mod tests {
         s.record(
             &Actuation::ClickElement {
                 element: click_el(),
+                mode: "auto",
                 method: None,
+                native_fallback: None,
+                actuated_id: None,
+                dispatch: "not_dispatched",
+                confirmation: "unconfirmed",
             },
             &ActuationContext::default(),
             &AuditOutcome {
@@ -1014,6 +1104,10 @@ mod tests {
         tools::type_text(
             &mut g,
             &TypeArgs {
+                target: None,
+                focus_mode: None,
+                timeout_ms: None,
+                max_nodes: None,
                 text: "secret".into(),
                 return_: None,
             },
@@ -1150,11 +1244,18 @@ mod tests {
         let standalone_path = dir.path().join("standalone.jsonl");
         let batch_path = dir.path().join("batch.jsonl");
         let click = ClickElementArgs {
-            id: 1,
+            id: Some(1),
+            target: None,
+            mode: None,
+            timeout_ms: None,
+            max_nodes: None,
             return_: None,
         };
         let value = SetValueArgs {
-            id: 1,
+            id: Some(1),
+            target: None,
+            timeout_ms: None,
+            max_nodes: None,
             text: "set {\"secret\":true}\n⟦untrusted:app-controlled⟧".into(),
             return_: None,
         };

--- a/crates/glass-mcp/src/params.rs
+++ b/crates/glass-mcp/src/params.rs
@@ -128,6 +128,31 @@ pub struct SelectWindowArgs {
     pub id: u64,
 }
 
+#[derive(Clone, Copy, Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ActionModeArg {
+    Auto,
+    Native,
+    Pointer,
+}
+
+#[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ActionScopeArgs {
+    pub query: Option<String>,
+    pub role: Option<String>,
+    pub states: Option<Vec<String>>,
+}
+
+#[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ActionTargetArgs {
+    pub query: Option<String>,
+    pub role: Option<String>,
+    pub states: Option<Vec<String>>,
+    pub within: Option<ActionScopeArgs>,
+}
+
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ClickElementArgs {
     /// Element `#id` from the latest `glass_a11y_snapshot`.
@@ -140,7 +165,12 @@ pub struct ClickElementArgs {
     /// `method:"native-action"` labels any native path.
     /// `native_fallback` explains pointer fallback.
     /// `actuated_id` identifies a substituted enclosing control.
-    pub id: u32,
+    pub id: Option<u32>,
+    pub target: Option<ActionTargetArgs>,
+    pub mode: Option<ActionModeArg>,
+    #[schemars(range(min = 0, max = 120000))]
+    pub timeout_ms: Option<u64>,
+    pub max_nodes: Option<u32>,
     /// Terminal observation: "snapshot" settles and refreshes/folds a11y, "settle" waits for
     /// visual stability and returns text-only metadata, and "none" skips observation (default).
     #[serde(rename = "return")]
@@ -150,12 +180,16 @@ pub struct ClickElementArgs {
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct SetValueArgs {
     /// The element `#id` from `glass_a11y_snapshot`.
-    pub id: u32,
+    pub id: Option<u32>,
+    pub target: Option<ActionTargetArgs>,
     /// The value to set. For a text field, the text. For a spin/slider, a number.
     /// For a switch/checkbox/toggle, a boolean (`"true"`/`"false"`/`"on"`/`"off"`/
     /// `"1"`/`"0"`) — idempotent. For a dropdown/combo box, an option label
     /// (case-insensitive); glass opens it and picks that option.
     pub text: String,
+    #[schemars(range(min = 0, max = 120000))]
+    pub timeout_ms: Option<u64>,
+    pub max_nodes: Option<u32>,
     /// Optional observe folded into the result: "snapshot" (wait for the UI to settle, then
     /// fold a fresh a11y tree, also refreshing the snapshot cache), "settle" (waits for visual
     /// stability and returns text-only metadata), or "none" (default).
@@ -302,6 +336,11 @@ pub struct TypeArgs {
     /// focus a field, so click or `glass_click_element` one first. Sent as synthetic
     /// key events, not pasted, so an app's per-keystroke handlers run.
     pub text: String,
+    pub target: Option<ActionTargetArgs>,
+    pub focus_mode: Option<ActionModeArg>,
+    #[schemars(range(min = 0, max = 120000))]
+    pub timeout_ms: Option<u64>,
+    pub max_nodes: Option<u32>,
     /// Terminal observation: "snapshot" settles and refreshes/folds a11y, "settle" waits for
     /// visual stability and returns text-only metadata, and "none" skips observation (default).
     #[serde(rename = "return")]
@@ -896,20 +935,20 @@ mod tests {
     #[test]
     fn click_element_args_parse() {
         let a: ClickElementArgs = serde_json::from_str(r#"{"id":5}"#).unwrap();
-        assert_eq!(a.id, 5);
+        assert_eq!(a.id, Some(5));
     }
 
     #[test]
     fn set_value_args_parse() {
         let a: SetValueArgs = serde_json::from_str(r#"{"id":5,"text":"hi"}"#).unwrap();
-        assert_eq!(a.id, 5);
+        assert_eq!(a.id, Some(5));
         assert_eq!(a.text, "hi");
     }
 
     #[test]
     fn click_element_args_parse_return() {
         let a: ClickElementArgs = serde_json::from_str(r#"{"id":5,"return":"snapshot"}"#).unwrap();
-        assert_eq!(a.id, 5);
+        assert_eq!(a.id, Some(5));
         assert_eq!(a.return_.as_deref(), Some("snapshot"));
         let b: ClickElementArgs = serde_json::from_str(r#"{"id":1}"#).unwrap();
         assert!(b.return_.is_none());
@@ -919,8 +958,170 @@ mod tests {
     fn set_value_args_parse_return() {
         let a: SetValueArgs =
             serde_json::from_str(r#"{"id":2,"text":"hi","return":"settle"}"#).unwrap();
-        assert_eq!(a.id, 2);
+        assert_eq!(a.id, Some(2));
         assert_eq!(a.return_.as_deref(), Some("settle"));
+    }
+
+    #[test]
+    fn click_element_args_parse_id_with_typed_mode() {
+        let a: ClickElementArgs = serde_json::from_str(r#"{"id":42,"mode":"pointer"}"#).unwrap();
+        assert_eq!(a.id, Some(42));
+        assert!(matches!(a.mode, Some(ActionModeArg::Pointer)));
+        assert!(a.target.is_none());
+    }
+
+    #[test]
+    fn click_element_args_parse_semantic_target_controls() {
+        let a: ClickElementArgs = serde_json::from_str(
+            r#"{
+              "target":{"query":"Save account","role":"Button","states":["enabled"],
+                        "within":{"query":"Account","role":"Document"}},
+              "timeout_ms":10000,"max_nodes":0,"mode":"auto","return":"snapshot"
+            }"#,
+        )
+        .unwrap();
+        let target = a.target.as_ref().unwrap();
+        assert_eq!(target.query.as_deref(), Some("Save account"));
+        assert_eq!(target.role.as_deref(), Some("Button"));
+        assert_eq!(
+            target.states.as_deref(),
+            Some(["enabled".to_string()].as_slice())
+        );
+        assert_eq!(
+            target
+                .within
+                .as_ref()
+                .and_then(|scope| scope.query.as_deref()),
+            Some("Account")
+        );
+        assert_eq!(a.timeout_ms, Some(10_000));
+        assert_eq!(a.max_nodes, Some(0));
+        assert!(matches!(a.mode, Some(ActionModeArg::Auto)));
+        assert_eq!(a.return_.as_deref(), Some("snapshot"));
+    }
+
+    #[test]
+    fn set_value_args_parse_semantic_target() {
+        let a: SetValueArgs = serde_json::from_str(
+            r#"{"target":{"query":"Account name","role":"TextField"},"text":"Ada"}"#,
+        )
+        .unwrap();
+        assert!(a.id.is_none());
+        assert_eq!(
+            a.target.as_ref().and_then(|t| t.query.as_deref()),
+            Some("Account name")
+        );
+        assert_eq!(a.text, "Ada");
+    }
+
+    #[test]
+    fn type_args_parse_semantic_target_controls() {
+        let a: TypeArgs = serde_json::from_str(
+            r#"{
+              "target":{"query":"Account name","role":"TextField"},
+              "text":"Ada","focus_mode":"native","timeout_ms":5000
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(
+            a.target.as_ref().and_then(|t| t.role.as_deref()),
+            Some("TextField")
+        );
+        assert!(matches!(a.focus_mode, Some(ActionModeArg::Native)));
+        assert_eq!(a.timeout_ms, Some(5_000));
+    }
+
+    fn json_contains_number(value: &serde_json::Value, key: &str, expected: u64) -> bool {
+        match value {
+            serde_json::Value::Object(object) => {
+                object.get(key).and_then(serde_json::Value::as_u64) == Some(expected)
+                    || object
+                        .values()
+                        .any(|child| json_contains_number(child, key, expected))
+            }
+            serde_json::Value::Array(array) => array
+                .iter()
+                .any(|child| json_contains_number(child, key, expected)),
+            _ => false,
+        }
+    }
+
+    #[test]
+    fn click_element_args_schema_adds_optional_target_mode_and_bounded_timeout() {
+        let click = serde_json::to_value(schemars::schema_for!(ClickElementArgs)).unwrap();
+        let click_properties = click["properties"].as_object().unwrap();
+        for field in ["id", "target", "mode", "timeout_ms", "max_nodes", "return"] {
+            assert!(
+                click_properties.contains_key(field),
+                "missing click {field}"
+            );
+        }
+        assert!(
+            !click["required"]
+                .as_array()
+                .is_some_and(|required| required.iter().any(|name| name == "id"))
+        );
+
+        let set_value = serde_json::to_value(schemars::schema_for!(SetValueArgs)).unwrap();
+        let set_properties = set_value["properties"].as_object().unwrap();
+        for field in ["id", "target", "text", "timeout_ms", "max_nodes", "return"] {
+            assert!(
+                set_properties.contains_key(field),
+                "missing set_value {field}"
+            );
+        }
+        assert!(
+            !set_value["required"]
+                .as_array()
+                .is_some_and(|required| required.iter().any(|name| name == "id"))
+        );
+
+        let type_args = serde_json::to_value(schemars::schema_for!(TypeArgs)).unwrap();
+        let type_properties = type_args["properties"].as_object().unwrap();
+        for field in [
+            "text",
+            "target",
+            "focus_mode",
+            "timeout_ms",
+            "max_nodes",
+            "return",
+        ] {
+            assert!(type_properties.contains_key(field), "missing type {field}");
+        }
+
+        for timeout in [
+            &click_properties["timeout_ms"],
+            &set_properties["timeout_ms"],
+            &type_properties["timeout_ms"],
+        ] {
+            assert!(json_contains_number(timeout, "maximum", 120_000));
+        }
+
+        let mode_schema = serde_json::to_value(schemars::schema_for!(ActionModeArg)).unwrap();
+        assert_eq!(
+            mode_schema["enum"],
+            serde_json::json!(["auto", "native", "pointer"])
+        );
+    }
+
+    #[test]
+    fn action_schema_keeps_semantic_structs_embedded_in_existing_variants() {
+        let schema = serde_json::to_value(schemars::schema_for!(Action)).unwrap();
+        let encoded = schema.to_string();
+        for definition in ["ClickElementArgs", "SetValueArgs", "TypeArgs"] {
+            assert!(
+                encoded.contains(definition),
+                "missing {definition}: {encoded}"
+            );
+        }
+        assert!(
+            encoded.contains("target"),
+            "missing semantic target fields: {encoded}"
+        );
+        assert!(
+            encoded.contains("focus_mode"),
+            "missing targeted type mode: {encoded}"
+        );
     }
 
     #[test]

--- a/crates/glass-mcp/src/params.rs
+++ b/crates/glass-mcp/src/params.rs
@@ -332,9 +332,9 @@ pub struct ScrollArgs {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct TypeArgs {
-    /// Text to type into whatever currently has keyboard focus — this tool does not
-    /// focus a field, so click or `glass_click_element` one first. Sent as synthetic
-    /// key events, not pasted, so an app's per-keystroke handlers run.
+    /// Text to type. When `target` is omitted, text is sent to the current keyboard focus.
+    /// When `target` is supplied, Glass resolves and focuses that element before typing.
+    /// Sent as synthetic key events, not pasted, so an app's per-keystroke handlers run.
     pub text: String,
     pub target: Option<ActionTargetArgs>,
     pub focus_mode: Option<ActionModeArg>,
@@ -1029,6 +1029,34 @@ mod tests {
         );
         assert!(matches!(a.focus_mode, Some(ActionModeArg::Native)));
         assert_eq!(a.timeout_ms, Some(5_000));
+    }
+
+    #[test]
+    fn type_args_text_schema_distinguishes_targeted_and_untargeted_focus() {
+        let schema = serde_json::to_value(schemars::schema_for!(TypeArgs)).unwrap();
+        let description = schema["properties"]["text"]["description"]
+            .as_str()
+            .expect("text has a public schema description");
+        assert!(
+            description.contains("When `target` is omitted"),
+            "{description}"
+        );
+        assert!(
+            description.contains("current keyboard focus"),
+            "{description}"
+        );
+        assert!(
+            description.contains("When `target` is supplied"),
+            "{description}"
+        );
+        assert!(
+            description.contains("resolves and focuses"),
+            "{description}"
+        );
+        assert!(
+            !description.contains("does not focus a field"),
+            "{description}"
+        );
     }
 
     fn json_contains_number(value: &serde_json::Value, key: &str, expected: u64) -> bool {

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -1892,7 +1892,11 @@ mod tests {
             .expect("explicit snapshot");
         let automatic = server
             .glass_click_element(Parameters(ClickElementArgs {
-                id: 1,
+                id: Some(1),
+                target: None,
+                mode: None,
+                timeout_ms: None,
+                max_nodes: None,
                 return_: Some("snapshot".into()),
             }))
             .await

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -605,7 +605,7 @@ impl GlassServer {
         &self,
         Parameters(a): Parameters<TypeArgs>,
     ) -> Result<CallToolResult, McpError> {
-        self.run("glass_type", tool_effect("glass_type"), move |g| {
+        self.run_batch("glass_type", tool_effect("glass_type"), move |g| {
             tools::type_text(g, &a)
         })
         .await
@@ -899,7 +899,7 @@ impl GlassServer {
         &self,
         Parameters(a): Parameters<ClickElementArgs>,
     ) -> Result<CallToolResult, McpError> {
-        self.run(
+        self.run_batch(
             "glass_click_element",
             tool_effect("glass_click_element"),
             move |g| tools::click_element(g, &a),
@@ -941,7 +941,7 @@ impl GlassServer {
         &self,
         Parameters(a): Parameters<SetValueArgs>,
     ) -> Result<CallToolResult, McpError> {
-        self.run(
+        self.run_batch(
             "glass_set_value",
             tool_effect("glass_set_value"),
             move |g| tools::set_value(g, &a),
@@ -1924,6 +1924,65 @@ mod tests {
         assert_eq!(r.is_error, Some(true));
         assert_eq!(r.content.len(), 2);
         assert!(first_text(&r).contains("step_failed"));
+    }
+
+    #[tokio::test]
+    async fn semantic_standalone_endpoints_use_structured_batch_transport() {
+        const SENTINEL: &str = "SERVER_TYPE_PAYLOAD_SENTINEL_219bb7";
+        let server = GlassServer::new(
+            crate::boot(None),
+            crate::audit::report_from_config(None, |_| None),
+        );
+        let click_args: ClickElementArgs =
+            serde_json::from_str(r#"{"target":{"role":"Button"},"timeout_ms":0}"#).unwrap();
+        let set_args: SetValueArgs = serde_json::from_str(
+            r#"{"target":{"role":"TextField"},"text":"SERVER_SET_PAYLOAD_SENTINEL","timeout_ms":0}"#,
+        )
+        .unwrap();
+        let type_args: TypeArgs = serde_json::from_value(serde_json::json!({
+            "target": {"role": "TextField"},
+            "text": SENTINEL,
+            "timeout_ms": 0,
+        }))
+        .unwrap();
+
+        for (tool, result) in [
+            (
+                "glass_click_element",
+                server
+                    .glass_click_element(Parameters(click_args))
+                    .await
+                    .unwrap(),
+            ),
+            (
+                "glass_set_value",
+                server.glass_set_value(Parameters(set_args)).await.unwrap(),
+            ),
+            (
+                "glass_type",
+                server.glass_type(Parameters(type_args)).await.unwrap(),
+            ),
+        ] {
+            assert_eq!(result.is_error, Some(true));
+            let envelope: serde_json::Value =
+                serde_json::from_str(&first_text(&result)).expect("structured semantic error");
+            assert_eq!(envelope["ok"], false);
+            assert_eq!(envelope["tool"], tool);
+            assert!(envelope["error"]["code"].as_str().is_some());
+            assert!(envelope["error"]["summary"].as_str().is_some());
+            assert!(
+                result
+                    .content
+                    .iter()
+                    .filter_map(|content| content.as_text())
+                    .all(|text| !text.text.contains(SENTINEL))
+            );
+        }
+    }
+
+    #[test]
+    fn semantic_transport_keeps_the_tool_registry_count_unchanged() {
+        assert_eq!(registered_tools().len(), 31);
     }
 
     #[test]

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -586,9 +586,12 @@ impl GlassServer {
             destructive_hint = false,
             open_world_hint = false
         ),
-        description = "Type a string of text into the focused window. Does not focus anything \
-                       itself — click the field first (glass_click_element, or glass_click), or \
-                       the text goes wherever focus already was. Sent as individual keystrokes, \
+        description = "Type text once. Without `target`, this preserves focused-window typing and \
+                       sends text wherever focus already is. With `target`, Glass resolves one \
+                       fresh unique semantic element, focuses it by `focus_mode` auto (default), \
+                       native, or pointer, confirms focus, then types once. Unconfirmed focus never types \
+                       and never tries another focus path. Selector timeout defaults to 10 seconds; \
+                       `max_nodes` bounds each fresh accessibility read. Sent as individual keystrokes, \
                        not a paste, so per-key handlers, autocomplete and validation all run; a \
                        newline in `text` does not press Return, so send that as a separate \
                        glass_key. Prefer glass_set_value for a field the a11y tree exposes: it \
@@ -876,7 +879,11 @@ impl GlassServer {
             destructive_hint = false,
             open_world_hint = false
         ),
-        description = "Click an element by its #id from glass_a11y_snapshot (actuates via the \
+        description = "Click exactly one `id` or `target`. A semantic target resolves fresh and \
+                       uniquely within one selector timeout (10 seconds by default); mode auto \
+                       (default), native, or pointer selects the action path. Pointer waits for \
+                       two-sample stability and reports every actionability verdict. ID targets remain immediate. \
+                       Glass never retries after possible dispatch. An id from glass_a11y_snapshot actuates via the \
                        platform's native accessibility action when the element exposes one — \
                        works even when it's occluded or scrolled off-screen — else falls back \
                        to a synthetic pointer click at the center of its bounds; the result's \
@@ -913,8 +920,10 @@ impl GlassServer {
             destructive_hint = false,
             open_world_hint = false
         ),
-        description = "Set an editable element's value — pick the element's #id from \
-                       glass_a11y_snapshot. Where the platform can write the value directly this is \
+        description = "Set exactly one editable `id` or `target` and require backend confirmation. \
+                       A semantic target resolves fresh and uniquely within one selector timeout \
+                       (10 seconds by default); `max_nodes` bounds each fresh read. An id may come \
+                       from glass_a11y_snapshot and remains immediate. Where the platform can write the value directly this is \
                        instant and takes no keystrokes; where it has to be typed, glass taps the \
                        element, clears it and types, then reads the element back to confirm — up to \
                        three accessibility reads, since a field may commit a frame or two later. \
@@ -929,7 +938,7 @@ impl GlassServer {
                        this backend knows about that. A separate \
                        error says the text WAS typed but the write could not be confirmed — the \
                        read-back failed, or could not tell which element now holds it. Do NOT write \
-                       again on that one: the keystrokes already went out, and re-snapshotting is \
+                       again on that one: post-write uncertainty is terminal because the keystrokes already went out, and re-snapshotting is \
                        how you see where they landed. \
                        Optional `return`: \"snapshot\" settles the UI then folds a fresh a11y \
                        tree into the result (and refreshes the snapshot cache); \"settle\" waits \
@@ -1114,9 +1123,10 @@ impl GlassServer {
             open_world_hint = false
         ),
         description = "Prefer glass_do whenever at least two upcoming actions or verification waits \
-                       are already known. Typical form flow: take one fresh glass_a11y_snapshot, \
-                       retain the needed ids, then run set_value, wait_for_element, click_element, \
-                       and wait_for_element here in one ordered call. Use standalone tools only when \
+                       are already known. Typical form flow: give each unique intended target directly \
+                       to set_value or click_element, then run set_value, wait_for_element, click_element, \
+                       and wait_for_element here in one ordered call. Use glass_find_elements when \
+                       candidates need inspection and glass_a11y_snapshot for broad structure. Use standalone tools only when \
                        the next step depends on newly observed state. Inspect the structured outcomes \
                        before recovery. Run fixed static ordered actions in one call: click, move, drag, scroll, type, \
                        key, settle, click_element, set_value, wait_for_element, scroll_to_element. \
@@ -1150,20 +1160,24 @@ const SERVER_INSTRUCTIONS: &str = "glass gives you a build → see → interact 
      app — no app integration needed. One active session; tools target it implicitly; \
      choose a backend at glass_start (defaults to the host; see the `backend` param). \
      glass_start launches the app and captures its logs (glass_logs for stdout/stderr).\n\n\
-     SEE AND ADDRESS THE UI CHEAPLY FIRST — the low-token default. When the target is approximate, \
-     duplicated, or not yet identified, call glass_find_elements first: it returns a small ranked \
-     set of actionable ids and context from a fresh accessibility read. Use glass_a11y_snapshot for \
-     broad structural inspection, and glass_wait_for_element when one precise known condition must \
-     become true. Retain returned ids only until the UI changes. Prefer this semantic path over \
+     SEE AND ADDRESS THE UI CHEAPLY FIRST — the low-token default. Give one unique intended target \
+     directly to glass_click_element, glass_set_value, or targeted glass_type so it resolves fresh \
+     immediately before acting. When a target is approximate, duplicated, or not yet identified, \
+     call glass_find_elements to inspect a small ranked candidate set. Use glass_a11y_snapshot for \
+     broad structural diagnosis, and glass_wait_for_element when one precise condition must become \
+     true. Prefer this semantic path over \
      screenshots and pixel-hunting whenever it works.\n\n\
      BATCH KNOWN WORK: Prefer glass_do whenever at least two upcoming actions or verification waits \
-     are already known. Typical form flow: take one fresh glass_a11y_snapshot, retain the needed ids, \
-     then run set_value, wait_for_element, click_element, and wait_for_element in one ordered call. \
+     are already known. Typical form flow: give each unique intended target directly to set_value or \
+     click_element, then run set_value, wait_for_element, click_element, and wait_for_element in one \
+     ordered call. Use glass_find_elements when candidates need inspection and \
+     glass_a11y_snapshot for broad structure. \
      Use standalone tools only when the next step depends on newly observed state. Inspect the \
      structured outcomes before recovery.\n\n\
-     ADDRESS RETURNED IDS DIRECTLY: glass_click_element clicks one, glass_set_value writes an \
-     editable element's value, and glass_wait_for_element verifies semantic transition completion, \
-     including exact editable text with value.\n\n\
+     ACT ON ONE TARGET: glass_click_element clicks one id or fresh unique target, glass_set_value \
+     writes one id or fresh unique editable target with confirmation, and targeted glass_type \
+     focuses, confirms, then types once. Existing ids remain immediate. glass_wait_for_element \
+     verifies semantic transition completion, including exact editable text with value.\n\n\
      PIXELS ARE THE FALLBACK — for a canvas/black-box app with no tree (glass_a11y_snapshot \
      errors there): glass_screenshot to see it, then glass_click / glass_type / glass_key / \
      glass_scroll / glass_drag (glass_gesture for multi-touch where supported) to interact. \
@@ -1751,8 +1765,10 @@ mod tests {
             "glass_do must lead with when to choose it: {description}"
         );
         for required in [
-            "one fresh glass_a11y_snapshot",
+            "give each unique intended target directly",
             "set_value, wait_for_element, click_element, and wait_for_element",
+            "glass_find_elements when candidates need inspection",
+            "glass_a11y_snapshot for broad structure",
             "Use standalone tools only when the next step depends on newly observed state",
             "Inspect the structured outcomes before recovery",
         ] {
@@ -2042,8 +2058,145 @@ mod tests {
     }
 
     #[test]
-    fn semantic_transport_keeps_the_tool_registry_count_unchanged() {
-        assert_eq!(registered_tools().len(), 31);
+    fn semantic_transport_keeps_the_exact_tool_registry_unchanged() {
+        let expected = [
+            "glass_a11y_marks",
+            "glass_a11y_snapshot",
+            "glass_baseline_save",
+            "glass_capabilities",
+            "glass_click",
+            "glass_click_element",
+            "glass_clipboard_get",
+            "glass_clipboard_set",
+            "glass_diff",
+            "glass_do",
+            "glass_doctor",
+            "glass_drag",
+            "glass_find_elements",
+            "glass_gesture",
+            "glass_key",
+            "glass_list_windows",
+            "glass_logs",
+            "glass_move",
+            "glass_screenshot",
+            "glass_scroll",
+            "glass_scroll_to_element",
+            "glass_select_window",
+            "glass_set_value",
+            "glass_start",
+            "glass_stop",
+            "glass_type",
+            "glass_wait_for_element",
+            "glass_wait_for_log",
+            "glass_wait_for_region",
+            "glass_wait_stable",
+            "glass_window",
+        ]
+        .into_iter()
+        .map(str::to_owned)
+        .collect::<BTreeSet<_>>();
+        assert_eq!(registered_tools(), expected);
+    }
+
+    #[test]
+    fn semantic_action_registry_and_reference_publish_the_complete_contract() {
+        let params = registered_params();
+        assert!(params["glass_click_element"].contains("id"));
+        assert!(params["glass_set_value"].contains("id"));
+        for field in ["target", "timeout_ms", "max_nodes"] {
+            assert!(params["glass_click_element"].contains(field));
+            assert!(params["glass_set_value"].contains(field));
+            assert!(params["glass_type"].contains(field));
+        }
+        assert!(params["glass_click_element"].contains("mode"));
+        assert!(params["glass_type"].contains("focus_mode"));
+
+        for required in [
+            "target.query",
+            "target.role",
+            "target.states",
+            "target.within",
+            "no_match",
+            "ambiguous_target",
+            "ambiguous_scope",
+            "incomplete_tree",
+            "unproven_selector_state",
+            "not_actionable",
+            "unstable_target",
+            "focus_unconfirmed",
+            "unsupported_mode",
+            "action_deadline_exceeded",
+            "sequence_deadline_exceeded",
+        ] {
+            assert!(
+                TOOLS_MD.contains(required),
+                "canonical tool reference missing {required:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn semantic_action_descriptions_explain_resolution_dispatch_and_confirmation() {
+        let descriptions: BTreeMap<String, String> = GlassServer::tool_router()
+            .list_all()
+            .into_iter()
+            .map(|tool| {
+                (
+                    tool.name.to_string(),
+                    tool.description.unwrap_or_default().to_string(),
+                )
+            })
+            .collect();
+        let click = &descriptions["glass_click_element"];
+        for required in [
+            "exactly one",
+            "fresh",
+            "uniquely",
+            "auto",
+            "native",
+            "pointer",
+            "10 seconds",
+            "stability",
+            "actionability",
+            "ID targets remain immediate",
+            "never retries after possible dispatch",
+        ] {
+            assert!(
+                click.contains(required),
+                "click description missing {required:?}"
+            );
+        }
+        let set_value = &descriptions["glass_set_value"];
+        for required in [
+            "exactly one",
+            "fresh",
+            "uniquely",
+            "backend confirmation",
+            "10 seconds",
+            "post-write uncertainty is terminal",
+        ] {
+            assert!(
+                set_value.contains(required),
+                "set-value description missing {required:?}"
+            );
+        }
+        let type_text = &descriptions["glass_type"];
+        for required in [
+            "Without `target`",
+            "focused-window typing",
+            "fresh",
+            "auto",
+            "native",
+            "pointer",
+            "confirms focus",
+            "types once",
+            "Unconfirmed focus never types",
+        ] {
+            assert!(
+                type_text.contains(required),
+                "type description missing {required:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -1980,6 +1980,67 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn targeted_type_snapshot_resource_never_persists_submitted_or_coincident_text() {
+        const SENTINEL: &str = "SERVER_TARGETED_TYPE_SNAPSHOT_SENTINEL_76b1";
+        let output = crate::tools::semantic_action::tests::targeted_type_snapshot_output_for_server(
+            SENTINEL,
+        );
+        assert!(output.text_bytes() > crate::output_policy::MAX_TEXT_BYTES);
+        let root = tempfile::tempdir().unwrap();
+        let store = ArtifactStore::for_test(root.path(), 1 << 20).unwrap();
+        let server = GlassServer::new_with_store(
+            crate::boot(None),
+            crate::audit::report_from_config(None, |_| None),
+            store,
+        )
+        .unwrap();
+        let result = server
+            .run_test_outcome(ToolCallOutcome {
+                tool: "glass_type",
+                effect: ToolEffect::MayMutate,
+                is_error: false,
+                target_access: TargetAccess::NoActiveTarget,
+                output,
+            })
+            .await
+            .unwrap();
+        assert_ne!(result.is_error, Some(true));
+        assert!(
+            result
+                .content
+                .iter()
+                .filter_map(|content| content.as_text())
+                .map(|text| text.text.len())
+                .sum::<usize>()
+                <= crate::output_policy::MAX_TEXT_BYTES
+        );
+        assert!(
+            result
+                .content
+                .iter()
+                .filter_map(|content| content.as_text())
+                .all(|text| !text.text.contains(SENTINEL))
+        );
+        let links = result
+            .content
+            .iter()
+            .filter_map(|content| content.as_resource_link())
+            .collect::<Vec<_>>();
+        assert!(
+            !links.is_empty(),
+            "oversized targeted type snapshot externalized"
+        );
+        for link in links {
+            let resource = server.read_resource_for_test(&link.uri).unwrap();
+            assert_eq!(resource.contents.len(), 1);
+            let ResourceContents::TextResourceContents { text, .. } = &resource.contents[0] else {
+                panic!("expected text resource")
+            };
+            assert!(!text.contains(SENTINEL));
+        }
+    }
+
     #[test]
     fn semantic_transport_keeps_the_tool_registry_count_unchanged() {
         assert_eq!(registered_tools().len(), 31);

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -300,6 +300,11 @@ impl ContextualError {
         self
     }
 
+    pub fn scrub_message(mut self) -> Self {
+        self.message = self.safe_summary.into();
+        self
+    }
+
     pub fn sequence_deadline(message: String) -> Self {
         Self {
             code: "sequence_deadline_exceeded",
@@ -691,6 +696,7 @@ fn resolve_return_with(
     glass: &mut Glass,
     ret: Option<&str>,
     context: ToolContext,
+    include_application_text: bool,
 ) -> Result<ReturnObservation, ContextualError> {
     if !context.allow_wait && matches!(ret, Some("settle" | "snapshot")) {
         let category = if context.owner == Some(glass_core::Whose::Caller) {
@@ -753,9 +759,13 @@ fn resolve_return_with(
             }
             // Reuse the session's current limits so a fold after a raised/unbounded snapshot
             // isn't silently re-truncated to the default cap.
-            let tree = glass
+            let mut tree = glass
                 .a11y_resnapshot(context.deadline)
                 .map_err(|e| ContextualError::from_core(e, context))?;
+            if !include_application_text {
+                tree.subject = None;
+                scrub_ax_text(&mut tree.root);
+            }
             // Same shape as `a11y_snapshot`: the app-derived outline stays untrusted-wrapped;
             // glass's own steers are separate trusted blocks, not baked into that body.
             let body = glass_core::outline::render_compact(&tree);
@@ -776,6 +786,16 @@ fn resolve_return_with(
     }
 }
 
+fn scrub_ax_text(node: &mut glass_core::AxNode) {
+    node.raw_role.clear();
+    node.name = None;
+    node.description = None;
+    node.value = None;
+    for child in &mut node.children {
+        scrub_ax_text(child);
+    }
+}
+
 pub(crate) fn semantic_return_error(
     tool: &'static str,
     outcome: &glass_core::SemanticActionOutcome,
@@ -786,13 +806,23 @@ pub(crate) fn semantic_return_error(
     let mut contents = disclosure.0.into_iter();
     if let Some(OutContent::Envelope(envelope)) = contents.next() {
         let mut result = envelope.result;
+        let (_, side_effects_may_have_occurred) =
+            semantic_action::mutation_provenance(outcome.focus.as_ref(), outcome.action.dispatch);
         result["dispatch"] = json!(outcome.action.dispatch.as_str());
-        result["side_effects_may_have_occurred"] = json!(true);
+        result["side_effects_may_have_occurred"] = json!(side_effects_may_have_occurred);
         result["retry"] = json!("do_not_retry");
         error.result = Some(result);
     }
     error.siblings = contents.collect();
-    error.after_dispatch().annotate(annotation)
+    let (bound_dispatch, side_effects_may_have_occurred) =
+        semantic_action::mutation_provenance(outcome.focus.as_ref(), outcome.action.dispatch);
+    error = if side_effects_may_have_occurred {
+        error.after_dispatch()
+    } else {
+        error.bound_dispatch = Some(bound_dispatch);
+        error
+    };
+    error.annotate(annotation)
 }
 
 pub fn click_element(glass: &mut Glass, a: &ClickElementArgs) -> BatchToolResult {
@@ -831,18 +861,20 @@ pub(crate) fn click_element_with(
         allow_wait: outcome.bound.allow_wait,
     };
     let (observed, extra, timed_out_by) =
-        resolve_return_with(glass, a.return_.as_deref(), action_context).map_err(|error| {
-            if semantic {
-                semantic_return_error(
-                    "glass_click_element",
-                    &outcome,
-                    error,
-                    "click was dispatched; return observe failed",
-                )
-            } else {
-                error.after_dispatch()
-            }
-        })?;
+        resolve_return_with(glass, a.return_.as_deref(), action_context, true).map_err(
+            |error| {
+                if semantic {
+                    semantic_return_error(
+                        "glass_click_element",
+                        &outcome,
+                        error,
+                        "click was dispatched; return observe failed",
+                    )
+                } else {
+                    error.after_dispatch()
+                }
+            },
+        )?;
     let output = if semantic {
         semantic_action::success_output("glass_click_element", &outcome, observed, extra)
     } else {
@@ -897,11 +929,14 @@ pub(crate) fn set_value_with(
             } else {
                 let message = error.to_string();
                 match error.source {
-                    Some(source) => ContextualError::from_caller_bound(source, context),
+                    Some(source) => {
+                        ContextualError::from_caller_bound(source, context).scrub_message()
+                    }
                     None => ContextualError::from_caller_bound(
                         glass_core::GlassError::Backend(message),
                         context,
-                    ),
+                    )
+                    .scrub_message(),
                 }
             }
         })?;
@@ -911,18 +946,20 @@ pub(crate) fn set_value_with(
         allow_wait: outcome.bound.allow_wait,
     };
     let (observed, extra, timed_out_by) =
-        resolve_return_with(glass, a.return_.as_deref(), action_context).map_err(|error| {
-            if semantic {
-                semantic_return_error(
-                    "glass_set_value",
-                    &outcome,
-                    error,
-                    "value was written; return observe failed",
-                )
-            } else {
-                error.after_dispatch()
-            }
-        })?;
+        resolve_return_with(glass, a.return_.as_deref(), action_context, true).map_err(
+            |error| {
+                if semantic {
+                    semantic_return_error(
+                        "glass_set_value",
+                        &outcome,
+                        error,
+                        "set-value return observe failed",
+                    )
+                } else {
+                    error.after_dispatch()
+                }
+            },
+        )?;
     let output = if semantic {
         semantic_action::success_output("glass_set_value", &outcome, observed, extra)
     } else {

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -7,8 +7,8 @@ use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use glass_core::{
-    AppSpec, BoundDispatch, Glass, GlassError, MarkLabel, MouseButton, WindowGeometry, WindowHint,
-    WindowId, WindowOp, frame_to_webp,
+    AppSpec, BoundDispatch, Glass, MarkLabel, MouseButton, WindowGeometry, WindowHint, WindowId,
+    WindowOp, frame_to_webp,
 };
 use serde::Serialize;
 use serde_json::json;
@@ -22,11 +22,15 @@ pub type ToolResult = Result<ToolOutput, String>;
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct ToolContext {
     pub deadline: glass_core::Deadline,
+    pub owner: Option<glass_core::Whose>,
+    pub allow_wait: bool,
 }
 
 impl ToolContext {
     pub const UNBOUNDED: Self = Self {
         deadline: glass_core::Deadline::UNBOUNDED,
+        owner: None,
+        allow_wait: true,
     };
 }
 
@@ -54,17 +58,29 @@ impl ContextualOutput {
 
 #[derive(Debug)]
 pub(crate) struct ContextualError {
+    pub code: &'static str,
     pub message: String,
     pub category: SafeErrorCategory,
     pub safe_summary: &'static str,
     pub sequence_deadline_exceeded: bool,
     pub bound_dispatch: Option<BoundDispatch>,
+    pub result: Option<serde_json::Value>,
+    pub siblings: Vec<OutContent>,
     post_write: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum SafeErrorCategory {
+    NoMatch,
+    AmbiguousTarget,
+    AmbiguousScope,
+    IncompleteTree,
+    UnprovenSelectorState,
+    NotActionable,
+    UnstableTarget,
+    FocusUnconfirmed,
+    UnsupportedMode,
     NoActiveSession,
     StaleElement,
     NotEditable,
@@ -108,6 +124,15 @@ impl SafeErrorCategory {
 
     fn summary(self) -> &'static str {
         match self {
+            Self::NoMatch => "semantic target was not found",
+            Self::AmbiguousTarget => "semantic target is ambiguous",
+            Self::AmbiguousScope => "semantic scope is ambiguous",
+            Self::IncompleteTree => "accessibility tree is incomplete",
+            Self::UnprovenSelectorState => "selector state could not be proven",
+            Self::NotActionable => "semantic target is not actionable",
+            Self::UnstableTarget => "semantic target is unstable",
+            Self::FocusUnconfirmed => "target focus was not confirmed",
+            Self::UnsupportedMode => "semantic action mode is unsupported",
             Self::NoActiveSession => "no active session",
             Self::StaleElement => "element is stale or missing",
             Self::NotEditable => "element is not editable",
@@ -119,6 +144,31 @@ impl SafeErrorCategory {
             Self::ActionDeadlineExceeded => "action deadline exceeded",
             Self::SequenceDeadlineExceeded => "sequence deadline exceeded",
             Self::Other => "action execution failed",
+        }
+    }
+
+    fn code(self) -> &'static str {
+        match self {
+            Self::NoMatch => "no_match",
+            Self::AmbiguousTarget => "ambiguous_target",
+            Self::AmbiguousScope => "ambiguous_scope",
+            Self::IncompleteTree => "incomplete_tree",
+            Self::UnprovenSelectorState => "unproven_selector_state",
+            Self::NotActionable => "not_actionable",
+            Self::UnstableTarget => "unstable_target",
+            Self::FocusUnconfirmed => "focus_unconfirmed",
+            Self::UnsupportedMode => "unsupported_mode",
+            Self::NoActiveSession => "no_active_session",
+            Self::StaleElement => "stale_element",
+            Self::NotEditable => "not_editable",
+            Self::InvalidValue => "invalid_value",
+            Self::OptionNotFound => "option_not_found",
+            Self::UnsupportedAccessibility => "unsupported_accessibility",
+            Self::PermissionDenied => "permission_denied",
+            Self::TransportFailure => "transport_failure",
+            Self::ActionDeadlineExceeded => "action_deadline_exceeded",
+            Self::SequenceDeadlineExceeded => "sequence_deadline_exceeded",
+            Self::Other => "action_failed",
         }
     }
 
@@ -142,12 +192,19 @@ impl SafeErrorCategory {
 
 impl ContextualError {
     pub fn validation(message: String) -> Self {
+        Self::validation_with_code("invalid_argument", message)
+    }
+
+    pub fn validation_with_code(code: &'static str, message: String) -> Self {
         Self {
+            code,
             message,
             category: SafeErrorCategory::Other,
             safe_summary: "action validation failed",
             sequence_deadline_exceeded: false,
             bound_dispatch: Some(BoundDispatch::NotDispatched),
+            result: None,
+            siblings: Vec::new(),
             post_write: false,
         }
     }
@@ -167,6 +224,7 @@ impl ContextualError {
             .then_some(BoundDispatch::NotDispatched)
         });
         Self {
+            code: category.code(),
             message: error.to_string(),
             category,
             safe_summary: if post_write {
@@ -176,16 +234,23 @@ impl ContextualError {
             },
             sequence_deadline_exceeded: error.bound_owner() == Some(glass_core::Whose::Caller),
             bound_dispatch,
+            result: None,
+            siblings: Vec::new(),
             post_write,
         }
     }
 
-    pub fn from_core(error: glass_core::GlassError, _context: ToolContext) -> Self {
-        Self::from_error(error)
+    pub fn from_core(error: glass_core::GlassError, context: ToolContext) -> Self {
+        let out = Self::from_error(error);
+        if context.owner == Some(glass_core::Whose::Caller) && context.deadline.has_passed() {
+            out.after_sequence_deadline()
+        } else {
+            out
+        }
     }
 
-    pub fn from_caller_bound(error: glass_core::GlassError, _context: ToolContext) -> Self {
-        Self::from_error(error)
+    pub fn from_caller_bound(error: glass_core::GlassError, context: ToolContext) -> Self {
+        Self::from_core(error, context)
     }
 
     pub fn from_resolved_bound(
@@ -195,11 +260,12 @@ impl ContextualError {
     ) -> Self {
         let bounded = error.bound().is_some();
         let mut out = Self::from_error(error);
-        if context.deadline.has_passed() {
+        if context.owner == Some(glass_core::Whose::Caller) && context.deadline.has_passed() {
             return out.after_sequence_deadline();
         }
         if whose == glass_core::Whose::Callee && bounded {
             out.category = SafeErrorCategory::ActionDeadlineExceeded;
+            out.code = out.category.code();
             out.safe_summary = if out.post_write {
                 SafeErrorCategory::ActionDeadlineExceeded.post_write_summary()
             } else {
@@ -219,6 +285,7 @@ impl ContextualError {
     /// operation's safe detail or its dispatch verdict.
     pub fn after_sequence_deadline(mut self) -> Self {
         self.category = SafeErrorCategory::SequenceDeadlineExceeded;
+        self.code = self.category.code();
         self.safe_summary = if self.post_write {
             SafeErrorCategory::SequenceDeadlineExceeded.post_write_summary()
         } else {
@@ -235,11 +302,14 @@ impl ContextualError {
 
     pub fn sequence_deadline(message: String) -> Self {
         Self {
+            code: "sequence_deadline_exceeded",
             message,
             category: SafeErrorCategory::SequenceDeadlineExceeded,
             safe_summary: SafeErrorCategory::SequenceDeadlineExceeded.summary(),
             sequence_deadline_exceeded: true,
             bound_dispatch: None,
+            result: None,
+            siblings: Vec::new(),
             post_write: false,
         }
     }
@@ -252,12 +322,50 @@ type ReturnObservation = (
     Option<glass_core::Whose>,
 );
 
-fn erase_context(result: ContextualToolResult) -> ToolResult {
-    result.map(|o| o.output).map_err(|e| e.message)
-}
-
 /// Batch tool result: either outcome may carry structured MCP content.
 pub(crate) type BatchToolResult = Result<ToolOutput, ToolOutput>;
+
+pub(crate) fn erase_semantic_context(
+    tool: &'static str,
+    result: ContextualToolResult,
+) -> BatchToolResult {
+    result.map(|output| output.output).map_err(|error| {
+        let ContextualError {
+            code,
+            category,
+            safe_summary,
+            bound_dispatch,
+            result,
+            mut siblings,
+            ..
+        } = error;
+        let mut envelope = json!({
+            "ok": false,
+            "tool": tool,
+            "error": {
+                "code": code,
+                "category": category,
+                "summary": safe_summary,
+            },
+        });
+        envelope["result"] = result.unwrap_or_else(|| {
+            let dispatch = match bound_dispatch {
+                Some(BoundDispatch::NotDispatched) => "not_dispatched",
+                Some(BoundDispatch::MayHaveDispatched) | None => "may_have_dispatched",
+            };
+            json!({
+                "dispatch": dispatch,
+                "side_effects_may_have_occurred": dispatch != "not_dispatched",
+            })
+        });
+        if !siblings.is_empty() {
+            envelope["content_blocks"] = json!((1..=siblings.len()).collect::<Vec<usize>>());
+        }
+        let mut contents = vec![OutContent::trusted_error(envelope.to_string())];
+        contents.append(&mut siblings);
+        ToolOutput(contents)
+    })
+}
 
 fn geometry_value(g: &WindowGeometry) -> serde_json::Value {
     json!({ "x": g.x, "y": g.y, "width": g.width, "height": g.height })
@@ -584,6 +692,24 @@ fn resolve_return_with(
     ret: Option<&str>,
     context: ToolContext,
 ) -> Result<ReturnObservation, ContextualError> {
+    if !context.allow_wait && matches!(ret, Some("settle" | "snapshot")) {
+        let category = if context.owner == Some(glass_core::Whose::Caller) {
+            SafeErrorCategory::SequenceDeadlineExceeded
+        } else {
+            SafeErrorCategory::ActionDeadlineExceeded
+        };
+        return Err(ContextualError {
+            code: category.code(),
+            message: category.summary().into(),
+            category,
+            safe_summary: category.summary(),
+            sequence_deadline_exceeded: category == SafeErrorCategory::SequenceDeadlineExceeded,
+            bound_dispatch: Some(BoundDispatch::NotDispatched),
+            result: None,
+            siblings: Vec::new(),
+            post_write: false,
+        });
+    }
     match ret {
         None | Some("none") => Ok((None, vec![], None)),
         Some("settle") => {
@@ -650,8 +776,30 @@ fn resolve_return_with(
     }
 }
 
-pub fn click_element(glass: &mut Glass, a: &ClickElementArgs) -> ToolResult {
-    erase_context(click_element_with(glass, a, ToolContext::UNBOUNDED))
+pub(crate) fn semantic_return_error(
+    tool: &'static str,
+    outcome: &glass_core::SemanticActionOutcome,
+    mut error: ContextualError,
+    annotation: &str,
+) -> ContextualError {
+    let disclosure = semantic_action::success_output(tool, outcome, None, Vec::new());
+    let mut contents = disclosure.0.into_iter();
+    if let Some(OutContent::Envelope(envelope)) = contents.next() {
+        let mut result = envelope.result;
+        result["dispatch"] = json!(outcome.action.dispatch.as_str());
+        result["side_effects_may_have_occurred"] = json!(true);
+        result["retry"] = json!("do_not_retry");
+        error.result = Some(result);
+    }
+    error.siblings = contents.collect();
+    error.after_dispatch().annotate(annotation)
+}
+
+pub fn click_element(glass: &mut Glass, a: &ClickElementArgs) -> BatchToolResult {
+    erase_semantic_context(
+        "glass_click_element",
+        click_element_with(glass, a, ToolContext::UNBOUNDED),
+    )
 }
 
 pub(crate) fn click_element_with(
@@ -660,49 +808,78 @@ pub(crate) fn click_element_with(
     context: ToolContext,
 ) -> ContextualToolResult {
     let params = semantic_action::validate_click_element_args(a)?;
+    let semantic = matches!(&params.target, glass_core::ActionTarget::Semantic(_));
     let outcome = glass
         .click_target_by(&params, context.deadline)
         .map_err(|error| {
-            let message = error.to_string();
-            match error.source {
-                Some(source) => ContextualError::from_caller_bound(source, context),
-                None => ContextualError::from_caller_bound(GlassError::Backend(message), context),
+            if semantic {
+                semantic_action::semantic_error("glass_click_element", error)
+            } else {
+                let message = error.to_string();
+                match error.source {
+                    Some(source) => ContextualError::from_caller_bound(source, context),
+                    None => ContextualError::from_caller_bound(
+                        glass_core::GlassError::Backend(message),
+                        context,
+                    ),
+                }
             }
         })?;
-    let (observed, extra, timed_out_by) = resolve_return_with(glass, a.return_.as_deref(), context)
-        .map_err(ContextualError::after_dispatch)?;
-    let mut result = serde_json::json!({ "id": outcome.target.id.0 });
-    match outcome.action.method {
-        glass_core::ActionMethod::NativeAction { actuated } => {
-            result["method"] = serde_json::json!("native-action");
-            if let Some(actuated) = actuated {
-                result["actuated_id"] = serde_json::json!(actuated.0);
+    let action_context = ToolContext {
+        deadline: outcome.bound.deadline,
+        owner: outcome.bound.owner,
+        allow_wait: outcome.bound.allow_wait,
+    };
+    let (observed, extra, timed_out_by) =
+        resolve_return_with(glass, a.return_.as_deref(), action_context).map_err(|error| {
+            if semantic {
+                semantic_return_error(
+                    "glass_click_element",
+                    &outcome,
+                    error,
+                    "click was dispatched; return observe failed",
+                )
+            } else {
+                error.after_dispatch()
+            }
+        })?;
+    let output = if semantic {
+        semantic_action::success_output("glass_click_element", &outcome, observed, extra)
+    } else {
+        let mut result = json!({ "id": outcome.target.id.0 });
+        match &outcome.action.method {
+            glass_core::ActionMethod::NativeAction { actuated } => {
+                result["method"] = json!("native-action");
+                if let Some(actuated) = actuated {
+                    result["actuated_id"] = json!(actuated.0);
+                }
+            }
+            glass_core::ActionMethod::Pointer { native_fallback } => {
+                result["method"] = json!("pointer");
+                if let Some(reason) = native_fallback {
+                    result["native_fallback"] = json!(reason);
+                }
+            }
+            glass_core::ActionMethod::AccessibilityValue => {
+                result["method"] = json!("accessibility-value");
+            }
+            glass_core::ActionMethod::Keyboard => {
+                result["method"] = json!("keyboard");
             }
         }
-        glass_core::ActionMethod::Pointer { native_fallback } => {
-            result["method"] = serde_json::json!("pointer");
-            if let Some(reason) = native_fallback {
-                result["native_fallback"] = serde_json::json!(reason);
-            }
+        if let Some(observed) = observed {
+            result["observed"] = observed;
         }
-        glass_core::ActionMethod::AccessibilityValue => {
-            result["method"] = serde_json::json!("accessibility-value");
-        }
-        glass_core::ActionMethod::Keyboard => {
-            result["method"] = serde_json::json!("keyboard");
-        }
-    }
-    if let Some(o) = observed {
-        result["observed"] = o;
-    }
-    Ok(ContextualOutput::with_timeout(
-        ToolOutput::result_with("glass_click_element", result, extra),
-        timed_out_by,
-    ))
+        ToolOutput::result_with("glass_click_element", result, extra)
+    };
+    Ok(ContextualOutput::with_timeout(output, timed_out_by))
 }
 
-pub fn set_value(glass: &mut Glass, a: &SetValueArgs) -> ToolResult {
-    erase_context(set_value_with(glass, a, ToolContext::UNBOUNDED))
+pub fn set_value(glass: &mut Glass, a: &SetValueArgs) -> BatchToolResult {
+    erase_semantic_context(
+        "glass_set_value",
+        set_value_with(glass, a, ToolContext::UNBOUNDED),
+    )
 }
 
 pub(crate) fn set_value_with(
@@ -711,25 +888,51 @@ pub(crate) fn set_value_with(
     context: ToolContext,
 ) -> ContextualToolResult {
     let params = semantic_action::validate_set_value_args(a)?;
+    let semantic = matches!(&params.target, glass_core::ActionTarget::Semantic(_));
     let outcome = glass
         .set_value_target_by(&params, &a.text, context.deadline)
         .map_err(|error| {
-            let message = error.to_string();
-            match error.source {
-                Some(source) => ContextualError::from_caller_bound(source, context),
-                None => ContextualError::from_caller_bound(GlassError::Backend(message), context),
+            if semantic {
+                semantic_action::semantic_error("glass_set_value", error)
+            } else {
+                let message = error.to_string();
+                match error.source {
+                    Some(source) => ContextualError::from_caller_bound(source, context),
+                    None => ContextualError::from_caller_bound(
+                        glass_core::GlassError::Backend(message),
+                        context,
+                    ),
+                }
             }
         })?;
-    let (observed, extra, timed_out_by) = resolve_return_with(glass, a.return_.as_deref(), context)
-        .map_err(ContextualError::after_dispatch)?;
-    let mut result = serde_json::json!({ "id": outcome.target.id.0 });
-    if let Some(o) = observed {
-        result["observed"] = o;
-    }
-    Ok(ContextualOutput::with_timeout(
-        ToolOutput::result_with("glass_set_value", result, extra),
-        timed_out_by,
-    ))
+    let action_context = ToolContext {
+        deadline: outcome.bound.deadline,
+        owner: outcome.bound.owner,
+        allow_wait: outcome.bound.allow_wait,
+    };
+    let (observed, extra, timed_out_by) =
+        resolve_return_with(glass, a.return_.as_deref(), action_context).map_err(|error| {
+            if semantic {
+                semantic_return_error(
+                    "glass_set_value",
+                    &outcome,
+                    error,
+                    "value was written; return observe failed",
+                )
+            } else {
+                error.after_dispatch()
+            }
+        })?;
+    let output = if semantic {
+        semantic_action::success_output("glass_set_value", &outcome, observed, extra)
+    } else {
+        let mut result = json!({ "id": outcome.target.id.0 });
+        if let Some(observed) = observed {
+            result["observed"] = observed;
+        }
+        ToolOutput::result_with("glass_set_value", result, extra)
+    };
+    Ok(ContextualOutput::with_timeout(output, timed_out_by))
 }
 
 pub fn a11y_marks(glass: &mut Glass) -> ToolResult {

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -948,7 +948,7 @@ pub(crate) fn set_value_with(
     let (observed, extra, timed_out_by) =
         resolve_return_with(glass, a.return_.as_deref(), action_context, true).map_err(
             |error| {
-                if semantic {
+                let error = if semantic {
                     semantic_return_error(
                         "glass_set_value",
                         &outcome,
@@ -957,7 +957,10 @@ pub(crate) fn set_value_with(
                     )
                 } else {
                     error.after_dispatch()
-                }
+                };
+                error
+                    .scrub_message()
+                    .annotate("set-value return observe failed")
             },
         )?;
     let output = if semantic {

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use glass_core::{
-    AppSpec, AxNodeId, BoundDispatch, Glass, MarkLabel, MouseButton, WindowGeometry, WindowHint,
+    AppSpec, BoundDispatch, Glass, GlassError, MarkLabel, MouseButton, WindowGeometry, WindowHint,
     WindowId, WindowOp, frame_to_webp,
 };
 use serde::Serialize;
@@ -539,6 +539,30 @@ fn settle_params() -> glass_core::WaitStableParams {
     }
 }
 
+pub(crate) fn validate_settle_args(a: &SettleArgs) -> Result<(), ContextualError> {
+    if a.interval_ms == Some(0) {
+        return Err(ContextualError::validation(
+            "`interval_ms` must be greater than 0".into(),
+        ));
+    }
+    let validate_region = |name: &str, region: &RegionArgs| {
+        if region.width == 0 || region.height == 0 {
+            Err(ContextualError::validation(format!(
+                "`{name}` regions must have non-zero width and height"
+            )))
+        } else {
+            Ok(())
+        }
+    };
+    if let Some(region) = a.stability_region.as_ref() {
+        validate_region("stability_region", region)?;
+    }
+    for region in a.ignore.as_deref().unwrap_or_default() {
+        validate_region("ignore", region)?;
+    }
+    Ok(())
+}
+
 /// Reject an unknown `return` value without touching the session. For a tool whose
 /// action mutates the app (typing, clicking), call this BEFORE acting — a bad
 /// argument must not leave the action applied, or an agent retrying the errored
@@ -635,19 +659,38 @@ pub(crate) fn click_element_with(
     a: &ClickElementArgs,
     context: ToolContext,
 ) -> ContextualToolResult {
-    // Bad `return` value → reject before the click lands (see `validate_return`).
-    validate_return(a.return_.as_deref()).map_err(ContextualError::validation)?;
-    let method = glass
-        .click_element_by(AxNodeId(a.id), context.deadline)
-        .map_err(|e| ContextualError::from_caller_bound(e, context))?;
+    let params = semantic_action::validate_click_element_args(a)?;
+    let outcome = glass
+        .click_target_by(&params, context.deadline)
+        .map_err(|error| {
+            let message = error.to_string();
+            match error.source {
+                Some(source) => ContextualError::from_caller_bound(source, context),
+                None => ContextualError::from_caller_bound(GlassError::Backend(message), context),
+            }
+        })?;
     let (observed, extra, timed_out_by) = resolve_return_with(glass, a.return_.as_deref(), context)
         .map_err(ContextualError::after_dispatch)?;
-    let mut result = serde_json::json!({ "id": a.id, "method": method.label() });
-    if let Some(reason) = method.native_fallback() {
-        result["native_fallback"] = serde_json::json!(reason);
-    }
-    if let Some(actuated) = method.actuated() {
-        result["actuated_id"] = serde_json::json!(actuated.0);
+    let mut result = serde_json::json!({ "id": outcome.target.id.0 });
+    match outcome.action.method {
+        glass_core::ActionMethod::NativeAction { actuated } => {
+            result["method"] = serde_json::json!("native-action");
+            if let Some(actuated) = actuated {
+                result["actuated_id"] = serde_json::json!(actuated.0);
+            }
+        }
+        glass_core::ActionMethod::Pointer { native_fallback } => {
+            result["method"] = serde_json::json!("pointer");
+            if let Some(reason) = native_fallback {
+                result["native_fallback"] = serde_json::json!(reason);
+            }
+        }
+        glass_core::ActionMethod::AccessibilityValue => {
+            result["method"] = serde_json::json!("accessibility-value");
+        }
+        glass_core::ActionMethod::Keyboard => {
+            result["method"] = serde_json::json!("keyboard");
+        }
     }
     if let Some(o) = observed {
         result["observed"] = o;
@@ -667,14 +710,19 @@ pub(crate) fn set_value_with(
     a: &SetValueArgs,
     context: ToolContext,
 ) -> ContextualToolResult {
-    // Bad `return` value → reject before the value is written (see `validate_return`).
-    validate_return(a.return_.as_deref()).map_err(ContextualError::validation)?;
-    glass
-        .set_value_by(AxNodeId(a.id), &a.text, context.deadline)
-        .map_err(|e| ContextualError::from_caller_bound(e, context))?;
+    let params = semantic_action::validate_set_value_args(a)?;
+    let outcome = glass
+        .set_value_target_by(&params, &a.text, context.deadline)
+        .map_err(|error| {
+            let message = error.to_string();
+            match error.source {
+                Some(source) => ContextualError::from_caller_bound(source, context),
+                None => ContextualError::from_caller_bound(GlassError::Backend(message), context),
+            }
+        })?;
     let (observed, extra, timed_out_by) = resolve_return_with(glass, a.return_.as_deref(), context)
         .map_err(ContextualError::after_dispatch)?;
-    let mut result = serde_json::json!({ "id": a.id });
+    let mut result = serde_json::json!({ "id": outcome.target.id.0 });
     if let Some(o) = observed {
         result["observed"] = o;
     }
@@ -735,6 +783,7 @@ mod clipboard;
 #[allow(dead_code)]
 mod find;
 mod input; // filled in Task 5
+pub(crate) mod semantic_action;
 mod wait;
 
 #[cfg(test)]

--- a/crates/glass-mcp/src/tools/batch.rs
+++ b/crates/glass-mcp/src/tools/batch.rs
@@ -101,7 +101,11 @@ pub fn do_actions(glass: &mut Glass, a: &DoArgs) -> BatchToolResult {
             "`timeout_ms` is outside this platform's monotonic clock range",
         ));
     };
-    let context = ToolContext { deadline };
+    let context = ToolContext {
+        deadline,
+        owner: Some(glass_core::Whose::Caller),
+        allow_wait: true,
+    };
     let n = a.actions.len();
     let mut steps = Vec::with_capacity(n);
     let mut siblings = Vec::new();

--- a/crates/glass-mcp/src/tools/batch.rs
+++ b/crates/glass-mcp/src/tools/batch.rs
@@ -1,6 +1,6 @@
 //! `glass_do`: run an ordered input sequence server-side, then optionally observe.
 
-use glass_core::{Deadline, Glass, Whose};
+use glass_core::{BoundDispatch, Deadline, Glass, Whose};
 use serde_json::json;
 use std::time::{Duration, Instant};
 
@@ -94,6 +94,11 @@ pub fn do_actions(glass: &mut Glass, a: &DoArgs) -> BatchToolResult {
             "`timeout_ms` must be between 1 and {MAX_TIMEOUT_MS}"
         )));
     }
+    for (index, action) in a.actions.iter().enumerate() {
+        if let Err(error) = crate::tools::semantic_action::validate_action(action) {
+            return Err(validation_error_at(index, action.kind(), error));
+        }
+    }
     let started = Instant::now();
     let Some(deadline) = checked_sequence_deadline(started, Duration::from_millis(timeout_ms))
     else {
@@ -112,16 +117,15 @@ pub fn do_actions(glass: &mut Glass, a: &DoArgs) -> BatchToolResult {
     for (i, action) in a.actions.iter().enumerate() {
         let kind = action.kind();
         if context.deadline.has_passed() {
+            let error = ContextualError::validation(
+                "sequence deadline exceeded before action started".into(),
+            )
+            .after_sequence_deadline();
             return Err(step_failure(
                 &a.actions,
                 i,
-                kind,
-                false,
-                false,
-                Some(SafeErrorCategory::SequenceDeadlineExceeded),
-                "sequence deadline exceeded before action started",
-                None,
-                true,
+                action,
+                error,
                 steps,
                 siblings,
                 started.elapsed().as_millis(),
@@ -196,24 +200,11 @@ pub fn do_actions(glass: &mut Glass, a: &DoArgs) -> BatchToolResult {
                 } else {
                     error
                 };
-                let detail = redacted_error_detail(action, &error);
-                let attempted =
-                    error.bound_dispatch != Some(glass_core::BoundDispatch::NotDispatched);
-                let summary = matches!(
-                    error.category,
-                    SafeErrorCategory::InvalidValue | SafeErrorCategory::OptionNotFound
-                )
-                .then_some(error.safe_summary);
                 return Err(step_failure(
                     &a.actions,
                     i,
-                    kind,
-                    attempted,
-                    attempted && action.is_side_effecting(),
-                    Some(error.category),
-                    detail,
-                    summary,
-                    error.sequence_deadline_exceeded,
+                    action,
+                    error,
                     steps,
                     siblings,
                     started.elapsed().as_millis(),
@@ -318,41 +309,41 @@ fn predicate_failure(
     )
 }
 
-#[allow(clippy::too_many_arguments)]
 fn step_failure(
     actions: &[Action],
     index: usize,
-    action: &'static str,
-    attempted: bool,
-    side_effects_may_have_occurred: bool,
-    category: Option<SafeErrorCategory>,
-    detail: &str,
-    summary: Option<&str>,
-    sequence_deadline_exceeded: bool,
+    action: &Action,
+    mut error: ContextualError,
     mut steps: Vec<StepOutcome>,
     mut siblings: Vec<OutContent>,
     elapsed_ms: u128,
 ) -> ToolOutput {
-    let (code, default_summary) = if sequence_deadline_exceeded {
-        ("sequence_deadline_exceeded", "sequence deadline exceeded")
-    } else {
-        ("action_failed", "action execution failed")
+    let attempted = match error.bound_dispatch {
+        Some(BoundDispatch::NotDispatched) => false,
+        Some(BoundDispatch::MayHaveDispatched) | None => true,
     };
-    let summary = summary.unwrap_or(default_summary);
-    let content_block = siblings.len() + 1;
+    let side_effects_may_have_occurred = attempted && action.is_side_effecting();
+    let detail = match action {
+        Action::Type(_) | Action::SetValue(_) => error.safe_summary,
+        _ => &error.message,
+    };
+    let content_start = siblings.len() + 1;
+    let content_count = error.siblings.len() + 1;
+    siblings.append(&mut error.siblings);
     siblings.push(OutContent::untrusted_observation(detail));
+    let content_blocks = (content_start..content_start + content_count).collect();
     steps.push(StepOutcome::Failed {
         index,
-        action,
+        action: action.kind(),
         attempted,
-        result: None,
+        result: error.result,
         error: StepError {
-            code,
-            summary: summary.into(),
-            category,
+            code: error.code,
+            summary: error.safe_summary.into(),
+            category: Some(error.category),
         },
         side_effects_may_have_occurred,
-        content_blocks: vec![content_block],
+        content_blocks,
     });
     steps.extend(
         actions[index + 1..]
@@ -367,18 +358,15 @@ fn step_failure(
         json!({
             "ok": false,
             "tool": "glass_do",
-            "error": { "code": code, "step": index, "summary": summary },
+            "error": {
+                "code": error.code,
+                "step": index,
+                "summary": error.safe_summary,
+            },
             "outcome": failure_outcome(steps, index, elapsed_ms),
         }),
         siblings,
     )
-}
-
-fn redacted_error_detail<'a>(action: &Action, error: &'a ContextualError) -> &'a str {
-    match action {
-        Action::Type(_) | Action::SetValue(_) => error.safe_summary,
-        _ => &error.message,
-    }
 }
 
 fn validation_error(summary: &str) -> ToolOutput {
@@ -387,6 +375,22 @@ fn validation_error(summary: &str) -> ToolOutput {
             "ok": false,
             "tool": "glass_do",
             "error": { "code": "invalid_sequence", "summary": summary },
+        }),
+        Vec::new(),
+    )
+}
+
+fn validation_error_at(index: usize, action: &'static str, error: ContextualError) -> ToolOutput {
+    error_output(
+        json!({
+            "ok": false,
+            "tool": "glass_do",
+            "error": {
+                "code": "invalid_sequence",
+                "step": index,
+                "action": action,
+                "summary": error.message,
+            },
         }),
         Vec::new(),
     )

--- a/crates/glass-mcp/src/tools/batch/tests.rs
+++ b/crates/glass-mcp/src/tools/batch/tests.rs
@@ -3,12 +3,13 @@ use crate::tools::start as start_tool;
 use crate::tools::testutil::*;
 use crate::tools::{OutContent, baseline_save};
 use glass_core::{
-    A11yThread, Accessibility, AppSpec, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxStates,
-    AxTree, Backend, BaselineStore, Deadline, Frame, GlassError, KeyEvent, Platform,
-    PlatformFactory, PointerEvent, Region, Result as GlassResult, Stream, WindowGeometry, WindowId,
-    WindowInfo, WindowOp,
+    A11yThread, Accessibility, AppSpec, AxContext, AxNode, AxNodeId, AxRect, AxRole,
+    AxStateCoverage, AxStates, AxTarget, AxTree, Backend, BaselineStore, Deadline, Frame,
+    GlassError, KeyEvent, Platform, PlatformFactory, PointerEvent, Region, Result as GlassResult,
+    Stream, WindowGeometry, WindowId, WindowInfo, WindowOp,
 };
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -43,12 +44,14 @@ enum DeadlineBehavior {
     ComboEscapeFailure,
     OtherFailure,
     ResizeAfterOneScroll,
+    FocusConfirmationSequenceDeadline,
 }
 
 struct DeadlinePlatform {
     inner: FakePlatform,
     deadlines: Arc<Mutex<Vec<Deadline>>>,
     behavior: DeadlineBehavior,
+    pointer_tree_changed: Option<Arc<AtomicBool>>,
 }
 
 type DeadlineFixture = (Glass, Arc<Mutex<Vec<Deadline>>>, Arc<Mutex<Vec<String>>>);
@@ -151,14 +154,25 @@ fn untrusted_nonce_normalization_changes_only_wrapper_markers() {
 
 struct DeadlineAccessibility {
     tree: AxTree,
+    tree_after_pointer: Option<(Arc<AtomicBool>, AxTree)>,
     deadlines: Arc<Mutex<Vec<Deadline>>>,
     events: Arc<Mutex<Vec<String>>>,
     behavior: DeadlineBehavior,
+    coverage: AxStateCoverage,
+    focus_dispatched: bool,
 }
 
 impl Accessibility for DeadlineAccessibility {
     fn snapshot(&mut self, context: &AxContext) -> GlassResult<AxTree> {
         self.deadlines.lock().unwrap().push(context.deadline);
+        if matches!(
+            self.behavior,
+            DeadlineBehavior::FocusConfirmationSequenceDeadline
+        ) && self.focus_dispatched
+            && context.deadline != Deadline::UNBOUNDED
+        {
+            sleep_past(context.deadline);
+        }
         if matches!(self.behavior, DeadlineBehavior::A11yNotReadyLate)
             && context.deadline != Deadline::UNBOUNDED
         {
@@ -176,7 +190,21 @@ impl Accessibility for DeadlineAccessibility {
                 "the read reached its effective deadline",
             ));
         }
-        Ok(self.tree.clone())
+        Ok(self
+            .tree_after_pointer
+            .as_ref()
+            .filter(|(changed, _)| changed.load(Ordering::SeqCst))
+            .map_or_else(|| self.tree.clone(), |(_, tree)| tree.clone()))
+    }
+
+    fn state_coverage(&self) -> AxStateCoverage {
+        self.coverage
+    }
+
+    fn focus(&mut self, _context: &AxContext, _target: &AxTarget) -> GlassResult<Option<AxNodeId>> {
+        self.events.lock().unwrap().push("focus".into());
+        self.focus_dispatched = true;
+        Ok(None)
     }
 
     fn set_value(
@@ -244,6 +272,9 @@ impl Accessibility for DeadlineAccessibility {
         _context: &AxContext,
         _target: &glass_core::AxTarget,
     ) -> GlassResult<Option<glass_core::AxNodeId>> {
+        if matches!(self.behavior, DeadlineBehavior::UnsupportedAccessibility) {
+            return Err(GlassError::AxUnsupported);
+        }
         self.events.lock().unwrap().push("click_element".into());
         Ok(None)
     }
@@ -312,7 +343,7 @@ impl Platform for DeadlinePlatform {
 
     fn send_pointer_by(&mut self, event: &PointerEvent, deadline: Deadline) -> GlassResult<()> {
         self.deadlines.lock().unwrap().push(deadline);
-        match self.behavior {
+        let result = match self.behavior {
             DeadlineBehavior::Normal => self.inner.send_pointer(event),
             DeadlineBehavior::CompleteLate => {
                 sleep_past(deadline);
@@ -368,8 +399,16 @@ impl Platform for DeadlinePlatform {
             | DeadlineBehavior::SetValueWorkerSpawnFailure
             | DeadlineBehavior::InvalidBoolean
             | DeadlineBehavior::OptionNotFound
-            | DeadlineBehavior::ComboEscapeFailure => self.inner.send_pointer(event),
+            | DeadlineBehavior::ComboEscapeFailure
+            | DeadlineBehavior::FocusConfirmationSequenceDeadline => self.inner.send_pointer(event),
+        };
+        if result.is_ok()
+            && matches!(event, PointerEvent::Click { .. })
+            && let Some(changed) = &self.pointer_tree_changed
+        {
+            changed.store(true, Ordering::SeqCst);
         }
+        result
     }
     fn send_key_by(&mut self, event: &KeyEvent, deadline: Deadline) -> GlassResult<()> {
         self.deadlines.lock().unwrap().push(deadline);
@@ -416,6 +455,7 @@ fn deadline_glass(behavior: DeadlineBehavior, frames: Vec<Frame>) -> DeadlineFix
             .with_event_log(events.clone()),
         deadlines: deadlines.clone(),
         behavior,
+        pointer_tree_changed: None,
     };
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path().join("baselines");
@@ -456,15 +496,35 @@ fn deadline_a11y_glass_with_behavior(
     behavior: DeadlineBehavior,
     frames: Vec<Frame>,
 ) -> A11yReturnDeadlineFixture {
+    deadline_a11y_glass_with_tree_behavior(
+        behavior,
+        frames,
+        fake_tree(),
+        None,
+        AxStateCoverage::NONE,
+    )
+}
+
+fn deadline_a11y_glass_with_tree_behavior(
+    behavior: DeadlineBehavior,
+    frames: Vec<Frame>,
+    tree: AxTree,
+    tree_after_pointer: Option<(Arc<AtomicBool>, AxTree)>,
+    coverage: AxStateCoverage,
+) -> A11yReturnDeadlineFixture {
     let platform_deadlines = Arc::new(Mutex::new(Vec::new()));
     let accessibility_deadlines = Arc::new(Mutex::new(Vec::new()));
     let events = Arc::new(Mutex::new(Vec::new()));
+    let pointer_tree_changed = tree_after_pointer
+        .as_ref()
+        .map(|(changed, _)| Arc::clone(changed));
     let platform = DeadlinePlatform {
         inner: FakePlatform::new(100, 100)
             .with_frames(frames)
             .with_event_log(events.clone()),
         deadlines: platform_deadlines.clone(),
         behavior,
+        pointer_tree_changed,
     };
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path().join("baselines");
@@ -472,10 +532,13 @@ fn deadline_a11y_glass_with_behavior(
     let mut held = Some(Backend {
         platform: Box::new(platform),
         accessibility: Some(Box::new(DeadlineAccessibility {
-            tree: fake_tree(),
+            tree,
+            tree_after_pointer,
             deadlines: accessibility_deadlines.clone(),
             events: events.clone(),
             behavior,
+            coverage,
+            focus_dispatched: false,
         })),
     });
     let factory: PlatformFactory = Box::new(move |_| {
@@ -512,6 +575,52 @@ fn do_args(actions: Vec<Action>, timeout_ms: u64) -> DoArgs {
         timeout_ms: Some(timeout_ms),
         encoded_argument_bytes: 0,
     }
+}
+
+fn parsed_action(raw: &str) -> Action {
+    serde_json::from_str(raw).unwrap()
+}
+
+fn semantic_control_tree(role: AxRole, name: &str, focused: bool) -> AxTree {
+    let control = AxNode {
+        id: AxNodeId(0),
+        role,
+        raw_role: format!("{role:?}"),
+        name: Some(name.into()),
+        description: None,
+        value: None,
+        states: AxStates {
+            enabled: true,
+            visible: true,
+            focusable: true,
+            editable: role == AxRole::TextField,
+            focused,
+            ..AxStates::default()
+        },
+        bounds: Some(AxRect {
+            x: 10,
+            y: 10,
+            width: 20,
+            height: 20,
+        }),
+        children: vec![],
+    };
+    AxTree::new(AxNode {
+        id: AxNodeId(0),
+        role: AxRole::Window,
+        raw_role: "frame".into(),
+        name: Some("Win".into()),
+        description: None,
+        value: None,
+        states: AxStates::default(),
+        bounds: Some(AxRect {
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 100,
+        }),
+        children: vec![control],
+    })
 }
 
 fn sleep_past(deadline: Deadline) {
@@ -762,6 +871,7 @@ fn started_scripted_combo(trees: Vec<AxTree>) -> (Glass, Arc<Mutex<Vec<String>>>
         inner: FakePlatform::new(100, 100).with_event_log(events.clone()),
         deadlines: Arc::new(Mutex::new(Vec::new())),
         behavior: DeadlineBehavior::ComboEscapeFailure,
+        pointer_tree_changed: None,
     };
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path().join("baselines");
@@ -1129,7 +1239,7 @@ fn sequence_uses_one_absolute_deadline_for_every_action() {
                     chord: "Tab".into(),
                 }),
                 Action::Settle(SettleArgs {
-                    interval_ms: Some(0),
+                    interval_ms: Some(1),
                     settle_frames: Some(1),
                     tolerance: None,
                     timeout_ms: Some(2000),
@@ -1285,8 +1395,8 @@ fn action_owned_bounded_wait_read_is_action_failed_not_sequence_deadline() {
     let envelope = envelope(&error);
     let step = &envelope["outcome"]["steps"][0];
 
-    assert_eq!(envelope["error"]["code"], "action_failed");
-    assert_eq!(step["error"]["code"], "action_failed");
+    assert_eq!(envelope["error"]["code"], "transport_failure");
+    assert_eq!(step["error"]["code"], "transport_failure");
     assert_eq!(step["error"]["category"], "transport_failure");
     assert_eq!(step["attempted"], true);
     assert_eq!(step["side_effects_may_have_occurred"], false);
@@ -1401,7 +1511,7 @@ fn settle_own_timeout_is_completed_but_sequence_timeout_fails() {
     let black = Frame::solid(100, 100, [0, 0, 0, 255]);
     let white = Frame::solid(100, 100, [255, 255, 255, 255]);
     let settle = Action::Settle(SettleArgs {
-        interval_ms: Some(0),
+        interval_ms: Some(1),
         settle_frames: Some(u32::MAX),
         tolerance: None,
         timeout_ms: Some(2),
@@ -1418,7 +1528,7 @@ fn settle_own_timeout_is_completed_but_sequence_timeout_fails() {
         false
     );
     let caller_settle = Action::Settle(SettleArgs {
-        interval_ms: Some(0),
+        interval_ms: Some(1),
         settle_frames: Some(u32::MAX),
         tolerance: None,
         timeout_ms: Some(1000),
@@ -1470,7 +1580,7 @@ fn action_owned_capture_timeout_is_not_a_sequence_deadline() {
         &mut g,
         &do_args(
             vec![Action::Settle(SettleArgs {
-                interval_ms: Some(0),
+                interval_ms: Some(1),
                 settle_frames: Some(2),
                 tolerance: None,
                 timeout_ms: Some(20),
@@ -1484,8 +1594,8 @@ fn action_owned_capture_timeout_is_not_a_sequence_deadline() {
     let envelope = envelope(&error);
     let step = &envelope["outcome"]["steps"][0];
 
-    assert_eq!(envelope["error"]["code"], "action_failed");
-    assert_eq!(step["error"]["code"], "action_failed");
+    assert_eq!(envelope["error"]["code"], "action_deadline_exceeded");
+    assert_eq!(step["error"]["code"], "action_deadline_exceeded");
     assert_eq!(step["error"]["category"], "action_deadline_exceeded");
     assert_eq!(step["attempted"], true);
     assert_eq!(step["side_effects_may_have_occurred"], false);
@@ -1588,7 +1698,7 @@ fn return_snapshot_propagates_settle_capture_failure_after_dispatch() {
     let envelope = envelope(&error);
     let step = &envelope["outcome"]["steps"][0];
 
-    assert_eq!(envelope["error"]["code"], "action_failed");
+    assert_eq!(envelope["error"]["code"], "transport_failure");
     assert_eq!(step["error"]["category"], "transport_failure");
     assert_eq!(step["attempted"], true);
     assert_eq!(step["side_effects_may_have_occurred"], true);
@@ -1731,7 +1841,7 @@ fn set_value_backend_ceiling_shorter_than_sequence_is_transport_failure() {
     let envelope = envelope(&error);
     let step = &envelope["outcome"]["steps"][0];
 
-    assert_eq!(envelope["error"]["code"], "action_failed");
+    assert_eq!(envelope["error"]["code"], "transport_failure");
     assert_eq!(step["error"]["category"], "transport_failure");
     assert_eq!(step["attempted"], true);
     assert_eq!(step["side_effects_may_have_occurred"], true);
@@ -1837,7 +1947,7 @@ fn nested_prior_dispatch_remains_attempted_and_warns_about_side_effects() {
     let envelope: serde_json::Value = serde_json::from_str(&error_text(err)).unwrap();
     let step = &envelope["outcome"]["steps"][0];
 
-    assert_eq!(envelope["error"]["code"], "action_failed");
+    assert_eq!(envelope["error"]["code"], "transport_failure");
     assert_eq!(step["attempted"], true);
     assert_eq!(step["side_effects_may_have_occurred"], true);
 }
@@ -2088,6 +2198,115 @@ fn invalid_sequence_rejects_empty_actions_before_actuation() {
     assert!(err.contains("at least one"), "got: {err}");
 }
 
+fn assert_invalid_later_action_is_preflighted(case: &str, action: Action) {
+    let kind = action.kind();
+    let (mut glass, platform_deadlines, accessibility_deadlines, events) =
+        deadline_a11y_glass_with_behavior(DeadlineBehavior::Normal, vec![]);
+    let error = do_actions(&mut glass, &do_args(vec![click(1, 1), action], 1_000)).unwrap_err();
+    let envelope = envelope(&error);
+
+    assert_eq!(envelope["error"]["code"], "invalid_sequence", "{case}");
+    assert_eq!(envelope["error"]["step"], 1, "{case}");
+    assert_eq!(envelope["error"]["action"], kind, "{case}");
+    assert!(envelope.get("outcome").is_none(), "{case}: {envelope}");
+    assert_eq!(
+        error.0.len(),
+        1,
+        "{case}: validation must stay trusted-only"
+    );
+    assert!(
+        events.lock().unwrap().is_empty(),
+        "{case}: mutation occurred"
+    );
+    assert!(
+        platform_deadlines.lock().unwrap().is_empty(),
+        "{case}: platform state was read or mutated"
+    );
+    assert!(
+        accessibility_deadlines.lock().unwrap().is_empty(),
+        "{case}: selector resolution or accessibility state read occurred"
+    );
+}
+
+#[test]
+fn invalid_semantic_actions_are_preflighted_before_mutation() {
+    let cases = [
+        (
+            "invalid return",
+            r#"{"action":"click_element","id":1,"return":"invalid"}"#,
+        ),
+        (
+            "both target forms",
+            r#"{"action":"click_element","id":1,"target":{"role":"Button"}}"#,
+        ),
+        (
+            "neither target form",
+            r#"{"action":"set_value","text":"secret"}"#,
+        ),
+        (
+            "target timeout",
+            r#"{"action":"click_element","target":{"role":"Button"},"timeout_ms":120001}"#,
+        ),
+        (
+            "selector state",
+            r#"{"action":"click_element","target":{"role":"Button","states":["hovered"]}}"#,
+        ),
+        (
+            "target role",
+            r#"{"action":"type","target":{"role":"Mystery"},"text":"secret"}"#,
+        ),
+    ];
+
+    for (case, raw) in cases {
+        assert_invalid_later_action_is_preflighted(case, parsed_action(raw));
+    }
+}
+
+#[test]
+fn invalid_semantic_preflight_covers_every_later_action_variant() {
+    let cases = [
+        ("click count", r#"{"action":"click","x":1,"y":1,"count":0}"#),
+        (
+            "click modifier",
+            r#"{"action":"click","x":1,"y":1,"modifiers":["invalid"]}"#,
+        ),
+        (
+            "drag modifier",
+            r#"{"action":"drag","x1":1,"y1":1,"x2":2,"y2":2,"modifiers":["invalid"]}"#,
+        ),
+        (
+            "scroll magnitude",
+            r#"{"action":"scroll","x":1,"y":1,"dx":101}"#,
+        ),
+        (
+            "targetless type controls",
+            r#"{"action":"type","text":"secret","focus_mode":"auto"}"#,
+        ),
+        ("key chord", r#"{"action":"key","chord":"ctrl+"}"#),
+        ("settle interval", r#"{"action":"settle","interval_ms":0}"#),
+        (
+            "wait selector",
+            r#"{"action":"wait_for_element","condition":"appears"}"#,
+        ),
+        (
+            "wait condition",
+            r#"{"action":"wait_for_element","role":"Button","condition":"mystery"}"#,
+        ),
+        (
+            "scroll direction",
+            r#"{"action":"scroll_to_element","role":"Button","direction":"diagonal"}"#,
+        ),
+        (
+            "half scroll anchor",
+            r#"{"action":"scroll_to_element","role":"Button","x":1}"#,
+        ),
+    ];
+
+    for (case, raw) in cases {
+        assert_invalid_later_action_is_preflighted(case, parsed_action(raw));
+    }
+}
+
 #[test]
 fn mutating_action_validation_failures_are_proven_not_dispatched() {
     let events = Arc::new(Mutex::new(Vec::new()));
@@ -2222,12 +2441,22 @@ fn mutating_action_validation_failures_are_proven_not_dispatched() {
     for (case, action) in cases {
         let error = do_actions(&mut g, &do_args(vec![action], 1_000)).unwrap_err();
         let envelope = envelope(&error);
-        let step = &envelope["outcome"]["steps"][0];
-        assert_eq!(step["attempted"], false, "{case}: {envelope}");
-        assert_eq!(
-            step["side_effects_may_have_occurred"], false,
-            "{case}: {envelope}"
+        let runtime_geometry_check = matches!(
+            case,
+            "click bounds" | "drag bounds" | "scroll bounds" | "scroll_to_element anchor bounds"
         );
+        if runtime_geometry_check {
+            let step = &envelope["outcome"]["steps"][0];
+            assert_eq!(step["attempted"], false, "{case}: {envelope}");
+            assert_eq!(
+                step["side_effects_may_have_occurred"], false,
+                "{case}: {envelope}"
+            );
+        } else {
+            assert_eq!(envelope["error"]["code"], "invalid_sequence", "{case}");
+            assert_eq!(envelope["error"]["step"], 0, "{case}");
+            assert!(envelope.get("outcome").is_none(), "{case}: {envelope}");
+        }
     }
     assert!(
         events.lock().unwrap().is_empty(),
@@ -2255,11 +2484,10 @@ fn batch_click_rejects_zero_and_unbounded_count_without_platform_dispatch() {
         )
         .unwrap_err();
         let envelope = envelope(&error);
-        let step = &envelope["outcome"]["steps"][0];
-
-        assert_eq!(envelope["error"]["code"], "action_failed");
-        assert_eq!(step["attempted"], false);
-        assert_eq!(step["side_effects_may_have_occurred"], false);
+        assert_eq!(envelope["error"]["code"], "invalid_sequence");
+        assert_eq!(envelope["error"]["step"], 0);
+        assert_eq!(envelope["error"]["action"], "click");
+        assert!(envelope.get("outcome").is_none());
         assert!(
             output_text(&error).contains("between 1 and 10"),
             "unexpected validation detail for {count}: {}",
@@ -2301,11 +2529,10 @@ fn batch_scroll_rejects_extreme_magnitudes_without_platform_dispatch() {
         )
         .unwrap_err();
         let envelope = envelope(&error);
-        let step = &envelope["outcome"]["steps"][0];
-
-        assert_eq!(envelope["error"]["code"], "action_failed");
-        assert_eq!(step["attempted"], false);
-        assert_eq!(step["side_effects_may_have_occurred"], false);
+        assert_eq!(envelope["error"]["code"], "invalid_sequence");
+        assert_eq!(envelope["error"]["step"], 0);
+        assert_eq!(envelope["error"]["action"], "scroll");
+        assert!(envelope.get("outcome").is_none());
         assert!(
             output_text(&error).contains("between -100 and 100"),
             "unexpected validation detail for ({dx:?}, {dy:?}): {}",
@@ -2448,6 +2675,205 @@ fn semantic_actions_delegate_and_retain_standalone_results() {
 }
 
 #[test]
+fn semantic_step_selector_resolves_at_execution_time() {
+    let changed = Arc::new(AtomicBool::new(false));
+    let (mut glass, _, accessibility_deadlines, events) = deadline_a11y_glass_with_tree_behavior(
+        DeadlineBehavior::Normal,
+        vec![],
+        semantic_control_tree(AxRole::Button, "Before", false),
+        Some((
+            Arc::clone(&changed),
+            semantic_control_tree(AxRole::Button, "Save", false),
+        )),
+        AxStateCoverage::NONE,
+    );
+
+    let output = do_actions(
+        &mut glass,
+        &do_args(
+            vec![
+                click(1, 1),
+                parsed_action(
+                    r#"{"action":"click_element","target":{"query":"Save","role":"Button"},"mode":"native","timeout_ms":0}"#,
+                ),
+            ],
+            1_000,
+        ),
+    )
+    .unwrap();
+
+    assert_eq!(assert_envelope(&output, "glass_do")["executed"], 2);
+    assert!(changed.load(Ordering::SeqCst));
+    assert_eq!(*events.lock().unwrap(), vec!["click(1,1)", "click_element"]);
+    assert_eq!(
+        accessibility_deadlines.lock().unwrap().len(),
+        1,
+        "the selector must resolve exactly when its step begins"
+    );
+}
+
+#[test]
+fn semantic_step_timeout_is_bounded_by_the_earlier_sequence_deadline() {
+    let (mut glass, _, accessibility_deadlines, _) =
+        deadline_a11y_glass_with_behavior(DeadlineBehavior::Normal, vec![]);
+    let output = do_actions(
+        &mut glass,
+        &do_args(
+            vec![parsed_action(
+                r#"{"action":"click_element","target":{"query":"Save","role":"Button"},"mode":"native","timeout_ms":120000}"#,
+            )],
+            100,
+        ),
+    )
+    .unwrap();
+
+    assert_eq!(assert_envelope(&output, "glass_do")["executed"], 1);
+    let deadline = accessibility_deadlines.lock().unwrap()[0];
+    let remaining = deadline.remaining().unwrap();
+    assert!(remaining <= Duration::from_millis(100));
+    assert!(remaining > Duration::from_millis(50));
+}
+
+#[test]
+fn semantic_step_uses_its_ten_second_default_inside_a_longer_sequence() {
+    let (mut glass, _, accessibility_deadlines, _) =
+        deadline_a11y_glass_with_behavior(DeadlineBehavior::Normal, vec![]);
+    let output = do_actions(
+        &mut glass,
+        &do_args(
+            vec![parsed_action(
+                r#"{"action":"click_element","target":{"query":"Save","role":"Button"},"mode":"native"}"#,
+            )],
+            120_000,
+        ),
+    )
+    .unwrap();
+
+    assert_eq!(assert_envelope(&output, "glass_do")["executed"], 1);
+    let deadline = accessibility_deadlines.lock().unwrap()[0];
+    let remaining = deadline.remaining().unwrap();
+    assert!(remaining <= Duration::from_secs(10));
+    assert!(remaining > Duration::from_millis(9_900));
+}
+
+#[test]
+fn sequence_deadline_after_focus_prevents_type_and_marks_side_effects_possible() {
+    let coverage = AxStateCoverage {
+        enabled: true,
+        visible: true,
+        focused: true,
+        focusable: true,
+        editable: true,
+        ..AxStateCoverage::NONE
+    };
+    let (mut glass, _, _, events) = deadline_a11y_glass_with_tree_behavior(
+        DeadlineBehavior::FocusConfirmationSequenceDeadline,
+        vec![],
+        semantic_control_tree(AxRole::TextField, "Account", false),
+        None,
+        coverage,
+    );
+    let error = do_actions(
+        &mut glass,
+        &do_args(
+            vec![parsed_action(
+                r#"{"action":"type","target":{"query":"Account","role":"TextField"},"focus_mode":"native","timeout_ms":10000,"text":"secret"}"#,
+            )],
+            30,
+        ),
+    )
+    .unwrap_err();
+    let envelope = envelope(&error);
+    let step = &envelope["outcome"]["steps"][0];
+
+    assert_eq!(envelope["error"]["code"], "sequence_deadline_exceeded");
+    assert_eq!(step["attempted"], true);
+    assert_eq!(step["side_effects_may_have_occurred"], true);
+    assert_eq!(step["result"]["dispatch"], "not_dispatched");
+    assert_eq!(step["result"]["focus"]["dispatch"], "dispatched");
+    assert_eq!(step["content_blocks"], json!([1, 2]));
+    assert_eq!(*events.lock().unwrap(), vec!["focus"]);
+    assert!(!output_text(&error).contains("secret"));
+}
+
+#[test]
+fn semantic_failure_keeps_resolution_actionability_dispatch_and_content_blocks() {
+    let (mut glass, _, _, events) = deadline_a11y_glass_with_tree_behavior(
+        DeadlineBehavior::UnsupportedAccessibility,
+        vec![],
+        semantic_control_tree(AxRole::Button, "Save", false),
+        None,
+        AxStateCoverage::NONE,
+    );
+    let error = do_actions(
+        &mut glass,
+        &do_args(
+            vec![parsed_action(
+                r#"{"action":"click_element","target":{"query":"Save","role":"Button"},"mode":"native","timeout_ms":1000}"#,
+            )],
+            5_000,
+        ),
+    )
+    .unwrap_err();
+    let envelope = envelope(&error);
+    let step = &envelope["outcome"]["steps"][0];
+
+    assert_eq!(envelope["error"]["code"], "unsupported_accessibility");
+    assert_eq!(step["error"]["category"], "unsupported_accessibility");
+    assert_eq!(step["attempted"], false);
+    assert_eq!(step["side_effects_may_have_occurred"], false);
+    assert!(step["result"]["resolution"].is_object());
+    assert!(step["result"]["actionability"].is_array());
+    assert_eq!(step["result"]["dispatch"], "not_dispatched");
+    assert_eq!(step["content_blocks"], json!([1, 2]));
+    assert_eq!(error.0.len(), 3);
+    assert!(output_text(&error).contains("Save"));
+    assert!(events.lock().unwrap().is_empty());
+}
+
+#[test]
+fn standalone_and_batch_semantic_click_results_match_except_for_sequence_fields() {
+    fn args() -> ClickElementArgs {
+        serde_json::from_str(
+            r#"{"target":{"query":"Save","role":"Button"},"mode":"native","timeout_ms":0}"#,
+        )
+        .unwrap()
+    }
+
+    let mut standalone = started_a11y_session(glass_with_a11y_invoke_ok(
+        FakePlatform::new(100, 100),
+        fake_tree(),
+    ));
+    let standalone_output = crate::tools::click_element(&mut standalone, &args()).unwrap();
+    let mut standalone_result = assert_envelope(&standalone_output, "glass_click_element").clone();
+
+    let mut batch = started_a11y_session(glass_with_a11y_invoke_ok(
+        FakePlatform::new(100, 100),
+        fake_tree(),
+    ));
+    let batch_output = do_actions(
+        &mut batch,
+        &do_args(vec![Action::ClickElement(args())], 1_000),
+    )
+    .unwrap();
+    let mut batch_result = assert_envelope(&batch_output, "glass_do")["steps"][0]["result"].clone();
+
+    standalone_result["resolution"]
+        .as_object_mut()
+        .unwrap()
+        .remove("elapsed_ms");
+    batch_result["resolution"]
+        .as_object_mut()
+        .unwrap()
+        .remove("elapsed_ms");
+    assert_eq!(batch_result, standalone_result);
+    assert_eq!(
+        exact_content_slice(&batch_output.0[1..]),
+        exact_content_slice(&standalone_output.0[1..])
+    );
+}
+
+#[test]
 fn click_element_stale_target_stops_with_structured_detail() {
     let mut g = started_a11y(FakePlatform::new(100, 100));
     let err = error_text(
@@ -2476,7 +2902,7 @@ fn click_element_stale_target_stops_with_structured_detail() {
     );
     let error: serde_json::Value = serde_json::from_str(&err).unwrap();
     let step = &error["outcome"]["steps"][0];
-    assert_eq!(error["error"]["code"], "action_failed");
+    assert_eq!(error["error"]["code"], "stale_element");
     assert_eq!(step["action"], "click_element");
     assert_eq!(step["attempted"], true);
     assert_eq!(step["side_effects_may_have_occurred"], true);
@@ -2730,14 +3156,14 @@ fn stale_target_detail_is_not_embedded_in_trusted_error_json() {
     assert!(!text.as_str().contains(APP_DETAIL), "{trusted}");
     assert_eq!(
         trusted["error"],
-        json!({"code":"action_failed","step":0,"summary":"action execution failed"})
+        json!({"code":"transport_failure","step":0,"summary":"backend transport failed"})
     );
     let step = &trusted["outcome"]["steps"][0];
     assert_eq!(
         step["error"],
         json!({
-            "code":"action_failed",
-            "summary":"action execution failed",
+            "code":"transport_failure",
+            "summary":"backend transport failed",
             "category":"transport_failure"
         })
     );
@@ -3686,6 +4112,40 @@ fn error_code(out: ToolOutput) -> String {
         .as_str()
         .unwrap()
         .to_string()
+}
+
+#[test]
+fn batch_limits_remain_sixty_four_actions_and_65536_encoded_bytes() {
+    let mut accepted_actions = started(FakePlatform::new(10, 10));
+    assert!(
+        do_actions(
+            &mut accepted_actions,
+            &DoArgs {
+                actions: limit_actions(64),
+                then: None,
+                timeout_ms: None,
+                encoded_argument_bytes: 65_536,
+            },
+        )
+        .is_ok()
+    );
+
+    for (actions, encoded_argument_bytes) in [(65, 0), (1, 65_537)] {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let mut rejected = started(FakePlatform::new(10, 10).with_event_log(Arc::clone(&events)));
+        let error = do_actions(
+            &mut rejected,
+            &DoArgs {
+                actions: limit_actions(actions),
+                then: None,
+                timeout_ms: None,
+                encoded_argument_bytes,
+            },
+        )
+        .unwrap_err();
+        assert_eq!(error_code(error), "invalid_sequence");
+        assert!(events.lock().unwrap().is_empty());
+    }
 }
 
 #[test]

--- a/crates/glass-mcp/src/tools/batch/tests.rs
+++ b/crates/glass-mcp/src/tools/batch/tests.rs
@@ -592,6 +592,10 @@ fn type_secret_failure_preserves_no_active_session_without_echoing_input() {
         &mut glass,
         &DoArgs {
             actions: vec![Action::Type(TypeArgs {
+                target: None,
+                focus_mode: None,
+                timeout_ms: None,
+                max_nodes: None,
                 text: secret.into(),
                 return_: None,
             })],
@@ -617,7 +621,10 @@ fn set_value_secret_failure_preserves_no_active_session_without_echoing_input() 
         &mut glass,
         &DoArgs {
             actions: vec![Action::SetValue(SetValueArgs {
-                id: 1,
+                id: Some(1),
+                target: None,
+                timeout_ms: None,
+                max_nodes: None,
                 text: secret.into(),
                 return_: None,
             })],
@@ -648,7 +655,10 @@ fn assert_safe_set_value_category(
         &mut glass,
         &DoArgs {
             actions: vec![Action::SetValue(SetValueArgs {
-                id: 1,
+                id: Some(1),
+                target: None,
+                timeout_ms: None,
+                max_nodes: None,
                 text: secret.into(),
                 return_: None,
             })],
@@ -805,7 +815,10 @@ fn real_combo_missing_option_after_open_and_failed_escape_is_attempted_and_secre
         &mut glass,
         &DoArgs {
             actions: vec![Action::SetValue(SetValueArgs {
-                id: 1,
+                id: Some(1),
+                target: None,
+                timeout_ms: None,
+                max_nodes: None,
                 text: submitted_secret.into(),
                 return_: None,
             })],
@@ -846,6 +859,10 @@ fn secret_failure_omits_backend_detail_containing_submitted_input() {
         &mut type_glass,
         &DoArgs {
             actions: vec![Action::Type(TypeArgs {
+                target: None,
+                focus_mode: None,
+                timeout_ms: None,
+                max_nodes: None,
                 text: typed_secret.into(),
                 return_: None,
             })],
@@ -866,7 +883,10 @@ fn secret_failure_omits_backend_detail_containing_submitted_input() {
         &mut set_glass,
         &DoArgs {
             actions: vec![Action::SetValue(SetValueArgs {
-                id: 1,
+                id: Some(1),
+                target: None,
+                timeout_ms: None,
+                max_nodes: None,
                 text: set_secret.into(),
                 return_: None,
             })],
@@ -986,6 +1006,10 @@ fn sequence_deadline_construction_is_checked() {
 fn standalone_return_handlers_keep_wire_shape_and_unbounded_context() {
     let frame = Frame::solid(100, 100, [7, 8, 9, 255]);
     let settle_args = TypeArgs {
+        target: None,
+        focus_mode: None,
+        timeout_ms: None,
+        max_nodes: None,
         text: "private".into(),
         return_: Some("settle".into()),
     };
@@ -1020,6 +1044,10 @@ fn standalone_return_handlers_keep_wire_shape_and_unbounded_context() {
     assert_eq!(contextual_deadlines.lock().unwrap()[0], Deadline::UNBOUNDED);
 
     let snapshot_args = TypeArgs {
+        target: None,
+        focus_mode: None,
+        timeout_ms: None,
+        max_nodes: None,
         text: "private".into(),
         return_: Some("snapshot".into()),
     };
@@ -1059,6 +1087,10 @@ fn standalone_return_handlers_keep_wire_shape_and_unbounded_context() {
     }
 
     let invalid = TypeArgs {
+        target: None,
+        focus_mode: None,
+        timeout_ms: None,
+        max_nodes: None,
         text: "private".into(),
         return_: Some("later".into()),
     };
@@ -1466,6 +1498,10 @@ fn caller_soft_return_settle_fails_the_mutating_action() {
             vec![
                 click(1, 1),
                 Action::Type(TypeArgs {
+                    target: None,
+                    focus_mode: None,
+                    timeout_ms: None,
+                    max_nodes: None,
                     text: "secret".into(),
                     return_: Some("settle".into()),
                 }),
@@ -1502,6 +1538,10 @@ fn caller_soft_return_snapshot_stops_before_accessibility_work() {
         &mut g,
         &do_args(
             vec![Action::Type(TypeArgs {
+                target: None,
+                focus_mode: None,
+                timeout_ms: None,
+                max_nodes: None,
                 text: "secret".into(),
                 return_: Some("snapshot".into()),
             })],
@@ -1527,6 +1567,10 @@ fn return_snapshot_propagates_settle_capture_failure_after_dispatch() {
         &mut g,
         &do_args(
             vec![Action::Type(TypeArgs {
+                target: None,
+                focus_mode: None,
+                timeout_ms: None,
+                max_nodes: None,
                 text: "secret".into(),
                 return_: Some("snapshot".into()),
             })],
@@ -1559,6 +1603,10 @@ fn type_return_not_dispatched_after_actuation_remains_attempted() {
         &mut g,
         &do_args(
             vec![Action::Type(TypeArgs {
+                target: None,
+                focus_mode: None,
+                timeout_ms: None,
+                max_nodes: None,
                 text: "secret".into(),
                 return_: Some("settle".into()),
             })],
@@ -1579,7 +1627,11 @@ fn click_element_return_not_dispatched_after_actuation_remains_attempted() {
         &mut g,
         &do_args(
             vec![Action::ClickElement(ClickElementArgs {
-                id: 1,
+                id: Some(1),
+                target: None,
+                mode: None,
+                timeout_ms: None,
+                max_nodes: None,
                 return_: Some("settle".into()),
             })],
             100,
@@ -1599,7 +1651,10 @@ fn set_value_return_not_dispatched_after_actuation_remains_attempted() {
         &mut g,
         &do_args(
             vec![Action::SetValue(SetValueArgs {
-                id: 1,
+                id: Some(1),
+                target: None,
+                timeout_ms: None,
+                max_nodes: None,
                 text: "secret".into(),
                 return_: Some("settle".into()),
             })],
@@ -1620,7 +1675,10 @@ fn set_value_caller_deadline_shorter_than_backend_ceiling_is_sequence_deadline_e
         &mut g,
         &do_args(
             vec![Action::SetValue(SetValueArgs {
-                id: 1,
+                id: Some(1),
+                target: None,
+                timeout_ms: None,
+                max_nodes: None,
                 text: "secret".into(),
                 return_: None,
             })],
@@ -1652,7 +1710,10 @@ fn set_value_backend_ceiling_shorter_than_sequence_is_transport_failure() {
         &mut g,
         &do_args(
             vec![Action::SetValue(SetValueArgs {
-                id: 1,
+                id: Some(1),
+                target: None,
+                timeout_ms: None,
+                max_nodes: None,
                 text: "secret".into(),
                 return_: None,
             })],
@@ -1684,7 +1745,10 @@ fn set_value_transport_failure_keeps_post_write_retry_guidance() {
         &mut g,
         &do_args(
             vec![Action::SetValue(SetValueArgs {
-                id: 1,
+                id: Some(1),
+                target: None,
+                timeout_ms: None,
+                max_nodes: None,
                 text: "secret".into(),
                 return_: None,
             })],
@@ -1714,7 +1778,10 @@ fn set_value_worker_spawn_failure_is_unattempted_and_safe_to_retry() {
         &mut g,
         &do_args(
             vec![Action::SetValue(SetValueArgs {
-                id: 1,
+                id: Some(1),
+                target: None,
+                timeout_ms: None,
+                max_nodes: None,
                 text: "secret".into(),
                 return_: None,
             })],
@@ -1850,6 +1917,10 @@ fn success_retains_existing_fields_and_adds_every_step_result() {
             actions: vec![
                 click(10, 20),
                 Action::Type(TypeArgs {
+                    target: None,
+                    focus_mode: None,
+                    timeout_ms: None,
+                    max_nodes: None,
                     text: "alice".into(),
                     return_: None,
                 }),
@@ -1897,6 +1968,10 @@ fn type_return_snapshot_is_retained_in_content_blocks() {
         &mut g,
         &DoArgs {
             actions: vec![Action::Type(TypeArgs {
+                target: None,
+                focus_mode: None,
+                timeout_ms: None,
+                max_nodes: None,
                 text: "hi".into(),
                 return_: Some("snapshot".into()),
             })],
@@ -1930,6 +2005,10 @@ fn type_action_with_return_none_is_allowed() {
         &mut g,
         &DoArgs {
             actions: vec![Action::Type(TypeArgs {
+                target: None,
+                focus_mode: None,
+                timeout_ms: None,
+                max_nodes: None,
                 text: "hi".into(),
                 return_: Some("none".into()),
             })],
@@ -2101,6 +2180,10 @@ fn mutating_action_validation_failures_are_proven_not_dispatched() {
         (
             "type return",
             Action::Type(TypeArgs {
+                target: None,
+                focus_mode: None,
+                timeout_ms: None,
+                max_nodes: None,
                 text: "secret".into(),
                 return_: Some("invalid".into()),
             }),
@@ -2108,14 +2191,21 @@ fn mutating_action_validation_failures_are_proven_not_dispatched() {
         (
             "click_element return",
             Action::ClickElement(ClickElementArgs {
-                id: 1,
+                id: Some(1),
+                target: None,
+                mode: None,
+                timeout_ms: None,
+                max_nodes: None,
                 return_: Some("invalid".into()),
             }),
         ),
         (
             "set_value return",
             Action::SetValue(SetValueArgs {
-                id: 1,
+                id: Some(1),
+                target: None,
+                timeout_ms: None,
+                max_nodes: None,
                 text: "secret".into(),
                 return_: Some("invalid".into()),
             }),
@@ -2235,7 +2325,10 @@ fn invalid_boolean_semantic_validation_is_proven_not_dispatched() {
         &mut g,
         &do_args(
             vec![Action::SetValue(SetValueArgs {
-                id: 1,
+                id: Some(1),
+                target: None,
+                timeout_ms: None,
+                max_nodes: None,
                 text: "not-a-boolean".into(),
                 return_: None,
             })],
@@ -2263,11 +2356,18 @@ fn semantic_actions_delegate_and_retain_standalone_results() {
         &DoArgs {
             actions: vec![
                 Action::ClickElement(ClickElementArgs {
-                    id: 1,
+                    id: Some(1),
+                    target: None,
+                    mode: None,
+                    timeout_ms: None,
+                    max_nodes: None,
                     return_: None,
                 }),
                 Action::SetValue(SetValueArgs {
-                    id: 1,
+                    id: Some(1),
+                    target: None,
+                    timeout_ms: None,
+                    max_nodes: None,
                     text: "secret".into(),
                     return_: None,
                 }),
@@ -2349,7 +2449,11 @@ fn click_element_stale_target_stops_with_structured_detail() {
             &DoArgs {
                 actions: vec![
                     Action::ClickElement(ClickElementArgs {
-                        id: 99,
+                        id: Some(99),
+                        target: None,
+                        mode: None,
+                        timeout_ms: None,
+                        max_nodes: None,
                         return_: None,
                     }),
                     Action::Key(KeyArgs {
@@ -2501,7 +2605,11 @@ fn semantic_return_snapshot_keeps_untrusted_outline_outside_the_envelope() {
         &mut g,
         &DoArgs {
             actions: vec![Action::ClickElement(ClickElementArgs {
-                id: 1,
+                id: Some(1),
+                target: None,
+                mode: None,
+                timeout_ms: None,
+                max_nodes: None,
                 return_: Some("snapshot".into()),
             })],
             then: None,
@@ -2539,7 +2647,11 @@ fn app_element_details_stay_in_untrusted_step_content() {
         &mut g,
         &DoArgs {
             actions: vec![Action::ClickElement(ClickElementArgs {
-                id: 1,
+                id: Some(1),
+                target: None,
+                mode: None,
+                timeout_ms: None,
+                max_nodes: None,
                 return_: Some("snapshot".into()),
             })],
             then: None,
@@ -2588,7 +2700,11 @@ fn stale_target_detail_is_not_embedded_in_trusted_error_json() {
         &DoArgs {
             actions: vec![
                 Action::ClickElement(ClickElementArgs {
-                    id: 1,
+                    id: Some(1),
+                    target: None,
+                    mode: None,
+                    timeout_ms: None,
+                    max_nodes: None,
                     return_: None,
                 }),
                 Action::Key(KeyArgs {
@@ -2637,11 +2753,18 @@ fn typed_and_set_value_text_are_never_echoed() {
         &DoArgs {
             actions: vec![
                 Action::Type(TypeArgs {
+                    target: None,
+                    focus_mode: None,
+                    timeout_ms: None,
+                    max_nodes: None,
                     text: typed_success.into(),
                     return_: None,
                 }),
                 Action::SetValue(SetValueArgs {
-                    id: 1,
+                    id: Some(1),
+                    target: None,
+                    timeout_ms: None,
+                    max_nodes: None,
                     text: set_success.into(),
                     return_: None,
                 }),
@@ -2670,6 +2793,10 @@ fn typed_and_set_value_text_are_never_echoed() {
         &mut type_g,
         &DoArgs {
             actions: vec![Action::Type(TypeArgs {
+                target: None,
+                focus_mode: None,
+                timeout_ms: None,
+                max_nodes: None,
                 text: typed_failure.into(),
                 return_: Some("not-a-return".into()),
             })],
@@ -2684,7 +2811,10 @@ fn typed_and_set_value_text_are_never_echoed() {
         &mut set_g,
         &DoArgs {
             actions: vec![Action::SetValue(SetValueArgs {
-                id: 99,
+                id: Some(99),
+                target: None,
+                timeout_ms: None,
+                max_nodes: None,
                 text: set_failure.into(),
                 return_: None,
             })],
@@ -2717,6 +2847,10 @@ fn typed_and_set_value_text_are_never_echoed() {
         &mut type_g,
         &DoArgs {
             actions: vec![Action::Type(TypeArgs {
+                target: None,
+                focus_mode: None,
+                timeout_ms: None,
+                max_nodes: None,
                 text: typed_dispatch_failure.into(),
                 return_: None,
             })],
@@ -2741,7 +2875,10 @@ fn typed_and_set_value_text_are_never_echoed() {
         &mut set_g,
         &DoArgs {
             actions: vec![Action::SetValue(SetValueArgs {
-                id: 1,
+                id: Some(1),
+                target: None,
+                timeout_ms: None,
+                max_nodes: None,
                 text: set_dispatch_failure.into(),
                 return_: None,
             })],
@@ -2794,11 +2931,19 @@ fn content_indices_cover_completed_step_siblings_before_failure_detail() {
         &DoArgs {
             actions: vec![
                 Action::ClickElement(ClickElementArgs {
-                    id: 1,
+                    id: Some(1),
+                    target: None,
+                    mode: None,
+                    timeout_ms: None,
+                    max_nodes: None,
                     return_: Some("snapshot".into()),
                 }),
                 Action::ClickElement(ClickElementArgs {
-                    id: 99,
+                    id: Some(99),
+                    target: None,
+                    mode: None,
+                    timeout_ms: None,
+                    max_nodes: None,
                     return_: None,
                 }),
                 Action::Key(KeyArgs {
@@ -3447,6 +3592,10 @@ fn terminal_content_blocks_reference_images_and_notes_in_response_order() {
         &mut g,
         &DoArgs {
             actions: vec![Action::Type(TypeArgs {
+                target: None,
+                focus_mode: None,
+                timeout_ms: None,
+                max_nodes: None,
                 text: "secret".into(),
                 return_: Some("snapshot".into()),
             })],

--- a/crates/glass-mcp/src/tools/batch/tests.rs
+++ b/crates/glass-mcp/src/tools/batch/tests.rs
@@ -1096,16 +1096,23 @@ fn standalone_return_handlers_keep_wire_shape_and_unbounded_context() {
     };
     let mut standalone = started(FakePlatform::new(100, 100));
     let mut contextual = started(FakePlatform::new(100, 100));
+    let standalone = crate::tools::type_text(&mut standalone, &invalid).unwrap_err();
+    let contextual = crate::tools::type_text_with(
+        &mut contextual,
+        &invalid,
+        crate::tools::ToolContext::UNBOUNDED,
+    )
+    .unwrap_err();
+    let envelope: serde_json::Value =
+        serde_json::from_str(&standalone.render_text_blocks()[0]).unwrap();
+    assert_eq!(envelope["error"]["code"], contextual.code);
+    assert_eq!(envelope["error"]["summary"], contextual.safe_summary);
     assert_eq!(
-        crate::tools::type_text(&mut standalone, &invalid).unwrap_err(),
-        crate::tools::type_text_with(
-            &mut contextual,
-            &invalid,
-            crate::tools::ToolContext::UNBOUNDED,
-        )
-        .unwrap_err()
-        .message
+        contextual.bound_dispatch,
+        Some(glass_core::BoundDispatch::NotDispatched)
     );
+    assert_eq!(envelope["result"]["dispatch"], "not_dispatched");
+    assert_eq!(envelope["result"]["side_effects_may_have_occurred"], false);
 }
 
 #[test]

--- a/crates/glass-mcp/src/tools/find.rs
+++ b/crates/glass-mcp/src/tools/find.rs
@@ -1,10 +1,10 @@
 use glass_core::{
     AxRole, FindElementsParams, Glass, MatchField, MatchTier, ScopeResolution, SemanticMatch,
-    SemanticQuery, SemanticSelector, SemanticState,
+    SemanticQuery, SemanticSelector, SemanticState, SemanticTarget,
 };
 use serde_json::{Value, json};
 
-use crate::params::{FindElementsArgs, FindSelectorArgs};
+use crate::params::{ActionTargetArgs, FindElementsArgs, FindSelectorArgs};
 use crate::tools::{OutContent, ToolOutput, ToolResult};
 
 const DEFAULT_MAX_RESULTS: usize = 10;
@@ -42,7 +42,7 @@ pub fn find_elements(glass: &mut Glass, a: &FindElementsArgs) -> ToolResult {
         return Err(bounded_error("max_results must be between 1 and 20"));
     }
 
-    let target = selector(a.query.clone(), a.role.as_deref(), a.states.as_deref())?;
+    let target = semantic_selector(a.query.clone(), a.role.as_deref(), a.states.as_deref())?;
     let within = a.within.as_ref().map(selector_args).transpose()?;
     let query = SemanticQuery::new(target, within, max_results as usize)
         .map_err(|error| bounded_error(error.to_string()))?;
@@ -89,14 +89,14 @@ pub fn find_elements(glass: &mut Glass, a: &FindElementsArgs) -> ToolResult {
 }
 
 fn selector_args(args: &FindSelectorArgs) -> Result<SemanticSelector, String> {
-    selector(
+    semantic_selector(
         args.query.clone(),
         args.role.as_deref(),
         args.states.as_deref(),
     )
 }
 
-fn selector(
+pub(crate) fn semantic_selector(
     query: Option<String>,
     role: Option<&str>,
     states: Option<&[String]>,
@@ -117,6 +117,28 @@ fn selector(
         })
         .collect::<Result<Vec<_>, _>>()?;
     SemanticSelector::new(query, role, states).map_err(|error| bounded_error(error.to_string()))
+}
+
+pub(crate) fn semantic_target(args: &ActionTargetArgs) -> Result<SemanticTarget, String> {
+    let within = args
+        .within
+        .as_ref()
+        .map(|scope| {
+            semantic_selector(
+                scope.query.clone(),
+                scope.role.as_deref(),
+                scope.states.as_deref(),
+            )
+        })
+        .transpose()?;
+    Ok(SemanticTarget {
+        target: semantic_selector(
+            args.query.clone(),
+            args.role.as_deref(),
+            args.states.as_deref(),
+        )?,
+        within,
+    })
 }
 
 fn render_match(matched: &SemanticMatch) -> RenderedMatch {

--- a/crates/glass-mcp/src/tools/input.rs
+++ b/crates/glass-mcp/src/tools/input.rs
@@ -4,8 +4,8 @@ use glass_core::{Glass, KeyEvent, Modifier, MouseButton, PointerEvent};
 
 use crate::params::*;
 use crate::tools::{
-    ContextualError, ContextualOutput, ContextualToolResult, ToolContext, ToolOutput, ToolResult,
-    parse_button,
+    BatchToolResult, ContextualError, ContextualOutput, ContextualToolResult, ToolContext,
+    ToolOutput, ToolResult, erase_semantic_context, parse_button, semantic_return_error,
 };
 
 fn standalone(result: ContextualToolResult) -> ToolResult {
@@ -204,8 +204,11 @@ pub(crate) fn scroll_with(
     )))
 }
 
-pub fn type_text(glass: &mut Glass, a: &TypeArgs) -> ToolResult {
-    standalone(type_text_with(glass, a, ToolContext::UNBOUNDED))
+pub fn type_text(glass: &mut Glass, a: &TypeArgs) -> BatchToolResult {
+    erase_semantic_context(
+        "glass_type",
+        type_text_with(glass, a, ToolContext::UNBOUNDED),
+    )
 }
 
 pub(crate) fn type_text_with(
@@ -214,39 +217,59 @@ pub(crate) fn type_text_with(
     context: ToolContext,
 ) -> ContextualToolResult {
     match crate::tools::semantic_action::validate_type_args(a)? {
-        crate::tools::semantic_action::ValidatedType::Untargeted => glass
-            .key_by(&KeyEvent::Text(a.text.clone()), context.deadline)
-            .map_err(|e| ContextualError::from_caller_bound(e, context))?,
-        crate::tools::semantic_action::ValidatedType::Targeted(params) => {
+        crate::tools::semantic_action::ValidatedType::Untargeted => {
             glass
+                .key_by(&KeyEvent::Text(a.text.clone()), context.deadline)
+                .map_err(|e| ContextualError::from_caller_bound(e, context))?;
+            let (observed, extra, timed_out_by) =
+                crate::tools::resolve_return_with(glass, a.return_.as_deref(), context).map_err(
+                    |error| {
+                        error
+                            .after_dispatch()
+                            .annotate("text was typed; return observe failed")
+                    },
+                )?;
+            let mut result = serde_json::json!({});
+            if let Some(observed) = observed {
+                result["observed"] = observed;
+            }
+            Ok(ContextualOutput::with_timeout(
+                ToolOutput::result_with("glass_type", result, extra),
+                timed_out_by,
+            ))
+        }
+        crate::tools::semantic_action::ValidatedType::Targeted(params) => {
+            let outcome = glass
                 .type_target_by(&params, &a.text, context.deadline)
                 .map_err(|error| {
-                    let message = error.to_string();
-                    match error.source {
-                        Some(source) => ContextualError::from_caller_bound(source, context),
-                        None => ContextualError::from_caller_bound(
-                            glass_core::GlassError::Backend(message),
-                            context,
-                        ),
-                    }
+                    crate::tools::semantic_action::semantic_error("glass_type", error)
                 })?;
+            let action_context = ToolContext {
+                deadline: outcome.bound.deadline,
+                owner: outcome.bound.owner,
+                allow_wait: outcome.bound.allow_wait,
+            };
+            let (observed, extra, timed_out_by) =
+                crate::tools::resolve_return_with(glass, a.return_.as_deref(), action_context)
+                    .map_err(|error| {
+                        semantic_return_error(
+                            "glass_type",
+                            &outcome,
+                            error,
+                            "text was typed; return observe failed",
+                        )
+                    })?;
+            Ok(ContextualOutput::with_timeout(
+                crate::tools::semantic_action::success_output(
+                    "glass_type",
+                    &outcome,
+                    observed,
+                    extra,
+                ),
+                timed_out_by,
+            ))
         }
     }
-    // Past this point the keystrokes have landed: a failing observe (e.g. `snapshot`
-    // with no a11y reader) must say so, or an agent retries and types the text twice.
-    let (observed, extra, timed_out_by) =
-        crate::tools::resolve_return_with(glass, a.return_.as_deref(), context).map_err(|e| {
-            e.after_dispatch()
-                .annotate("text was typed; return observe failed")
-        })?;
-    let mut result = serde_json::json!({});
-    if let Some(o) = observed {
-        result["observed"] = o;
-    }
-    Ok(ContextualOutput::with_timeout(
-        ToolOutput::result_with("glass_type", result, extra),
-        timed_out_by,
-    ))
 }
 
 pub fn key(glass: &mut Glass, a: &KeyArgs) -> ToolResult {

--- a/crates/glass-mcp/src/tools/input.rs
+++ b/crates/glass-mcp/src/tools/input.rs
@@ -1,6 +1,6 @@
 //! Pointer and keyboard tools.
 
-use glass_core::{Glass, KeyEvent, Modifier, PointerEvent};
+use glass_core::{Glass, KeyEvent, Modifier, MouseButton, PointerEvent};
 
 use crate::params::*;
 use crate::tools::{
@@ -22,6 +22,54 @@ pub(crate) fn parse_modifiers(mods: Option<&[String]>) -> Result<Vec<Modifier>, 
     Ok(out)
 }
 
+fn validate_click_count(count: Option<u32>) -> Result<u32, ContextualError> {
+    let count = count.unwrap_or(1);
+    if !(1..=MAX_CLICK_COUNT).contains(&count) {
+        return Err(ContextualError::validation(format!(
+            "`count` must be between 1 and {MAX_CLICK_COUNT}"
+        )));
+    }
+    Ok(count)
+}
+
+pub(crate) fn validate_click_args(
+    a: &ClickArgs,
+) -> Result<(MouseButton, Vec<Modifier>, u32), ContextualError> {
+    let count = validate_click_count(a.count)?;
+    let button = parse_button(a.button.as_deref()).map_err(ContextualError::validation)?;
+    let modifiers = parse_modifiers(a.modifiers.as_deref()).map_err(ContextualError::validation)?;
+    Ok((button, modifiers, count))
+}
+
+pub(crate) fn validate_drag_args(
+    a: &DragArgs,
+) -> Result<(MouseButton, Vec<Modifier>), ContextualError> {
+    let button = parse_button(a.button.as_deref()).map_err(ContextualError::validation)?;
+    let modifiers = parse_modifiers(a.modifiers.as_deref()).map_err(ContextualError::validation)?;
+    Ok((button, modifiers))
+}
+
+pub(crate) fn validate_scroll_args(
+    a: &ScrollArgs,
+) -> Result<(i32, i32, Vec<Modifier>), ContextualError> {
+    let dx = a.dx.unwrap_or(0);
+    let dy = a.dy.unwrap_or(0);
+    let valid = -MAX_SCROLL_NOTCHES..=MAX_SCROLL_NOTCHES;
+    if !valid.contains(&dx) || !valid.contains(&dy) {
+        return Err(ContextualError::validation(format!(
+            "`dx` and `dy` must each be between -{MAX_SCROLL_NOTCHES} and {MAX_SCROLL_NOTCHES}"
+        )));
+    }
+    let modifiers = parse_modifiers(a.modifiers.as_deref()).map_err(ContextualError::validation)?;
+    Ok((dx, dy, modifiers))
+}
+
+pub(crate) fn validate_key_args(a: &KeyArgs) -> Result<(), ContextualError> {
+    glass_core::keys::parse_chord(&a.chord)
+        .map(|_| ())
+        .map_err(|error| ContextualError::validation(error.to_string()))
+}
+
 pub fn click(glass: &mut Glass, a: &ClickArgs) -> ToolResult {
     standalone(click_with(glass, a, ToolContext::UNBOUNDED))
 }
@@ -31,14 +79,7 @@ pub(crate) fn click_with(
     a: &ClickArgs,
     context: ToolContext,
 ) -> ContextualToolResult {
-    let count = a.count.unwrap_or(1);
-    if !(1..=MAX_CLICK_COUNT).contains(&count) {
-        return Err(ContextualError::validation(format!(
-            "`count` must be between 1 and {MAX_CLICK_COUNT}"
-        )));
-    }
-    let button = parse_button(a.button.as_deref()).map_err(ContextualError::validation)?;
-    let modifiers = parse_modifiers(a.modifiers.as_deref()).map_err(ContextualError::validation)?;
+    let (button, modifiers, count) = validate_click_args(a)?;
     glass
         .pointer_by(
             &PointerEvent::Click {
@@ -84,8 +125,7 @@ pub(crate) fn drag_with(
     a: &DragArgs,
     context: ToolContext,
 ) -> ContextualToolResult {
-    let button = parse_button(a.button.as_deref()).map_err(ContextualError::validation)?;
-    let modifiers = parse_modifiers(a.modifiers.as_deref()).map_err(ContextualError::validation)?;
+    let (button, modifiers) = validate_drag_args(a)?;
     glass
         .pointer_by(
             &PointerEvent::Drag {
@@ -145,15 +185,7 @@ pub(crate) fn scroll_with(
     a: &ScrollArgs,
     context: ToolContext,
 ) -> ContextualToolResult {
-    let dx = a.dx.unwrap_or(0);
-    let dy = a.dy.unwrap_or(0);
-    let valid = -MAX_SCROLL_NOTCHES..=MAX_SCROLL_NOTCHES;
-    if !valid.contains(&dx) || !valid.contains(&dy) {
-        return Err(ContextualError::validation(format!(
-            "`dx` and `dy` must each be between -{MAX_SCROLL_NOTCHES} and {MAX_SCROLL_NOTCHES}"
-        )));
-    }
-    let modifiers = parse_modifiers(a.modifiers.as_deref()).map_err(ContextualError::validation)?;
+    let (dx, dy, modifiers) = validate_scroll_args(a)?;
     glass
         .pointer_by(
             &PointerEvent::Scroll {
@@ -181,11 +213,25 @@ pub(crate) fn type_text_with(
     a: &TypeArgs,
     context: ToolContext,
 ) -> ContextualToolResult {
-    // Bad `return` value → reject before injecting anything (see `validate_return`).
-    crate::tools::validate_return(a.return_.as_deref()).map_err(ContextualError::validation)?;
-    glass
-        .key_by(&KeyEvent::Text(a.text.clone()), context.deadline)
-        .map_err(|e| ContextualError::from_caller_bound(e, context))?;
+    match crate::tools::semantic_action::validate_type_args(a)? {
+        crate::tools::semantic_action::ValidatedType::Untargeted => glass
+            .key_by(&KeyEvent::Text(a.text.clone()), context.deadline)
+            .map_err(|e| ContextualError::from_caller_bound(e, context))?,
+        crate::tools::semantic_action::ValidatedType::Targeted(params) => {
+            glass
+                .type_target_by(&params, &a.text, context.deadline)
+                .map_err(|error| {
+                    let message = error.to_string();
+                    match error.source {
+                        Some(source) => ContextualError::from_caller_bound(source, context),
+                        None => ContextualError::from_caller_bound(
+                            glass_core::GlassError::Backend(message),
+                            context,
+                        ),
+                    }
+                })?;
+        }
+    }
     // Past this point the keystrokes have landed: a failing observe (e.g. `snapshot`
     // with no a11y reader) must say so, or an agent retries and types the text twice.
     let (observed, extra, timed_out_by) =
@@ -212,6 +258,7 @@ pub(crate) fn key_with(
     a: &KeyArgs,
     context: ToolContext,
 ) -> ContextualToolResult {
+    validate_key_args(a)?;
     glass
         .key_by(&KeyEvent::Chord(a.chord.clone()), context.deadline)
         .map_err(|e| ContextualError::from_caller_bound(e, context))?;
@@ -342,6 +389,10 @@ mod tests {
             &type_text(
                 &mut g,
                 &TypeArgs {
+                    target: None,
+                    focus_mode: None,
+                    timeout_ms: None,
+                    max_nodes: None,
                     text: "hi".into(),
                     return_: None,
                 },

--- a/crates/glass-mcp/src/tools/input.rs
+++ b/crates/glass-mcp/src/tools/input.rs
@@ -226,6 +226,7 @@ pub(crate) fn type_text_with(
                     .map_err(|error| {
                         error
                             .after_dispatch()
+                            .scrub_message()
                             .annotate("text was typed; return observe failed")
                     })?;
             let mut result = serde_json::json!({});
@@ -261,6 +262,8 @@ pub(crate) fn type_text_with(
                     error,
                     "text was typed; return observe failed",
                 )
+                .scrub_message()
+                .annotate("text was typed; return observe failed")
             })?;
             Ok(ContextualOutput::with_timeout(
                 crate::tools::semantic_action::success_output(

--- a/crates/glass-mcp/src/tools/input.rs
+++ b/crates/glass-mcp/src/tools/input.rs
@@ -220,15 +220,14 @@ pub(crate) fn type_text_with(
         crate::tools::semantic_action::ValidatedType::Untargeted => {
             glass
                 .key_by(&KeyEvent::Text(a.text.clone()), context.deadline)
-                .map_err(|e| ContextualError::from_caller_bound(e, context))?;
+                .map_err(|e| ContextualError::from_caller_bound(e, context).scrub_message())?;
             let (observed, extra, timed_out_by) =
-                crate::tools::resolve_return_with(glass, a.return_.as_deref(), context).map_err(
-                    |error| {
+                crate::tools::resolve_return_with(glass, a.return_.as_deref(), context, true)
+                    .map_err(|error| {
                         error
                             .after_dispatch()
                             .annotate("text was typed; return observe failed")
-                    },
-                )?;
+                    })?;
             let mut result = serde_json::json!({});
             if let Some(observed) = observed {
                 result["observed"] = observed;
@@ -249,16 +248,20 @@ pub(crate) fn type_text_with(
                 owner: outcome.bound.owner,
                 allow_wait: outcome.bound.allow_wait,
             };
-            let (observed, extra, timed_out_by) =
-                crate::tools::resolve_return_with(glass, a.return_.as_deref(), action_context)
-                    .map_err(|error| {
-                        semantic_return_error(
-                            "glass_type",
-                            &outcome,
-                            error,
-                            "text was typed; return observe failed",
-                        )
-                    })?;
+            let (observed, extra, timed_out_by) = crate::tools::resolve_return_with(
+                glass,
+                a.return_.as_deref(),
+                action_context,
+                false,
+            )
+            .map_err(|error| {
+                semantic_return_error(
+                    "glass_type",
+                    &outcome,
+                    error,
+                    "text was typed; return observe failed",
+                )
+            })?;
             Ok(ContextualOutput::with_timeout(
                 crate::tools::semantic_action::success_output(
                     "glass_type",

--- a/crates/glass-mcp/src/tools/semantic_action.rs
+++ b/crates/glass-mcp/src/tools/semantic_action.rs
@@ -1,0 +1,169 @@
+use glass_core::{
+    ActionMode, ActionTarget, AxNodeId, ClickTargetParams, SEMANTIC_ACTION_DEFAULT_TIMEOUT_MS,
+    SEMANTIC_ACTION_MAX_TIMEOUT_MS, SetValueTargetParams, TypeTargetParams,
+};
+
+use crate::params::{Action, ActionModeArg, ClickElementArgs, SetValueArgs, TypeArgs};
+use crate::tools::find::semantic_target;
+use crate::tools::{ContextualError, validate_return, validate_settle_args};
+
+pub(crate) enum ValidatedType {
+    Untargeted,
+    Targeted(TypeTargetParams),
+}
+
+impl From<ActionModeArg> for ActionMode {
+    fn from(value: ActionModeArg) -> Self {
+        match value {
+            ActionModeArg::Auto => Self::Auto,
+            ActionModeArg::Native => Self::Native,
+            ActionModeArg::Pointer => Self::Pointer,
+        }
+    }
+}
+
+fn validate_return_arg(return_: Option<&str>) -> Result<(), ContextualError> {
+    validate_return(return_).map_err(ContextualError::validation)
+}
+
+fn semantic_timeout(timeout_ms: Option<u64>) -> Result<u64, ContextualError> {
+    let timeout_ms = timeout_ms.unwrap_or(SEMANTIC_ACTION_DEFAULT_TIMEOUT_MS);
+    if timeout_ms > SEMANTIC_ACTION_MAX_TIMEOUT_MS {
+        return Err(ContextualError::validation(format!(
+            "`timeout_ms` must be between 0 and {SEMANTIC_ACTION_MAX_TIMEOUT_MS}"
+        )));
+    }
+    Ok(timeout_ms)
+}
+
+pub(crate) fn validate_click_element_args(
+    a: &ClickElementArgs,
+) -> Result<ClickTargetParams, ContextualError> {
+    validate_return_arg(a.return_.as_deref())?;
+    let mode = a.mode.map(Into::into).unwrap_or(ActionMode::Auto);
+    let target = match (a.id, a.target.as_ref()) {
+        (Some(id), None) => {
+            if a.timeout_ms.is_some() {
+                return Err(ContextualError::validation(
+                    "`timeout_ms` is available only with `target`, not `id`".into(),
+                ));
+            }
+            if a.max_nodes.is_some() {
+                return Err(ContextualError::validation(
+                    "`max_nodes` is available only with `target`, not `id`".into(),
+                ));
+            }
+            return Ok(ClickTargetParams {
+                target: ActionTarget::Id(AxNodeId(id)),
+                mode,
+                timeout_ms: None,
+                max_nodes: None,
+            });
+        }
+        (None, Some(target)) => {
+            ActionTarget::Semantic(semantic_target(target).map_err(ContextualError::validation)?)
+        }
+        _ => {
+            return Err(ContextualError::validation(
+                "specify exactly one of `id` or `target`".into(),
+            ));
+        }
+    };
+    Ok(ClickTargetParams {
+        target,
+        mode,
+        timeout_ms: Some(semantic_timeout(a.timeout_ms)?),
+        max_nodes: a.max_nodes.map(|value| value as usize),
+    })
+}
+
+pub(crate) fn validate_set_value_args(
+    a: &SetValueArgs,
+) -> Result<SetValueTargetParams, ContextualError> {
+    validate_return_arg(a.return_.as_deref())?;
+    let target = match (a.id, a.target.as_ref()) {
+        (Some(id), None) => {
+            if a.timeout_ms.is_some() {
+                return Err(ContextualError::validation(
+                    "`timeout_ms` is available only with `target`, not `id`".into(),
+                ));
+            }
+            if a.max_nodes.is_some() {
+                return Err(ContextualError::validation(
+                    "`max_nodes` is available only with `target`, not `id`".into(),
+                ));
+            }
+            return Ok(SetValueTargetParams {
+                target: ActionTarget::Id(AxNodeId(id)),
+                timeout_ms: None,
+                max_nodes: None,
+            });
+        }
+        (None, Some(target)) => {
+            ActionTarget::Semantic(semantic_target(target).map_err(ContextualError::validation)?)
+        }
+        _ => {
+            return Err(ContextualError::validation(
+                "specify exactly one of `id` or `target`".into(),
+            ));
+        }
+    };
+    Ok(SetValueTargetParams {
+        target,
+        timeout_ms: Some(semantic_timeout(a.timeout_ms)?),
+        max_nodes: a.max_nodes.map(|value| value as usize),
+    })
+}
+
+pub(crate) fn validate_type_args(a: &TypeArgs) -> Result<ValidatedType, ContextualError> {
+    validate_return_arg(a.return_.as_deref())?;
+    let Some(target) = a.target.as_ref() else {
+        if a.focus_mode.is_some() {
+            return Err(ContextualError::validation(
+                "`focus_mode` requires a targeted type action".into(),
+            ));
+        }
+        if a.timeout_ms.is_some() {
+            return Err(ContextualError::validation(
+                "`timeout_ms` requires a targeted type action".into(),
+            ));
+        }
+        if a.max_nodes.is_some() {
+            return Err(ContextualError::validation(
+                "`max_nodes` requires a targeted type action".into(),
+            ));
+        }
+        return Ok(ValidatedType::Untargeted);
+    };
+    Ok(ValidatedType::Targeted(TypeTargetParams {
+        target: semantic_target(target).map_err(ContextualError::validation)?,
+        focus_mode: a.focus_mode.map(Into::into).unwrap_or(ActionMode::Auto),
+        timeout_ms: semantic_timeout(a.timeout_ms)?,
+        max_nodes: a.max_nodes.map(|value| value as usize),
+    }))
+}
+
+pub(crate) fn validate_action(action: &Action) -> Result<(), ContextualError> {
+    match action {
+        Action::Click(args) => super::input::validate_click_args(args).map(|_| ()),
+        Action::Move(_) => Ok(()),
+        Action::Drag(args) => super::input::validate_drag_args(args).map(|_| ()),
+        Action::Scroll(args) => super::input::validate_scroll_args(args).map(|_| ()),
+        Action::Type(args) => validate_type_args(args).map(|_| ()),
+        Action::Key(args) => super::input::validate_key_args(args),
+        Action::Settle(args) => validate_settle_args(args),
+        Action::ClickElement(args) => validate_click_element_args(args).map(|_| ()),
+        Action::SetValue(args) => validate_set_value_args(args).map(|_| ()),
+        Action::WaitForElement(args) => {
+            super::wait::validate_wait_for_element_args(args).map(|_| ())
+        }
+        Action::ScrollToElement(args) => {
+            super::wait::validate_scroll_to_element_args(args).map(|_| ())
+        }
+    }
+}
+
+const _: fn(&Action) -> Result<(), ContextualError> = validate_action;
+
+#[cfg(test)]
+mod tests;

--- a/crates/glass-mcp/src/tools/semantic_action.rs
+++ b/crates/glass-mcp/src/tools/semantic_action.rs
@@ -354,6 +354,22 @@ fn merge_object(target: &mut Value, source: Value) {
     target.extend(source);
 }
 
+pub(crate) fn mutation_provenance(
+    focus: Option<&MutationReport>,
+    action_dispatch: DispatchStatus,
+) -> (glass_core::BoundDispatch, bool) {
+    let may_have_dispatched = action_dispatch != DispatchStatus::NotDispatched
+        || focus.is_some_and(|report| report.dispatch != DispatchStatus::NotDispatched);
+    (
+        if may_have_dispatched {
+            glass_core::BoundDispatch::MayHaveDispatched
+        } else {
+            glass_core::BoundDispatch::NotDispatched
+        },
+        may_have_dispatched,
+    )
+}
+
 pub(crate) fn success_output(
     tool: &'static str,
     outcome: &SemanticActionOutcome,
@@ -424,9 +440,11 @@ fn semantic_category(error: &SemanticActionError) -> SafeErrorCategory {
 }
 
 fn failure_result(error: &SemanticActionError) -> Value {
+    let (_, side_effects_may_have_occurred) =
+        mutation_provenance(error.focus.as_ref(), error.action_dispatch);
     let mut result = json!({
         "dispatch": error.action_dispatch.as_str(),
-        "side_effects_may_have_occurred": error.action_dispatch != DispatchStatus::NotDispatched,
+        "side_effects_may_have_occurred": side_effects_may_have_occurred,
         "retry": error.retry.as_str(),
         "actionability": actionability_json(&error.actionability),
         "candidate_count": error.candidates.len(),
@@ -445,33 +463,22 @@ pub(crate) fn semantic_error(tool: &'static str, error: SemanticActionError) -> 
     let include_text = tool != "glass_type";
     let mut siblings = Vec::new();
     if !error.candidates.is_empty() {
-        let body = if error.candidates.len() == 1
-            && matches!(
-                error.kind,
-                SemanticActionFailureKind::UnprovenSelectorState
-                    | SemanticActionFailureKind::NotActionable
-                    | SemanticActionFailureKind::UnstableTarget
-                    | SemanticActionFailureKind::FocusUnconfirmed
-            ) {
-            json!({ "target": element_json(&error.candidates[0].element, include_text) })
-        } else {
-            json!({ "candidates": candidates_json(&error.candidates, include_text) })
-        };
-        siblings.push(OutContent::untrusted_observation(&body.to_string()));
+        siblings.push(OutContent::untrusted_observation(
+            &json!({ "candidates": candidates_json(&error.candidates, include_text) }).to_string(),
+        ));
+    } else if let Some(target) = &error.target {
+        siblings.push(OutContent::untrusted_observation(
+            &json!({ "target": element_json(target, include_text) }).to_string(),
+        ));
     }
-    let bound_dispatch = Some(match error.action_dispatch {
-        DispatchStatus::NotDispatched => glass_core::BoundDispatch::NotDispatched,
-        DispatchStatus::Dispatched | DispatchStatus::MayHaveDispatched => {
-            glass_core::BoundDispatch::MayHaveDispatched
-        }
-    });
+    let (bound_dispatch, _) = mutation_provenance(error.focus.as_ref(), error.action_dispatch);
     ContextualError {
         code: category.code(),
         message: category.summary().into(),
         category,
         safe_summary: category.summary(),
         sequence_deadline_exceeded: category == SafeErrorCategory::SequenceDeadlineExceeded,
-        bound_dispatch,
+        bound_dispatch: Some(bound_dispatch),
         result: Some(failure_result(&error)),
         siblings,
         post_write: false,
@@ -479,4 +486,4 @@ pub(crate) fn semantic_error(tool: &'static str, error: SemanticActionError) -> 
 }
 
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;

--- a/crates/glass-mcp/src/tools/semantic_action.rs
+++ b/crates/glass-mcp/src/tools/semantic_action.rs
@@ -1,11 +1,18 @@
 use glass_core::{
-    ActionMode, ActionTarget, AxNodeId, ClickTargetParams, SEMANTIC_ACTION_DEFAULT_TIMEOUT_MS,
-    SEMANTIC_ACTION_MAX_TIMEOUT_MS, SetValueTargetParams, TypeTargetParams,
+    ActionMethod, ActionMode, ActionTarget, ActionabilityReport, AxNodeId, ClickTargetParams,
+    DispatchStatus, ElementInfo, MatchField, MatchTier, MutationReport, ResolutionReport,
+    SEMANTIC_ACTION_DEFAULT_TIMEOUT_MS, SEMANTIC_ACTION_MAX_TIMEOUT_MS, ScopeResolution,
+    SemanticActionError, SemanticActionFailureKind, SemanticActionOutcome, SemanticMatch,
+    SetValueTargetParams, TypeTargetParams, Whose,
 };
+use serde_json::{Value, json};
 
 use crate::params::{Action, ActionModeArg, ClickElementArgs, SetValueArgs, TypeArgs};
 use crate::tools::find::semantic_target;
-use crate::tools::{ContextualError, validate_return, validate_settle_args};
+use crate::tools::{
+    ContextualError, OutContent, SafeErrorCategory, ToolOutput, validate_return,
+    validate_settle_args,
+};
 
 pub(crate) enum ValidatedType {
     Untargeted,
@@ -23,15 +30,17 @@ impl From<ActionModeArg> for ActionMode {
 }
 
 fn validate_return_arg(return_: Option<&str>) -> Result<(), ContextualError> {
-    validate_return(return_).map_err(ContextualError::validation)
+    validate_return(return_)
+        .map_err(|message| ContextualError::validation_with_code("invalid_return", message))
 }
 
 fn semantic_timeout(timeout_ms: Option<u64>) -> Result<u64, ContextualError> {
     let timeout_ms = timeout_ms.unwrap_or(SEMANTIC_ACTION_DEFAULT_TIMEOUT_MS);
     if timeout_ms > SEMANTIC_ACTION_MAX_TIMEOUT_MS {
-        return Err(ContextualError::validation(format!(
-            "`timeout_ms` must be between 0 and {SEMANTIC_ACTION_MAX_TIMEOUT_MS}"
-        )));
+        return Err(ContextualError::validation_with_code(
+            "invalid_action_target",
+            format!("`timeout_ms` must be between 0 and {SEMANTIC_ACTION_MAX_TIMEOUT_MS}"),
+        ));
     }
     Ok(timeout_ms)
 }
@@ -44,12 +53,14 @@ pub(crate) fn validate_click_element_args(
     let target = match (a.id, a.target.as_ref()) {
         (Some(id), None) => {
             if a.timeout_ms.is_some() {
-                return Err(ContextualError::validation(
+                return Err(ContextualError::validation_with_code(
+                    "invalid_action_target",
                     "`timeout_ms` is available only with `target`, not `id`".into(),
                 ));
             }
             if a.max_nodes.is_some() {
-                return Err(ContextualError::validation(
+                return Err(ContextualError::validation_with_code(
+                    "invalid_action_target",
                     "`max_nodes` is available only with `target`, not `id`".into(),
                 ));
             }
@@ -61,10 +72,13 @@ pub(crate) fn validate_click_element_args(
             });
         }
         (None, Some(target)) => {
-            ActionTarget::Semantic(semantic_target(target).map_err(ContextualError::validation)?)
+            ActionTarget::Semantic(semantic_target(target).map_err(|message| {
+                ContextualError::validation_with_code("invalid_action_target", message)
+            })?)
         }
         _ => {
-            return Err(ContextualError::validation(
+            return Err(ContextualError::validation_with_code(
+                "invalid_action_target",
                 "specify exactly one of `id` or `target`".into(),
             ));
         }
@@ -84,12 +98,14 @@ pub(crate) fn validate_set_value_args(
     let target = match (a.id, a.target.as_ref()) {
         (Some(id), None) => {
             if a.timeout_ms.is_some() {
-                return Err(ContextualError::validation(
+                return Err(ContextualError::validation_with_code(
+                    "invalid_action_target",
                     "`timeout_ms` is available only with `target`, not `id`".into(),
                 ));
             }
             if a.max_nodes.is_some() {
-                return Err(ContextualError::validation(
+                return Err(ContextualError::validation_with_code(
+                    "invalid_action_target",
                     "`max_nodes` is available only with `target`, not `id`".into(),
                 ));
             }
@@ -100,10 +116,13 @@ pub(crate) fn validate_set_value_args(
             });
         }
         (None, Some(target)) => {
-            ActionTarget::Semantic(semantic_target(target).map_err(ContextualError::validation)?)
+            ActionTarget::Semantic(semantic_target(target).map_err(|message| {
+                ContextualError::validation_with_code("invalid_action_target", message)
+            })?)
         }
         _ => {
-            return Err(ContextualError::validation(
+            return Err(ContextualError::validation_with_code(
+                "invalid_action_target",
                 "specify exactly one of `id` or `target`".into(),
             ));
         }
@@ -119,24 +138,29 @@ pub(crate) fn validate_type_args(a: &TypeArgs) -> Result<ValidatedType, Contextu
     validate_return_arg(a.return_.as_deref())?;
     let Some(target) = a.target.as_ref() else {
         if a.focus_mode.is_some() {
-            return Err(ContextualError::validation(
+            return Err(ContextualError::validation_with_code(
+                "invalid_action_target",
                 "`focus_mode` requires a targeted type action".into(),
             ));
         }
         if a.timeout_ms.is_some() {
-            return Err(ContextualError::validation(
+            return Err(ContextualError::validation_with_code(
+                "invalid_action_target",
                 "`timeout_ms` requires a targeted type action".into(),
             ));
         }
         if a.max_nodes.is_some() {
-            return Err(ContextualError::validation(
+            return Err(ContextualError::validation_with_code(
+                "invalid_action_target",
                 "`max_nodes` requires a targeted type action".into(),
             ));
         }
         return Ok(ValidatedType::Untargeted);
     };
     Ok(ValidatedType::Targeted(TypeTargetParams {
-        target: semantic_target(target).map_err(ContextualError::validation)?,
+        target: semantic_target(target).map_err(|message| {
+            ContextualError::validation_with_code("invalid_action_target", message)
+        })?,
         focus_mode: a.focus_mode.map(Into::into).unwrap_or(ActionMode::Auto),
         timeout_ms: semantic_timeout(a.timeout_ms)?,
         max_nodes: a.max_nodes.map(|value| value as usize),
@@ -144,7 +168,7 @@ pub(crate) fn validate_type_args(a: &TypeArgs) -> Result<ValidatedType, Contextu
 }
 
 pub(crate) fn validate_action(action: &Action) -> Result<(), ContextualError> {
-    match action {
+    let result = match action {
         Action::Click(args) => super::input::validate_click_args(args).map(|_| ()),
         Action::Move(_) => Ok(()),
         Action::Drag(args) => super::input::validate_drag_args(args).map(|_| ()),
@@ -160,10 +184,299 @@ pub(crate) fn validate_action(action: &Action) -> Result<(), ContextualError> {
         Action::ScrollToElement(args) => {
             super::wait::validate_scroll_to_element_args(args).map(|_| ())
         }
-    }
+    };
+    result.map_err(|error| ContextualError::validation_with_code("invalid_sequence", error.message))
 }
 
 const _: fn(&Action) -> Result<(), ContextualError> = validate_action;
+
+fn action_method(method: &ActionMethod) -> &'static str {
+    match method {
+        ActionMethod::NativeAction { .. } => "native-action",
+        ActionMethod::Pointer { .. } => "pointer",
+        ActionMethod::AccessibilityValue => "accessibility-value",
+        ActionMethod::Keyboard => "keyboard",
+    }
+}
+
+fn scope_json(scope: ScopeResolution) -> (&'static str, Option<Value>, Option<usize>) {
+    match scope {
+        ScopeResolution::Unscoped => ("unscoped", None, None),
+        ScopeResolution::NotFound => ("not_found", None, None),
+        ScopeResolution::Resolved(id) => ("resolved", Some(json!(id.0)), None),
+        ScopeResolution::Ambiguous { observed } => ("ambiguous", None, Some(observed)),
+    }
+}
+
+fn bounds_json(bounds: Option<glass_core::AxRect>) -> Value {
+    bounds.map_or(Value::Null, |bounds| {
+        json!({
+            "x": bounds.x,
+            "y": bounds.y,
+            "width": bounds.width,
+            "height": bounds.height,
+        })
+    })
+}
+
+fn match_field(field: MatchField) -> &'static str {
+    match field {
+        MatchField::Name => "name",
+        MatchField::Description => "description",
+        MatchField::Value => "value",
+    }
+}
+
+fn match_tier(tier: MatchTier) -> &'static str {
+    match tier {
+        MatchTier::ExactName => "exact_name",
+        MatchTier::NameSubstring => "name_substring",
+        MatchTier::DescriptionSubstring => "description_substring",
+        MatchTier::ValueSubstring => "value_substring",
+        MatchTier::FilterOnly => "filter_only",
+    }
+}
+
+pub(super) fn actionability_json(report: &ActionabilityReport) -> Value {
+    Value::Array(
+        report
+            .checks
+            .iter()
+            .map(|check| {
+                json!({
+                    "check": check.name.as_str(),
+                    "verdict": check.verdict.as_str(),
+                    "required": check.required,
+                    "source": check.source.as_str(),
+                })
+            })
+            .collect(),
+    )
+}
+
+pub(super) fn resolution_json(report: &ResolutionReport) -> Value {
+    let (scope_status, resolved_scope_id, ambiguous_scope_matches) = scope_json(report.scope);
+    let mut value = json!({
+        "source": "semantic",
+        "elapsed_ms": report.elapsed_ms,
+        "scope_status": scope_status,
+        "matches_in_walk": report.matches_in_walk,
+        "search_complete": report.search_complete,
+        "tree_truncated": report.tree_truncated,
+        "unreadable_subtrees": report.unreadable_subtrees,
+        "unexposed_placeholders": report.unexposed_placeholders,
+    });
+    if let Some(id) = resolved_scope_id {
+        value["resolved_scope_id"] = id;
+    }
+    if let Some(matches) = ambiguous_scope_matches {
+        value["ambiguous_scope_matches"] = json!(matches);
+    }
+    if let Some(owner) = report.timed_out_by {
+        value["timed_out_by"] = json!(match owner {
+            Whose::Callee => "action",
+            Whose::Caller => "sequence",
+        });
+    }
+    value
+}
+
+pub(super) fn mutation_json(report: &MutationReport) -> Value {
+    let mut value = json!({
+        "method": action_method(&report.method),
+        "dispatch": report.dispatch.as_str(),
+        "confirmation": report.confirmation.as_str(),
+    });
+    match &report.method {
+        ActionMethod::NativeAction { actuated: Some(id) } => {
+            value["actuated_id"] = json!(id.0);
+        }
+        ActionMethod::Pointer {
+            native_fallback: Some(reason),
+        } => {
+            value["native_fallback"] = json!(reason);
+        }
+        ActionMethod::NativeAction { actuated: None }
+        | ActionMethod::Pointer {
+            native_fallback: None,
+        }
+        | ActionMethod::AccessibilityValue
+        | ActionMethod::Keyboard => {}
+    }
+    value
+}
+
+pub(super) fn element_json(element: &ElementInfo, include_text: bool) -> Value {
+    json!({
+        "id": element.id.0,
+        "role": format!("{:?}", element.role),
+        "name": include_text.then(|| element.name.clone()).flatten(),
+        "description": include_text.then(|| element.description.clone()).flatten(),
+        "value": (include_text && !element.states.secure)
+            .then(|| element.value.clone())
+            .flatten(),
+        "bounds": bounds_json(element.bounds),
+        "states": element.states.active(),
+    })
+}
+
+pub(super) fn candidates_json(candidates: &[SemanticMatch], include_text: bool) -> Value {
+    Value::Array(
+        candidates
+            .iter()
+            .map(|candidate| {
+                let matched_text = include_text.then(|| match candidate.field {
+                    Some(MatchField::Name) => candidate.element.name.clone(),
+                    Some(MatchField::Description) => candidate.element.description.clone(),
+                    Some(MatchField::Value) if !candidate.element.states.secure => {
+                        candidate.element.value.clone()
+                    }
+                    Some(MatchField::Value) | None => None,
+                });
+                let mut value = element_json(&candidate.element, include_text);
+                value["matched_field"] = candidate.field.map(match_field).into();
+                value["matched_text"] = matched_text.flatten().into();
+                value["match_tier"] = json!(match_tier(candidate.tier));
+                value["context"] = include_text.then(|| candidate.context.clone()).into();
+                value
+            })
+            .collect(),
+    )
+}
+
+fn merge_object(target: &mut Value, source: Value) {
+    let Some(target) = target.as_object_mut() else {
+        return;
+    };
+    let Value::Object(source) = source else {
+        return;
+    };
+    target.extend(source);
+}
+
+pub(crate) fn success_output(
+    tool: &'static str,
+    outcome: &SemanticActionOutcome,
+    observed: Option<Value>,
+    mut extra: Vec<OutContent>,
+) -> ToolOutput {
+    let mut result = json!({
+        "id": outcome.target.id.0,
+        "actionability": actionability_json(&outcome.actionability),
+    });
+    if let Some(focus) = &outcome.focus {
+        result["focus_method"] = json!(action_method(&focus.method));
+        result["focus_dispatch"] = json!(focus.dispatch.as_str());
+        result["focus_confirmation"] = json!(focus.confirmation.as_str());
+        result["type_dispatch"] = json!(outcome.action.dispatch.as_str());
+    } else {
+        merge_object(&mut result, mutation_json(&outcome.action));
+    }
+    if let Some(resolution) = &outcome.resolution {
+        result["resolution"] = resolution_json(resolution);
+        let include_text = tool != "glass_type";
+        extra.insert(
+            0,
+            OutContent::untrusted_observation(
+                &json!({ "target": element_json(&outcome.target, include_text) }).to_string(),
+            ),
+        );
+        result["content_blocks"] = json!([1]);
+    }
+    if let Some(observed) = observed {
+        result["observed"] = observed;
+    }
+    ToolOutput::result_with(tool, result, extra)
+}
+
+fn semantic_category(error: &SemanticActionError) -> SafeErrorCategory {
+    let sequence_deadline = error
+        .resolution
+        .as_ref()
+        .is_some_and(|report| report.timed_out_by == Some(Whose::Caller))
+        || (error.bound.owner == Some(Whose::Caller) && error.bound.deadline.has_passed());
+    if sequence_deadline {
+        return SafeErrorCategory::SequenceDeadlineExceeded;
+    }
+    match error.kind {
+        SemanticActionFailureKind::NoMatch => SafeErrorCategory::NoMatch,
+        SemanticActionFailureKind::AmbiguousTarget => SafeErrorCategory::AmbiguousTarget,
+        SemanticActionFailureKind::AmbiguousScope => SafeErrorCategory::AmbiguousScope,
+        SemanticActionFailureKind::IncompleteTree => SafeErrorCategory::IncompleteTree,
+        SemanticActionFailureKind::UnprovenSelectorState => {
+            SafeErrorCategory::UnprovenSelectorState
+        }
+        SemanticActionFailureKind::NotActionable => SafeErrorCategory::NotActionable,
+        SemanticActionFailureKind::UnstableTarget => SafeErrorCategory::UnstableTarget,
+        SemanticActionFailureKind::FocusUnconfirmed => SafeErrorCategory::FocusUnconfirmed,
+        SemanticActionFailureKind::UnsupportedMode => SafeErrorCategory::UnsupportedMode,
+        SemanticActionFailureKind::ActionDeadlineExceeded => {
+            SafeErrorCategory::ActionDeadlineExceeded
+        }
+        SemanticActionFailureKind::SequenceDeadlineExceeded => {
+            SafeErrorCategory::SequenceDeadlineExceeded
+        }
+        SemanticActionFailureKind::ActionFailed => error
+            .source
+            .as_ref()
+            .map_or(SafeErrorCategory::Other, SafeErrorCategory::from_error),
+    }
+}
+
+fn failure_result(error: &SemanticActionError) -> Value {
+    let mut result = json!({
+        "dispatch": error.action_dispatch.as_str(),
+        "side_effects_may_have_occurred": error.action_dispatch != DispatchStatus::NotDispatched,
+        "retry": error.retry.as_str(),
+        "actionability": actionability_json(&error.actionability),
+        "candidate_count": error.candidates.len(),
+    });
+    if let Some(resolution) = &error.resolution {
+        result["resolution"] = resolution_json(resolution);
+    }
+    if let Some(focus) = &error.focus {
+        result["focus"] = mutation_json(focus);
+    }
+    result
+}
+
+pub(crate) fn semantic_error(tool: &'static str, error: SemanticActionError) -> ContextualError {
+    let category = semantic_category(&error);
+    let include_text = tool != "glass_type";
+    let mut siblings = Vec::new();
+    if !error.candidates.is_empty() {
+        let body = if error.candidates.len() == 1
+            && matches!(
+                error.kind,
+                SemanticActionFailureKind::UnprovenSelectorState
+                    | SemanticActionFailureKind::NotActionable
+                    | SemanticActionFailureKind::UnstableTarget
+                    | SemanticActionFailureKind::FocusUnconfirmed
+            ) {
+            json!({ "target": element_json(&error.candidates[0].element, include_text) })
+        } else {
+            json!({ "candidates": candidates_json(&error.candidates, include_text) })
+        };
+        siblings.push(OutContent::untrusted_observation(&body.to_string()));
+    }
+    let bound_dispatch = Some(match error.action_dispatch {
+        DispatchStatus::NotDispatched => glass_core::BoundDispatch::NotDispatched,
+        DispatchStatus::Dispatched | DispatchStatus::MayHaveDispatched => {
+            glass_core::BoundDispatch::MayHaveDispatched
+        }
+    });
+    ContextualError {
+        code: category.code(),
+        message: category.summary().into(),
+        category,
+        safe_summary: category.summary(),
+        sequence_deadline_exceeded: category == SafeErrorCategory::SequenceDeadlineExceeded,
+        bound_dispatch,
+        result: Some(failure_result(&error)),
+        siblings,
+        post_write: false,
+    }
+}
 
 #[cfg(test)]
 mod tests;

--- a/crates/glass-mcp/src/tools/semantic_action.rs
+++ b/crates/glass-mcp/src/tools/semantic_action.rs
@@ -458,7 +458,11 @@ fn failure_result(error: &SemanticActionError) -> Value {
     result
 }
 
-pub(crate) fn semantic_error(tool: &'static str, error: SemanticActionError) -> ContextualError {
+pub(crate) fn semantic_error(
+    tool: &'static str,
+    error: impl Into<Box<SemanticActionError>>,
+) -> ContextualError {
+    let error = error.into();
     let category = semantic_category(&error);
     let include_text = tool != "glass_type";
     let mut siblings = Vec::new();

--- a/crates/glass-mcp/src/tools/semantic_action/tests.rs
+++ b/crates/glass-mcp/src/tools/semantic_action/tests.rs
@@ -85,6 +85,7 @@ struct InstrumentedPlatform {
     counters: Arc<SessionIoCounters>,
     geometry: WindowGeometry,
     key_error: Option<String>,
+    capture_error: Option<String>,
 }
 
 impl Platform for InstrumentedPlatform {
@@ -113,6 +114,9 @@ impl Platform for InstrumentedPlatform {
     ) -> glass_core::Result<Frame> {
         self.counters
             .record(SessionIoKind::Capture, "capture_frame");
+        if let Some(message) = &self.capture_error {
+            return Err(GlassError::CaptureFailed(message.clone()));
+        }
         Frame::new(1, 1, vec![0, 0, 0, 255])
     }
 
@@ -124,6 +128,9 @@ impl Platform for InstrumentedPlatform {
     ) -> glass_core::Result<Frame> {
         self.counters
             .record(SessionIoKind::Capture, "capture_window");
+        if let Some(message) = &self.capture_error {
+            return Err(GlassError::CaptureFailed(message.clone()));
+        }
         Frame::new(1, 1, vec![0, 0, 0, 255])
     }
 
@@ -305,7 +312,7 @@ fn started_instrumented_glass_with(
     coverage: AxStateCoverage,
     invoke_result: Option<AxNodeId>,
 ) -> (Glass, Arc<SessionIoCounters>, Arc<AtomicUsize>) {
-    started_instrumented_glass_with_errors(tree, coverage, invoke_result, None, None)
+    started_instrumented_glass_with_errors(tree, coverage, invoke_result, None, None, None)
 }
 
 fn started_instrumented_glass_with_errors(
@@ -314,6 +321,7 @@ fn started_instrumented_glass_with_errors(
     invoke_result: Option<AxNodeId>,
     key_error: Option<String>,
     set_error: Option<String>,
+    capture_error: Option<String>,
 ) -> (Glass, Arc<SessionIoCounters>, Arc<AtomicUsize>) {
     let counters = Arc::new(SessionIoCounters::default());
     let geometry = WindowGeometry {
@@ -327,6 +335,7 @@ fn started_instrumented_glass_with_errors(
             counters: counters.clone(),
             geometry,
             key_error,
+            capture_error,
         }),
         accessibility: Some(Box::new(InstrumentedAccessibility {
             counters: counters.clone(),
@@ -1425,6 +1434,7 @@ fn untargeted_type_scrubs_payload_from_context_batch_standalone_and_artifacts() 
             None,
             Some(format!("backend echoed {SENTINEL}")),
             None,
+            None,
         )
         .0
     };
@@ -1481,6 +1491,7 @@ fn legacy_set_value_scrubs_payload_from_context_batch_standalone_and_artifacts()
             None,
             None,
             Some(format!("backend echoed {SENTINEL}")),
+            None,
         )
         .0;
         glass.a11y_snapshot(None).unwrap();
@@ -1520,6 +1531,141 @@ fn legacy_set_value_scrubs_payload_from_context_batch_standalone_and_artifacts()
             .iter()
             .all(|b| !b.contains(SENTINEL))
     );
+}
+
+#[test]
+fn untargeted_type_return_error_scrubs_submitted_capture_text() {
+    const SENTINEL: &str = "UNTARGETED_TYPE_RETURN_SENTINEL_5d38";
+    let args = TypeArgs {
+        target: None,
+        focus_mode: None,
+        timeout_ms: None,
+        max_nodes: None,
+        text: SENTINEL.into(),
+        return_: Some("snapshot".into()),
+    };
+    let mut glass = started_instrumented_glass_with_errors(
+        crate::tools::testutil::empty_tree(),
+        AxStateCoverage::NONE,
+        None,
+        None,
+        None,
+        Some(SENTINEL.into()),
+    )
+    .0;
+
+    let error = type_text_with(&mut glass, &args, ToolContext::UNBOUNDED).unwrap_err();
+
+    assert_eq!(error.code, "transport_failure");
+    assert_eq!(error.category, SafeErrorCategory::TransportFailure);
+    assert_eq!(error.bound_dispatch, Some(BoundDispatch::MayHaveDispatched));
+    assert!(!error.post_write);
+    assert!(!error.message.contains(SENTINEL), "{}", error.message);
+}
+
+#[test]
+fn targeted_type_return_error_scrubs_submitted_capture_text_and_keeps_evidence() {
+    const SENTINEL: &str = "TARGETED_TYPE_RETURN_SENTINEL_b415";
+    let coverage = AxStateCoverage {
+        focused: true,
+        ..semantic_control_coverage()
+    };
+    let mut glass = started_instrumented_glass_with_errors(
+        semantic_control_tree(AxRole::TextField, "Account", Some("old"), true),
+        coverage,
+        None,
+        None,
+        None,
+        Some(SENTINEL.into()),
+    )
+    .0;
+    let args: TypeArgs = serde_json::from_value(serde_json::json!({
+        "target": {"query": "Account", "role": "TextField"},
+        "focus_mode": "native",
+        "text": SENTINEL,
+        "timeout_ms": 1_000,
+        "max_nodes": 0,
+        "return": "snapshot",
+    }))
+    .unwrap();
+
+    let error = type_text_with(&mut glass, &args, ToolContext::UNBOUNDED).unwrap_err();
+
+    assert_eq!(error.code, "transport_failure");
+    assert_eq!(error.category, SafeErrorCategory::TransportFailure);
+    assert_eq!(error.bound_dispatch, Some(BoundDispatch::MayHaveDispatched));
+    assert_eq!(error.result.as_ref().unwrap()["dispatch"], "dispatched");
+    assert_eq!(error.siblings.len(), 1);
+    assert!(!error.post_write);
+    assert!(!error.message.contains(SENTINEL), "{}", error.message);
+}
+
+#[test]
+fn legacy_set_value_return_error_scrubs_submitted_capture_text() {
+    const SENTINEL: &str = "LEGACY_SET_RETURN_SENTINEL_c941";
+    let mut glass = started_instrumented_glass_with_errors(
+        semantic_control_tree(AxRole::TextField, "Account", Some("old"), false),
+        semantic_control_coverage(),
+        None,
+        None,
+        None,
+        Some(SENTINEL.into()),
+    )
+    .0;
+    glass.a11y_snapshot(None).unwrap();
+    let args = SetValueArgs {
+        id: Some(1),
+        target: None,
+        timeout_ms: None,
+        max_nodes: None,
+        text: SENTINEL.into(),
+        return_: Some("snapshot".into()),
+    };
+
+    let error = set_value_with(&mut glass, &args, ToolContext::UNBOUNDED).unwrap_err();
+
+    assert_eq!(error.code, "transport_failure");
+    assert_eq!(error.category, SafeErrorCategory::TransportFailure);
+    assert_eq!(error.bound_dispatch, Some(BoundDispatch::MayHaveDispatched));
+    assert!(error.result.is_none());
+    assert!(!error.post_write);
+    assert!(!error.message.contains(SENTINEL), "{}", error.message);
+}
+
+#[test]
+fn semantic_set_value_return_error_scrubs_submitted_capture_text_and_keeps_noop() {
+    const SENTINEL: &str = "SEMANTIC_SET_RETURN_SENTINEL_31a7";
+    let mut tree = semantic_control_tree(AxRole::ComboBox, SENTINEL, Some(SENTINEL), false);
+    tree.root.children[0].states.editable = true;
+    let mut glass = started_instrumented_glass_with_errors(
+        tree,
+        semantic_control_coverage(),
+        None,
+        None,
+        None,
+        Some(SENTINEL.into()),
+    )
+    .0;
+    let args: SetValueArgs = serde_json::from_value(serde_json::json!({
+        "target": {"query": SENTINEL, "role": "ComboBox"},
+        "text": SENTINEL,
+        "timeout_ms": 1_000,
+        "max_nodes": 0,
+        "return": "snapshot",
+    }))
+    .unwrap();
+
+    let error = set_value_with(&mut glass, &args, ToolContext::UNBOUNDED).unwrap_err();
+
+    assert_eq!(error.code, "transport_failure");
+    assert_eq!(error.category, SafeErrorCategory::TransportFailure);
+    assert_eq!(error.bound_dispatch, Some(BoundDispatch::NotDispatched));
+    let result = error.result.as_ref().unwrap();
+    assert_eq!(result["dispatch"], "not_dispatched");
+    assert_eq!(result["side_effects_may_have_occurred"], false);
+    assert_eq!(error.siblings.len(), 1);
+    assert!(!error.post_write);
+    assert!(!error.message.contains(SENTINEL), "{}", error.message);
 }
 
 fn semantic_success_with_total_text_bytes(total: usize) -> crate::tools::ToolOutput {

--- a/crates/glass-mcp/src/tools/semantic_action/tests.rs
+++ b/crates/glass-mcp/src/tools/semantic_action/tests.rs
@@ -1,8 +1,13 @@
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use glass_core::{
-    ActionMode, ActionTarget, Backend, BaselineStore, BoundDispatch, Glass, PlatformFactory,
+    Accessibility, ActionMode, ActionTarget, AppSpec, AxContext, AxNodeId, AxStateCoverage,
+    AxTarget, Backend, BaselineStore, BoundDispatch, ChangeSignal, Deadline, Frame, Glass,
+    GlassError, HostPathProtectionMode, KeyEvent, Platform, PlatformFactory, PointerEvent,
+    PointerHit, ProtectedHostPath, Region, SandboxLevel, Stream, WindowGeometry, WindowId,
+    WindowInfo, WindowOp,
 };
 
 use super::{
@@ -14,18 +19,339 @@ use crate::tools::{
     ContextualError, ToolContext, click_element_with, set_value_with, type_text_with,
 };
 
-fn panicking_glass() -> (Glass, Arc<AtomicBool>) {
-    let touched = Arc::new(AtomicBool::new(false));
-    let factory_touched = touched.clone();
-    let factory: PlatformFactory = Box::new(move |_| -> glass_core::Result<Backend> {
-        factory_touched.store(true, Ordering::SeqCst);
-        panic!("invalid request reached the platform factory")
+#[derive(Clone, Copy)]
+enum SessionIoKind {
+    Action,
+    Input,
+    Capture,
+    Accessibility,
+    Other,
+}
+
+#[derive(Default)]
+struct SessionIoCounters {
+    action: AtomicUsize,
+    input: AtomicUsize,
+    capture: AtomicUsize,
+    accessibility: AtomicUsize,
+    other: AtomicUsize,
+    calls: Mutex<Vec<&'static str>>,
+}
+
+impl SessionIoCounters {
+    fn record(&self, kind: SessionIoKind, call: &'static str) {
+        let counter = match kind {
+            SessionIoKind::Action => &self.action,
+            SessionIoKind::Input => &self.input,
+            SessionIoKind::Capture => &self.capture,
+            SessionIoKind::Accessibility => &self.accessibility,
+            SessionIoKind::Other => &self.other,
+        };
+        counter.fetch_add(1, Ordering::SeqCst);
+        self.calls.lock().unwrap().push(call);
+    }
+
+    fn clear(&self) {
+        self.action.store(0, Ordering::SeqCst);
+        self.input.store(0, Ordering::SeqCst);
+        self.capture.store(0, Ordering::SeqCst);
+        self.accessibility.store(0, Ordering::SeqCst);
+        self.other.store(0, Ordering::SeqCst);
+        self.calls.lock().unwrap().clear();
+    }
+
+    fn assert_zero(&self, name: &str) {
+        let counts = [
+            ("action", self.action.load(Ordering::SeqCst)),
+            ("input", self.input.load(Ordering::SeqCst)),
+            ("capture", self.capture.load(Ordering::SeqCst)),
+            ("accessibility", self.accessibility.load(Ordering::SeqCst)),
+            ("other", self.other.load(Ordering::SeqCst)),
+        ];
+        assert!(
+            counts.iter().all(|(_, count)| *count == 0),
+            "{name}: invalid request performed post-start session I/O: {counts:?}; calls={:?}",
+            self.calls.lock().unwrap()
+        );
+    }
+}
+
+struct InstrumentedPlatform {
+    counters: Arc<SessionIoCounters>,
+    geometry: WindowGeometry,
+}
+
+impl Platform for InstrumentedPlatform {
+    fn configure_protected_host_paths(
+        &mut self,
+        _paths: &[ProtectedHostPath],
+    ) -> glass_core::Result<HostPathProtectionMode> {
+        self.counters.record(SessionIoKind::Other, "configure");
+        Ok(HostPathProtectionMode::SandboxRules)
+    }
+
+    fn start_app(&mut self, _spec: &AppSpec) -> glass_core::Result<WindowGeometry> {
+        self.counters.record(SessionIoKind::Other, "start");
+        Ok(self.geometry.clone())
+    }
+
+    fn stop_app_by(&mut self, _deadline: Deadline) -> glass_core::Result<()> {
+        self.counters.record(SessionIoKind::Other, "stop");
+        Ok(())
+    }
+
+    fn capture_frame_by(
+        &mut self,
+        _region: Option<&Region>,
+        _deadline: Deadline,
+    ) -> glass_core::Result<Frame> {
+        self.counters
+            .record(SessionIoKind::Capture, "capture_frame");
+        Frame::new(1, 1, vec![0, 0, 0, 255])
+    }
+
+    fn capture_window_by(
+        &mut self,
+        _id: WindowId,
+        _region: Option<&Region>,
+        _deadline: Deadline,
+    ) -> glass_core::Result<Frame> {
+        self.counters
+            .record(SessionIoKind::Capture, "capture_window");
+        Frame::new(1, 1, vec![0, 0, 0, 255])
+    }
+
+    fn send_pointer_by(
+        &mut self,
+        _event: &PointerEvent,
+        _deadline: Deadline,
+    ) -> glass_core::Result<()> {
+        self.counters.record(SessionIoKind::Input, "pointer");
+        Ok(())
+    }
+
+    fn send_key_by(&mut self, _event: &KeyEvent, _deadline: Deadline) -> glass_core::Result<()> {
+        self.counters.record(SessionIoKind::Input, "key");
+        Ok(())
+    }
+
+    fn get_clipboard(&mut self) -> glass_core::Result<String> {
+        self.counters.record(SessionIoKind::Other, "get_clipboard");
+        Ok(String::new())
+    }
+
+    fn set_clipboard(&mut self, _text: &str) -> glass_core::Result<()> {
+        self.counters.record(SessionIoKind::Other, "set_clipboard");
+        Ok(())
+    }
+
+    fn window_by(
+        &mut self,
+        _op: &WindowOp,
+        _deadline: Deadline,
+    ) -> glass_core::Result<WindowGeometry> {
+        self.counters.record(SessionIoKind::Action, "window");
+        Ok(self.geometry.clone())
+    }
+
+    fn list_windows_by(&mut self, _deadline: Deadline) -> glass_core::Result<Vec<WindowInfo>> {
+        self.counters.record(SessionIoKind::Other, "list_windows");
+        Ok(vec![WindowInfo {
+            id: WindowId(1),
+            title: Some("instrumented".into()),
+            class: None,
+            geometry: self.geometry.clone(),
+            active: true,
+        }])
+    }
+
+    fn select_window_by(
+        &mut self,
+        _id: WindowId,
+        _deadline: Deadline,
+    ) -> glass_core::Result<WindowGeometry> {
+        self.counters.record(SessionIoKind::Action, "select_window");
+        Ok(self.geometry.clone())
+    }
+
+    fn drain_logs(&mut self) -> Vec<(Stream, String)> {
+        self.counters.record(SessionIoKind::Other, "drain_logs");
+        Vec::new()
+    }
+
+    fn app_pid(&self) -> Option<u32> {
+        self.counters.record(SessionIoKind::Other, "app_pid");
+        None
+    }
+
+    fn app_pids(&self) -> Vec<u32> {
+        self.counters.record(SessionIoKind::Other, "app_pids");
+        Vec::new()
+    }
+
+    fn app_pids_by(&self, _deadline: Deadline) -> glass_core::Result<Vec<u32>> {
+        self.counters.record(SessionIoKind::Other, "app_pids_by");
+        Ok(Vec::new())
+    }
+
+    fn a11y_bus_addr(&self) -> Option<String> {
+        self.counters.record(SessionIoKind::Other, "a11y_bus_addr");
+        None
+    }
+
+    fn active_window_handle(&self) -> Option<i64> {
+        self.counters
+            .record(SessionIoKind::Other, "active_window_handle");
+        None
+    }
+
+    fn a11y_toggle_control_at_trailing_edge(&self) -> bool {
+        self.counters
+            .record(SessionIoKind::Other, "a11y_toggle_control_at_trailing_edge");
+        false
+    }
+}
+
+struct InstrumentedAccessibility {
+    counters: Arc<SessionIoCounters>,
+}
+
+impl Accessibility for InstrumentedAccessibility {
+    fn snapshot(&mut self, _ctx: &AxContext) -> glass_core::Result<glass_core::AxTree> {
+        self.counters
+            .record(SessionIoKind::Accessibility, "a11y_snapshot");
+        Ok(crate::tools::testutil::empty_tree())
+    }
+
+    fn subscribe_changes(&mut self, _ctx: &AxContext) -> Option<Box<dyn ChangeSignal>> {
+        self.counters
+            .record(SessionIoKind::Accessibility, "a11y_subscribe");
+        None
+    }
+
+    fn state_coverage(&self) -> AxStateCoverage {
+        self.counters
+            .record(SessionIoKind::Accessibility, "a11y_state_coverage");
+        AxStateCoverage::NONE
+    }
+
+    fn focus(
+        &mut self,
+        _ctx: &AxContext,
+        _target: &AxTarget,
+    ) -> glass_core::Result<Option<AxNodeId>> {
+        self.counters.record(SessionIoKind::Action, "a11y_focus");
+        Ok(None)
+    }
+
+    fn pointer_target_at(
+        &mut self,
+        _ctx: &AxContext,
+        _target: &AxTarget,
+        _point: (i32, i32),
+    ) -> glass_core::Result<PointerHit> {
+        self.counters
+            .record(SessionIoKind::Accessibility, "a11y_pointer_target");
+        Ok(PointerHit::Inconclusive)
+    }
+
+    fn set_value(
+        &mut self,
+        _ctx: &AxContext,
+        _target: &AxTarget,
+        _text: &str,
+    ) -> glass_core::Result<()> {
+        self.counters
+            .record(SessionIoKind::Action, "a11y_set_value");
+        Ok(())
+    }
+
+    fn invoke(
+        &mut self,
+        _ctx: &AxContext,
+        _target: &AxTarget,
+    ) -> glass_core::Result<Option<AxNodeId>> {
+        self.counters.record(SessionIoKind::Action, "a11y_invoke");
+        Ok(None)
+    }
+}
+
+fn started_instrumented_glass() -> (Glass, Arc<SessionIoCounters>, Arc<AtomicUsize>) {
+    let counters = Arc::new(SessionIoCounters::default());
+    let geometry = WindowGeometry {
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 100,
+    };
+    let mut held = Some(Backend {
+        platform: Box::new(InstrumentedPlatform {
+            counters: counters.clone(),
+            geometry,
+        }),
+        accessibility: Some(Box::new(InstrumentedAccessibility {
+            counters: counters.clone(),
+        })),
     });
-    let root = tempfile::tempdir().unwrap().path().join("baselines");
-    (
-        Glass::new(factory, "x11".into(), BaselineStore::new(root), 100),
-        touched,
-    )
+    let factory_calls = Arc::new(AtomicUsize::new(0));
+    let recorded_factory_calls = factory_calls.clone();
+    let factory: PlatformFactory = Box::new(move |_| {
+        recorded_factory_calls.fetch_add(1, Ordering::SeqCst);
+        held.take()
+            .ok_or_else(|| GlassError::Backend("test factory called twice".into()))
+    });
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().join("baselines");
+    std::mem::forget(dir);
+    let mut glass = Glass::new(factory, "x11".into(), BaselineStore::new(root), 100);
+    glass
+        .start(&AppSpec {
+            build: None,
+            run: vec!["app".into()],
+            cwd: None,
+            env: Vec::new(),
+            window_hint: None,
+            timeout_ms: 1,
+            sandbox: SandboxLevel::Off,
+            a11y: true,
+        })
+        .unwrap();
+    assert_eq!(factory_calls.load(Ordering::SeqCst), 1);
+    counters.clear();
+    (glass, counters, factory_calls)
+}
+
+#[test]
+fn invalid_handler_harness_runs_with_an_active_session() {
+    let (glass, counters, factory_calls) = started_instrumented_glass();
+    assert!(
+        glass.geometry().is_ok(),
+        "invalid-handler tests must exercise validation against an active session"
+    );
+    counters.assert_zero("harness setup");
+    assert_eq!(factory_calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn invalid_handler_harness_observes_every_session_io_category() {
+    let (mut glass, counters, _) = started_instrumented_glass();
+    glass.screenshot(None, None).unwrap();
+    glass.key(&KeyEvent::Text("x".into())).unwrap();
+    glass.a11y_snapshot(None).unwrap();
+    glass.window(&WindowOp::Geometry).unwrap();
+
+    for (kind, count) in [
+        ("action", counters.action.load(Ordering::SeqCst)),
+        ("input", counters.input.load(Ordering::SeqCst)),
+        ("capture", counters.capture.load(Ordering::SeqCst)),
+        (
+            "accessibility",
+            counters.accessibility.load(Ordering::SeqCst),
+        ),
+        ("other", counters.other.load(Ordering::SeqCst)),
+    ] {
+        assert!(count > 0, "instrumentation did not observe {kind} I/O");
+    }
 }
 
 enum InvalidHandlerArgs {
@@ -35,7 +361,7 @@ enum InvalidHandlerArgs {
 }
 
 fn assert_invalid_handler(name: &str, args: InvalidHandlerArgs, expected: &str) {
-    let (mut glass, touched) = panicking_glass();
+    let (mut glass, counters, factory_calls) = started_instrumented_glass();
     let result = match args {
         InvalidHandlerArgs::Click(args) => {
             click_element_with(&mut glass, &args, ToolContext::UNBOUNDED)
@@ -56,9 +382,11 @@ fn assert_invalid_handler(name: &str, args: InvalidHandlerArgs, expected: &str) 
         Some(BoundDispatch::NotDispatched),
         "{name}: validation must be proven pre-dispatch"
     );
-    assert!(
-        !touched.load(Ordering::SeqCst),
-        "{name}: validation touched the platform factory"
+    counters.assert_zero(name);
+    assert_eq!(
+        factory_calls.load(Ordering::SeqCst),
+        1,
+        "{name}: validation attempted to create another session"
     );
 }
 

--- a/crates/glass-mcp/src/tools/semantic_action/tests.rs
+++ b/crates/glass-mcp/src/tools/semantic_action/tests.rs
@@ -18,10 +18,10 @@ use super::{
     ValidatedType, candidates_json, element_json, semantic_error, success_output, validate_action,
     validate_click_element_args, validate_set_value_args, validate_type_args,
 };
-use crate::params::{Action, ClickElementArgs, SetValueArgs, TypeArgs};
+use crate::params::{Action, ClickElementArgs, DoArgs, SetValueArgs, TypeArgs};
 use crate::tools::{
-    ContextualError, SafeErrorCategory, ToolContext, click_element_with, erase_semantic_context,
-    set_value_with, type_text_with,
+    ContextualError, SafeErrorCategory, ToolContext, click_element_with, do_actions,
+    erase_semantic_context, set_value, set_value_with, type_text, type_text_with,
 };
 
 #[derive(Clone, Copy)]
@@ -84,6 +84,7 @@ impl SessionIoCounters {
 struct InstrumentedPlatform {
     counters: Arc<SessionIoCounters>,
     geometry: WindowGeometry,
+    key_error: Option<String>,
 }
 
 impl Platform for InstrumentedPlatform {
@@ -137,7 +138,10 @@ impl Platform for InstrumentedPlatform {
 
     fn send_key_by(&mut self, _event: &KeyEvent, _deadline: Deadline) -> glass_core::Result<()> {
         self.counters.record(SessionIoKind::Input, "key");
-        Ok(())
+        match &self.key_error {
+            Some(message) => Err(GlassError::Backend(message.clone())),
+            None => Ok(()),
+        }
     }
 
     fn get_clipboard(&mut self) -> glass_core::Result<String> {
@@ -222,6 +226,7 @@ struct InstrumentedAccessibility {
     tree: glass_core::AxTree,
     coverage: AxStateCoverage,
     invoke_result: Option<AxNodeId>,
+    set_error: Option<String>,
 }
 
 impl Accessibility for InstrumentedAccessibility {
@@ -271,7 +276,10 @@ impl Accessibility for InstrumentedAccessibility {
     ) -> glass_core::Result<()> {
         self.counters
             .record(SessionIoKind::Action, "a11y_set_value");
-        Ok(())
+        match &self.set_error {
+            Some(message) => Err(GlassError::Backend(message.clone())),
+            None => Ok(()),
+        }
     }
 
     fn invoke(
@@ -297,6 +305,16 @@ fn started_instrumented_glass_with(
     coverage: AxStateCoverage,
     invoke_result: Option<AxNodeId>,
 ) -> (Glass, Arc<SessionIoCounters>, Arc<AtomicUsize>) {
+    started_instrumented_glass_with_errors(tree, coverage, invoke_result, None, None)
+}
+
+fn started_instrumented_glass_with_errors(
+    tree: glass_core::AxTree,
+    coverage: AxStateCoverage,
+    invoke_result: Option<AxNodeId>,
+    key_error: Option<String>,
+    set_error: Option<String>,
+) -> (Glass, Arc<SessionIoCounters>, Arc<AtomicUsize>) {
     let counters = Arc::new(SessionIoCounters::default());
     let geometry = WindowGeometry {
         x: 0,
@@ -308,12 +326,14 @@ fn started_instrumented_glass_with(
         platform: Box::new(InstrumentedPlatform {
             counters: counters.clone(),
             geometry,
+            key_error,
         }),
         accessibility: Some(Box::new(InstrumentedAccessibility {
             counters: counters.clone(),
             tree,
             coverage,
             invoke_result,
+            set_error,
         })),
     });
     let factory_calls = Arc::new(AtomicUsize::new(0));
@@ -782,6 +802,7 @@ fn semantic_failure(
         focus: None,
         action_dispatch: DispatchStatus::NotDispatched,
         candidates,
+        target: None,
         bound: action_bound(owner),
         retry: RetryGuidance::WaitOrRefine,
         source: Some(GlassError::Backend(
@@ -1054,21 +1075,165 @@ fn structured_ambiguity_error_keeps_candidates_only_in_untrusted_sibling() {
 
 #[test]
 fn structured_actionability_failure_uses_one_untrusted_known_target_block() {
-    let error = semantic_error(
-        "glass_set_value",
-        semantic_failure(
-            SemanticActionFailureKind::NotActionable,
-            None,
-            None,
-            vec![semantic_match("Disabled account", "inside settings")],
-        ),
-    );
+    let mut failure =
+        semantic_failure(SemanticActionFailureKind::NotActionable, None, None, vec![]);
+    failure.target = Some(Box::new(element_with_text(
+        "Disabled account",
+        "old",
+        false,
+    )));
+    let error = semantic_error("glass_set_value", failure);
     let output = erase_semantic_context("glass_set_value", Err(error)).unwrap_err();
     assert_eq!(output.0.len(), 2);
     let sibling = output.text_block(1).expect("known target sibling");
     let body: serde_json::Value = serde_json::from_str(untrusted_body(&sibling.body)).unwrap();
     assert!(body.get("target").is_some(), "{body}");
     assert!(body.get("candidates").is_none(), "{body}");
+}
+
+fn semantic_control_tree(
+    role: AxRole,
+    name: &str,
+    value: Option<&str>,
+    focused: bool,
+) -> glass_core::AxTree {
+    glass_core::AxTree::new(AxNode {
+        id: AxNodeId(0),
+        role: AxRole::Window,
+        raw_role: "window".into(),
+        name: Some("App".into()),
+        description: None,
+        value: None,
+        states: AxStates::default(),
+        bounds: Some(AxRect {
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 100,
+        }),
+        children: vec![AxNode {
+            id: AxNodeId(0),
+            role,
+            raw_role: format!("{role:?}"),
+            name: Some(name.into()),
+            description: None,
+            value: value.map(str::to_owned),
+            states: AxStates {
+                enabled: true,
+                visible: true,
+                focusable: matches!(role, AxRole::TextField | AxRole::ComboBox),
+                editable: role == AxRole::TextField,
+                focused,
+                ..AxStates::default()
+            },
+            bounds: Some(AxRect {
+                x: 10,
+                y: 10,
+                width: 40,
+                height: 20,
+            }),
+            children: vec![],
+        }],
+    })
+}
+
+fn semantic_control_coverage() -> AxStateCoverage {
+    AxStateCoverage {
+        enabled: true,
+        visible: true,
+        focused: false,
+        focusable: true,
+        editable: true,
+        ..AxStateCoverage::NONE
+    }
+}
+
+#[test]
+fn unstable_handler_error_retains_the_real_target_in_one_untrusted_sibling() {
+    let tree = semantic_control_tree(AxRole::Button, "Save", None, false);
+    let (mut glass, _, _) =
+        started_instrumented_glass_with(tree, semantic_control_coverage(), None);
+    let args: ClickElementArgs = serde_json::from_str(
+        r#"{"target":{"query":"Save","role":"Button"},"mode":"pointer","timeout_ms":0}"#,
+    )
+    .unwrap();
+
+    let error = click_element_with(&mut glass, &args, ToolContext::UNBOUNDED).unwrap_err();
+
+    assert_eq!(error.code, "unstable_target");
+    assert_eq!(error.bound_dispatch, Some(BoundDispatch::NotDispatched));
+    assert_eq!(error.siblings.len(), 1);
+    let target: serde_json::Value =
+        serde_json::from_str(untrusted_body(&error.siblings[0].render_text().unwrap())).unwrap();
+    assert_eq!(target["target"]["id"], 1);
+    assert_eq!(target["target"]["name"], "Save");
+}
+
+#[test]
+fn focus_unconfirmed_combines_focus_and_type_dispatch_evidence_truthfully() {
+    let args: TypeArgs = serde_json::from_str(
+        r#"{"target":{"query":"Account","role":"TextField"},"focus_mode":"native","text":"secret","timeout_ms":0}"#,
+    )
+    .unwrap();
+    let make = || {
+        started_instrumented_glass_with(
+            semantic_control_tree(AxRole::TextField, "Account", Some("old"), false),
+            semantic_control_coverage(),
+            None,
+        )
+        .0
+    };
+    let mut contextual_glass = make();
+    let error = type_text_with(&mut contextual_glass, &args, ToolContext::UNBOUNDED).unwrap_err();
+    assert_eq!(error.code, "focus_unconfirmed");
+    assert_eq!(error.bound_dispatch, Some(BoundDispatch::MayHaveDispatched));
+    let result = error.result.as_ref().unwrap();
+    assert_eq!(result["dispatch"], "not_dispatched");
+    assert_eq!(result["side_effects_may_have_occurred"], true);
+    assert_eq!(result["focus"]["dispatch"], "dispatched");
+    assert_eq!(error.siblings.len(), 1);
+    let target: serde_json::Value =
+        serde_json::from_str(untrusted_body(&error.siblings[0].render_text().unwrap())).unwrap();
+    assert_eq!(target["target"]["id"], 1);
+    assert_eq!(target["target"]["name"], serde_json::Value::Null);
+
+    let mut standalone_glass = make();
+    let output = type_text(&mut standalone_glass, &args).unwrap_err();
+    let envelope = error_envelope(&output);
+    assert_eq!(envelope["result"]["dispatch"], "not_dispatched");
+    assert_eq!(envelope["result"]["side_effects_may_have_occurred"], true);
+    assert_eq!(envelope["content_blocks"], serde_json::json!([1]));
+}
+
+#[test]
+fn noop_set_value_return_failure_preserves_not_dispatched_provenance() {
+    let args: SetValueArgs = serde_json::from_str(
+        r#"{"target":{"query":"already","role":"ComboBox"},"text":"already","timeout_ms":0,"return":"settle"}"#,
+    )
+    .unwrap();
+    let make = || {
+        started_instrumented_glass_with(
+            semantic_control_tree(AxRole::ComboBox, "already", Some("already"), false),
+            semantic_control_coverage(),
+            None,
+        )
+        .0
+    };
+    let mut contextual_glass = make();
+    let error = set_value_with(&mut contextual_glass, &args, ToolContext::UNBOUNDED).unwrap_err();
+    assert_eq!(error.code, "action_deadline_exceeded");
+    assert_eq!(error.bound_dispatch, Some(BoundDispatch::NotDispatched));
+    assert!(!error.message.contains("value was written"));
+    let result = error.result.as_ref().unwrap();
+    assert_eq!(result["dispatch"], "not_dispatched");
+    assert_eq!(result["side_effects_may_have_occurred"], false);
+    assert_eq!(result["retry"], "do_not_retry");
+
+    let mut standalone_glass = make();
+    let output = set_value(&mut standalone_glass, &args).unwrap_err();
+    let envelope = error_envelope(&output);
+    assert_eq!(envelope["result"]["dispatch"], "not_dispatched");
+    assert_eq!(envelope["result"]["side_effects_may_have_occurred"], false);
 }
 
 #[test]
@@ -1153,22 +1318,208 @@ fn structured_type_failure_excludes_submitted_payload_from_blocks_and_artifacts(
             .all(|block| !block.contains(SENTINEL))
     );
 
+    assert_forced_artifacts_exclude_payload(output, "glass_type", SENTINEL);
+}
+
+pub(crate) fn targeted_type_snapshot_output_for_server(sentinel: &str) -> crate::tools::ToolOutput {
+    let mut tree = semantic_control_tree(AxRole::TextField, "Account", Some(sentinel), true);
+    tree.root.children.extend((0..600).map(|index| AxNode {
+        id: AxNodeId(0),
+        role: AxRole::Label,
+        raw_role: "label".into(),
+        name: Some(format!("{sentinel}-{index}")),
+        description: Some(sentinel.into()),
+        value: Some(sentinel.into()),
+        states: AxStates {
+            visible: true,
+            ..AxStates::default()
+        },
+        bounds: None,
+        children: vec![],
+    }));
+    tree.subject = Some(glass_core::Subject {
+        asked: sentinel.into(),
+        actual: sentinel.into(),
+    });
+    tree.assign_ids();
+    let coverage = AxStateCoverage {
+        focused: true,
+        ..semantic_control_coverage()
+    };
+    let (mut glass, _, _) = started_instrumented_glass_with(tree, coverage, None);
+    let args: TypeArgs = serde_json::from_value(serde_json::json!({
+        "target": {"query": "Account", "role": "TextField"},
+        "focus_mode": "native",
+        "text": sentinel,
+        "timeout_ms": 1_000,
+        "max_nodes": 0,
+        "return": "snapshot",
+    }))
+    .unwrap();
+    type_text(&mut glass, &args).unwrap()
+}
+
+#[test]
+fn targeted_type_snapshot_clears_submitted_and_coincident_text_before_output_policy() {
+    const SENTINEL: &str = "TARGETED_TYPE_SNAPSHOT_SENTINEL_ef317";
+    let output = targeted_type_snapshot_output_for_server(SENTINEL);
+    assert!(output.text_bytes() > crate::output_policy::MAX_TEXT_BYTES);
+    assert!(
+        output
+            .render_text_blocks()
+            .iter()
+            .all(|block| !block.contains(SENTINEL))
+    );
+}
+
+fn assert_forced_artifacts_exclude_payload(
+    mut output: crate::tools::ToolOutput,
+    tool: &'static str,
+    sentinel: &str,
+) {
+    output.0.push(crate::tools::OutContent::trusted_guidance(
+        "safe-padding".repeat(900),
+    ));
     let root = tempfile::tempdir().unwrap();
     let store = crate::artifacts::ArtifactStore::for_test(root.path(), 1 << 20).unwrap();
-    let policy = crate::output_policy::OutputPolicy::new(store.clone());
-    let applied = policy.apply(crate::output_policy::ToolCallOutcome {
-        tool: "glass_type",
-        effect: crate::output::ToolEffect::MayMutate,
-        is_error: true,
-        target_access: crate::output::TargetAccess::NoActiveTarget,
-        output,
-    });
-    for content in &applied.output.0 {
-        if let crate::tools::OutContent::ResourceLink(descriptor) = content {
-            let artifact = store.read(descriptor.uri()).unwrap();
-            assert!(!artifact.text.contains(SENTINEL));
-        }
+    let applied = crate::output_policy::OutputPolicy::new(store.clone()).apply(
+        crate::output_policy::ToolCallOutcome {
+            tool,
+            effect: crate::output::ToolEffect::MayMutate,
+            is_error: true,
+            target_access: crate::output::TargetAccess::NoActiveTarget,
+            output,
+        },
+    );
+    let resources = applied
+        .output
+        .0
+        .iter()
+        .filter_map(|content| match content {
+            crate::tools::OutContent::ResourceLink(descriptor) => Some(descriptor),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert!(!resources.is_empty(), "forced output must externalize");
+    for descriptor in resources {
+        let artifact = store.read(descriptor.uri()).unwrap();
+        assert!(!artifact.text.contains(sentinel));
     }
+}
+
+#[test]
+fn untargeted_type_scrubs_payload_from_context_batch_standalone_and_artifacts() {
+    const SENTINEL: &str = "UNTARGETED_TYPE_CONTEXT_SENTINEL_91f2";
+    let args = TypeArgs {
+        target: None,
+        focus_mode: None,
+        timeout_ms: None,
+        max_nodes: None,
+        text: SENTINEL.into(),
+        return_: None,
+    };
+    let make = || {
+        started_instrumented_glass_with_errors(
+            crate::tools::testutil::empty_tree(),
+            AxStateCoverage::NONE,
+            None,
+            Some(format!("backend echoed {SENTINEL}")),
+            None,
+        )
+        .0
+    };
+
+    let mut contextual_glass = make();
+    let contextual =
+        type_text_with(&mut contextual_glass, &args, ToolContext::UNBOUNDED).unwrap_err();
+    assert!(!contextual.message.contains(SENTINEL));
+
+    let mut standalone_glass = make();
+    let standalone = type_text(&mut standalone_glass, &args).unwrap_err();
+    assert!(
+        standalone
+            .render_text_blocks()
+            .iter()
+            .all(|b| !b.contains(SENTINEL))
+    );
+    assert_forced_artifacts_exclude_payload(standalone, "glass_type", SENTINEL);
+
+    let mut batch_glass = make();
+    let batch = do_actions(
+        &mut batch_glass,
+        &DoArgs {
+            actions: vec![Action::Type(args)],
+            then: None,
+            timeout_ms: None,
+            encoded_argument_bytes: 0,
+        },
+    )
+    .unwrap_err();
+    assert!(
+        batch
+            .render_text_blocks()
+            .iter()
+            .all(|b| !b.contains(SENTINEL))
+    );
+}
+
+#[test]
+fn legacy_set_value_scrubs_payload_from_context_batch_standalone_and_artifacts() {
+    const SENTINEL: &str = "LEGACY_SET_CONTEXT_SENTINEL_6aa4";
+    let args = SetValueArgs {
+        id: Some(1),
+        target: None,
+        timeout_ms: None,
+        max_nodes: None,
+        text: SENTINEL.into(),
+        return_: None,
+    };
+    let make = || {
+        let mut glass = started_instrumented_glass_with_errors(
+            semantic_control_tree(AxRole::TextField, "Account", Some("old"), false),
+            semantic_control_coverage(),
+            None,
+            None,
+            Some(format!("backend echoed {SENTINEL}")),
+        )
+        .0;
+        glass.a11y_snapshot(None).unwrap();
+        glass
+    };
+
+    let mut contextual_glass = make();
+    let contextual =
+        set_value_with(&mut contextual_glass, &args, ToolContext::UNBOUNDED).unwrap_err();
+    assert_eq!(contextual.code, "transport_failure");
+    assert!(!contextual.message.contains(SENTINEL));
+
+    let mut standalone_glass = make();
+    let standalone = set_value(&mut standalone_glass, &args).unwrap_err();
+    assert!(
+        standalone
+            .render_text_blocks()
+            .iter()
+            .all(|b| !b.contains(SENTINEL))
+    );
+    assert_forced_artifacts_exclude_payload(standalone, "glass_set_value", SENTINEL);
+
+    let mut batch_glass = make();
+    let batch = do_actions(
+        &mut batch_glass,
+        &DoArgs {
+            actions: vec![Action::SetValue(args)],
+            then: None,
+            timeout_ms: None,
+            encoded_argument_bytes: 0,
+        },
+    )
+    .unwrap_err();
+    assert!(
+        batch
+            .render_text_blocks()
+            .iter()
+            .all(|b| !b.contains(SENTINEL))
+    );
 }
 
 fn semantic_success_with_total_text_bytes(total: usize) -> crate::tools::ToolOutput {

--- a/crates/glass-mcp/src/tools/semantic_action/tests.rs
+++ b/crates/glass-mcp/src/tools/semantic_action/tests.rs
@@ -1,0 +1,335 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use glass_core::{
+    ActionMode, ActionTarget, Backend, BaselineStore, BoundDispatch, Glass, PlatformFactory,
+};
+
+use super::{
+    ValidatedType, validate_action, validate_click_element_args, validate_set_value_args,
+    validate_type_args,
+};
+use crate::params::{Action, ClickElementArgs, SetValueArgs, TypeArgs};
+use crate::tools::{
+    ContextualError, ToolContext, click_element_with, set_value_with, type_text_with,
+};
+
+fn panicking_glass() -> (Glass, Arc<AtomicBool>) {
+    let touched = Arc::new(AtomicBool::new(false));
+    let factory_touched = touched.clone();
+    let factory: PlatformFactory = Box::new(move |_| -> glass_core::Result<Backend> {
+        factory_touched.store(true, Ordering::SeqCst);
+        panic!("invalid request reached the platform factory")
+    });
+    let root = tempfile::tempdir().unwrap().path().join("baselines");
+    (
+        Glass::new(factory, "x11".into(), BaselineStore::new(root), 100),
+        touched,
+    )
+}
+
+enum InvalidHandlerArgs {
+    Click(ClickElementArgs),
+    SetValue(SetValueArgs),
+    Type(TypeArgs),
+}
+
+fn assert_invalid_handler(name: &str, args: InvalidHandlerArgs, expected: &str) {
+    let (mut glass, touched) = panicking_glass();
+    let result = match args {
+        InvalidHandlerArgs::Click(args) => {
+            click_element_with(&mut glass, &args, ToolContext::UNBOUNDED)
+        }
+        InvalidHandlerArgs::SetValue(args) => {
+            set_value_with(&mut glass, &args, ToolContext::UNBOUNDED)
+        }
+        InvalidHandlerArgs::Type(args) => type_text_with(&mut glass, &args, ToolContext::UNBOUNDED),
+    };
+    let error = result.unwrap_err();
+    assert!(
+        error.message.contains(expected),
+        "{name}: expected {expected:?}, got {:?}",
+        error.message
+    );
+    assert_eq!(
+        error.bound_dispatch,
+        Some(BoundDispatch::NotDispatched),
+        "{name}: validation must be proven pre-dispatch"
+    );
+    assert!(
+        !touched.load(Ordering::SeqCst),
+        "{name}: validation touched the platform factory"
+    );
+}
+
+#[test]
+fn invalid_semantic_handler_arguments_fail_before_session_io() {
+    let click =
+        |json| InvalidHandlerArgs::Click(serde_json::from_str::<ClickElementArgs>(json).unwrap());
+    let set_value =
+        |json| InvalidHandlerArgs::SetValue(serde_json::from_str::<SetValueArgs>(json).unwrap());
+    let type_text =
+        |json| InvalidHandlerArgs::Type(serde_json::from_str::<TypeArgs>(json).unwrap());
+
+    let rows = [
+        ("click neither", click(r#"{}"#), "exactly one"),
+        (
+            "click both",
+            click(r#"{"id":1,"target":{"role":"Button"}}"#),
+            "exactly one",
+        ),
+        (
+            "click id timeout",
+            click(r#"{"id":1,"timeout_ms":1}"#),
+            "timeout_ms",
+        ),
+        (
+            "click id max nodes",
+            click(r#"{"id":1,"max_nodes":0}"#),
+            "max_nodes",
+        ),
+        (
+            "click selector timeout too large",
+            click(r#"{"target":{"role":"Button"},"timeout_ms":120001}"#),
+            "120000",
+        ),
+        (
+            "click empty target",
+            click(r#"{"target":{}}"#),
+            "specify query",
+        ),
+        (
+            "click unknown role",
+            click(r#"{"target":{"role":"Mystery"}}"#),
+            "unknown role",
+        ),
+        (
+            "click unknown state",
+            click(r#"{"target":{"states":["sparkling"]}}"#),
+            "unknown state",
+        ),
+        (
+            "click contradictory states",
+            click(r#"{"target":{"states":["enabled","disabled"]}}"#),
+            "contradict",
+        ),
+        (
+            "click unknown return",
+            click(r#"{"id":1,"return":"later"}"#),
+            "unknown return",
+        ),
+        ("set neither", set_value(r#"{"text":"Ada"}"#), "exactly one"),
+        (
+            "set both",
+            set_value(r#"{"id":1,"target":{"role":"TextField"},"text":"Ada"}"#),
+            "exactly one",
+        ),
+        (
+            "set id timeout",
+            set_value(r#"{"id":1,"text":"Ada","timeout_ms":1}"#),
+            "timeout_ms",
+        ),
+        (
+            "set id max nodes",
+            set_value(r#"{"id":1,"text":"Ada","max_nodes":0}"#),
+            "max_nodes",
+        ),
+        (
+            "set unknown role",
+            set_value(r#"{"target":{"role":"Mystery"},"text":"Ada"}"#),
+            "unknown role",
+        ),
+        (
+            "set unknown return",
+            set_value(r#"{"id":1,"text":"Ada","return":"later"}"#),
+            "unknown return",
+        ),
+        (
+            "untargeted type focus mode",
+            type_text(r#"{"text":"Ada","focus_mode":"auto"}"#),
+            "focus_mode",
+        ),
+        (
+            "untargeted type timeout",
+            type_text(r#"{"text":"Ada","timeout_ms":1}"#),
+            "timeout_ms",
+        ),
+        (
+            "untargeted type max nodes",
+            type_text(r#"{"text":"Ada","max_nodes":0}"#),
+            "max_nodes",
+        ),
+        (
+            "targeted type timeout too large",
+            type_text(r#"{"target":{"role":"TextField"},"text":"Ada","timeout_ms":120001}"#),
+            "120000",
+        ),
+        (
+            "targeted type unknown state",
+            type_text(r#"{"target":{"states":["sparkling"]},"text":"Ada"}"#),
+            "unknown state",
+        ),
+        (
+            "type unknown return",
+            type_text(r#"{"text":"Ada","return":"later"}"#),
+            "unknown return",
+        ),
+    ];
+
+    for (name, args, expected) in rows {
+        assert_invalid_handler(name, args, expected);
+    }
+}
+
+#[test]
+fn invalid_typed_modes_and_recursive_or_misspelled_scopes_fail_deserialization() {
+    assert!(serde_json::from_str::<ClickElementArgs>(r#"{"id":1,"mode":"magic"}"#).is_err());
+    assert!(
+        serde_json::from_str::<TypeArgs>(
+            r#"{"target":{"role":"TextField"},"text":"Ada","focus_mode":"magic"}"#
+        )
+        .is_err()
+    );
+    assert!(
+        serde_json::from_str::<Action>(r#"{"action":"click_element","id":1,"mode":"magic"}"#)
+            .is_err()
+    );
+    assert!(
+        serde_json::from_str::<Action>(
+            r#"{"action":"type","target":{"role":"TextField"},"text":"Ada","focus_mode":"magic"}"#
+        )
+        .is_err()
+    );
+
+    for json in [
+        r#"{"target":{"role":"Button","within":{"role":"Document","within":{"role":"Group"}}}}"#,
+        r#"{"target":{"role":"Button","statse":["enabled"]}}"#,
+        r#"{"target":{"role":"Button","within":{"rol":"Document"}}}"#,
+    ] {
+        assert!(
+            serde_json::from_str::<ClickElementArgs>(json).is_err(),
+            "recursive or misspelled scope unexpectedly parsed: {json}"
+        );
+    }
+}
+
+#[test]
+fn valid_target_forms_bind_legacy_and_semantic_defaults() {
+    let legacy: ClickElementArgs = serde_json::from_str(r#"{"id":42,"mode":"pointer"}"#).unwrap();
+    let legacy = validate_click_element_args(&legacy).unwrap();
+    assert!(matches!(legacy.target, ActionTarget::Id(id) if id.0 == 42));
+    assert_eq!(legacy.mode, ActionMode::Pointer);
+    assert_eq!(legacy.timeout_ms, None);
+    assert_eq!(legacy.max_nodes, None);
+
+    let semantic: ClickElementArgs =
+        serde_json::from_str(r#"{"target":{"role":"Button"}}"#).unwrap();
+    let semantic = validate_click_element_args(&semantic).unwrap();
+    assert!(matches!(semantic.target, ActionTarget::Semantic(_)));
+    assert_eq!(semantic.mode, ActionMode::Auto);
+    assert_eq!(semantic.timeout_ms, Some(10_000));
+    assert_eq!(semantic.max_nodes, None);
+
+    let zero: SetValueArgs =
+        serde_json::from_str(r#"{"target":{"role":"TextField"},"text":"Ada","timeout_ms":0}"#)
+            .unwrap();
+    let zero = validate_set_value_args(&zero).unwrap();
+    assert_eq!(zero.timeout_ms, Some(0));
+    assert_eq!(zero.max_nodes, None);
+
+    let targeted: TypeArgs =
+        serde_json::from_str(r#"{"target":{"role":"TextField"},"text":"Ada"}"#).unwrap();
+    let ValidatedType::Targeted(targeted) = validate_type_args(&targeted).unwrap() else {
+        panic!("targeted type must bind targeted params")
+    };
+    assert_eq!(targeted.focus_mode, ActionMode::Auto);
+    assert_eq!(targeted.timeout_ms, 10_000);
+    assert_eq!(targeted.max_nodes, None);
+
+    let untargeted: TypeArgs =
+        serde_json::from_str(r#"{"text":"Ada","return":"snapshot"}"#).unwrap();
+    assert!(matches!(
+        validate_type_args(&untargeted).unwrap(),
+        ValidatedType::Untargeted
+    ));
+}
+
+fn action(json: &str) -> Action {
+    serde_json::from_str(json).unwrap()
+}
+
+#[test]
+fn validate_action_accepts_every_variant_without_session_state() {
+    for action in [
+        action(r#"{"action":"click","x":1,"y":2}"#),
+        action(r#"{"action":"move","x":1,"y":2}"#),
+        action(r#"{"action":"drag","x1":1,"y1":2,"x2":3,"y2":4}"#),
+        action(r#"{"action":"scroll","x":1,"y":2}"#),
+        action(r#"{"action":"type","text":"Ada"}"#),
+        action(r#"{"action":"key","chord":"Return"}"#),
+        action(r#"{"action":"settle"}"#),
+        action(r#"{"action":"click_element","id":1}"#),
+        action(r#"{"action":"set_value","id":1,"text":"Ada"}"#),
+        action(r#"{"action":"wait_for_element","role":"Button"}"#),
+        action(r#"{"action":"scroll_to_element","role":"Button"}"#),
+    ] {
+        validate_action(&action).unwrap();
+    }
+}
+
+#[test]
+fn validate_action_routes_each_invalid_variant_to_its_pure_helper() {
+    let rows = [
+        (
+            action(r#"{"action":"click","x":1,"y":2,"count":0}"#),
+            "count",
+        ),
+        (
+            action(r#"{"action":"drag","x1":1,"y1":2,"x2":3,"y2":4,"button":"bad"}"#),
+            "button",
+        ),
+        (
+            action(r#"{"action":"scroll","x":1,"y":2,"dx":101}"#),
+            "between",
+        ),
+        (
+            action(r#"{"action":"type","text":"Ada","focus_mode":"auto"}"#),
+            "focus_mode",
+        ),
+        (action(r#"{"action":"key","chord":"ctrl+"}"#), "key"),
+        (
+            action(r#"{"action":"settle","interval_ms":0}"#),
+            "interval_ms",
+        ),
+        (
+            action(r#"{"action":"settle","stability_region":{"x":0,"y":0,"width":0,"height":1}}"#),
+            "stability_region",
+        ),
+        (
+            action(r#"{"action":"settle","ignore":[{"x":0,"y":0,"width":1,"height":0}]}"#),
+            "ignore",
+        ),
+        (action(r#"{"action":"click_element"}"#), "exactly one"),
+        (
+            action(r#"{"action":"set_value","text":"Ada"}"#),
+            "exactly one",
+        ),
+        (
+            action(r#"{"action":"wait_for_element","role":"Mystery"}"#),
+            "unknown role",
+        ),
+        (
+            action(r#"{"action":"scroll_to_element","role":"Button","x":1}"#),
+            "both",
+        ),
+    ];
+    for (action, expected) in rows {
+        let error: ContextualError = validate_action(&action).unwrap_err();
+        assert!(
+            error.message.contains(expected),
+            "expected {expected:?}, got {:?}",
+            error.message
+        );
+        assert_eq!(error.bound_dispatch, Some(BoundDispatch::NotDispatched));
+    }
+}

--- a/crates/glass-mcp/src/tools/semantic_action/tests.rs
+++ b/crates/glass-mcp/src/tools/semantic_action/tests.rs
@@ -3,20 +3,25 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use glass_core::{
-    Accessibility, ActionMode, ActionTarget, AppSpec, AxContext, AxNodeId, AxStateCoverage,
-    AxTarget, Backend, BaselineStore, BoundDispatch, ChangeSignal, Deadline, Frame, Glass,
-    GlassError, HostPathProtectionMode, KeyEvent, Platform, PlatformFactory, PointerEvent,
-    PointerHit, ProtectedHostPath, Region, SandboxLevel, Stream, WindowGeometry, WindowId,
-    WindowInfo, WindowOp,
+    Accessibility, ActionDeadline, ActionMethod, ActionMode, ActionTarget, ActionabilityCheck,
+    ActionabilityCheckName, ActionabilityReport, ActionabilitySource, ActionabilityVerdict,
+    AppSpec, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxStateCoverage, AxStates, AxTarget,
+    Backend, BaselineStore, BoundDispatch, ChangeSignal, ConfirmationStatus, Deadline,
+    DispatchStatus, ElementInfo, Frame, Glass, GlassError, HostPathProtectionMode, KeyEvent,
+    MatchField, MatchTier, MutationReport, Platform, PlatformFactory, PointerEvent, PointerHit,
+    ProtectedHostPath, Region, ResolutionReport, RetryGuidance, SandboxLevel, ScopeResolution,
+    SemanticActionError, SemanticActionFailureKind, SemanticActionOutcome, SemanticMatch, Stream,
+    Whose, WindowGeometry, WindowId, WindowInfo, WindowOp,
 };
 
 use super::{
-    ValidatedType, validate_action, validate_click_element_args, validate_set_value_args,
-    validate_type_args,
+    ValidatedType, candidates_json, element_json, semantic_error, success_output, validate_action,
+    validate_click_element_args, validate_set_value_args, validate_type_args,
 };
 use crate::params::{Action, ClickElementArgs, SetValueArgs, TypeArgs};
 use crate::tools::{
-    ContextualError, ToolContext, click_element_with, set_value_with, type_text_with,
+    ContextualError, SafeErrorCategory, ToolContext, click_element_with, erase_semantic_context,
+    set_value_with, type_text_with,
 };
 
 #[derive(Clone, Copy)]
@@ -214,13 +219,16 @@ impl Platform for InstrumentedPlatform {
 
 struct InstrumentedAccessibility {
     counters: Arc<SessionIoCounters>,
+    tree: glass_core::AxTree,
+    coverage: AxStateCoverage,
+    invoke_result: Option<AxNodeId>,
 }
 
 impl Accessibility for InstrumentedAccessibility {
     fn snapshot(&mut self, _ctx: &AxContext) -> glass_core::Result<glass_core::AxTree> {
         self.counters
             .record(SessionIoKind::Accessibility, "a11y_snapshot");
-        Ok(crate::tools::testutil::empty_tree())
+        Ok(self.tree.clone())
     }
 
     fn subscribe_changes(&mut self, _ctx: &AxContext) -> Option<Box<dyn ChangeSignal>> {
@@ -232,7 +240,7 @@ impl Accessibility for InstrumentedAccessibility {
     fn state_coverage(&self) -> AxStateCoverage {
         self.counters
             .record(SessionIoKind::Accessibility, "a11y_state_coverage");
-        AxStateCoverage::NONE
+        self.coverage
     }
 
     fn focus(
@@ -272,11 +280,23 @@ impl Accessibility for InstrumentedAccessibility {
         _target: &AxTarget,
     ) -> glass_core::Result<Option<AxNodeId>> {
         self.counters.record(SessionIoKind::Action, "a11y_invoke");
-        Ok(None)
+        Ok(self.invoke_result)
     }
 }
 
 fn started_instrumented_glass() -> (Glass, Arc<SessionIoCounters>, Arc<AtomicUsize>) {
+    started_instrumented_glass_with(
+        crate::tools::testutil::empty_tree(),
+        AxStateCoverage::NONE,
+        None,
+    )
+}
+
+fn started_instrumented_glass_with(
+    tree: glass_core::AxTree,
+    coverage: AxStateCoverage,
+    invoke_result: Option<AxNodeId>,
+) -> (Glass, Arc<SessionIoCounters>, Arc<AtomicUsize>) {
     let counters = Arc::new(SessionIoCounters::default());
     let geometry = WindowGeometry {
         x: 0,
@@ -291,6 +311,9 @@ fn started_instrumented_glass() -> (Glass, Arc<SessionIoCounters>, Arc<AtomicUsi
         }),
         accessibility: Some(Box::new(InstrumentedAccessibility {
             counters: counters.clone(),
+            tree,
+            coverage,
+            invoke_result,
         })),
     });
     let factory_calls = Arc::new(AtomicUsize::new(0));
@@ -660,4 +683,690 @@ fn validate_action_routes_each_invalid_variant_to_its_pure_helper() {
         );
         assert_eq!(error.bound_dispatch, Some(BoundDispatch::NotDispatched));
     }
+}
+
+fn element_with_text(name: &str, value: &str, secure: bool) -> ElementInfo {
+    ElementInfo {
+        id: AxNodeId(4),
+        role: AxRole::Button,
+        name: Some(name.into()),
+        description: Some(format!("description for {name}")),
+        value: Some(value.into()),
+        bounds: Some(AxRect {
+            x: 10,
+            y: 20,
+            width: 30,
+            height: 40,
+        }),
+        states: AxStates {
+            enabled: true,
+            visible: true,
+            secure,
+            ..AxStates::default()
+        },
+    }
+}
+
+fn actionability_report() -> ActionabilityReport {
+    ActionabilityReport {
+        checks: vec![ActionabilityCheck::new(
+            ActionabilityCheckName::Unique,
+            ActionabilityVerdict::Passed,
+            true,
+            ActionabilitySource::SemanticResolution,
+        )],
+    }
+}
+
+fn resolution_report(timed_out_by: Option<Whose>) -> ResolutionReport {
+    ResolutionReport {
+        elapsed_ms: 12,
+        scope: ScopeResolution::Resolved(AxNodeId(3)),
+        matches_in_walk: 1,
+        search_complete: true,
+        timed_out_by,
+        tree_truncated: false,
+        unreadable_subtrees: 0,
+        unexposed_placeholders: 0,
+    }
+}
+
+fn action_bound(owner: Option<Whose>) -> ActionDeadline {
+    ActionDeadline {
+        deadline: Deadline::UNBOUNDED,
+        owner,
+        allow_wait: true,
+    }
+}
+
+fn outcome(
+    method: ActionMethod,
+    focus: Option<MutationReport>,
+    semantic: bool,
+    name: &str,
+) -> SemanticActionOutcome {
+    SemanticActionOutcome {
+        target: element_with_text(name, "application value", false),
+        resolution: semantic.then(|| resolution_report(None)),
+        actionability: actionability_report(),
+        focus,
+        action: MutationReport {
+            method,
+            dispatch: DispatchStatus::Dispatched,
+            confirmation: ConfirmationStatus::DispatchConfirmed,
+        },
+        bound: action_bound(Some(Whose::Callee)),
+    }
+}
+
+fn semantic_match(name: &str, context: &str) -> SemanticMatch {
+    SemanticMatch {
+        element: element_with_text(name, "candidate value", false),
+        field: Some(MatchField::Name),
+        tier: MatchTier::ExactName,
+        context: context.into(),
+    }
+}
+
+fn semantic_failure(
+    kind: SemanticActionFailureKind,
+    timed_out_by: Option<Whose>,
+    owner: Option<Whose>,
+    candidates: Vec<SemanticMatch>,
+) -> SemanticActionError {
+    SemanticActionError {
+        kind,
+        summary: "APP CONTROLLED SUMMARY MUST NOT BE USED",
+        resolution: Some(resolution_report(timed_out_by)),
+        actionability: actionability_report(),
+        focus: None,
+        action_dispatch: DispatchStatus::NotDispatched,
+        candidates,
+        bound: action_bound(owner),
+        retry: RetryGuidance::WaitOrRefine,
+        source: Some(GlassError::Backend(
+            "APP CONTROLLED BACKEND DETAIL MUST NOT BE USED".into(),
+        )),
+    }
+}
+
+fn success_result(output: &crate::tools::ToolOutput) -> &serde_json::Value {
+    let crate::tools::OutContent::Envelope(envelope) = &output.0[0] else {
+        panic!("expected success envelope")
+    };
+    &envelope.result
+}
+
+fn error_envelope(output: &crate::tools::ToolOutput) -> serde_json::Value {
+    let block = output.render_text_blocks().remove(0);
+    serde_json::from_str(&block).expect("structured error envelope")
+}
+
+fn untrusted_body(block: &str) -> &str {
+    let after_open = block.split_once("⟧\n").expect("untrusted open marker").1;
+    after_open
+        .rsplit_once("\n⟦/untrusted:")
+        .expect("untrusted close marker")
+        .0
+}
+
+#[test]
+fn semantic_success_shapes_disclose_mutation_and_complete_evidence() {
+    let click = success_output(
+        "glass_click_element",
+        &outcome(
+            ActionMethod::NativeAction {
+                actuated: Some(AxNodeId(9)),
+            },
+            None,
+            true,
+            "Save",
+        ),
+        None,
+        vec![],
+    );
+    let click_result = success_result(&click);
+    assert_eq!(click_result["id"], 4);
+    assert_eq!(click_result["method"], "native-action");
+    assert_eq!(click_result["dispatch"], "dispatched");
+    assert_eq!(click_result["confirmation"], "dispatch_confirmed");
+    assert_eq!(click_result["actuated_id"], 9);
+    assert_eq!(click_result["resolution"]["source"], "semantic");
+    assert_eq!(click_result["resolution"]["elapsed_ms"], 12);
+    assert_eq!(click_result["resolution"]["scope_status"], "resolved");
+    assert_eq!(click_result["resolution"]["resolved_scope_id"], 3);
+    assert_eq!(click_result["resolution"]["search_complete"], true);
+    assert_eq!(click_result["resolution"]["tree_truncated"], false);
+    assert_eq!(
+        click_result["actionability"][0],
+        serde_json::json!({
+            "check": "unique",
+            "verdict": "passed",
+            "required": true,
+            "source": "semantic_resolution",
+        })
+    );
+
+    let set = success_output(
+        "glass_set_value",
+        &outcome(ActionMethod::AccessibilityValue, None, true, "Account name"),
+        Some(serde_json::json!({"settled": true})),
+        vec![],
+    );
+    let set_result = success_result(&set);
+    assert_eq!(set_result["method"], "accessibility-value");
+    assert_eq!(set_result["dispatch"], "dispatched");
+    assert_eq!(set_result["confirmation"], "dispatch_confirmed");
+    assert_eq!(set_result["observed"]["settled"], true);
+
+    let typed = success_output(
+        "glass_type",
+        &outcome(
+            ActionMethod::Keyboard,
+            Some(MutationReport {
+                method: ActionMethod::NativeAction { actuated: None },
+                dispatch: DispatchStatus::Dispatched,
+                confirmation: ConfirmationStatus::FocusConfirmed,
+            }),
+            true,
+            "UNIQUE_SUBMITTED_TYPE_SENTINEL",
+        ),
+        None,
+        vec![],
+    );
+    let type_result = success_result(&typed);
+    assert_eq!(type_result["focus_method"], "native-action");
+    assert_eq!(type_result["focus_dispatch"], "dispatched");
+    assert_eq!(type_result["focus_confirmation"], "focus_confirmed");
+    assert_eq!(type_result["type_dispatch"], "dispatched");
+    assert!(type_result.get("method").is_none());
+    assert!(
+        typed
+            .render_text_blocks()
+            .iter()
+            .all(|block| !block.contains("UNIQUE_SUBMITTED_TYPE_SENTINEL"))
+    );
+}
+
+#[test]
+fn semantic_selector_success_has_one_untrusted_target_sibling_and_trusted_text_is_clean() {
+    let output = success_output(
+        "glass_click_element",
+        &outcome(
+            ActionMethod::Pointer {
+                native_fallback: None,
+            },
+            None,
+            true,
+            "Pay now",
+        ),
+        None,
+        vec![],
+    );
+    assert_eq!(output.0.len(), 2);
+    let trusted = output.render_text_blocks()[0].clone();
+    assert!(!trusted.contains("Pay now"));
+    assert!(!trusted.contains("description for"));
+    assert!(!trusted.contains("application value"));
+    let sibling = output.text_block(1).expect("target sibling");
+    assert_eq!(
+        sibling.trust,
+        crate::output::TextTrust::UntrustedApplication
+    );
+    let body: serde_json::Value =
+        serde_json::from_str(untrusted_body(&sibling.body)).expect("target JSON");
+    assert_eq!(body["target"]["name"], "Pay now");
+    assert_eq!(
+        success_result(&output)["content_blocks"],
+        serde_json::json!([1])
+    );
+
+    let legacy = success_output(
+        "glass_click_element",
+        &outcome(
+            ActionMethod::Pointer {
+                native_fallback: None,
+            },
+            None,
+            false,
+            "Pay now",
+        ),
+        None,
+        vec![],
+    );
+    assert_eq!(legacy.0.len(), 1);
+    assert!(success_result(&legacy).get("resolution").is_none());
+    assert!(success_result(&legacy).get("content_blocks").is_none());
+}
+
+#[test]
+fn element_and_candidate_rendering_enforce_text_and_secure_value_policy() {
+    let secure = element_with_text("Secret field", "TOP SECRET", true);
+    let visible = element_json(&secure, true);
+    assert_eq!(visible["name"], "Secret field");
+    assert_eq!(visible["value"], serde_json::Value::Null);
+
+    let hidden = element_json(&secure, false);
+    assert_eq!(hidden["name"], serde_json::Value::Null);
+    assert_eq!(hidden["description"], serde_json::Value::Null);
+    assert_eq!(hidden["value"], serde_json::Value::Null);
+
+    let candidates = candidates_json(&[semantic_match("Neighbor", "near Account")], false);
+    assert_eq!(candidates[0]["name"], serde_json::Value::Null);
+    assert_eq!(candidates[0]["matched_text"], serde_json::Value::Null);
+    assert_eq!(candidates[0]["context"], serde_json::Value::Null);
+    assert_eq!(candidates[0]["id"], 4);
+    assert_eq!(candidates[0]["match_tier"], "exact_name");
+}
+
+#[test]
+fn semantic_error_categories_and_codes_are_stable_snake_case() {
+    let rows = [
+        (
+            SemanticActionFailureKind::NoMatch,
+            SafeErrorCategory::NoMatch,
+            "no_match",
+        ),
+        (
+            SemanticActionFailureKind::AmbiguousTarget,
+            SafeErrorCategory::AmbiguousTarget,
+            "ambiguous_target",
+        ),
+        (
+            SemanticActionFailureKind::AmbiguousScope,
+            SafeErrorCategory::AmbiguousScope,
+            "ambiguous_scope",
+        ),
+        (
+            SemanticActionFailureKind::IncompleteTree,
+            SafeErrorCategory::IncompleteTree,
+            "incomplete_tree",
+        ),
+        (
+            SemanticActionFailureKind::UnprovenSelectorState,
+            SafeErrorCategory::UnprovenSelectorState,
+            "unproven_selector_state",
+        ),
+        (
+            SemanticActionFailureKind::NotActionable,
+            SafeErrorCategory::NotActionable,
+            "not_actionable",
+        ),
+        (
+            SemanticActionFailureKind::UnstableTarget,
+            SafeErrorCategory::UnstableTarget,
+            "unstable_target",
+        ),
+        (
+            SemanticActionFailureKind::FocusUnconfirmed,
+            SafeErrorCategory::FocusUnconfirmed,
+            "focus_unconfirmed",
+        ),
+        (
+            SemanticActionFailureKind::UnsupportedMode,
+            SafeErrorCategory::UnsupportedMode,
+            "unsupported_mode",
+        ),
+    ];
+    for (kind, category, code) in rows {
+        let rendered = semantic_error(
+            "glass_click_element",
+            semantic_failure(kind, None, None, vec![]),
+        );
+        assert_eq!(rendered.category, category);
+        assert_eq!(rendered.code, code);
+        assert_eq!(serde_json::to_value(category).unwrap(), code);
+        assert!(!rendered.message.contains("APP CONTROLLED"));
+    }
+}
+
+#[test]
+fn structured_ambiguity_error_keeps_candidates_only_in_untrusted_sibling() {
+    let error = semantic_error(
+        "glass_click_element",
+        semantic_failure(
+            SemanticActionFailureKind::AmbiguousTarget,
+            None,
+            None,
+            vec![
+                semantic_match("Pay personal", "inside Personal card"),
+                semantic_match("Pay business", "inside Business card"),
+            ],
+        ),
+    );
+    let output = erase_semantic_context("glass_click_element", Err(error)).unwrap_err();
+    let envelope = error_envelope(&output);
+    assert_eq!(envelope["ok"], false);
+    assert_eq!(envelope["tool"], "glass_click_element");
+    assert_eq!(envelope["error"]["code"], "ambiguous_target");
+    assert_eq!(envelope["error"]["summary"], "semantic target is ambiguous");
+    assert_eq!(envelope["result"]["dispatch"], "not_dispatched");
+    assert_eq!(envelope["result"]["side_effects_may_have_occurred"], false);
+    assert_eq!(envelope["result"]["retry"], "wait_or_refine");
+    assert_eq!(envelope["content_blocks"], serde_json::json!([1]));
+    let trusted = output.render_text_blocks()[0].clone();
+    assert!(!trusted.contains("Pay personal"));
+    assert!(!trusted.contains("Business card"));
+    let sibling = output.text_block(1).expect("candidate sibling");
+    assert!(sibling.body.contains("Pay personal"));
+    assert!(sibling.body.contains("Business card"));
+}
+
+#[test]
+fn structured_actionability_failure_uses_one_untrusted_known_target_block() {
+    let error = semantic_error(
+        "glass_set_value",
+        semantic_failure(
+            SemanticActionFailureKind::NotActionable,
+            None,
+            None,
+            vec![semantic_match("Disabled account", "inside settings")],
+        ),
+    );
+    let output = erase_semantic_context("glass_set_value", Err(error)).unwrap_err();
+    assert_eq!(output.0.len(), 2);
+    let sibling = output.text_block(1).expect("known target sibling");
+    let body: serde_json::Value = serde_json::from_str(untrusted_body(&sibling.body)).unwrap();
+    assert!(body.get("target").is_some(), "{body}");
+    assert!(body.get("candidates").is_none(), "{body}");
+}
+
+#[test]
+fn caller_owned_or_expired_semantic_context_uses_sequence_deadline_and_keeps_evidence() {
+    let error = semantic_error(
+        "glass_click_element",
+        semantic_failure(
+            SemanticActionFailureKind::NoMatch,
+            Some(Whose::Caller),
+            Some(Whose::Caller),
+            vec![],
+        ),
+    );
+    assert_eq!(error.code, "sequence_deadline_exceeded");
+    assert_eq!(error.category, SafeErrorCategory::SequenceDeadlineExceeded);
+    let result = error.result.expect("semantic evidence");
+    assert_eq!(result["resolution"]["timed_out_by"], "sequence");
+    assert_eq!(result["resolution"]["matches_in_walk"], 1);
+    assert_eq!(result["resolution"]["search_complete"], true);
+
+    let action_timeout = semantic_error(
+        "glass_click_element",
+        semantic_failure(
+            SemanticActionFailureKind::NoMatch,
+            Some(Whose::Callee),
+            Some(Whose::Callee),
+            vec![],
+        ),
+    );
+    assert_eq!(action_timeout.code, "no_match");
+    assert_eq!(
+        action_timeout.result.unwrap()["resolution"]["timed_out_by"],
+        "action"
+    );
+}
+
+#[test]
+fn structured_backend_stale_and_deadline_errors_do_not_format_backend_source() {
+    let mut stale = semantic_failure(SemanticActionFailureKind::ActionFailed, None, None, vec![]);
+    stale.source = Some(GlassError::AxElementChanged(4));
+    let stale = semantic_error("glass_click_element", stale);
+    assert_eq!(stale.code, "stale_element");
+    assert_eq!(stale.category, SafeErrorCategory::StaleElement);
+
+    for (kind, owner, code) in [
+        (
+            SemanticActionFailureKind::ActionDeadlineExceeded,
+            Some(Whose::Callee),
+            "action_deadline_exceeded",
+        ),
+        (
+            SemanticActionFailureKind::SequenceDeadlineExceeded,
+            Some(Whose::Caller),
+            "sequence_deadline_exceeded",
+        ),
+    ] {
+        let rendered = semantic_error(
+            "glass_click_element",
+            semantic_failure(kind, owner, owner, vec![]),
+        );
+        assert_eq!(rendered.code, code);
+        assert!(!rendered.message.contains("APP CONTROLLED BACKEND DETAIL"));
+    }
+}
+
+#[test]
+fn structured_type_failure_excludes_submitted_payload_from_blocks_and_artifacts() {
+    const SENTINEL: &str = "TYPE_PAYLOAD_SENTINEL_7e3e5037";
+    let mut failure = semantic_failure(
+        SemanticActionFailureKind::FocusUnconfirmed,
+        None,
+        None,
+        vec![semantic_match(SENTINEL, SENTINEL)],
+    );
+    failure.source = Some(GlassError::Backend(format!("backend echoed {SENTINEL}")));
+    let output = erase_semantic_context("glass_type", Err(semantic_error("glass_type", failure)))
+        .unwrap_err();
+    assert!(
+        output
+            .render_text_blocks()
+            .iter()
+            .all(|block| !block.contains(SENTINEL))
+    );
+
+    let root = tempfile::tempdir().unwrap();
+    let store = crate::artifacts::ArtifactStore::for_test(root.path(), 1 << 20).unwrap();
+    let policy = crate::output_policy::OutputPolicy::new(store.clone());
+    let applied = policy.apply(crate::output_policy::ToolCallOutcome {
+        tool: "glass_type",
+        effect: crate::output::ToolEffect::MayMutate,
+        is_error: true,
+        target_access: crate::output::TargetAccess::NoActiveTarget,
+        output,
+    });
+    for content in &applied.output.0 {
+        if let crate::tools::OutContent::ResourceLink(descriptor) = content {
+            let artifact = store.read(descriptor.uri()).unwrap();
+            assert!(!artifact.text.contains(SENTINEL));
+        }
+    }
+}
+
+fn semantic_success_with_total_text_bytes(total: usize) -> crate::tools::ToolOutput {
+    let mut output = success_output(
+        "glass_click_element",
+        &outcome(
+            ActionMethod::Pointer {
+                native_fallback: None,
+            },
+            None,
+            true,
+            "",
+        ),
+        None,
+        vec![],
+    );
+    output.0[1] = crate::tools::OutContent::untrusted_observation(
+        &serde_json::json!({"target": {"padding": ""}}).to_string(),
+    );
+    let padding = "x".repeat(total - output.text_bytes());
+    output.0[1] = crate::tools::OutContent::untrusted_observation(
+        &serde_json::json!({"target": {"padding": padding}}).to_string(),
+    );
+    assert_eq!(output.text_bytes(), total);
+    output
+}
+
+fn semantic_error_with_total_text_bytes(total: usize) -> crate::tools::ToolOutput {
+    let mut output = erase_semantic_context(
+        "glass_click_element",
+        Err(semantic_error(
+            "glass_click_element",
+            semantic_failure(
+                SemanticActionFailureKind::AmbiguousTarget,
+                None,
+                None,
+                vec![semantic_match("", "")],
+            ),
+        )),
+    )
+    .unwrap_err();
+    output.0[1] = crate::tools::OutContent::untrusted_observation(
+        &serde_json::json!({"candidates": [{"padding": ""}]}).to_string(),
+    );
+    let padding = "x".repeat(total - output.text_bytes());
+    output.0[1] = crate::tools::OutContent::untrusted_observation(
+        &serde_json::json!({"candidates": [{"padding": padding}]}).to_string(),
+    );
+    assert_eq!(output.text_bytes(), total);
+    output
+}
+
+fn assert_output_budget_roundtrip(total: usize, is_error: bool, output: crate::tools::ToolOutput) {
+    let original = output.render_text_blocks();
+    let root = tempfile::tempdir().unwrap();
+    let store = crate::artifacts::ArtifactStore::for_test(root.path(), 1 << 20).unwrap();
+    let policy = crate::output_policy::OutputPolicy::new(store.clone());
+    let applied = policy.apply(crate::output_policy::ToolCallOutcome {
+        tool: "glass_click_element",
+        effect: crate::output::ToolEffect::MayMutate,
+        is_error,
+        target_access: crate::output::TargetAccess::NoActiveTarget,
+        output,
+    });
+    assert!(applied.output.text_bytes() <= crate::output_policy::MAX_TEXT_BYTES);
+    assert_eq!(applied.is_error, is_error);
+    if total <= crate::output_policy::MAX_TEXT_BYTES {
+        assert_eq!(applied.output.render_text_blocks(), original);
+        assert!(applied.output_metadata().is_none());
+    } else {
+        let descriptor = applied
+            .output
+            .0
+            .iter()
+            .find_map(|content| match content {
+                crate::tools::OutContent::ResourceLink(descriptor) => Some(descriptor),
+                _ => None,
+            })
+            .expect("oversized semantic block externalized");
+        let artifact = store.read(descriptor.uri()).unwrap();
+        let externalized = if artifact.text.starts_with(crate::untrusted::NOTE) {
+            artifact.text
+        } else {
+            let manifest: serde_json::Value = serde_json::from_str(&artifact.text).unwrap();
+            manifest["blocks"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|block| block["index"] == 1)
+                .and_then(|block| block["text"].as_str())
+                .expect("manifest preserves externalized semantic block")
+                .to_owned()
+        };
+        assert_eq!(externalized, original[1]);
+        assert!(externalized.starts_with(crate::untrusted::NOTE));
+    }
+}
+
+#[test]
+fn output_budget_success_target_8191_8192_8193_roundtrips_exact_untrusted_block() {
+    for total in [8_191, 8_192, 8_193] {
+        assert_output_budget_roundtrip(total, false, semantic_success_with_total_text_bytes(total));
+    }
+}
+
+#[test]
+fn output_budget_error_candidates_8191_8192_8193_preserve_error_and_roundtrip() {
+    for total in [8_191, 8_192, 8_193] {
+        assert_output_budget_roundtrip(total, true, semantic_error_with_total_text_bytes(total));
+    }
+}
+
+#[test]
+fn zero_timeout_return_observe_fails_after_dispatch_without_waiting() {
+    let mut tree = crate::tools::testutil::empty_tree();
+    tree.root.children.push(AxNode {
+        id: AxNodeId(0),
+        role: AxRole::Button,
+        raw_role: "button".into(),
+        name: Some("Save".into()),
+        description: None,
+        value: None,
+        states: AxStates {
+            enabled: true,
+            visible: true,
+            ..AxStates::default()
+        },
+        bounds: Some(AxRect {
+            x: 10,
+            y: 10,
+            width: 20,
+            height: 20,
+        }),
+        children: vec![],
+    });
+    tree.assign_ids();
+    let coverage = AxStateCoverage {
+        enabled: true,
+        visible: true,
+        ..AxStateCoverage::NONE
+    };
+    let (mut glass, counters, _) =
+        started_instrumented_glass_with(tree, coverage, Some(AxNodeId(1)));
+    let args: ClickElementArgs = serde_json::from_str(
+        r#"{"target":{"query":"Save","role":"Button"},"mode":"native","timeout_ms":0,"return":"settle"}"#,
+    )
+    .unwrap();
+    counters.clear();
+    let started = std::time::Instant::now();
+    let error = click_element_with(&mut glass, &args, ToolContext::UNBOUNDED).unwrap_err();
+    assert_eq!(error.code, "action_deadline_exceeded");
+    assert_eq!(error.category, SafeErrorCategory::ActionDeadlineExceeded);
+    assert_eq!(error.bound_dispatch, Some(BoundDispatch::MayHaveDispatched));
+    assert_eq!(
+        counters
+            .calls
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|call| **call == "a11y_invoke")
+            .count(),
+        1,
+        "one native dispatch"
+    );
+    assert_eq!(
+        counters.capture.load(Ordering::SeqCst),
+        0,
+        "no settle capture"
+    );
+    assert!(
+        started.elapsed() < std::time::Duration::from_millis(100),
+        "return path must not sleep for the settle interval"
+    );
+}
+
+#[test]
+fn semantic_validators_assign_stable_request_codes_without_app_text_codes() {
+    let invalid_return: ClickElementArgs =
+        serde_json::from_str(r#"{"id":1,"return":"APP_TEXT_CODE"}"#).unwrap();
+    let error = validate_click_element_args(&invalid_return).unwrap_err();
+    assert_eq!(error.code, "invalid_return");
+    assert_ne!(error.code, "APP_TEXT_CODE");
+
+    let invalid_target: ClickElementArgs = serde_json::from_str(r#"{}"#).unwrap();
+    assert_eq!(
+        validate_click_element_args(&invalid_target)
+            .unwrap_err()
+            .code,
+        "invalid_action_target"
+    );
+
+    let invalid_sequence = Action::ClickElement(invalid_target);
+    assert_eq!(
+        validate_action(&invalid_sequence).unwrap_err().code,
+        "invalid_sequence"
+    );
+    assert_eq!(
+        ContextualError::validation("legacy".into()).code,
+        "invalid_argument"
+    );
 }

--- a/crates/glass-mcp/src/tools/tests.rs
+++ b/crates/glass-mcp/src/tools/tests.rs
@@ -494,7 +494,10 @@ fn set_value_tool_ok_and_errors() {
     let out = set_value(
         &mut g,
         &SetValueArgs {
-            id: 1,
+            id: Some(1),
+            target: None,
+            timeout_ms: None,
+            max_nodes: None,
             text: "hello".into(),
             return_: None,
         },
@@ -506,7 +509,10 @@ fn set_value_tool_ok_and_errors() {
     let err = set_value(
         &mut g,
         &SetValueArgs {
-            id: 99,
+            id: Some(99),
+            target: None,
+            timeout_ms: None,
+            max_nodes: None,
             text: "x".into(),
             return_: None,
         },
@@ -540,7 +546,10 @@ fn set_value_tool_rejects_uneditable_and_stale() {
     let err = set_value(
         &mut g,
         &SetValueArgs {
-            id: 1,
+            id: Some(1),
+            target: None,
+            timeout_ms: None,
+            max_nodes: None,
             text: "x".into(),
             return_: None,
         },
@@ -559,7 +568,10 @@ fn set_value_tool_rejects_uneditable_and_stale() {
     let err = set_value(
         &mut g,
         &SetValueArgs {
-            id: 1,
+            id: Some(1),
+            target: None,
+            timeout_ms: None,
+            max_nodes: None,
             text: "x".into(),
             return_: None,
         },
@@ -587,7 +599,11 @@ fn click_element_tool_ok_and_errors() {
         click_element(
             &mut g,
             &ClickElementArgs {
-                id: 1,
+                id: Some(1),
+                target: None,
+                mode: None,
+                timeout_ms: None,
+                max_nodes: None,
                 return_: None
             }
         )
@@ -596,7 +612,11 @@ fn click_element_tool_ok_and_errors() {
     let err = click_element(
         &mut g,
         &ClickElementArgs {
-            id: 99,
+            id: Some(99),
+            target: None,
+            mode: None,
+            timeout_ms: None,
+            max_nodes: None,
             return_: None,
         },
     )
@@ -770,7 +790,11 @@ fn return_none_is_confirmation_only() {
     let out = click_element(
         &mut g,
         &ClickElementArgs {
-            id: 1,
+            id: Some(1),
+            target: None,
+            mode: None,
+            timeout_ms: None,
+            max_nodes: None,
             return_: None,
         },
     )
@@ -790,7 +814,11 @@ fn return_none_is_confirmation_only() {
     let out2 = click_element(
         &mut g,
         &ClickElementArgs {
-            id: 1,
+            id: Some(1),
+            target: None,
+            mode: None,
+            timeout_ms: None,
+            max_nodes: None,
             return_: Some("none".into()),
         },
     )
@@ -816,7 +844,11 @@ fn click_element_discloses_native_action_with_no_fallback() {
     let out = click_element(
         &mut g,
         &ClickElementArgs {
-            id: 1,
+            id: Some(1),
+            target: None,
+            mode: None,
+            timeout_ms: None,
+            max_nodes: None,
             return_: None,
         },
     )
@@ -849,7 +881,11 @@ fn click_element_names_the_element_it_actuated_instead() {
     let out = click_element(
         &mut g,
         &ClickElementArgs {
-            id: 1,
+            id: Some(1),
+            target: None,
+            mode: None,
+            timeout_ms: None,
+            max_nodes: None,
             return_: None,
         },
     )
@@ -878,7 +914,11 @@ fn click_element_omits_actuated_id_when_the_target_itself_was_clicked() {
     let out = click_element(
         &mut g,
         &ClickElementArgs {
-            id: 1,
+            id: Some(1),
+            target: None,
+            mode: None,
+            timeout_ms: None,
+            max_nodes: None,
             return_: None,
         },
     )
@@ -896,7 +936,11 @@ fn return_unknown_errors() {
     let err = click_element(
         &mut g,
         &ClickElementArgs {
-            id: 1,
+            id: Some(1),
+            target: None,
+            mode: None,
+            timeout_ms: None,
+            max_nodes: None,
             return_: Some("wat".into()),
         },
     )
@@ -910,7 +954,11 @@ fn return_snapshot_appends_tree_and_refreshes_cache() {
     let out = click_element(
         &mut g,
         &ClickElementArgs {
-            id: 1,
+            id: Some(1),
+            target: None,
+            mode: None,
+            timeout_ms: None,
+            max_nodes: None,
             return_: Some("snapshot".into()),
         },
     )
@@ -944,7 +992,11 @@ fn return_snapshot_appends_tree_and_refreshes_cache() {
         click_element(
             &mut g,
             &ClickElementArgs {
-                id: 1,
+                id: Some(1),
+                target: None,
+                mode: None,
+                timeout_ms: None,
+                max_nodes: None,
                 return_: None
             }
         )
@@ -976,7 +1028,11 @@ fn return_snapshot_discloses_an_unpublished_document_the_same_way_a_snapshot_doe
     let out = click_element(
         &mut g,
         &ClickElementArgs {
-            id: 1,
+            id: Some(1),
+            target: None,
+            mode: None,
+            timeout_ms: None,
+            max_nodes: None,
             return_: Some("snapshot".into()),
         },
     )
@@ -1034,7 +1090,11 @@ fn return_snapshot_settles_before_folding() {
     let out = click_element(
         &mut g,
         &ClickElementArgs {
-            id: 1,
+            id: Some(1),
+            target: None,
+            mode: None,
+            timeout_ms: None,
+            max_nodes: None,
             return_: Some("snapshot".into()),
         },
     )
@@ -1055,7 +1115,11 @@ fn return_snapshot_without_frames_propagates_settle_failure() {
     let error = click_element(
         &mut g,
         &ClickElementArgs {
-            id: 1,
+            id: Some(1),
+            target: None,
+            mode: None,
+            timeout_ms: None,
+            max_nodes: None,
             return_: Some("snapshot".into()),
         },
     )
@@ -1073,7 +1137,11 @@ fn return_settle_appends_settled_text() {
     let out = click_element(
         &mut g,
         &ClickElementArgs {
-            id: 1,
+            id: Some(1),
+            target: None,
+            mode: None,
+            timeout_ms: None,
+            max_nodes: None,
             return_: Some("settle".into()),
         },
     )
@@ -1094,7 +1162,10 @@ fn set_value_return_snapshot() {
     let out = set_value(
         &mut g,
         &SetValueArgs {
-            id: 1,
+            id: Some(1),
+            target: None,
+            timeout_ms: None,
+            max_nodes: None,
             text: "x".into(),
             return_: Some("snapshot".into()),
         },
@@ -1116,7 +1187,10 @@ fn set_value_return_settle_folds_into_observed() {
     let out = set_value(
         &mut g,
         &SetValueArgs {
-            id: 1,
+            id: Some(1),
+            target: None,
+            timeout_ms: None,
+            max_nodes: None,
             text: "x".into(),
             return_: Some("settle".into()),
         },
@@ -1140,6 +1214,10 @@ fn type_return_settle_folds_into_observed() {
     let out = type_text(
         &mut g,
         &TypeArgs {
+            target: None,
+            focus_mode: None,
+            timeout_ms: None,
+            max_nodes: None,
             text: "hi".into(),
             return_: Some("settle".into()),
         },
@@ -1160,6 +1238,10 @@ fn type_return_snapshot_appends_outline() {
     let out = type_text(
         &mut g,
         &TypeArgs {
+            target: None,
+            focus_mode: None,
+            timeout_ms: None,
+            max_nodes: None,
             text: "x".into(),
             return_: Some("snapshot".into()),
         },
@@ -1180,7 +1262,11 @@ fn type_return_snapshot_appends_outline() {
         click_element(
             &mut g,
             &ClickElementArgs {
-                id: 1,
+                id: Some(1),
+                target: None,
+                mode: None,
+                timeout_ms: None,
+                max_nodes: None,
                 return_: None
             }
         )
@@ -1209,6 +1295,10 @@ fn type_unknown_return_rejected_before_any_keystroke() {
     let err = type_text(
         &mut g,
         &TypeArgs {
+            target: None,
+            focus_mode: None,
+            timeout_ms: None,
+            max_nodes: None,
             text: "x".into(),
             return_: Some("bogus".into()),
         },
@@ -1244,6 +1334,10 @@ fn type_observe_failure_says_text_was_typed() {
     let err = type_text(
         &mut g,
         &TypeArgs {
+            target: None,
+            focus_mode: None,
+            timeout_ms: None,
+            max_nodes: None,
             text: "hi".into(),
             return_: Some("snapshot".into()),
         },
@@ -1365,7 +1459,11 @@ fn production_application_text_conduits_have_explicit_trust_roles() {
     let automatic = click_element(
         &mut semantic,
         &ClickElementArgs {
-            id: 1,
+            id: Some(1),
+            target: None,
+            mode: None,
+            timeout_ms: None,
+            max_nodes: None,
             return_: Some("snapshot".into()),
         },
     )
@@ -1449,7 +1547,11 @@ fn production_application_text_conduits_have_explicit_trust_roles() {
         &mut failed,
         &DoArgs {
             actions: vec![Action::ClickElement(ClickElementArgs {
-                id: 1,
+                id: Some(1),
+                target: None,
+                mode: None,
+                timeout_ms: None,
+                max_nodes: None,
                 return_: None,
             })],
             then: None,

--- a/crates/glass-mcp/src/tools/tests.rs
+++ b/crates/glass-mcp/src/tools/tests.rs
@@ -16,6 +16,15 @@ fn start_args() -> StartArgs {
     }
 }
 
+fn structured_error(output: &ToolOutput, tool: &str) -> serde_json::Value {
+    let blocks = output.render_text_blocks();
+    let envelope: serde_json::Value =
+        serde_json::from_str(&blocks[0]).expect("structured standalone error envelope");
+    assert_eq!(envelope["ok"], false);
+    assert_eq!(envelope["tool"], tool);
+    envelope
+}
+
 #[test]
 fn a11y_defaults_on_when_omitted() {
     // The a11y-first path is the low-token default, so an omitted flag enables it.
@@ -518,7 +527,8 @@ fn set_value_tool_ok_and_errors() {
         },
     )
     .unwrap_err();
-    assert!(err.contains("not in the current snapshot"), "msg: {err}");
+    let err = structured_error(&err, "glass_set_value");
+    assert_eq!(err["error"]["code"], "stale_element");
 }
 
 #[test]
@@ -555,7 +565,8 @@ fn set_value_tool_rejects_uneditable_and_stale() {
         },
     )
     .unwrap_err();
-    assert!(err.contains("not editable"), "msg: {err}");
+    let err = structured_error(&err, "glass_set_value");
+    assert_eq!(err["error"]["code"], "not_editable");
 
     // Element changed since the snapshot: same contract — error, not success.
     let mut g = glass_with_a11y_outcome(
@@ -577,7 +588,8 @@ fn set_value_tool_rejects_uneditable_and_stale() {
         },
     )
     .unwrap_err();
-    assert!(err.contains("changed since the snapshot"), "msg: {err}");
+    let err = structured_error(&err, "glass_set_value");
+    assert_eq!(err["error"]["code"], "stale_element");
 }
 
 #[test]
@@ -621,7 +633,8 @@ fn click_element_tool_ok_and_errors() {
         },
     )
     .unwrap_err();
-    assert!(err.contains("not in the current snapshot"), "msg: {err}");
+    let err = structured_error(&err, "glass_click_element");
+    assert_eq!(err["error"]["code"], "stale_element");
 }
 
 #[test]
@@ -945,7 +958,8 @@ fn return_unknown_errors() {
         },
     )
     .unwrap_err();
-    assert!(err.contains("unknown return"), "msg: {err}");
+    let err = structured_error(&err, "glass_click_element");
+    assert_eq!(err["error"]["code"], "invalid_return");
 }
 
 #[test]
@@ -1124,10 +1138,11 @@ fn return_snapshot_without_frames_propagates_settle_failure() {
         },
     )
     .unwrap_err();
-    assert!(
-        error.contains("capture failed: no scripted frames"),
-        "{error}"
-    );
+    let error = structured_error(&error, "glass_click_element");
+    assert_eq!(error["error"]["category"], "transport_failure");
+    assert_eq!(error["error"]["summary"], "backend transport failed");
+    assert_eq!(error["result"]["dispatch"], "may_have_dispatched");
+    assert_eq!(error["result"]["side_effects_may_have_occurred"], true);
 }
 
 #[test]
@@ -1304,7 +1319,8 @@ fn type_unknown_return_rejected_before_any_keystroke() {
         },
     )
     .unwrap_err();
-    assert!(err.contains("unknown return"), "msg: {err}");
+    let err = structured_error(&err, "glass_type");
+    assert_eq!(err["error"]["code"], "invalid_return");
     assert!(
         log.lock().unwrap().is_empty(),
         "no input injected on a rejected `return`: {:?}",
@@ -1343,8 +1359,90 @@ fn type_observe_failure_says_text_was_typed() {
         },
     )
     .unwrap_err();
-    assert!(err.contains("text was typed"), "msg: {err}");
+    let rendered = err.render_text_blocks().join("\n");
+    let err = structured_error(&err, "glass_type");
+    assert_eq!(err["error"]["code"], "transport_failure");
+    assert_eq!(err["result"]["side_effects_may_have_occurred"], true);
+    assert!(
+        !rendered.contains("hi"),
+        "submitted text leaked: {rendered}"
+    );
     assert_eq!(*log.lock().unwrap(), vec!["type(hi)"], "keystrokes landed");
+}
+
+#[test]
+fn click_element_legacy_id_success_retains_wire_fields_without_semantic_resolution() {
+    let mut g = glass_with_a11y_invoke_on_another(FakePlatform::new(100, 100), fake_tree(), 7);
+    start(&mut g, &start_args()).unwrap();
+    a11y_snapshot(&mut g, &A11ySnapshotArgs { max_nodes: None }).unwrap();
+    let out = click_element(
+        &mut g,
+        &ClickElementArgs {
+            id: Some(1),
+            target: None,
+            mode: None,
+            timeout_ms: None,
+            max_nodes: None,
+            return_: None,
+        },
+    )
+    .unwrap();
+    let result = assert_envelope(&out, "glass_click_element");
+    assert_eq!(result["id"], 1);
+    assert_eq!(result["method"], "native-action");
+    assert_eq!(result["actuated_id"], 7);
+    assert!(result.get("dispatch").is_none());
+    assert!(result.get("confirmation").is_none());
+    assert!(result.get("resolution").is_none());
+    assert_eq!(out.0.len(), 1);
+}
+
+#[test]
+fn set_value_legacy_id_success_retains_wire_fields_without_semantic_resolution() {
+    let mut g = glass_with_a11y(FakePlatform::new(100, 100), fake_tree());
+    start(&mut g, &start_args()).unwrap();
+    a11y_snapshot(&mut g, &A11ySnapshotArgs { max_nodes: None }).unwrap();
+    let out = set_value(
+        &mut g,
+        &SetValueArgs {
+            id: Some(1),
+            target: None,
+            timeout_ms: None,
+            max_nodes: None,
+            text: "hello".into(),
+            return_: None,
+        },
+    )
+    .unwrap();
+    let result = assert_envelope(&out, "glass_set_value");
+    assert_eq!(result["id"], 1);
+    assert!(result.get("method").is_none());
+    assert!(result.get("dispatch").is_none());
+    assert!(result.get("confirmation").is_none());
+    assert!(result.get("resolution").is_none());
+    assert_eq!(out.0.len(), 1);
+}
+
+#[test]
+fn type_untargeted_preserves_key_by_behavior_and_empty_success_shape() {
+    use std::sync::{Arc, Mutex};
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let mut g = glass_with(FakePlatform::new(100, 100).with_event_log(log.clone()));
+    start(&mut g, &start_args()).unwrap();
+    let out = type_text(
+        &mut g,
+        &TypeArgs {
+            target: None,
+            focus_mode: None,
+            timeout_ms: None,
+            max_nodes: None,
+            text: "legacy typing".into(),
+            return_: None,
+        },
+    )
+    .unwrap();
+    assert_eq!(assert_envelope(&out, "glass_type"), serde_json::json!({}));
+    assert_eq!(*log.lock().unwrap(), vec!["type(legacy typing)"]);
 }
 
 #[test]

--- a/crates/glass-mcp/src/tools/wait.rs
+++ b/crates/glass-mcp/src/tools/wait.rs
@@ -31,15 +31,9 @@ fn standalone_scroll_to_element(result: ContextualToolResult) -> ToolResult {
     })
 }
 
-pub fn wait_for_element(glass: &mut Glass, a: &WaitForElementArgs) -> ToolResult {
-    standalone(wait_for_element_with(glass, a, ToolContext::UNBOUNDED))
-}
-
-pub(crate) fn wait_for_element_with(
-    glass: &mut Glass,
+pub(crate) fn validate_wait_for_element_args(
     a: &WaitForElementArgs,
-    context: ToolContext,
-) -> ContextualToolResult {
+) -> Result<(Option<AxRole>, ElementCondition), ContextualError> {
     if a.name.is_none() && a.description.is_none() && a.role.is_none() {
         return Err(ContextualError::validation(
             "specify `name`, `description`, and/or `role` to select an element".into(),
@@ -49,17 +43,70 @@ pub(crate) fn wait_for_element_with(
         return Err(ContextualError::validation("specify `value` for exact matching or `value_contains` for substring matching, not both".into()));
     }
     let role = match a.role.as_deref() {
-        Some(r) => Some(
-            AxRole::from_name(r)
-                .ok_or_else(|| ContextualError::validation(format!("unknown role '{r}'")))?,
+        Some(role) => Some(
+            AxRole::from_name(role)
+                .ok_or_else(|| ContextualError::validation(format!("unknown role '{role}'")))?,
         ),
         None => None,
     };
     let condition = match a.condition.as_deref() {
         None => ElementCondition::Appears,
-        Some(c) => ElementCondition::from_name(c)
-            .ok_or_else(|| ContextualError::validation(format!("unknown condition '{c}' (appears/disappears/enabled/disabled/checked/unchecked/selected/unselected/expanded/collapsed/focused/visible/hidden)")))?,
+        Some(condition) => ElementCondition::from_name(condition).ok_or_else(|| {
+            ContextualError::validation(format!(
+                "unknown condition '{condition}' (appears/disappears/enabled/disabled/checked/unchecked/selected/unselected/expanded/collapsed/focused/visible/hidden)"
+            ))
+        })?,
     };
+    Ok((role, condition))
+}
+
+#[allow(clippy::type_complexity)]
+pub(crate) fn validate_scroll_to_element_args(
+    a: &ScrollToElementArgs,
+) -> Result<(Option<AxRole>, Option<ScrollDirection>, Option<(i32, i32)>), ContextualError> {
+    if a.name.is_none() && a.description.is_none() && a.role.is_none() {
+        return Err(ContextualError::validation(
+            "specify `name`, `description`, and/or `role` to select the element to scroll to"
+                .into(),
+        ));
+    }
+    let role = match a.role.as_deref() {
+        Some(role) => Some(
+            AxRole::from_name(role)
+                .ok_or_else(|| ContextualError::validation(format!("unknown role '{role}'")))?,
+        ),
+        None => None,
+    };
+    let direction = match a.direction.as_deref() {
+        None => None,
+        Some(direction) => Some(ScrollDirection::from_name(direction).ok_or_else(|| {
+            ContextualError::validation(format!(
+                "unknown direction '{direction}' (use up/down/left/right)"
+            ))
+        })?),
+    };
+    let anchor = match (a.x, a.y) {
+        (Some(x), Some(y)) => Some((x, y)),
+        (None, None) => None,
+        _ => {
+            return Err(ContextualError::validation(
+                "specify both `x` and `y` for a scroll anchor, or neither".into(),
+            ));
+        }
+    };
+    Ok((role, direction, anchor))
+}
+
+pub fn wait_for_element(glass: &mut Glass, a: &WaitForElementArgs) -> ToolResult {
+    standalone(wait_for_element_with(glass, a, ToolContext::UNBOUNDED))
+}
+
+pub(crate) fn wait_for_element_with(
+    glass: &mut Glass,
+    a: &WaitForElementArgs,
+    context: ToolContext,
+) -> ContextualToolResult {
+    let (role, condition) = validate_wait_for_element_args(a)?;
     let params = WaitElementParams {
         name: a.name.clone(),
         description: a.description.clone(),
@@ -116,37 +163,7 @@ pub(crate) fn scroll_to_element_with(
     a: &ScrollToElementArgs,
     context: ToolContext,
 ) -> ContextualToolResult {
-    if a.name.is_none() && a.description.is_none() && a.role.is_none() {
-        return Err(ContextualError::validation(
-            "specify `name`, `description`, and/or `role` to select the element to scroll to"
-                .into(),
-        ));
-    }
-    let role = match a.role.as_deref() {
-        Some(r) => Some(
-            AxRole::from_name(r)
-                .ok_or_else(|| ContextualError::validation(format!("unknown role '{r}'")))?,
-        ),
-        None => None,
-    };
-    let direction = match a.direction.as_deref() {
-        None => None,
-        Some(d) => Some(ScrollDirection::from_name(d).ok_or_else(|| {
-            ContextualError::validation(format!("unknown direction '{d}' (use up/down/left/right)"))
-        })?),
-    };
-    // Anchor: both x and y, or neither (default: the target's own row/column). One
-    // without the other is a caller mistake worth naming rather than silently
-    // half-defaulting.
-    let anchor = match (a.x, a.y) {
-        (Some(x), Some(y)) => Some((x, y)),
-        (None, None) => None,
-        _ => {
-            return Err(ContextualError::validation(
-                "specify both `x` and `y` for a scroll anchor, or neither".into(),
-            ));
-        }
-    };
+    let (role, direction, anchor) = validate_scroll_to_element_args(a)?;
     let params = ScrollToElementParams {
         name: a.name.clone(),
         description: a.description.clone(),

--- a/crates/glass-mcp/tests/android_session_loop.rs
+++ b/crates/glass-mcp/tests/android_session_loop.rs
@@ -673,16 +673,6 @@ async fn android_semantic_actions_are_conservative_and_exactly_once() {
         "the 300ms fixture motion produced no observed bounds change: {movement_samples:?}"
     );
 
-    call(
-        &client,
-        "glass_click_element",
-        json!({
-            "target": {"query": "Restart movement", "role": "Button"},
-            "mode": "native",
-            "timeout_ms": 5_000,
-        }),
-    )
-    .await;
     let moving = call(
         &client,
         "glass_click_element",

--- a/crates/glass-mcp/tests/android_session_loop.rs
+++ b/crates/glass-mcp/tests/android_session_loop.rs
@@ -11,11 +11,15 @@ mod common;
 
 use std::time::Duration;
 
-use common::mcp_http::{InProcessMcpHarness, await_cleanup, call};
-use glass_android::{A11yServiceRegistry, AgentRegistry, AndroidPlatform, EmulatorRegistry};
+use common::mcp_http::{InProcessMcpHarness, await_cleanup, call, try_call_full};
+use glass_android::{
+    A11yServiceRegistry, AgentRegistry, AndroidA11y, AndroidPlatform, EmulatorRegistry,
+};
 use glass_core::Deadline;
 use glass_core::accessibility::{AxNode, AxTree, ClickMethod};
-use glass_core::{AppSpec, BaselineStore, Glass, PlatformFactory, SandboxLevel};
+use glass_core::{
+    AppSpec, Backend, BaselineStore, Glass, GlassError, PlatformFactory, SandboxLevel,
+};
 use rmcp::{Peer, RoleClient};
 use serde_json::json;
 
@@ -50,6 +54,35 @@ fn session_glass(device: &Companions) -> Glass {
         Box::new(move |b| glass_mcp::make_platform(b, &emulators, &agents, &a11y))
     };
 
+    let baselines = tempfile::tempdir()
+        .expect("a temp dir for the baseline store")
+        .keep();
+    Glass::new(
+        factory,
+        "android".to_string(),
+        BaselineStore::new(&baselines),
+        10_000,
+    )
+}
+
+/// The same public MCP/session path with the baseline reader selected explicitly, so its
+/// pre-dispatch native-focus refusal and core's automatic pointer fallback are exercised without
+/// mutating process-global environment while the HTTP server is running.
+fn uiautomator_session_glass(device: &Companions) -> Glass {
+    let (emulators, agents) = (device.emulators.clone(), device.agents.clone());
+    let factory: PlatformFactory = Box::new(move |backend| {
+        if backend != "android" {
+            return Err(GlassError::Backend(format!(
+                "uiautomator acceptance supports only android, got {backend:?}"
+            )));
+        }
+        let platform = AndroidPlatform::from_env(&emulators, &agents)?;
+        let accessibility = AndroidA11y::for_adb(platform.resolved_adb());
+        Ok(Backend {
+            platform: Box::new(platform),
+            accessibility: Some(Box::new(accessibility)),
+        })
+    });
     let baselines = tempfile::tempdir()
         .expect("a temp dir for the baseline store")
         .keep();
@@ -96,6 +129,103 @@ fn outline_nodes(outline: &str) -> Vec<OutlineNode<'_>> {
         .collect()
 }
 
+fn outline_line<'a>(outline: &'a str, needle: &str) -> &'a str {
+    outline
+        .lines()
+        .find(|line| line.contains(needle))
+        .unwrap_or_else(|| panic!("outline has no {needle:?}:\n{outline}"))
+}
+
+fn quoted_value(line: &str, prefix: &str) -> String {
+    line.split_once(prefix)
+        .and_then(|(_, rest)| rest.split_once('"'))
+        .map(|(value, _)| value.to_string())
+        .unwrap_or_else(|| panic!("{line:?} has no quoted {prefix:?} value"))
+}
+
+fn semantic_status(outline: &str) -> String {
+    let line = outline_line(outline, "desc=\"Semantic Status\"");
+    line.split('"')
+        .nth(1)
+        .unwrap_or_else(|| panic!("status line has no name: {line}"))
+        .to_string()
+}
+
+fn semantic_field_value(outline: &str) -> String {
+    quoted_value(
+        outline_line(outline, "TextField \"Semantic Field\""),
+        "value=\"",
+    )
+}
+
+fn semantic_focus_status(outline: &str) -> String {
+    let line = outline_line(outline, "desc=\"Semantic Focus Status\"");
+    line.split('"')
+        .nth(1)
+        .unwrap_or_else(|| panic!("focus status line has no name: {line}"))
+        .to_string()
+}
+
+fn node_bounds(outline: &str, needle: &str) -> (i32, i32, u32, u32) {
+    let line = outline_line(outline, needle);
+    let tuple = line
+        .rsplit_once('(')
+        .and_then(|(_, rest)| rest.split_once(')'))
+        .map(|(tuple, _)| tuple)
+        .unwrap_or_else(|| panic!("node has no bounds: {line}"));
+    let (position, size) = tuple
+        .split_once(' ')
+        .unwrap_or_else(|| panic!("node bounds have no size: {line}"));
+    let (x, y) = position
+        .split_once(',')
+        .unwrap_or_else(|| panic!("node bounds have no position: {line}"));
+    let (width, height) = size
+        .split_once('x')
+        .unwrap_or_else(|| panic!("node bounds have no dimensions: {line}"));
+    (
+        x.parse().expect("bounds x"),
+        y.parse().expect("bounds y"),
+        width.parse().expect("bounds width"),
+        height.parse().expect("bounds height"),
+    )
+}
+
+fn actionability(result: &serde_json::Value, check: &str) -> String {
+    result["actionability"]
+        .as_array()
+        .and_then(|checks| checks.iter().find(|item| item["check"] == check))
+        .and_then(|item| item["verdict"].as_str())
+        .unwrap_or_else(|| panic!("missing actionability check {check:?}: {result}"))
+        .to_string()
+}
+
+async fn snapshot_outline(client: &Peer<RoleClient>) -> String {
+    call(client, "glass_a11y_snapshot", json!({})).await.1
+}
+
+async fn await_exact_status(client: &Peer<RoleClient>, expected: &str) -> String {
+    let start = std::time::Instant::now();
+    loop {
+        let outline = snapshot_outline(client).await;
+        let status = semantic_status(&outline);
+        if status == expected {
+            tokio::time::sleep(Duration::from_millis(350)).await;
+            let quiet = snapshot_outline(client).await;
+            assert_eq!(
+                semantic_status(&quiet),
+                expected,
+                "handler count changed during the quiet window"
+            );
+            return quiet;
+        }
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "status did not reach {expected:?}; last was {status:?}\n{outline}"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
 fn unique_outline_id(
     outline: &str,
     label: &str,
@@ -115,10 +245,14 @@ fn name_id_from_outline_result(outline: &str) -> Result<u32, String> {
     let nodes = outline_nodes(outline);
     unique_outline_id(
         outline,
-        "TextField \"Name\"",
+        "Name TextField",
         nodes
             .iter()
-            .filter(|node| node.shape.starts_with("TextField \"Name\" value="))
+            .filter(|node| {
+                (node.shape.starts_with("TextField value=\"\" ")
+                    || node.shape.starts_with("TextField \"Name\" value=\"\" "))
+                    && node.shape.contains("editable")
+            })
             .map(|node| node.id),
     )
 }
@@ -288,7 +422,7 @@ async fn ime_form_proof(client: Peer<RoleClient>, fixture: String) {
             "timeout_ms": 20_000,
             "actions": [
                 {"action": "set_value", "id": name_id, "text": "viaBatch"},
-                {"action": "wait_for_element", "name": "Name", "value": "viaBatch", "timeout_ms": 5_000},
+                {"action": "wait_for_element", "role": "TextField", "value": "viaBatch", "timeout_ms": 5_000},
                 {"action": "click_element", "id": save_id},
                 {"action": "wait_for_element", "name": "Clicked 1", "description": "Counter", "timeout_ms": 5_000}
             ]
@@ -320,14 +454,403 @@ async fn ime_form_proof(client: Peer<RoleClient>, fixture: String) {
         json!("native-action"),
         "{all_text}"
     );
+    let (_, after) = call(&client, "glass_a11y_snapshot", json!({})).await;
+    let submitted = outline_nodes(&after)
+        .into_iter()
+        .filter(|node| {
+            node.shape.starts_with("TextField value=\"viaBatch\" ")
+                && node.shape.contains("editable")
+        })
+        .count();
+    assert_eq!(submitted, 1, "expected one submitted TextField:\n{after}");
 
     call(&client, "glass_stop", json!({})).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires a booted AVD + GLASS_ADB + GLASS_ANDROID_A11Y_APK + GLASS_ANDROID_ROLE_FIXTURE_APK"]
+async fn android_semantic_actions_are_conservative_and_exactly_once() {
+    let _device_lock = ANDROID_DEVICE_TEST.lock().await;
+    std::env::var("GLASS_ANDROID_A11Y_APK").expect("set GLASS_ANDROID_A11Y_APK");
+    let fixture = std::env::var("GLASS_ANDROID_ROLE_FIXTURE_APK")
+        .expect("set GLASS_ANDROID_ROLE_FIXTURE_APK");
+    let component = "tech.fixedwidth.glassrolefixture/.MainActivity";
+
+    let device = Companions {
+        agents: AgentRegistry::new(),
+        a11y: A11yServiceRegistry::new(),
+        emulators: EmulatorRegistry::new(),
+    };
+    let mcp = InProcessMcpHarness::boot(session_glass(&device), "android-semantic").await;
+    let client = mcp.peer();
+    call(
+        &client,
+        "glass_start",
+        json!({
+            "run": [fixture, component],
+            "backend": "android",
+            "timeout_ms": 10_000,
+        }),
+    )
+    .await;
+
+    let initial = snapshot_outline(&client).await;
+    assert!(
+        !initial.contains("PASSWORD_SENTINEL"),
+        "protected fixture text crossed the companion boundary: {initial}"
+    );
+    assert_eq!(
+        semantic_status(&initial),
+        "save=0 type=0 move=0 duplicate=0"
+    );
+    let duplicate_count = initial
+        .lines()
+        .filter(|line| line.contains("Button \"Duplicate semantic\""))
+        .count();
+    assert_eq!(
+        duplicate_count, 2,
+        "duplicate fixture must be genuinely ambiguous"
+    );
+
+    let native = call(
+        &client,
+        "glass_click_element",
+        json!({
+            "target": {"query": "Semantic Save", "role": "Button", "states": ["enabled"]},
+            "mode": "native",
+            "timeout_ms": 5_000,
+        }),
+    )
+    .await
+    .0;
+    assert_eq!(native["method"], "native-action");
+    assert_eq!(native["dispatch"], "dispatched");
+    await_exact_status(&client, "save=1 type=0 move=0 duplicate=0").await;
+
+    let pointer = call(
+        &client,
+        "glass_click_element",
+        json!({
+            "target": {
+                "query": "Semantic Save",
+                "role": "Button",
+                "states": ["enabled", "visible"]
+            },
+            "mode": "pointer",
+            "timeout_ms": 5_000,
+        }),
+    )
+    .await
+    .0;
+    assert_eq!(pointer["method"], "pointer");
+    assert_eq!(pointer["dispatch"], "dispatched");
+    assert_eq!(actionability(&pointer, "non_occluded"), "unproven");
+    await_exact_status(&client, "save=2 type=0 move=0 duplicate=0").await;
+
+    let set = call(
+        &client,
+        "glass_set_value",
+        json!({
+            "target": {"query": "Semantic Field", "role": "TextField", "states": ["enabled", "visible"]},
+            "text": "replaced",
+            "timeout_ms": 5_000,
+        }),
+    )
+    .await
+    .0;
+    assert_eq!(set["method"], "accessibility-value");
+    assert_eq!(set["dispatch"], "dispatched");
+    let after_set = await_exact_status(&client, "save=2 type=1 move=0 duplicate=0").await;
+    assert_eq!(semantic_field_value(&after_set), "replaced");
+
+    let before_type = semantic_field_value(&after_set);
+    let typed = call(
+        &client,
+        "glass_type",
+        json!({
+            "target": {"query": "Semantic Field", "role": "TextField", "states": ["enabled", "visible"]},
+            "focus_mode": "native",
+            "text": "Z",
+            "timeout_ms": 5_000,
+        }),
+    )
+    .await
+    .0;
+    assert_eq!(typed["focus_method"], "native-action");
+    assert_eq!(typed["focus_dispatch"], "dispatched");
+    assert_eq!(typed["focus_confirmation"], "focus_confirmed");
+    assert_eq!(typed["type_dispatch"], "dispatched");
+    let after_type = await_exact_status(&client, "save=2 type=2 move=0 duplicate=0").await;
+    assert_eq!(
+        semantic_focus_status(&after_type),
+        "focus_click=1 request=true focused=true",
+        "the fixture must observe exactly one native focus handler"
+    );
+    let after_type_value = semantic_field_value(&after_type);
+    assert_eq!(after_type_value.len(), before_type.len() + 1);
+    assert_eq!(after_type_value.matches('Z').count(), 1);
+    assert_eq!(after_type_value.replace('Z', ""), before_type);
+
+    let before_refusals = semantic_status(&after_type);
+    let disabled = try_call_full(
+        &client,
+        "glass_click_element",
+        json!({
+            "target": {"query": "Disabled semantic", "role": "Button"},
+            "mode": "pointer",
+            "timeout_ms": 5_000,
+        }),
+    )
+    .await
+    .expect_err("disabled target must be refused");
+    assert!(
+        disabled.contains("\"code\":\"not_actionable\""),
+        "{disabled}"
+    );
+    assert!(
+        disabled.contains("\"dispatch\":\"not_dispatched\""),
+        "{disabled}"
+    );
+    await_exact_status(&client, &before_refusals).await;
+
+    let duplicate = try_call_full(
+        &client,
+        "glass_click_element",
+        json!({
+            "target": {"query": "Duplicate semantic", "role": "Button"},
+            "mode": "native",
+            "timeout_ms": 5_000,
+        }),
+    )
+    .await
+    .expect_err("duplicate target must be refused");
+    assert!(
+        duplicate.contains("\"code\":\"ambiguous_target\""),
+        "{duplicate}"
+    );
+    assert!(
+        duplicate.contains("\"dispatch\":\"not_dispatched\""),
+        "{duplicate}"
+    );
+    await_exact_status(&client, &before_refusals).await;
+
+    call(
+        &client,
+        "glass_click_element",
+        json!({
+            "target": {"query": "Restart movement", "role": "Button"},
+            "mode": "native",
+            "timeout_ms": 5_000,
+        }),
+    )
+    .await;
+    let movement_started = std::time::Instant::now();
+    let mut movement_samples = Vec::new();
+    while movement_started.elapsed() < Duration::from_millis(500) {
+        let outline = snapshot_outline(&client).await;
+        movement_samples.push((
+            movement_started.elapsed(),
+            node_bounds(&outline, "Moving semantic"),
+        ));
+        if movement_samples
+            .iter()
+            .map(|(_, bounds)| bounds)
+            .collect::<std::collections::HashSet<_>>()
+            .len()
+            > 1
+        {
+            break;
+        }
+    }
+    println!("Android 300ms movement samples: {movement_samples:?}");
+    assert!(
+        movement_samples
+            .iter()
+            .map(|(_, bounds)| bounds)
+            .collect::<std::collections::HashSet<_>>()
+            .len()
+            > 1,
+        "the 300ms fixture motion produced no observed bounds change: {movement_samples:?}"
+    );
+
+    call(
+        &client,
+        "glass_click_element",
+        json!({
+            "target": {"query": "Restart movement", "role": "Button"},
+            "mode": "native",
+            "timeout_ms": 5_000,
+        }),
+    )
+    .await;
+    let moving = call(
+        &client,
+        "glass_click_element",
+        json!({
+            "target": {"query": "Moving semantic", "role": "Button", "states": ["enabled", "visible"]},
+            "mode": "pointer",
+            "timeout_ms": 5_000,
+        }),
+    )
+    .await
+    .0;
+    assert_eq!(moving["method"], "pointer");
+    assert_eq!(actionability(&moving, "stable"), "passed");
+    assert_eq!(actionability(&moving, "non_occluded"), "unproven");
+    await_exact_status(&client, "save=2 type=2 move=1 duplicate=0").await;
+
+    let stale_snapshot = snapshot_outline(&client).await;
+    let stale_status = outline_nodes(&stale_snapshot)
+        .into_iter()
+        .find(|node| node.shape.contains("desc=\"Semantic Status\""))
+        .expect("semantic status id");
+    let (x, y, width, height) = node_bounds(&stale_snapshot, "Button \"Semantic Save\"");
+    call(
+        &client,
+        "glass_click",
+        json!({"x": x + i32::try_from(width / 2).unwrap(), "y": y + i32::try_from(height / 2).unwrap()}),
+    )
+    .await;
+    tokio::time::sleep(Duration::from_millis(350)).await;
+    let stale = try_call_full(
+        &client,
+        "glass_click_element",
+        json!({"id": stale_status.id, "mode": "native"}),
+    )
+    .await
+    .expect_err("changed status identity must refuse the stale id");
+    assert!(stale.contains("\"code\":\"stale_element\""), "{stale}");
+    assert!(stale.contains("\"dispatch\":\"not_dispatched\""), "{stale}");
+    await_exact_status(&client, "save=3 type=2 move=1 duplicate=0").await;
+
+    call(&client, "glass_stop", json!({})).await;
+    mcp.shutdown().await.expect("companion semantic cleanup");
+
+    let fallback =
+        InProcessMcpHarness::boot(uiautomator_session_glass(&device), "android-fallback").await;
+    let client = fallback.peer();
+    call(
+        &client,
+        "glass_start",
+        json!({
+            "run": [std::env::var("GLASS_ANDROID_ROLE_FIXTURE_APK").unwrap(), component],
+            "backend": "android",
+            "timeout_ms": 10_000,
+        }),
+    )
+    .await;
+    let before = snapshot_outline(&client).await;
+    let before_value = semantic_field_value(&before);
+    let typed = call(
+        &client,
+        "glass_type",
+        json!({
+            "target": {"query": "Semantic Field", "role": "TextField", "states": ["enabled", "visible"]},
+            "focus_mode": "auto",
+            "text": "Q",
+            "timeout_ms": 30_000,
+        }),
+    )
+    .await
+    .0;
+    assert_eq!(typed["focus_method"], "pointer");
+    assert_eq!(typed["focus_confirmation"], "focus_confirmed");
+    assert_eq!(typed["type_dispatch"], "dispatched");
+    let after = await_exact_status(&client, "save=0 type=1 move=0 duplicate=0").await;
+    let after_value = semantic_field_value(&after);
+    assert_eq!(after_value.len(), before_value.len() + 1);
+    assert_eq!(after_value.matches('Q').count(), 1);
+    assert_eq!(after_value.replace('Q', ""), before_value);
+    call(&client, "glass_stop", json!({})).await;
+    fallback
+        .shutdown()
+        .await
+        .expect("fallback semantic cleanup");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "set GLASS_ANDROID_VERIFY_SCHEMA1=1 and point GLASS_ANDROID_A11Y_APK at the released schema-1 APK"]
+async fn released_schema_one_companion_falls_back_without_exposing_secure_text() {
+    if std::env::var("GLASS_ANDROID_VERIFY_SCHEMA1").as_deref() != Ok("1") {
+        eprintln!("schema-1 fallback acceptance not requested");
+        return;
+    }
+    let _device_lock = ANDROID_DEVICE_TEST.lock().await;
+    std::env::var("GLASS_ANDROID_A11Y_APK").expect("set the released schema-1 APK");
+    let fixture = std::env::var("GLASS_ANDROID_ROLE_FIXTURE_APK")
+        .expect("set GLASS_ANDROID_ROLE_FIXTURE_APK");
+    let device = Companions {
+        agents: AgentRegistry::new(),
+        a11y: A11yServiceRegistry::new(),
+        emulators: EmulatorRegistry::new(),
+    };
+    let mcp = InProcessMcpHarness::boot(session_glass(&device), "android-schema-one").await;
+    let client = mcp.peer();
+    call(
+        &client,
+        "glass_start",
+        json!({
+            "run": [fixture, "tech.fixedwidth.glassrolefixture/.MainActivity"],
+            "backend": "android",
+            "timeout_ms": 10_000,
+        }),
+    )
+    .await;
+
+    let before = snapshot_outline(&client).await;
+    assert!(!before.contains("PASSWORD_SENTINEL"), "{before}");
+    assert_eq!(semantic_status(&before), "save=0 type=0 move=0 duplicate=0");
+    let before_value = semantic_field_value(&before);
+    let native = try_call_full(
+        &client,
+        "glass_type",
+        json!({
+            "target": {"query": "Semantic Field", "role": "TextField"},
+            "focus_mode": "native",
+            "text": "NATIVE_SENTINEL",
+            "timeout_ms": 5_000,
+        }),
+    )
+    .await
+    .expect_err("uiautomator cannot claim native focus");
+    assert!(native.contains("unsupported"), "{native}");
+    assert!(
+        native.contains("\"dispatch\":\"not_dispatched\""),
+        "{native}"
+    );
+    assert!(!native.contains("NATIVE_SENTINEL"), "{native}");
+    let unchanged = await_exact_status(&client, "save=0 type=0 move=0 duplicate=0").await;
+    assert_eq!(semantic_field_value(&unchanged), before_value);
+
+    let typed = call(
+        &client,
+        "glass_type",
+        json!({
+            "target": {"query": "Semantic Field", "role": "TextField"},
+            "focus_mode": "auto",
+            "text": "Q",
+            "timeout_ms": 30_000,
+        }),
+    )
+    .await
+    .0;
+    assert_eq!(typed["focus_method"], "pointer");
+    assert_eq!(typed["focus_confirmation"], "focus_confirmed");
+    assert_eq!(typed["type_dispatch"], "dispatched");
+    let after = await_exact_status(&client, "save=0 type=1 move=0 duplicate=0").await;
+    let after_value = semantic_field_value(&after);
+    assert_eq!(after_value.matches('Q').count(), 1);
+    assert_eq!(after_value.replace('Q', ""), before_value);
+
+    call(&client, "glass_stop", json!({})).await;
+    mcp.shutdown().await.expect("schema-one fallback cleanup");
 }
 
 #[test]
 fn outline_selectors_require_the_observed_unique_control_shapes() {
     let outline = r#"
-  #3 TextField "Name" value="" (63,338 735x147) [focusable,enabled,visible,editable]
+  #3 TextField value="" (63,338 735x147) [focusable,enabled,visible,editable]
+    #4 Group "Name" (63,338 735x147) [enabled,visible]
     #5 Label "Save" (126,522 80x53) [enabled,visible]
     #6 Button (63,496 206x105) [enabled,visible]
 "#;
@@ -342,7 +865,7 @@ fn outline_selectors_reject_ambiguous_controls() {
   #4 TextField "Name" value="" (63,338 735x147) [focusable,enabled,visible,editable]
 "#;
     let error = name_id_from_outline_result(outline).unwrap_err();
-    assert!(error.contains("expected exactly one TextField \"Name\""));
+    assert!(error.contains("expected exactly one Name TextField"));
     assert!(error.contains(outline.trim()));
 
     let outline = r#"

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -9,7 +9,7 @@
 // `// SAFETY:`-documented).
 #![allow(unsafe_code)]
 
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use glass_a11y_windows::WindowsA11y;
@@ -141,6 +141,90 @@ fn glass_windows_with_a11y() -> Glass {
     let root = dir.path().join("baselines");
     std::mem::forget(dir);
     Glass::new(factory, "windows".into(), BaselineStore::new(root), 100)
+}
+
+type MovementSamples = Arc<Mutex<Vec<(Instant, glass_core::AxRect)>>>;
+
+struct RecordingWindowsA11y {
+    inner: WindowsA11y,
+    movement_samples: MovementSamples,
+}
+
+impl Accessibility for RecordingWindowsA11y {
+    fn snapshot(&mut self, ctx: &AxContext) -> glass_core::Result<AxTree> {
+        let tree = self.inner.snapshot(ctx)?;
+        if let Some(bounds) = named_node(&tree.root, "Moving semantic").and_then(|node| node.bounds)
+        {
+            self.movement_samples
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .push((Instant::now(), bounds));
+        }
+        Ok(tree)
+    }
+
+    fn subscribe_changes(&mut self, ctx: &AxContext) -> Option<Box<dyn ChangeSignal>> {
+        self.inner.subscribe_changes(ctx)
+    }
+
+    fn state_coverage(&self) -> glass_core::AxStateCoverage {
+        self.inner.state_coverage()
+    }
+
+    fn focus(
+        &mut self,
+        ctx: &AxContext,
+        target: &AxTarget,
+    ) -> glass_core::Result<Option<glass_core::AxNodeId>> {
+        self.inner.focus(ctx, target)
+    }
+
+    fn pointer_target_at(
+        &mut self,
+        ctx: &AxContext,
+        target: &AxTarget,
+        point: (i32, i32),
+    ) -> glass_core::Result<glass_core::PointerHit> {
+        self.inner.pointer_target_at(ctx, target, point)
+    }
+
+    fn set_value(
+        &mut self,
+        ctx: &AxContext,
+        target: &AxTarget,
+        text: &str,
+    ) -> glass_core::Result<()> {
+        self.inner.set_value(ctx, target, text)
+    }
+
+    fn invoke(
+        &mut self,
+        ctx: &AxContext,
+        target: &AxTarget,
+    ) -> glass_core::Result<Option<glass_core::AxNodeId>> {
+        self.inner.invoke(ctx, target)
+    }
+}
+
+fn glass_windows_with_movement_recording() -> (Glass, MovementSamples) {
+    let movement_samples = Arc::new(Mutex::new(Vec::new()));
+    let recorder = movement_samples.clone();
+    let factory: PlatformFactory = Box::new(move |_backend| {
+        Ok(Backend {
+            platform: Box::new(WindowsPlatform::new()?),
+            accessibility: Some(Box::new(RecordingWindowsA11y {
+                inner: WindowsA11y::new(),
+                movement_samples: recorder.clone(),
+            })),
+        })
+    });
+    let dir = tempfile::tempdir().expect("tempdir for baseline store");
+    let root = dir.path().join("baselines");
+    std::mem::forget(dir);
+    (
+        Glass::new(factory, "windows".into(), BaselineStore::new(root), 100),
+        movement_samples,
+    )
 }
 
 /// The repo root: two levels above `crates/glass-windows` (this crate's `CARGO_MANIFEST_DIR`),
@@ -307,27 +391,129 @@ fn log_cursor(glass: &mut Glass) -> u64 {
         .1
 }
 
-fn log_count_since(glass: &mut Glass, cursor: u64, contains: &str) -> usize {
-    glass
-        .logs(cursor, 100, None, Some(contains))
+fn exact_log_count_since(glass: &mut Glass, cursor: u64, expected: &str) -> usize {
+    let lines = glass
+        .logs(cursor, 1_000, None, None)
         .expect("read fixture logs")
-        .0
-        .len()
+        .0;
+    let messages = lines
+        .iter()
+        .map(|line| line.text.as_str())
+        .collect::<Vec<_>>();
+    count_exact_messages(&messages, expected)
 }
 
-fn await_one_log(glass: &mut Glass, cursor: u64, contains: &str) {
+fn await_exact_log_arrival(glass: &mut Glass, cursor: u64, expected: &str, count: usize) {
     let deadline = Instant::now() + Duration::from_secs(2);
     loop {
-        let count = log_count_since(glass, cursor, contains);
-        if count == 1 {
+        let observed = exact_log_count_since(glass, cursor, expected);
+        if observed == count {
             return;
         }
         assert!(
-            Instant::now() < deadline,
-            "expected exactly one {contains:?} log, got {count}"
+            observed < count && Instant::now() < deadline,
+            "expected exactly {count} {expected:?} logs, got {observed}"
         );
         std::thread::sleep(Duration::from_millis(25));
     }
+}
+
+fn await_exact_log_count(glass: &mut Glass, cursor: u64, expected: &str, count: usize) {
+    if count != 0 {
+        await_exact_log_arrival(glass, cursor, expected, count);
+    }
+    let quiet_until = Instant::now() + Duration::from_millis(400);
+    loop {
+        let observed = exact_log_count_since(glass, cursor, expected);
+        assert_eq!(
+            observed, count,
+            "expected {count} exact {expected:?} logs throughout the bounded quiet window"
+        );
+        if Instant::now() >= quiet_until {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn count_exact_messages(messages: &[&str], expected: &str) -> usize {
+    messages
+        .iter()
+        .filter(|message| **message == expected)
+        .count()
+}
+
+fn observed_change_before_stable_pair(
+    samples: &[(Duration, glass_core::AxRect)],
+    stable_gap: Duration,
+) -> bool {
+    let Some(last) = samples.windows(2).last() else {
+        return false;
+    };
+    last[0].1 == last[1].1
+        && last[1].0.saturating_sub(last[0].0) >= stable_gap
+        && samples[..samples.len() - 1]
+            .windows(2)
+            .any(|pair| pair[0].1 != pair[1].1)
+}
+
+#[test]
+fn semantic_log_oracle_matches_complete_messages() {
+    assert_eq!(
+        count_exact_messages(
+            &[
+                "[fixture] text=Z",
+                "[fixture] text=ZZ",
+                "prefix [fixture] text=Z"
+            ],
+            "[fixture] text=Z",
+        ),
+        1
+    );
+}
+
+#[test]
+fn movement_evidence_requires_change_before_the_final_stable_pair() {
+    let bounds = |x| glass_core::AxRect {
+        x,
+        y: 0,
+        width: 10,
+        height: 10,
+    };
+    let samples = [
+        (Duration::ZERO, bounds(0)),
+        (Duration::from_millis(25), bounds(4)),
+        (Duration::from_millis(150), bounds(4)),
+    ];
+    assert!(observed_change_before_stable_pair(
+        &samples,
+        Duration::from_millis(100)
+    ));
+    assert!(!observed_change_before_stable_pair(
+        &[
+            (Duration::ZERO, bounds(4)),
+            (Duration::from_millis(150), bounds(4)),
+        ],
+        Duration::from_millis(100)
+    ));
+    assert!(!observed_change_before_stable_pair(
+        &[
+            (Duration::ZERO, bounds(0)),
+            (Duration::from_millis(25), bounds(4)),
+            (Duration::from_millis(150), bounds(4)),
+            (Duration::from_millis(200), bounds(8)),
+        ],
+        Duration::from_millis(100)
+    ));
+    assert!(!observed_change_before_stable_pair(
+        &[
+            (Duration::ZERO, bounds(0)),
+            (Duration::from_millis(25), bounds(4)),
+            (Duration::from_millis(100), bounds(8)),
+            (Duration::from_millis(150), bounds(4)),
+        ],
+        Duration::from_millis(100)
+    ));
 }
 
 /// Nodes carrying UIA's Toggle pattern that are NOT already a checkbox or radio button —
@@ -865,12 +1051,16 @@ fn onbox_a11y_set_value() {
         bounds: b.bounds,
         value: b.value.clone(),
     };
+    let error = a11y
+        .set_value(&ctx, &bt, "x")
+        .expect_err("set_value on a Button must not dispatch");
     assert!(
-        matches!(
-            a11y.set_value(&ctx, &bt, "x"),
-            Err(GlassError::AxElementNotEditable(_))
-        ),
-        "set_value on a Button must error AxElementNotEditable"
+        matches!(error.cause(), GlassError::AxElementNotEditable(id) if *id == bt.id.0),
+        "set_value on a Button must preserve AxElementNotEditable: {error:?}"
+    );
+    assert_eq!(
+        error.bound_dispatch(),
+        Some(glass_core::BoundDispatch::NotDispatched)
     );
 
     let _ = p.stop_app();
@@ -935,10 +1125,11 @@ fn onbox_semantic_actions() {
 
     let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     dpi_aware_once();
-    let mut glass = glass_windows_with_a11y();
-    let geometry = glass
-        .start(&egui_fixture_spec(glass_core::SandboxLevel::Off))
-        .expect("build + launch the egui fixture");
+    let (mut glass, movement_samples) = glass_windows_with_movement_recording();
+    let mut spec = egui_fixture_spec(glass_core::SandboxLevel::Off);
+    spec.run.push("--movement-duration-ms=3000".into());
+    let geometry = glass.start(&spec).expect("build + launch the egui fixture");
+    await_exact_log_count(&mut glass, 0, "[fixture] movement_duration_ms=3000", 1);
 
     let initial = glass
         .a11y_snapshot(None)
@@ -959,6 +1150,15 @@ fn onbox_semantic_actions() {
     );
     let disabled = named_node(&initial.root, "Disabled semantic").expect("disabled semantic");
     assert!(!disabled.states.enabled);
+    let hidden = named_node(&initial.root, "Hidden semantic").expect("hidden semantic");
+    assert!(!hidden.states.visible);
+    assert!(
+        hidden
+            .bounds
+            .is_some_and(|bounds| bounds.y >= geometry.height as i32),
+        "hidden semantic bounds must remain outside the fixture viewport: {:?}",
+        hidden.bounds
+    );
     let moving_id = named_node(&initial.root, "Moving semantic")
         .expect("moving semantic")
         .id;
@@ -976,6 +1176,29 @@ fn onbox_semantic_actions() {
         .element_from_point(screen)
         .expect("UIA element from occluded center");
     assert_eq!(hit.get_name().expect("hit element name"), "Occluder");
+    let composite = named_node(&initial.root, "Composite semantic").expect("composite target");
+    let nested = named_node(composite, "Nested semantic").expect("nested interactive descendant");
+    assert!(nested.role.is_interactable());
+    let composite_center = composite
+        .bounds
+        .and_then(|bounds| bounds.clamped_center(geometry.width, geometry.height))
+        .expect("composite has actual in-window geometry");
+    let nested_hit = automation
+        .element_from_point(uiautomation::types::Point::new(
+            geometry
+                .x
+                .checked_add(composite_center.0)
+                .expect("composite screen x"),
+            geometry
+                .y
+                .checked_add(composite_center.1)
+                .expect("composite screen y"),
+        ))
+        .expect("UIA hit at composite target center");
+    assert_eq!(
+        nested_hit.get_name().expect("nested hit name"),
+        "Nested semantic"
+    );
 
     let native_save_cursor = log_cursor(&mut glass);
     let native_save = glass
@@ -995,44 +1218,14 @@ fn onbox_semantic_actions() {
         ActionMethod::NativeAction { actuated: None }
     );
     assert_eq!(native_save.action.dispatch, DispatchStatus::Dispatched);
-    await_one_log(&mut glass, native_save_cursor, "semantic_save");
+    await_exact_log_count(&mut glass, native_save_cursor, "[fixture] semantic_save", 1);
 
     let stale_cursor = log_cursor(&mut glass);
     let stale = glass
         .click_element(moving_id)
         .expect_err("moving bounds must stale the backend fingerprint before dispatch");
-    assert!(matches!(stale, GlassError::AxElementChanged(_)));
-    assert_eq!(
-        log_count_since(&mut glass, stale_cursor, "moving_semantic"),
-        0
-    );
-
-    let moving_cursor = log_cursor(&mut glass);
-    let moving_started = Instant::now();
-    let moving = glass
-        .click_target(&glass_core::ClickTargetParams {
-            target: ActionTarget::Semantic(semantic_target(
-                AxRole::Button,
-                "Moving semantic",
-                vec![SemanticState::Enabled, SemanticState::Visible],
-            )),
-            mode: ActionMode::Pointer,
-            timeout_ms: Some(5_000),
-            max_nodes: None,
-        })
-        .expect("stable forced pointer click");
-    assert!(moving_started.elapsed() >= Duration::from_millis(100));
-    assert_eq!(
-        moving.action.method,
-        ActionMethod::Pointer {
-            native_fallback: None
-        }
-    );
-    assert_eq!(
-        actionability_verdict(&moving.actionability, ActionabilityCheckName::Stable),
-        ActionabilityVerdict::Passed
-    );
-    await_one_log(&mut glass, moving_cursor, "moving_semantic");
+    assert!(matches!(stale.cause(), GlassError::AxElementChanged(_)));
+    await_exact_log_count(&mut glass, stale_cursor, "[fixture] moving_semantic", 0);
 
     let pointer_save_cursor = log_cursor(&mut glass);
     let pointer_save = glass
@@ -1053,7 +1246,12 @@ fn onbox_semantic_actions() {
             native_fallback: None
         }
     );
-    await_one_log(&mut glass, pointer_save_cursor, "semantic_save");
+    await_exact_log_count(
+        &mut glass,
+        pointer_save_cursor,
+        "[fixture] semantic_save",
+        1,
+    );
 
     let text_cursor = log_cursor(&mut glass);
     let typed = glass
@@ -1074,7 +1272,14 @@ fn onbox_semantic_actions() {
     let focus = typed.focus.expect("targeted type focus report");
     assert_eq!(focus.confirmation, ConfirmationStatus::FocusConfirmed);
     assert_eq!(focus.dispatch, DispatchStatus::Dispatched);
-    await_one_log(&mut glass, text_cursor, "[fixture] text=Z");
+    await_exact_log_count(&mut glass, text_cursor, "[fixture] text=Z", 1);
+    let typed_snapshot = glass
+        .a11y_snapshot(None)
+        .expect("snapshot exact targeted type result");
+    let mut typed_field = None;
+    first_role(&typed_snapshot.root, AxRole::TextField, &mut typed_field);
+    let typed_field = typed_field.expect("TextField after targeted typing");
+    assert_eq!(typed_field.value.as_deref(), Some("Z"));
 
     let disabled_cursor = log_cursor(&mut glass);
     let disabled = glass
@@ -1095,9 +1300,11 @@ fn onbox_semantic_actions() {
         actionability_verdict(&disabled.actionability, ActionabilityCheckName::Enabled),
         ActionabilityVerdict::Failed
     );
-    assert_eq!(
-        log_count_since(&mut glass, disabled_cursor, "disabled_semantic"),
-        0
+    await_exact_log_count(
+        &mut glass,
+        disabled_cursor,
+        "[fixture] disabled_semantic",
+        0,
     );
 
     let duplicate_cursor = log_cursor(&mut glass);
@@ -1115,9 +1322,11 @@ fn onbox_semantic_actions() {
         .expect_err("duplicate semantic target must be refused");
     assert_eq!(duplicate.kind, SemanticActionFailureKind::AmbiguousTarget);
     assert_eq!(duplicate.action_dispatch, DispatchStatus::NotDispatched);
-    assert_eq!(
-        log_count_since(&mut glass, duplicate_cursor, "duplicate_semantic"),
-        0
+    await_exact_log_count(
+        &mut glass,
+        duplicate_cursor,
+        "[fixture] duplicate_semantic",
+        0,
     );
 
     let occluded_cursor = log_cursor(&mut glass);
@@ -1139,10 +1348,127 @@ fn onbox_semantic_actions() {
         actionability_verdict(&occluded.actionability, ActionabilityCheckName::NonOccluded,),
         ActionabilityVerdict::Failed
     );
-    assert_eq!(
-        log_count_since(&mut glass, occluded_cursor, "occluded_semantic"),
-        0
+    await_exact_log_count(
+        &mut glass,
+        occluded_cursor,
+        "[fixture] occluded_semantic",
+        0,
     );
+
+    let nested_cursor = log_cursor(&mut glass);
+    let nested = glass
+        .click_target(&glass_core::ClickTargetParams {
+            target: ActionTarget::Semantic(semantic_target(
+                AxRole::Button,
+                "Composite semantic",
+                vec![SemanticState::Enabled, SemanticState::Visible],
+            )),
+            mode: ActionMode::Pointer,
+            timeout_ms: Some(5_000),
+            max_nodes: None,
+        })
+        .expect_err("an interactable descendant must fail closed before pointer dispatch");
+    assert_eq!(nested.kind, SemanticActionFailureKind::NotActionable);
+    assert_eq!(nested.action_dispatch, DispatchStatus::NotDispatched);
+    assert_eq!(
+        actionability_verdict(&nested.actionability, ActionabilityCheckName::NonOccluded),
+        ActionabilityVerdict::Failed
+    );
+    await_exact_log_count(&mut glass, nested_cursor, "[fixture] nested_semantic", 0);
+
+    let hidden_cursor = log_cursor(&mut glass);
+    let hidden = glass
+        .click_target(&glass_core::ClickTargetParams {
+            target: ActionTarget::Semantic(semantic_target(
+                AxRole::Button,
+                "Hidden semantic",
+                vec![SemanticState::Enabled],
+            )),
+            mode: ActionMode::Pointer,
+            timeout_ms: Some(5_000),
+            max_nodes: None,
+        })
+        .expect_err("an offscreen AccessKit target must be refused");
+    assert_eq!(hidden.kind, SemanticActionFailureKind::NotActionable);
+    assert_eq!(hidden.action_dispatch, DispatchStatus::NotDispatched);
+    assert_eq!(
+        actionability_verdict(&hidden.actionability, ActionabilityCheckName::Visible),
+        ActionabilityVerdict::Failed
+    );
+    await_exact_log_count(&mut glass, hidden_cursor, "[fixture] hidden_semantic", 0);
+
+    let restart_cursor = log_cursor(&mut glass);
+    glass
+        .click_target(&glass_core::ClickTargetParams {
+            target: ActionTarget::Semantic(semantic_target(
+                AxRole::Button,
+                "Restart movement",
+                vec![SemanticState::Enabled],
+            )),
+            mode: ActionMode::Native,
+            timeout_ms: Some(5_000),
+            max_nodes: None,
+        })
+        .expect("restart movement immediately before the pointer request");
+    await_exact_log_arrival(&mut glass, restart_cursor, "[fixture] movement_restart", 1);
+    movement_samples
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .clear();
+
+    let moving_cursor = log_cursor(&mut glass);
+    let moving = glass
+        .click_target(&glass_core::ClickTargetParams {
+            target: ActionTarget::Semantic(semantic_target(
+                AxRole::Button,
+                "Moving semantic",
+                vec![SemanticState::Enabled, SemanticState::Visible],
+            )),
+            mode: ActionMode::Pointer,
+            timeout_ms: Some(10_000),
+            max_nodes: None,
+        })
+        .expect("stable forced pointer click");
+    assert_eq!(
+        moving.action.method,
+        ActionMethod::Pointer {
+            native_fallback: None
+        }
+    );
+    assert_eq!(
+        actionability_verdict(&moving.actionability, ActionabilityCheckName::Stable),
+        ActionabilityVerdict::Passed
+    );
+    let samples = movement_samples
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .clone();
+    let first_observed_at = samples
+        .first()
+        .expect("pointer stabilization records at least one moving-target sample")
+        .0;
+    let elapsed_samples = samples
+        .iter()
+        .map(|(observed_at, bounds)| {
+            (
+                observed_at.saturating_duration_since(first_observed_at),
+                *bounds,
+            )
+        })
+        .collect::<Vec<_>>();
+    let artifact_dir = repo_root().join(".windows-artifacts");
+    std::fs::create_dir_all(&artifact_dir).expect("create semantic evidence directory");
+    std::fs::write(
+        artifact_dir.join("semantic-movement-samples.txt"),
+        format!("movement_duration_ms=3000\nstable_gap_ms=100\nsamples={elapsed_samples:?}\n"),
+    )
+    .expect("record real UIA movement samples");
+    assert!(
+        observed_change_before_stable_pair(&elapsed_samples, Duration::from_millis(100)),
+        "pointer stabilization samples must contain changed bounds before the final stable pair: {elapsed_samples:?}"
+    );
+    await_exact_log_count(&mut glass, moving_cursor, "[fixture] moving_semantic", 1);
+    await_exact_log_count(&mut glass, restart_cursor, "[fixture] movement_restart", 1);
 
     glass.stop().expect("stop egui semantic fixture");
 }

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -267,6 +267,69 @@ fn first_role_with_bounds<'a>(n: &'a AxNode, role: AxRole, out: &mut Option<&'a 
     }
 }
 
+fn named_node<'a>(node: &'a AxNode, name: &str) -> Option<&'a AxNode> {
+    if node.name.as_deref() == Some(name) {
+        return Some(node);
+    }
+    node.children
+        .iter()
+        .find_map(|child| named_node(child, name))
+}
+
+fn semantic_target(
+    role: AxRole,
+    name: &str,
+    states: Vec<glass_core::SemanticState>,
+) -> glass_core::SemanticTarget {
+    glass_core::SemanticTarget {
+        target: glass_core::SemanticSelector::new(Some(name.into()), Some(role), states)
+            .expect("valid semantic selector"),
+        within: None,
+    }
+}
+
+fn actionability_verdict(
+    report: &glass_core::ActionabilityReport,
+    name: glass_core::ActionabilityCheckName,
+) -> glass_core::ActionabilityVerdict {
+    report
+        .checks
+        .iter()
+        .find(|check| check.name == name)
+        .unwrap_or_else(|| panic!("missing {name:?} in {:?}", report.checks))
+        .verdict
+}
+
+fn log_cursor(glass: &mut Glass) -> u64 {
+    glass
+        .logs(0, 100, None, None)
+        .expect("read fixture log cursor")
+        .1
+}
+
+fn log_count_since(glass: &mut Glass, cursor: u64, contains: &str) -> usize {
+    glass
+        .logs(cursor, 100, None, Some(contains))
+        .expect("read fixture logs")
+        .0
+        .len()
+}
+
+fn await_one_log(glass: &mut Glass, cursor: u64, contains: &str) {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        let count = log_count_since(glass, cursor, contains);
+        if count == 1 {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "expected exactly one {contains:?} log, got {count}"
+        );
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
 /// Nodes carrying UIA's Toggle pattern that are NOT already a checkbox or radio button —
 /// the evidence for whether a `ToggleButton` mapping has anything to map. `checkable` is
 /// Toggle-pattern availability (see `StateFacts` in glass-a11y-windows), so this needs no
@@ -860,6 +923,228 @@ fn onbox_egui_set_value_honesty() {
     );
 
     let _ = p.stop_app();
+}
+
+#[test]
+#[ignore = "on-box only: needs the interactive desktop session + builds the egui fixture"]
+fn onbox_semantic_actions() {
+    use glass_core::{
+        ActionMethod, ActionMode, ActionTarget, ActionabilityCheckName, ActionabilityVerdict,
+        ConfirmationStatus, DispatchStatus, SemanticActionFailureKind, SemanticState,
+    };
+
+    let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    dpi_aware_once();
+    let mut glass = glass_windows_with_a11y();
+    let geometry = glass
+        .start(&egui_fixture_spec(glass_core::SandboxLevel::Off))
+        .expect("build + launch the egui fixture");
+
+    let initial = glass
+        .a11y_snapshot(None)
+        .expect("initial egui semantic snapshot");
+    assert_eq!(
+        Accessibility::state_coverage(&WindowsA11y::new()),
+        glass_core::AxStateCoverage {
+            enabled: true,
+            visible: true,
+            checkable: true,
+            checked: true,
+            selected: true,
+            expanded: true,
+            focused: true,
+            focusable: true,
+            editable: true,
+        }
+    );
+    let disabled = named_node(&initial.root, "Disabled semantic").expect("disabled semantic");
+    assert!(!disabled.states.enabled);
+    let moving_id = named_node(&initial.root, "Moving semantic")
+        .expect("moving semantic")
+        .id;
+    let occluded = named_node(&initial.root, "Occluded semantic").expect("occluded semantic");
+    let occluded_center = occluded
+        .bounds
+        .and_then(|bounds| bounds.clamped_center(geometry.width, geometry.height))
+        .expect("occluded semantic has an in-window center");
+    let automation = uiautomation::UIAutomation::new().expect("UI Automation client");
+    let screen = uiautomation::types::Point::new(
+        geometry.x.checked_add(occluded_center.0).expect("screen x"),
+        geometry.y.checked_add(occluded_center.1).expect("screen y"),
+    );
+    let hit = automation
+        .element_from_point(screen)
+        .expect("UIA element from occluded center");
+    assert_eq!(hit.get_name().expect("hit element name"), "Occluder");
+
+    let native_save_cursor = log_cursor(&mut glass);
+    let native_save = glass
+        .click_target(&glass_core::ClickTargetParams {
+            target: ActionTarget::Semantic(semantic_target(
+                AxRole::Button,
+                "Semantic Save",
+                vec![SemanticState::Enabled],
+            )),
+            mode: ActionMode::Native,
+            timeout_ms: Some(5_000),
+            max_nodes: None,
+        })
+        .expect("native semantic save");
+    assert_eq!(
+        native_save.action.method,
+        ActionMethod::NativeAction { actuated: None }
+    );
+    assert_eq!(native_save.action.dispatch, DispatchStatus::Dispatched);
+    await_one_log(&mut glass, native_save_cursor, "semantic_save");
+
+    let stale_cursor = log_cursor(&mut glass);
+    let stale = glass
+        .click_element(moving_id)
+        .expect_err("moving bounds must stale the backend fingerprint before dispatch");
+    assert!(matches!(stale, GlassError::AxElementChanged(_)));
+    assert_eq!(
+        log_count_since(&mut glass, stale_cursor, "moving_semantic"),
+        0
+    );
+
+    let moving_cursor = log_cursor(&mut glass);
+    let moving_started = Instant::now();
+    let moving = glass
+        .click_target(&glass_core::ClickTargetParams {
+            target: ActionTarget::Semantic(semantic_target(
+                AxRole::Button,
+                "Moving semantic",
+                vec![SemanticState::Enabled, SemanticState::Visible],
+            )),
+            mode: ActionMode::Pointer,
+            timeout_ms: Some(5_000),
+            max_nodes: None,
+        })
+        .expect("stable forced pointer click");
+    assert!(moving_started.elapsed() >= Duration::from_millis(100));
+    assert_eq!(
+        moving.action.method,
+        ActionMethod::Pointer {
+            native_fallback: None
+        }
+    );
+    assert_eq!(
+        actionability_verdict(&moving.actionability, ActionabilityCheckName::Stable),
+        ActionabilityVerdict::Passed
+    );
+    await_one_log(&mut glass, moving_cursor, "moving_semantic");
+
+    let pointer_save_cursor = log_cursor(&mut glass);
+    let pointer_save = glass
+        .click_target(&glass_core::ClickTargetParams {
+            target: ActionTarget::Semantic(semantic_target(
+                AxRole::Button,
+                "Semantic Save",
+                vec![SemanticState::Enabled],
+            )),
+            mode: ActionMode::Pointer,
+            timeout_ms: Some(5_000),
+            max_nodes: None,
+        })
+        .expect("forced pointer semantic save");
+    assert_eq!(
+        pointer_save.action.method,
+        ActionMethod::Pointer {
+            native_fallback: None
+        }
+    );
+    await_one_log(&mut glass, pointer_save_cursor, "semantic_save");
+
+    let text_cursor = log_cursor(&mut glass);
+    let typed = glass
+        .type_target(
+            &glass_core::TypeTargetParams {
+                target: semantic_target(
+                    AxRole::TextField,
+                    "Text",
+                    vec![SemanticState::Enabled, SemanticState::Visible],
+                ),
+                focus_mode: ActionMode::Native,
+                timeout_ms: 5_000,
+                max_nodes: None,
+            },
+            "Z",
+        )
+        .expect("native targeted type");
+    let focus = typed.focus.expect("targeted type focus report");
+    assert_eq!(focus.confirmation, ConfirmationStatus::FocusConfirmed);
+    assert_eq!(focus.dispatch, DispatchStatus::Dispatched);
+    await_one_log(&mut glass, text_cursor, "[fixture] text=Z");
+
+    let disabled_cursor = log_cursor(&mut glass);
+    let disabled = glass
+        .click_target(&glass_core::ClickTargetParams {
+            target: ActionTarget::Semantic(semantic_target(
+                AxRole::Button,
+                "Disabled semantic",
+                vec![],
+            )),
+            mode: ActionMode::Pointer,
+            timeout_ms: Some(0),
+            max_nodes: None,
+        })
+        .expect_err("disabled semantic target must be refused");
+    assert_eq!(disabled.kind, SemanticActionFailureKind::NotActionable);
+    assert_eq!(disabled.action_dispatch, DispatchStatus::NotDispatched);
+    assert_eq!(
+        actionability_verdict(&disabled.actionability, ActionabilityCheckName::Enabled),
+        ActionabilityVerdict::Failed
+    );
+    assert_eq!(
+        log_count_since(&mut glass, disabled_cursor, "disabled_semantic"),
+        0
+    );
+
+    let duplicate_cursor = log_cursor(&mut glass);
+    let duplicate = glass
+        .click_target(&glass_core::ClickTargetParams {
+            target: ActionTarget::Semantic(semantic_target(
+                AxRole::Button,
+                "Duplicate semantic",
+                vec![],
+            )),
+            mode: ActionMode::Native,
+            timeout_ms: Some(0),
+            max_nodes: None,
+        })
+        .expect_err("duplicate semantic target must be refused");
+    assert_eq!(duplicate.kind, SemanticActionFailureKind::AmbiguousTarget);
+    assert_eq!(duplicate.action_dispatch, DispatchStatus::NotDispatched);
+    assert_eq!(
+        log_count_since(&mut glass, duplicate_cursor, "duplicate_semantic"),
+        0
+    );
+
+    let occluded_cursor = log_cursor(&mut glass);
+    let occluded = glass
+        .click_target(&glass_core::ClickTargetParams {
+            target: ActionTarget::Semantic(semantic_target(
+                AxRole::Button,
+                "Occluded semantic",
+                vec![SemanticState::Enabled, SemanticState::Visible],
+            )),
+            mode: ActionMode::Pointer,
+            timeout_ms: Some(5_000),
+            max_nodes: None,
+        })
+        .expect_err("UIA must prove the foreground occluder before dispatch");
+    assert_eq!(occluded.kind, SemanticActionFailureKind::NotActionable);
+    assert_eq!(occluded.action_dispatch, DispatchStatus::NotDispatched);
+    assert_eq!(
+        actionability_verdict(&occluded.actionability, ActionabilityCheckName::NonOccluded,),
+        ActionabilityVerdict::Failed
+    );
+    assert_eq!(
+        log_count_since(&mut glass, occluded_cursor, "occluded_semantic"),
+        0
+    );
+
+    glass.stop().expect("stop egui semantic fixture");
 }
 
 // Uncontained: end-to-end verification that a Windows ctrl+scroll both DELIVERS the wheel with its

--- a/docs/explanation/web-content.md
+++ b/docs/explanation/web-content.md
@@ -44,6 +44,33 @@ When the likely target is known, an agent can search within the published page:
 
 `glass_find_elements` resolves the scope and targets from the same fresh accessibility read. The
 scope must identify one observed `Document`; a positive timeout can wait for delayed publication.
+When that query identifies one intended target, the action can carry the same selector directly:
+
+```json
+{
+  "target": {
+    "query": "Save",
+    "role": "Button",
+    "states": ["enabled"],
+    "within": {"query": "Glass web fixture", "role": "Document"}
+  },
+  "mode": "native"
+}
+```
+
+Native mode asks the platform accessibility API to invoke the control. It can legitimately activate
+a web control that is covered or outside the viewport, and reports visibility, stability,
+in-window geometry, and occlusion as optional evidence. Forced pointer mode instead requires stable
+in-window geometry, blocks a target known to be hidden or occluded, and discloses evidence a reader
+cannot prove as `unproven`:
+
+```json
+{
+  "target": {"query": "Save", "role": "Button", "states": ["enabled"]},
+  "mode": "pointer",
+  "timeout_ms": 5000
+}
+```
 
 Web content shows up in a `glass_a11y_snapshot` outline as one of three shapes, plus a fourth,
 older case that isn't specific to web content at all:
@@ -69,7 +96,7 @@ engine — a later version, or the same engine under a different embedder, can d
 
 | Platform | Engines read (2026-08-24) | What was read |
 |---|---|---|
-| Linux (AT-SPI) | Firefox 153 | Publishes `document web` at baseline (0.3–0.9s) on both X11 and Wayland; a nested `<iframe>` is its own `Document`. |
+| Linux (AT-SPI) | Firefox 154 | Publishes `document web` at baseline on both X11 and Wayland; a nested `<iframe>` is its own `Document`. Semantic native focus plus typing reaches an on-screen input. Firefox's Account Save button exposes no activation action, so `auto` uses the pointer fallback; forced pointer actions wait for stable bounds and refuse proven occlusion. Direct accessibility value replacement can be acknowledged without applying to a Firefox input, so use targeted typing for that case. |
 | Linux (AT-SPI) | Brave 151 (Chromium) | Publishes a null placeholder child while renderer accessibility is off — read as withheld content, not an empty page. |
 | Windows (UIA) | Edge 151, Brave 151, Firefox 154 | Publish at baseline (0.4–3.3s). A web page's `Document` and a text editor's edit surface report the same UIA control type; they're told apart per element by the `FrameworkId` each reports (`Chrome`/`Gecko` vs. `Win32`). Clicks and `set_value` land. |
 | macOS (AX) | Safari 26.5 (WebKit) | Publishes `AXWebArea` in the very first snapshot — reading the tree is itself what materializes the lazily built web area. `AXPress` clicks land; `set_value` on a web input is refused honestly (`AxValueNotApplied`) — type into it instead. |

--- a/docs/how-to/drive-glass-well.md
+++ b/docs/how-to/drive-glass-well.md
@@ -6,9 +6,9 @@ several turns rediscovering the loop by trial and error. The habits that matter:
 
 - **Verify with cheap text before spending a screenshot** — save a baseline, act, then check
   `glass_diff` or a `glass_wait_for_*` call (all text-only) before decoding a new image.
-- **Use accessibility before pixels** — try `glass_find_elements` first when you know approximate
-  text, role or state; use `glass_a11y_snapshot` for broad inspection; fall back to pixels only when
-  the app publishes no usable semantic tree.
+- **Use accessibility before pixels** — use a selector action when one intended target is unique;
+  use `glass_find_elements` when several candidates need inspection; use `glass_a11y_snapshot` only
+  for broad structural diagnosis. Fall back to pixels when the app publishes no usable semantic tree.
 - **Pace drags** so a frame-based GUI samples the motion, and **reach for multi-touch** where the app
   needs it.
 

--- a/docs/how-to/setup-android.md
+++ b/docs/how-to/setup-android.md
@@ -101,6 +101,12 @@ and sets editable fields via the real `ACTION_SET_TEXT`; glass enables it and re
 prior accessibility state on teardown. Without `glass-a11y.apk`, glass uses the `uiautomator` reader.
 Set `GLASS_ANDROID_A11Y=off` to force `uiautomator` even when the APK is present.
 
+The service must advertise accessibility node schema 2. Older APKs do not publish focus,
+visibility, focusability, or password state, so glass rejects them before requesting a tree and
+prints that it selected `uiautomator`. Until the APK is upgraded, Compose-rich snapshots, native
+accessibility focus, and `ACTION_SET_TEXT` are unavailable; pointer focus and keystroke-based value
+entry continue through the fallback reader.
+
 A click or `set_value` through this reader tolerates a control that moved. A screen whose open
 transition is playing reports its content at an offset that decays over about half a second, so
 glass can read the element tens of pixels from where your snapshot had it; where its role, name,

--- a/docs/how-to/verify-a-change.md
+++ b/docs/how-to/verify-a-change.md
@@ -84,6 +84,8 @@ command from Linux.
 ## Integration suites (Linux)
 
 `#[ignore]`d, so the ordinary `cargo test` never starts them. Each self-starts what it needs.
+On Debian/Ubuntu, install the full AT-SPI suite's fixtures with
+`sudo apt install at-spi2-core bubblewrap dbus-bin xvfb python3-gi gir1.2-gtk-3.0 gir1.2-gtk-4.0`.
 
 ```bash
 ./scripts/test-x11.sh [name]        # X11 suite; starts its own Xvfb

--- a/docs/reference/platforms.md
+++ b/docs/reference/platforms.md
@@ -8,6 +8,9 @@ Where glass stands by OS. **✓** supported · **◑** partial · **–** not su
 |---|:--:|:--:|:--:|:--:|:--:|
 | Capture · input · windows · clipboard · logs | ✓ | ✓ | ✓ † | ✓ § | ✓ ‡ |
 | Accessibility (semantic addressing) | ✓ AT-SPI | ✓ UI Automation | ✓ UIAutomator | ✓ idb § | ✓ AX |
+| Semantic state coverage | All selector states, plus focus and editable | All selector states, plus focus and editable | UIAutomator: all except expanded; companion schema 2: no selected or expanded | Enabled, checkable, and editable; no reliable visible, selected, expanded, or focused proof | Enabled, checkable, focus, and editable; no universal visible, selected, or expanded proof |
+| Explicit native focus | ✓ AT-SPI | ✓ UIA SetFocus | ◑ companion accessibility click; UIAutomator uses pointer focus | – pointer only; focus cannot be confirmed from idb | ✓ AXFocused |
+| Pointer occlusion proof | ✓ AT-SPI hit test | ✓ UIA element-from-point | ◑ unproven | ◑ unproven | ✓ AX element-at-position |
 | Containment / sandboxing | ✓ bubblewrap | ✓ Sandboxie Classic | ✓ the emulator VM | ✓ the Simulator | ✓ ‡ |
 | Display isolation (app off your desktop) | ✓ headless Xvfb / sway | ◑ virtual display · VM tier | ✓ headless emulator | ✓ headless simctl boot | 🚧 |
 
@@ -87,6 +90,12 @@ falls back to `adb`'s `input` (single-pointer only) and clipboard is unavailable
 a11y falls back to `uiautomator`. Window resize/move (apps are full-screen) and physical devices are
 non-goals.
 
+The Android AccessibilityService protocol requires node schema 2 for semantic actions. Older
+companion APKs are rejected before a tree read, and Glass selects the UIAutomator fallback instead.
+That fallback does not expose Compose-rich nodes or native value replacement, cannot prove
+`expanded`, uses pointer focus, and cannot prove pointer occlusion. Upgrade the companion APK to use
+its native click/focus path, explicit visible/focused/focusable/password facts, and `ACTION_SET_TEXT`.
+
 **§ iOS** is Simulator-only — macOS host required (`xcrun`/`simctl` ship with Xcode). Capture,
 clipboard, and logs work over `simctl`; pointer/keyboard input (tap, type, swipe, scroll) and the
 accessibility tree (snapshot, click-element, set-value) run over `idb_companion` (`brew install
@@ -101,6 +110,11 @@ at the right coordinate, the a11y tree, clear-then-type) is exercised by `#[igno
 tests on a macOS host with a booted Simulator (no CI wiring on the macOS runner yet). Containment has
 no separate glass-managed step, the same as Android — the Simulator's per-app data container is the
 isolation boundary.
+
+The idb accessibility schema does not publish reliable `visible`, `focused`, or `focusable` facts.
+The outline retains a legacy approximate visible flag, but explicit visible/hidden selectors refuse
+as unproven, pointer visibility and occlusion are disclosed as unproven, and targeted typing stops
+after an unconfirmed pointer focus without sending text.
 
 **‡ macOS** capture, input, windows, clipboard, and logs are built and CI-tested (ScreenCaptureKit
 capture, CGEvent input, AXUIElement windows). Containment is Seatbelt (`sandbox_init`): filesystem and

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -401,6 +401,14 @@ Click at window-relative coordinates.
 Type a string into the focused window.
 
 - `text` (string, **required**).
+- `target` (object) — optional semantic target with `query`, `role`, `states`, and an optional
+  non-recursive `within` scope using `query`, `role`, and `states`.
+- `focus_mode` (string) — `"auto"` (default), `"native"`, or `"pointer"`; accepted only with
+  `target`.
+- `timeout_ms` (integer, range 0–120000, default 10000) — semantic-target deadline; accepted only
+  with `target`.
+- `max_nodes` (integer) — accessibility walk limit for semantic-target resolution; accepted only
+  with `target`.
 - `return` (string) — `"snapshot"`, `"settle"`, or `"none"` (default), as for
   `glass_click_element`. All three values are also accepted inside a `glass_do` `type` action;
   the chosen observation is retained in that action step's `result` and sibling `content_blocks`.
@@ -719,7 +727,14 @@ Address an element by its `#id`. Glass tries the platform's role-appropriate nat
 operation first, falling back to a synthetic pointer click at the center of the element's bounds.
 For a text editor, the native operation may focus and confirm focus rather than activate it.
 
-- `id` (integer, **required**) — the `#id` from the latest snapshot.
+- `id` (integer) — the `#id` from the latest snapshot. Supply exactly one of `id` or `target`.
+- `target` (object) — semantic target with `query`, `role`, `states`, and an optional non-recursive
+  `within` scope using `query`, `role`, and `states`. Supply exactly one of `id` or `target`.
+- `mode` (string) — `"auto"` (default), `"native"`, or `"pointer"`.
+- `timeout_ms` (integer, range 0–120000, default 10000) — semantic-target deadline; accepted only
+  with `target`.
+- `max_nodes` (integer) — accessibility walk limit for semantic-target resolution; accepted only
+  with `target`.
 - `return` (string) — `"snapshot"` appends a fresh a11y outline as an untrusted sibling block (and
   refreshes the id cache), `"settle"` folds settle metadata into `result.observed`, or `"none"`
   (default) adds nothing.
@@ -766,8 +781,14 @@ fixes it. Clearing a field (`text: ""`) additionally needs the element to have a
 field is not by itself evidence the clear landed on the element you meant, so a nameless one reports
 unconfirmed rather than a success it cannot prove.
 
-- `id` (integer, **required**) — the element's `#id`.
+- `id` (integer) — the element's `#id`. Supply exactly one of `id` or `target`.
+- `target` (object) — semantic target with `query`, `role`, `states`, and an optional non-recursive
+  `within` scope using `query`, `role`, and `states`. Supply exactly one of `id` or `target`.
 - `text` (string, **required**) — the value to set.
+- `timeout_ms` (integer, range 0–120000, default 10000) — semantic-target deadline; accepted only
+  with `target`.
+- `max_nodes` (integer) — accessibility walk limit for semantic-target resolution; accepted only
+  with `target`.
 - `return` (string) — `"snapshot"`, `"settle"`, or `"none"` (default), as for `glass_click_element`.
 
 Returns `{id}` plus `observed: {settled, saw_motion, observed_ms}` when `return:"settle"`, exactly

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -398,11 +398,15 @@ Click at window-relative coordinates.
 
 ### `glass_type`
 
-Type a string into the focused window.
+Type text once. With no `target`, this preserves the original focused-window behavior and sends the
+text wherever focus already is. With a `target`, Glass resolves one fresh unique semantic element,
+focuses it by `focus_mode`, confirms focused state, and only then sends the text once. An unconfirmed
+focus returns `focus_unconfirmed` and sends no text; Glass does not try a second focus path after a
+focus may have dispatched.
 
 - `text` (string, **required**).
-- `target` (object) — optional semantic target with `query`, `role`, `states`, and an optional
-  non-recursive `within` scope using `query`, `role`, and `states`.
+- `target` (object) — optional semantic target. It follows the selector-action matching, deadline,
+  completeness, and output contract below.
 - `focus_mode` (string) — `"auto"` (default), `"native"`, or `"pointer"`; accepted only with
   `target`.
 - `timeout_ms` (integer, range 0–120000, default 10000) — semantic-target deadline; accepted only
@@ -413,8 +417,10 @@ Type a string into the focused window.
   `glass_click_element`. All three values are also accepted inside a `glass_do` `type` action;
   the chosen observation is retained in that action step's `result` and sibling `content_blocks`.
 
-Returns `{}` plus `observed: {settled, saw_motion, observed_ms}` when `return:"settle"`,
-exactly as for `glass_click_element`.
+Targeted typing returns the resolved target, focus method, focus dispatch and confirmation, and the
+single keyboard dispatch separately. Untargeted typing retains its existing empty result. Either
+form also includes `observed: {settled, saw_motion, observed_ms}` when `return:"settle"`, exactly as
+for `glass_click_element`.
 
 ### `glass_key`
 
@@ -495,10 +501,10 @@ the event — glass reports the binary and its build info if yours does not. Oth
 ### `glass_do`
 
 Prefer `glass_do` whenever at least two upcoming actions or verification waits are already known.
-Use `glass_find_elements` for each target that is not already known, retain the returned ids, then
-put the known mutations and waits into `glass_do`. Use `glass_a11y_snapshot` only when the task
-genuinely needs broad tree inspection. Use standalone tools only when the next step depends on newly
-observed state, and inspect the structured outcomes before recovery.
+Give each known unique target directly to its action. Use `glass_find_elements` when the selector
+still has several plausible candidates, and use `glass_a11y_snapshot` only when the task genuinely
+needs broad tree inspection. Use standalone tools only when the next step depends on newly observed
+state, and inspect the structured outcomes before recovery.
 
 The call runs a bounded, fixed sequence, then optionally observes. The sequence is a static list: it
 cannot use variables, references to earlier results, interpolation, branching, loops, retries, or
@@ -542,14 +548,14 @@ Do not replay a completed action or a failed action with
 `side_effects_may_have_occurred:true`. `attempted:false` proves only that the failed action itself
 was not dispatched. Inspect the outcomes and current app state before deciding what is safe to run.
 
-Example, using element ids obtained before the call:
+Example, resolving each intended target immediately before acting:
 
 ```json
 {
   "actions": [
-    {"action":"set_value","id":12,"text":"Alice"},
+    {"action":"set_value","target":{"query":"Name","role":"TextField","states":["enabled"]},"text":"Alice"},
     {"action":"wait_for_element","description":"Name","role":"TextField","value":"Alice","timeout_ms":3000},
-    {"action":"click_element","id":16,"return":"snapshot"},
+    {"action":"click_element","target":{"query":"Save","role":"Button","states":["enabled"]},"mode":"auto","return":"snapshot"},
     {"action":"wait_for_element","name":"Clicked 1","description":"Counter","timeout_ms":3000}
   ],
   "timeout_ms":10000
@@ -721,25 +727,71 @@ follow as siblings (the legend untrusted-wrapped), per the image ordering above.
 `glass_a11y_snapshot`. The box is only as precise as the toolkit's a11y geometry (can drift
 ~10–20px), but the `#id` and the click are exact.
 
+## Selector action contract
+
+`glass_click_element` and `glass_set_value` require exactly one of `id` or `target`. A target has
+`target.query`, `target.role`, `target.states`, and optional `target.within`; the scope has the same
+`query`, `role`, and `states` fields and cannot contain another scope. `query` is a case-insensitive
+substring over accessible name, description, and non-secure value, `role` uses Glass's normalized
+roles, and every supplied field and state is AND-combined. Secure values are never searched.
+
+A selector action performs fresh reads until exactly one target exists in exactly one optional
+scope. It refuses zero matches as `no_match`, duplicate targets as `ambiguous_target`, duplicate
+scopes as `ambiguous_scope`, and a truncated, unreadable, or withheld tree as `incomplete_tree` when
+that tree cannot prove uniqueness. Any explicitly requested selector state that the active reader
+does not cover returns `unproven_selector_state` before the first tree read.
+
+Selector `timeout_ms` defaults to 10000, accepts 0 through 120000, and zero performs one fresh
+attempt. Selector `max_nodes` omitted installs the default walk cap; zero removes only the node-count
+cap. One absolute deadline covers resolution, pointer stability, hit testing, backend rewalk,
+dispatch, confirmation, and an optional `return`; an enclosing `glass_do` deadline wins when it is
+earlier. Deadline failures are `action_deadline_exceeded` or `sequence_deadline_exceeded`.
+
+Pointer actions require the same semantic identity and exact bounds in two fresh samples at least
+100 ms apart. They require known enabled and visible state, stable in-window bounds, and no proven
+occluder. Native accessibility actions may bypass visibility, stability, window, and occlusion
+blockers because they do not depend on pointer geometry, while still disclosing those checks. Each
+actionability entry reports a `passed`, `failed`, or `unproven` verdict, whether it was `required`,
+and its evidence `source`. Actionability refusal is `not_actionable`; changed bounds that never
+settle return `unstable_target`; unavailable requested paths return `unsupported_mode`.
+
+Results distinguish dispatch from application effect. Click reports whether input dispatched and
+requires a separate observation for the resulting app state. Set-value succeeds only after backend
+value confirmation; uncertainty after a possible write is terminal and must not be retried. Targeted
+type reports focus and typing as separate phases, returns `focus_unconfirmed` without typing when
+focus cannot be proved, and never sends the text more than once.
+
+Resolved targets and known-target failures place application-controlled fields in nonce-delimited
+target content blocks. Ambiguity places candidates and their context in a nonce-delimited candidate
+content block. Successes and errors share the 8 KiB response policy; oversized logical content is
+externalized as a read-only artifact without changing error status.
+
+Legacy ID actions keep their immediate timing and existing result fields: they do not resolve
+freshly, wait for stability, or accept selector deadlines/limits. `glass_type` without `target`
+keeps focused-window typing. Selector behavior and error codes are the same in standalone calls and
+the corresponding `glass_do` actions.
+
 ### `glass_click_element`
 
-Address an element by its `#id`. Glass tries the platform's role-appropriate native accessibility
-operation first, falling back to a synthetic pointer click at the center of the element's bounds.
-For a text editor, the native operation may focus and confirm focus rather than activate it.
+Click one immediate `#id` or one freshly resolved semantic target. In `auto` mode Glass tries the
+role-appropriate native accessibility operation and falls back to pointer only after a proven
+pre-dispatch unsupported or unavailable native refusal. `native` and `pointer` force one path. No
+path is retried after it may have dispatched. For a text editor, a native operation may focus and
+confirm focus rather than activate it.
 
 - `id` (integer) — the `#id` from the latest snapshot. Supply exactly one of `id` or `target`.
-- `target` (object) — semantic target with `query`, `role`, `states`, and an optional non-recursive
-  `within` scope using `query`, `role`, and `states`. Supply exactly one of `id` or `target`.
+- `target` (object) — semantic target described above. Supply exactly one of `id` or `target`.
 - `mode` (string) — `"auto"` (default), `"native"`, or `"pointer"`.
 - `timeout_ms` (integer, range 0–120000, default 10000) — semantic-target deadline; accepted only
   with `target`.
-- `max_nodes` (integer) — accessibility walk limit for semantic-target resolution; accepted only
-  with `target`.
+- `max_nodes` (integer) — selector-only walk cap; omitted installs the default and `0` removes the
+  node cap. Accepted only with `target`.
 - `return` (string) — `"snapshot"` appends a fresh a11y outline as an untrusted sibling block (and
   refreshes the id cache), `"settle"` folds settle metadata into `result.observed`, or `"none"`
   (default) adds nothing.
 
-Returns `{id, method}` — the addressed `#id` and which path ran (`native-action`/`pointer`).
+Returns the resolved `id`, `method`, `dispatch`, `confirmation`, and `actionability`. The method is
+`native-action` or `pointer`.
 `native-action` is the stable umbrella label for the native path, not proof that an activation verb
 fired. The result also includes `native_fallback` (why the pointer path was used) when it was,
 `actuated_id` when the native operation targeted a different element than the one you named (a
@@ -748,7 +800,8 @@ and `observed: {settled, saw_motion, observed_ms}` when `return:"settle"`.
 
 ### `glass_set_value`
 
-Where the platform can write the value directly this is instant and takes no keystrokes. On a mobile
+Set exactly one immediate `#id` or one freshly resolved unique semantic target. Where the platform
+can write the value directly this is instant and takes no keystrokes. On a mobile
 backend (Android without the on-device accessibility service, and the iOS Simulator) it taps the
 element, clears it and types, then reads the element back to confirm — up to three reads, since a
 field may commit a frame or two later. Errors if the element isn't editable, changed since the
@@ -782,16 +835,16 @@ field is not by itself evidence the clear landed on the element you meant, so a 
 unconfirmed rather than a success it cannot prove.
 
 - `id` (integer) — the element's `#id`. Supply exactly one of `id` or `target`.
-- `target` (object) — semantic target with `query`, `role`, `states`, and an optional non-recursive
-  `within` scope using `query`, `role`, and `states`. Supply exactly one of `id` or `target`.
+- `target` (object) — semantic target described above. Supply exactly one of `id` or `target`.
 - `text` (string, **required**) — the value to set.
 - `timeout_ms` (integer, range 0–120000, default 10000) — semantic-target deadline; accepted only
   with `target`.
-- `max_nodes` (integer) — accessibility walk limit for semantic-target resolution; accepted only
-  with `target`.
+- `max_nodes` (integer) — selector-only walk cap; omitted installs the default and `0` removes the
+  node cap. Accepted only with `target`.
 - `return` (string) — `"snapshot"`, `"settle"`, or `"none"` (default), as for `glass_click_element`.
 
-Returns `{id}` plus `observed: {settled, saw_motion, observed_ms}` when `return:"settle"`, exactly
+Returns the resolved `id`, value-write `method`, `dispatch`, backend `confirmation`, and
+`actionability`, plus `observed: {settled, saw_motion, observed_ms}` when `return:"settle"`, exactly
 as for `glass_click_element`.
 
 ### `glass_scroll_to_element`

--- a/examples/android-role-fixture/src/tech/fixedwidth/glassrolefixture/MainActivity.java
+++ b/examples/android-role-fixture/src/tech/fixedwidth/glassrolefixture/MainActivity.java
@@ -4,8 +4,13 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.os.Bundle;
+import android.os.SystemClock;
+import android.text.Editable;
+import android.text.InputType;
+import android.text.TextWatcher;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.accessibility.AccessibilityNodeInfo;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.EditText;
@@ -48,6 +53,15 @@ import android.widget.Toolbar;
  * strip real apps use would change the evidence rather than modernize it.
  */
 public class MainActivity extends Activity {
+    private TextView semanticStatus;
+    private TextView semanticFocusStatus;
+    private Button movingSemantic;
+    private int semanticSaveCount;
+    private int semanticTypeCount;
+    private int semanticMoveCount;
+    private int duplicateSemanticCount;
+    private int semanticFocusClickCount;
+    private int semanticMovementGeneration;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -63,6 +77,8 @@ public class MainActivity extends Activity {
         toolbar.setContentDescription("the toolbar");
         toolbar.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_YES);
         root.addView(toolbar, matchWrap());
+
+        addSemanticControls(root);
 
         root.addView(tabs(), matchHeight(dp(130)));
         root.addView(label("list"), matchWrap());
@@ -109,6 +125,184 @@ public class MainActivity extends Activity {
         ScrollView scroller = new ScrollView(this);
         scroller.addView(root);
         setContentView(scroller);
+    }
+
+    /** Controls used by the semantic-action device acceptance suite. */
+    private void addSemanticControls(LinearLayout root) {
+        semanticStatus = new TextView(this);
+        semanticStatus.setContentDescription("Semantic Status");
+        updateSemanticStatus();
+        root.addView(semanticStatus, matchWrap());
+
+        Button save = new Button(this);
+        save.setText("Semantic Save");
+        save.setContentDescription("Semantic Save");
+        save.setOnClickListener(
+                new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        semanticSaveCount++;
+                        updateSemanticStatus();
+                    }
+                });
+        root.addView(save, matchWrap());
+
+        Button disabled = new Button(this);
+        disabled.setText("Disabled semantic");
+        disabled.setContentDescription("Disabled semantic");
+        disabled.setEnabled(false);
+        root.addView(disabled, matchWrap());
+
+        for (int i = 0; i < 2; i++) {
+            Button duplicate = new Button(this);
+            duplicate.setText("Duplicate semantic");
+            duplicate.setContentDescription("Duplicate semantic");
+            duplicate.setOnClickListener(
+                    new View.OnClickListener() {
+                        @Override
+                        public void onClick(View view) {
+                            duplicateSemanticCount++;
+                            updateSemanticStatus();
+                        }
+                    });
+            root.addView(duplicate, matchWrap());
+        }
+
+        movingSemantic = new Button(this);
+        movingSemantic.setText("Moving semantic");
+        movingSemantic.setContentDescription("Moving semantic");
+        movingSemantic.setOnClickListener(
+                new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        semanticMoveCount++;
+                        updateSemanticStatus();
+                    }
+                });
+        root.addView(movingSemantic, matchWrap());
+
+        Button restart = new Button(this);
+        restart.setText("Restart movement");
+        restart.setContentDescription("Restart movement");
+        restart.setOnClickListener(
+                new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        startSemanticMovement();
+                    }
+                });
+        root.addView(restart, matchWrap());
+
+        EditText field = new EditText(this);
+        semanticFocusStatus = new TextView(this);
+        semanticFocusStatus.setContentDescription("Semantic Focus Status");
+        updateSemanticFocusStatus(false, false);
+        root.addView(semanticFocusStatus, matchWrap());
+
+        field.setContentDescription("Semantic Field");
+        field.setText("seed");
+        field.setFocusable(true);
+        field.setFocusableInTouchMode(true);
+        field.setOnClickListener(
+                new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        view.requestFocus();
+                    }
+                });
+        field.setOnFocusChangeListener(
+                new View.OnFocusChangeListener() {
+                    @Override
+                    public void onFocusChange(View view, boolean focused) {
+                        updateSemanticFocusStatus(true, focused);
+                    }
+                });
+        field.setAccessibilityDelegate(
+                new View.AccessibilityDelegate() {
+                    @Override
+                    public boolean performAccessibilityAction(
+                            View host, int action, Bundle arguments) {
+                        if (action == AccessibilityNodeInfo.ACTION_CLICK) {
+                            semanticFocusClickCount++;
+                            boolean requested = host.requestFocus();
+                            updateSemanticFocusStatus(requested, host.hasFocus());
+                            return requested;
+                        }
+                        return super.performAccessibilityAction(host, action, arguments);
+                    }
+                });
+        field.addTextChangedListener(
+                new TextWatcher() {
+                    @Override
+                    public void beforeTextChanged(
+                            CharSequence text, int start, int count, int after) {}
+
+                    @Override
+                    public void onTextChanged(
+                            CharSequence text, int start, int before, int count) {}
+
+                    @Override
+                    public void afterTextChanged(Editable editable) {
+                        semanticTypeCount++;
+                        updateSemanticStatus();
+                    }
+                });
+        root.addView(field, matchWrap());
+
+        EditText password = new EditText(this);
+        password.setContentDescription("Semantic Password");
+        password.setInputType(
+                InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
+        password.setText("PASSWORD_SENTINEL");
+        root.addView(password, matchWrap());
+
+        movingSemantic.post(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        startSemanticMovement();
+                    }
+                });
+    }
+
+    private void startSemanticMovement() {
+        final int generation = ++semanticMovementGeneration;
+        final long started = SystemClock.uptimeMillis();
+        final float distance = dp(120);
+        movingSemantic.setTranslationX(0);
+        movingSemantic.post(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        if (generation != semanticMovementGeneration) return;
+                        long elapsed = SystemClock.uptimeMillis() - started;
+                        float fraction = Math.min(1f, elapsed / 300f);
+                        movingSemantic.setTranslationX(distance * fraction);
+                        if (elapsed < 300) movingSemantic.postDelayed(this, 16);
+                    }
+                });
+    }
+
+    private void updateSemanticStatus() {
+        semanticStatus.setText(
+                "save="
+                        + semanticSaveCount
+                        + " type="
+                        + semanticTypeCount
+                        + " move="
+                        + semanticMoveCount
+                        + " duplicate="
+                        + duplicateSemanticCount);
+    }
+
+    private void updateSemanticFocusStatus(boolean requested, boolean focused) {
+        semanticFocusStatus.setText(
+                "focus_click="
+                        + semanticFocusClickCount
+                        + " request="
+                        + requested
+                        + " focused="
+                        + focused);
     }
 
     /** A framework {@link PopupMenu} with two entries, opened by tapping the button. */

--- a/examples/ios-fixture/GlassFixture.swift
+++ b/examples/ios-fixture/GlassFixture.swift
@@ -21,19 +21,28 @@ struct GlassFixtureApp: App {
     }
 }
 
-/// Four elements with stable accessibility identifiers, each verifiable from a snapshot
-/// alone: `statusLabel` (READY, flips to TAPPED), `tapButton`, `inputField`, and
-/// `echoLabel` (mirrors the field, or `(empty)`). glass surfaces an iOS element's
-/// identifier as its name, so the identifier is how a test addresses each one.
+/// Controls with stable accessibility identifiers and snapshot-readable ground truth. glass
+/// surfaces an iOS element's identifier as its name, so the identifier is how a test addresses
+/// each one.
 struct ContentView: View {
     @State private var tapped = false
     @State private var text = ""
+    @State private var saveCount = 0
+    @State private var movingCount = 0
+    @State private var movingOffset: CGFloat = 0
+
+    private var status: String {
+        if saveCount > 0 || movingCount > 0 {
+            return "SAVED:\(saveCount) MOVED:\(movingCount)"
+        }
+        return tapped ? "TAPPED" : "READY"
+    }
 
     var body: some View {
-        VStack(spacing: 40) {
-            Text(tapped ? "TAPPED" : "READY")
+        VStack(spacing: 20) {
+            Text(status)
                 .font(.system(size: 44, weight: .bold))
-                .foregroundStyle(tapped ? .green : .primary)
+                .foregroundStyle(status == "READY" ? Color.primary : Color.green)
                 .accessibilityIdentifier("statusLabel")
 
             Button("Tap Me") { tapped.toggle() }
@@ -45,12 +54,37 @@ struct ContentView: View {
                 .textFieldStyle(.roundedBorder)
                 .font(.title2)
                 .padding(.horizontal, 40)
+                .textInputAutocapitalization(.never)
                 .accessibilityIdentifier("inputField")
 
             Text(text.isEmpty ? "(empty)" : text)
                 .font(.title3)
                 .foregroundStyle(.secondary)
                 .accessibilityIdentifier("echoLabel")
+
+            Button("Semantic Save") {
+                saveCount += 1
+                withAnimation(.linear(duration: 0.3)) {
+                    movingOffset = movingOffset == 0 ? 90 : 0
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .accessibilityIdentifier("semanticSave")
+
+            Button("Disabled Semantic") {}
+                .disabled(true)
+                .accessibilityIdentifier("disabledSemantic")
+
+            HStack {
+                Button("Duplicate Left") {}
+                    .accessibilityIdentifier("duplicateSemantic")
+                Button("Duplicate Right") {}
+                    .accessibilityIdentifier("duplicateSemantic")
+            }
+
+            Button("Moving Semantic") { movingCount += 1 }
+                .offset(x: movingOffset)
+                .accessibilityIdentifier("movingSemantic")
         }
         .padding()
     }

--- a/examples/web-role-fixture/index.html
+++ b/examples/web-role-fixture/index.html
@@ -3,7 +3,14 @@
 <head>
 <meta charset="utf-8">
 <title>Glass web fixture</title>
-<style>body{font:16px sans-serif;margin:24px} section{margin-bottom:16px} iframe{width:320px;height:120px}</style>
+<style>
+body{font:16px sans-serif;margin:24px} section{margin-bottom:16px} iframe{width:320px;height:120px}
+#motion-track{position:relative;width:360px;height:48px}
+#moving-semantic{position:absolute;left:0;top:0}
+#occlusion-stage{position:relative;width:240px;height:48px}
+#occluded-semantic,#occluder{position:absolute;left:0;top:0;width:200px;height:40px}
+#occluder{left:70px;width:60px;z-index:2}
+</style>
 </head>
 <body>
 <h1>Glass web fixture</h1>
@@ -14,6 +21,23 @@
   <input id="account-name" type="text" value="">
   <button id="save-account" type="button">Save account</button>
   <p id="account-status" aria-live="polite">Not saved</p>
+</section>
+<section aria-labelledby="semantic-action-heading">
+  <h2 id="semantic-action-heading">Semantic action cases</h2>
+  <button id="disabled-semantic" type="button" disabled>Disabled semantic</button>
+  <button class="duplicate-semantic" type="button">Duplicate semantic</button>
+  <button class="duplicate-semantic" type="button">Duplicate semantic</button>
+  <button id="restart-moving-semantic" type="button">Start motion</button>
+  <div id="motion-track">
+    <button id="moving-semantic" type="button">Moving semantic</button>
+  </div>
+  <div id="occlusion-stage">
+    <button id="occluded-semantic" type="button">Occluded semantic</button>
+    <button id="occluder" type="button">Occluder</button>
+  </div>
+  <button id="restart-delayed-semantic" type="button">Start delay</button>
+  <button id="delayed-semantic" type="button" hidden>Delayed semantic</button>
+  <p id="semantic-action-status" aria-live="polite">No semantic action activated</p>
 </section>
 <div id="large-page" aria-label="Large page sections"></div>
 <section>
@@ -51,6 +75,56 @@
 document.getElementById('save-account').addEventListener('click', function () {
   document.getElementById('account-status').textContent = 'Saved';
 });
+const semanticStatus = document.getElementById('semantic-action-status');
+const movingSemantic = document.getElementById('moving-semantic');
+const delayedSemantic = document.getElementById('delayed-semantic');
+let movingFrame = 0;
+let delayedTimer = 0;
+let movingActivations = 0;
+let delayedActivations = 0;
+let duplicateActivations = 0;
+let occludedActivations = 0;
+let occluderActivations = 0;
+function restartMotion() {
+  cancelAnimationFrame(movingFrame);
+  const started = performance.now();
+  function move(now) {
+    const elapsed = now - started;
+    movingSemantic.style.left = `${Math.min(elapsed / 300, 1) * 240}px`;
+    if (elapsed < 300) movingFrame = requestAnimationFrame(move);
+  }
+  movingFrame = requestAnimationFrame(move);
+}
+function restartDelay() {
+  clearTimeout(delayedTimer);
+  delayedSemantic.hidden = true;
+  delayedTimer = setTimeout(function () { delayedSemantic.hidden = false; }, 250);
+}
+document.getElementById('restart-moving-semantic').addEventListener('click', restartMotion);
+document.getElementById('restart-delayed-semantic').addEventListener('click', restartDelay);
+movingSemantic.addEventListener('click', function () {
+  movingActivations += 1;
+  semanticStatus.textContent = `Moving activated ${movingActivations}`;
+});
+delayedSemantic.addEventListener('click', function () {
+  delayedActivations += 1;
+  semanticStatus.textContent = `Delayed activated ${delayedActivations}`;
+});
+for (const duplicate of document.querySelectorAll('.duplicate-semantic')) {
+  duplicate.addEventListener('click', function () {
+    duplicateActivations += 1;
+    semanticStatus.textContent = `Duplicate activated ${duplicateActivations}`;
+  });
+}
+document.getElementById('occluded-semantic').addEventListener('click', function () {
+  occludedActivations += 1;
+  semanticStatus.textContent = `Occluded activated ${occludedActivations}`;
+});
+document.getElementById('occluder').addEventListener('click', function () {
+  occluderActivations += 1;
+  semanticStatus.textContent = `Occluder activated ${occluderActivations}`;
+});
+restartMotion();
 const largePage = document.getElementById('large-page');
 for (let index = 0; index < 200; index += 1) {
   const section = document.createElement('section');

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -149,7 +149,7 @@ if [ "$unit_only" -eq 0 ]; then
     fi
     classify_suite wayland ./scripts/test-wayland.sh
 
-    echo "coverage: running AT-SPI integration suite (needs dbus/at-spi2/GTK4)…"
+    echo "coverage: running AT-SPI integration suite (needs dbus/at-spi2/GTK3/GTK4)…"
     classify_suite a11y ./scripts/test-a11y.sh
 fi
 

--- a/scripts/test-a11y.sh
+++ b/scripts/test-a11y.sh
@@ -17,8 +17,8 @@ if ! command -v dbus-daemon >/dev/null 2>&1 \
    || ! command -v python3 >/dev/null 2>&1 \
    || ! python3 -c 'import gi; gi.require_version("Gtk", "4.0")' >/dev/null 2>&1; then
     echo "test-a11y: prerequisites missing — glass needs dbus-daemon, at-spi-bus-launcher,"
-    echo "           Xvfb, and python3 with GTK4 GI (apt install at-spi2-core"
-    echo "           gir1.2-gtk-4.0 python3-gi xvfb dbus-bin). Skipping."
+    echo "           Xvfb, and python3 with GTK3 + GTK4 GI (apt install at-spi2-core"
+    echo "           gir1.2-gtk-3.0 gir1.2-gtk-4.0 python3-gi xvfb dbus-bin). Skipping."
     exit 0
 fi
 


### PR DESCRIPTION
Accessibility actions can now resolve a unique semantic target immediately before input. `glass_click_element` and `glass_set_value` accept exactly one `id` or `target`; targeted `glass_type` resolves, focuses, confirms focus, and types once. Existing ID actions and untargeted typing retain their immediate behavior.

The shared core planner checks state coverage, search completeness, and actionability under one absolute action/sequence deadline. Pointer actions require the same target and exact bounds in two fresh samples at least 100ms apart. Results disclose native or pointer execution, fallback reasons, and unsupported checks. Automatic fallback requires proof that native input did not dispatch; potentially dispatched input is never retried.

Failure audits retain the resolved target and selected click path. MCP output preserves legacy fields, separates application text from trusted metadata, protects submitted text and secure values, and applies the existing 8192-byte output/artifact policy. No MCP tools, Rust dependencies, or selector language are added.

Android requires the schema-2 companion update in https://github.com/fixed-width/glass-android-agent/pull/11. Released schema-1 companions are rejected before their trees are exposed and use the disclosed UIAutomator fallback, with reduced companion capabilities until the APK is upgraded.

Validation on `c610df0`:

- [All 17 GitHub CI checks passed](https://github.com/fixed-width/glass/actions/runs/33944403224), including Linux, Windows, macOS, X11, Wayland, AT-SPI, coverage, and all eight mutation shards. Mutation totals: 492 generated, 316 caught, zero survivors/timeouts, 176 unviable.
- Added 22 behavioral regressions covering actionability, pointer geometry, focus/value dispatch evidence, complete/stable targeting, legacy reports, and Android schema refusal. GTK3 is explicitly installed for the full AT-SPI and coverage suites.
- Core: 1,020 library tests passed locally and on native macOS; strict workspace/all-target Clippy and formatting passed. The pointer-plan regression uses the standard action budget while retaining exact three-read/one-drag assertions.

Earlier full/native validation on `ca115f9`:


- Formatting and strict workspace/all-target Clippy passed; locked workspace tests: 3660 passed, 0 failed, 362 ignored, with required native cases executed separately. Windows GNU strict cross-Clippy also passed.
- Linux X11/Wayland/AT-SPI: 58/30/39 passed; Firefox acceptance passed on X11 and Wayland. The six-call public MCP Account workflow confirmed focus, typed once, read exact `Ada`, clicked Save, and read exact `Saved`.
- Native Windows: 1 semantic and 6 accessibility tests passed. Native macOS: five GUI acceptance markers, 97 library tests, and 2 explicitly invoked FFI tests passed.
- Android: 16 integration and 3 schema-2 MCP bodies passed; separate released-schema-1 fallback/security passed. iOS native fixture and semantic acceptance passed. Fixture/device/process cleanup checks passed.
- Trust/output boundaries, audit content policies, legacy request/result compatibility, and the unchanged 31-tool registry passed. Four new audit-failure regressions were demonstrated failing before the fix and passing afterward.

Known limits: Firefox's Account native value write still returns terminal `AxValueNotApplied`; acceptance uses confirmed focus plus typing upfront. iOS cannot prove visible/focused/focusable state, and its WKWebView probe remains evidence-only. Apple cross-Clippy stops in `aws-lc-sys` on unsupported Linux compiler flags before Glass; native macOS validation passed.
