### PR TITLE
Add optional session traces and offline evidence export

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,11 @@ optional on-device companions — an `app_process` agent (clipboard + high-fidel
 `AccessibilityService` (Compose-rich a11y tree + high-fidelity `set_value`); both live in the
 separate repo `github.com/fixed-width/glass-android-agent`, driven over `adb forward`.
 
+`glass-mcp/src/trace` records optional bounded session evidence (`--trace-dir`) and implements
+offline `trace inspect`/`trace export`. Its persistent store is separate from temporary output
+artifacts; protect the entire configured root before launching contained targets. Capture requested
+results only, preserve worker outcomes after cancellation, and keep trace-off MCP behavior unchanged.
+
 ## Commands
 
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ internal refactors, CI, or test-only changes.
 ## [Unreleased]
 
 ### Added
+- Optional `--trace-dir` retains supplied tool inputs and requested results in a bounded private session trace. Offline `trace inspect` and `trace export` validate and package evidence after the server stops, with explicit omissions and unchanged tool execution when recording reaches a limit or fails.
 - Optional `--tool-profile lean` exposes 20 tools with actions through `glass_do`; the complete 31-tool profile remains the default. `glass-mcp tools --json` reports either profile's definitions, shared instructions and schema cost without starting a session.
 - `glass_click_element`, `glass_set_value`, and `glass_type` can now resolve a unique semantic target immediately before acting, wait within one action deadline, and disclose native or pointer actionability and dispatch truth. Pointer actions refuse ambiguous, stale, disabled, hidden, moving, off-window, or provably occluded targets without unsafe retry; native accessibility actions may bypass geometry blockers. Existing ID actions and untargeted typing remain compatible.
 - `glass_find_elements` performs a fresh bounded accessibility search across native and published web content, returning up to 20 ranked actionable matches with semantic scope, optional publication waiting, compact context, explicit incompleteness, secure-value exclusion, and an 8 KiB total response ceiling.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,11 @@ optional on-device companions — an `app_process` agent (clipboard + high-fidel
 `AccessibilityService` (Compose-rich a11y tree + high-fidelity `set_value`); both live in the
 separate repo `github.com/fixed-width/glass-android-agent`, driven over `adb forward`.
 
+`glass-mcp/src/trace` records optional bounded session evidence (`--trace-dir`) and implements
+offline `trace inspect`/`trace export`. Its persistent store is separate from temporary output
+artifacts; protect the entire configured root before launching contained targets. Capture requested
+results only, preserve worker outcomes after cancellation, and keep trace-off MCP behavior unchanged.
+
 ## Commands
 
 ```bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,6 +471,48 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "cap-fs-ext"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ff379b70af8e08307a8f65e7040c7301cb4a572538ade16b4984f0da77847f"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b5f74729fd2f44701d1a8eb47e906cdb3ccd9ec0f02baad85a744b791940b18"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "ipnet",
+ "maybe-owned",
+ "rustix",
+ "rustix-linux-procfs",
+ "windows-sys 0.61.2",
+ "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ec78e242cfa2cfe276807ac2ecc00315a6c97786977414bcd1c3963b6c91b8"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "rustix",
+]
 
 [[package]]
 name = "cast"
@@ -998,6 +1046,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes 2.0.4",
+ "rustix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "fs4"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1318,6 +1377,8 @@ dependencies = [
  "anyhow",
  "axum",
  "base64 0.23.1",
+ "cap-fs-ext",
+ "cap-std",
  "chrono",
  "clap",
  "directories",
@@ -1353,6 +1414,7 @@ dependencies = [
  "tokio-util",
  "tower",
  "windows",
+ "zip",
 ]
 
 [[package]]
@@ -1832,6 +1894,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
+dependencies = [
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "io-lifetimes"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
+
+[[package]]
 name = "ipnet"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2093,6 +2177,12 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
@@ -3127,6 +3217,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3924,6 +4024,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4539,6 +4645,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags 2.13.1",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4787,6 +4903,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "indexmap",
+ "memchr",
+ "typed-path",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ Forced pointer mode waits for stable in-window bounds and refuses a target known
 hidden, moving, off-window, or occluded. Native accessibility actions can legitimately actuate a
 covered or off-screen control, so geometry and occlusion are optional disclosures on that path.
 
+To review a run after the app stops, opt into [session evidence recording](docs/how-to/record-session-evidence.md)
+with `--trace-dir`. Glass retains tool inputs and requested results in bounded storage, then
+`glass-mcp trace inspect` and `trace export` validate the trace and package its evidence in a ZIP.
+Recording is off by default; retained app content can contain sensitive data.
+
 ## Install at a glance
 
 Download the latest build for your platform from the

--- a/crates/glass-core/src/deadline.rs
+++ b/crates/glass-core/src/deadline.rs
@@ -102,8 +102,12 @@ impl Deadline {
     /// [`Self::UNBOUNDED`] stays unbounded: there is nothing to take a share of. Never lands
     /// before now, so it cannot underflow the monotonic clock.
     pub fn reserving(self, reserve: std::time::Duration) -> Self {
+        self.reserving_at(reserve, std::time::Instant::now())
+    }
+
+    fn reserving_at(self, reserve: std::time::Duration, now: std::time::Instant) -> Self {
         Self(self.0.map(|d| {
-            let left = d.saturating_duration_since(std::time::Instant::now());
+            let left = d.saturating_duration_since(now);
             d - reserve.min(left / 2)
         }))
     }
@@ -250,16 +254,14 @@ mod tests {
     /// A share taken out of one budget, so two steps in sequence cannot each spend the whole.
     #[test]
     fn reserving_takes_a_share_and_leaves_unbounded_unbounded() {
-        let left = Deadline::at(Instant::now() + Duration::from_secs(3))
-            .reserving(Duration::from_secs(1))
-            .remaining()
+        let now = Instant::now();
+        let left = Deadline::at(now + Duration::from_secs(3))
+            .reserving_at(Duration::from_secs(1), now)
+            .remaining_at(now)
             .expect("still bounded");
-        assert!(
-            left <= Duration::from_secs(2) && left > Duration::from_millis(1900),
-            "{left:?}"
-        );
+        assert_eq!(left, Duration::from_secs(2));
         assert_eq!(
-            Deadline::UNBOUNDED.reserving(Duration::from_secs(1)),
+            Deadline::UNBOUNDED.reserving_at(Duration::from_secs(1), now),
             Deadline::UNBOUNDED
         );
     }
@@ -268,13 +270,15 @@ mod tests {
     /// held back from gets a deadline already in the past and is skipped rather than run.
     #[test]
     fn a_reserve_larger_than_the_budget_takes_only_half() {
-        let left = Deadline::at(Instant::now() + Duration::from_millis(100))
-            .reserving(Duration::from_secs(30))
-            .remaining()
+        let now = Instant::now();
+        let left = Deadline::at(now + Duration::from_millis(100))
+            .reserving_at(Duration::from_secs(30), now)
+            .remaining_at(now)
             .expect("still bounded");
-        assert!(
-            left > Duration::from_millis(30) && left <= Duration::from_millis(50),
-            "a 30s reserve out of 100ms should leave about half, left {left:?}"
+        assert_eq!(left, Duration::from_millis(50));
+        assert_eq!(
+            Deadline::at(now).reserving_at(Duration::from_secs(30), now),
+            Deadline::at(now)
         );
     }
 }

--- a/crates/glass-core/src/session/lifecycle.rs
+++ b/crates/glass-core/src/session/lifecycle.rs
@@ -427,6 +427,7 @@ mod tests {
         let new_paths = vec![ProtectedHostPath::file("new")];
         g.set_protected_host_paths(old_paths.clone()).unwrap();
         g.start(&spec()).unwrap();
+        assert_eq!(g.active_backend(), Some("x11"));
 
         assert!(matches!(
             g.start(&spec()).unwrap_err(),
@@ -434,9 +435,11 @@ mod tests {
         ));
         assert_eq!(*stops.lock().unwrap(), 1);
         assert_eq!(g.host_path_access(), HostPathAccess::NoActiveTarget);
+        assert_eq!(g.active_backend(), None);
 
         g.set_protected_host_paths(new_paths.clone()).unwrap();
-        g.start(&spec()).unwrap();
+        g.start_on("wayland", &spec()).unwrap();
+        assert_eq!(g.active_backend(), Some("wayland"));
 
         assert_eq!(*configured.lock().unwrap(), vec![old_paths, new_paths]);
         assert_eq!(
@@ -500,7 +503,7 @@ mod tests {
     }
 
     #[test]
-    fn start_on_passes_backend_name_to_factory() {
+    fn start_on_tracks_the_backend_passed_to_the_factory_until_stop() {
         let seen = Arc::new(Mutex::new(Vec::new()));
         let seen2 = seen.clone();
         let factory: PlatformFactory = Box::new(move |backend| {
@@ -508,9 +511,14 @@ mod tests {
             Ok(Backend::display_only(Box::new(FakePlatform::new(10, 10))))
         });
         let mut g = glass_with_factory(factory);
+        assert_eq!(g.active_backend(), None);
         g.start(&spec()).unwrap(); // default ("x11")
+        assert_eq!(g.active_backend(), Some("x11"));
         g.start_on("wayland", &spec()).unwrap(); // explicit
+        assert_eq!(g.active_backend(), Some("wayland"));
         assert_eq!(*seen.lock().unwrap(), vec!["x11", "wayland"]);
+        g.stop().unwrap();
+        assert_eq!(g.active_backend(), None);
     }
 
     #[test]
@@ -539,7 +547,9 @@ mod tests {
         });
         let mut g = glass_with_factory(factory);
         g.start(&spec()).unwrap();
+        assert_eq!(g.active_backend(), Some("x11"));
         g.shutdown(soon());
+        assert_eq!(g.active_backend(), None);
         assert_eq!(
             *stops.lock().unwrap(),
             1,

--- a/crates/glass-core/src/session/lifecycle.rs
+++ b/crates/glass-core/src/session/lifecycle.rs
@@ -584,18 +584,16 @@ mod tests {
         g.set_shutdown_hook(Box::new(move |d| *hooked.lock().unwrap() = Some(d)));
         g.start(&spec()).unwrap();
 
-        let deadline = soon();
+        let deadline = Deadline::at(std::time::Instant::now() + Duration::from_secs(3600));
         g.shutdown(deadline);
 
         let at_stop = at_stop
             .lock()
             .unwrap()
             .expect("the backend must be stopped through `stop_app_by`, not `stop_app`");
-        // Each `remaining()` reads its own now, microseconds apart, so comparing them compares
-        // the instants they hold.
-        assert!(
-            at_stop.remaining().expect("a bounded share") < deadline.remaining().unwrap(),
-            "the session's share must stop short of the hook's, or the reserve is not held back"
+        assert_eq!(
+            deadline.instant().unwrap() - at_stop.instant().expect("a bounded share"),
+            crate::TEARDOWN_HOOK_RESERVE
         );
         assert_eq!(
             *at_hook.lock().unwrap(),
@@ -604,66 +602,33 @@ mod tests {
         );
     }
 
-    /// The reserve is a fixed 750ms, so without the clamp a caller whose whole budget is smaller
-    /// hands the sessions a deadline already in the past.
     #[test]
-    fn a_budget_smaller_than_the_reserve_still_leaves_the_sessions_time() {
+    fn the_hook_has_reserved_time_at_the_backend_deadline() {
         let at_stop = Arc::new(Mutex::new(None));
-        let recorded = at_stop.clone();
+        let recorded_stop = at_stop.clone();
         let factory: PlatformFactory = Box::new(move |_backend| {
             Ok(Backend::display_only(Box::new(
-                FakePlatform::new(10, 10).recording_stop_deadline(recorded.clone()),
-            )))
-        });
-        let mut g = glass_with_factory(factory);
-        g.start(&spec()).unwrap();
-
-        // A fifth of the reserve, so an unclamped subtraction lands well in the past.
-        let budget = crate::TEARDOWN_HOOK_RESERVE / 5;
-        let started = std::time::Instant::now();
-        g.shutdown(Deadline::at(started + budget));
-
-        // Measured from `started`, not from now: `remaining()` here would subtract whatever the
-        // test itself has since spent, and the margin is only tens of milliseconds.
-        let given = at_stop
-            .lock()
-            .unwrap()
-            .expect("the backend was stopped")
-            .remaining_at(started)
-            .expect("a bounded share");
-        assert!(
-            given >= budget / 3,
-            "the sessions were given {given:?} of a {budget:?} budget — the reserve was taken \
-             whole from a budget too small to pay it"
-        );
-    }
-
-    /// The property this whole split exists for (glass#422): a session that spends everything it is
-    /// given must still leave the hook enough to run.
-    #[test]
-    fn a_session_that_burns_its_deadline_still_leaves_the_hook_time_to_run() {
-        let factory: PlatformFactory = Box::new(move |_backend| {
-            Ok(Backend::display_only(Box::new(
-                FakePlatform::new(10, 10).burning_its_deadline(),
+                FakePlatform::new(10, 10).recording_stop_deadline(recorded_stop.clone()),
             )))
         });
         let left = Arc::new(Mutex::new(None));
         let recorded = left.clone();
         let mut g = glass_with_factory(factory);
         g.set_shutdown_hook(Box::new(move |d| {
-            *recorded.lock().unwrap() = d.remaining();
+            let stopped_at = at_stop
+                .lock()
+                .unwrap()
+                .expect("backend stopped before hook");
+            *recorded.lock().unwrap() = d.remaining_at(stopped_at.instant().unwrap());
         }));
         g.start(&spec()).unwrap();
 
-        // A tenth of the real budget, so the test costs what it measures rather than 3s.
-        let budget = crate::TEARDOWN_BUDGET / 10;
-        g.shutdown(Deadline::at(std::time::Instant::now() + budget));
+        g.shutdown(Deadline::at(
+            std::time::Instant::now() + Duration::from_secs(3600),
+        ));
 
         let left = left.lock().unwrap().expect("the hook ran at all");
-        assert!(
-            left > std::time::Duration::ZERO,
-            "the hook was handed a spent deadline, so every step behind the session is skipped"
-        );
+        assert_eq!(left, crate::TEARDOWN_HOOK_RESERVE);
     }
 
     #[test]

--- a/crates/glass-core/src/session/lifecycle.rs
+++ b/crates/glass-core/src/session/lifecycle.rs
@@ -45,6 +45,7 @@ impl Glass {
             ) => HostPathAccess::DeniedBySandbox,
         };
         let mut session = ActiveSession {
+            backend: backend.to_owned(),
             platform,
             accessibility,
             last_ax: None,
@@ -105,15 +106,22 @@ impl Glass {
     /// A third step between them is bounded by neither — dropping the session reaps the backend
     /// (Xvfb, sway, a Job object) and the log-stream children, each an unbounded `wait()`.
     pub fn shutdown(&mut self, deadline: Deadline) {
-        if let Some(mut s) = self.active.take() {
-            let _ = s
-                .platform
-                .stop_app_by(deadline.reserving(crate::TEARDOWN_HOOK_RESERVE));
+        let _ = self.shutdown_report(deadline);
+    }
+
+    /// Tear down the session and host hook, retaining any target-stop error.
+    pub fn shutdown_report(&mut self, deadline: Deadline) -> Result<()> {
+        let outcome = if let Some(mut s) = self.active.take() {
+            s.platform
+                .stop_app_by(deadline.reserving(crate::TEARDOWN_HOOK_RESERVE))
             // `s` drops here: the backend (Xvfb/sway/Job) is torn down.
-        }
+        } else {
+            Ok(())
+        };
         if let Some(hook) = self.shutdown_hook.take() {
             hook(deadline);
         }
+        outcome
     }
 
     pub fn geometry(&self) -> Result<WindowGeometry> {

--- a/crates/glass-core/src/session/mod.rs
+++ b/crates/glass-core/src/session/mod.rs
@@ -48,6 +48,7 @@ pub use wait::{
 };
 
 struct ActiveSession {
+    backend: String,
     platform: Box<dyn Platform + Send>,
     // Held here so the session owns the backend's accessibility reader and the
     // last-captured tree (read by the a11y tools).
@@ -111,6 +112,10 @@ pub struct Glass {
 }
 
 impl Glass {
+    /// Backend of the current session, without querying the target.
+    pub fn active_backend(&self) -> Option<&str> {
+        self.active.as_ref().map(|session| session.backend.as_str())
+    }
     pub fn new(
         factory: PlatformFactory,
         default_backend: String,

--- a/crates/glass-core/src/session/semantic_action/tests.rs
+++ b/crates/glass-core/src/session/semantic_action/tests.rs
@@ -428,7 +428,7 @@ fn semantic_glass(
 struct DeadlineRecordingAccessibility {
     tree: AxTree,
     coverage_delay: std::time::Duration,
-    coverage_finished: Arc<Mutex<Option<std::time::Instant>>>,
+    coverage_started: Arc<Mutex<Option<std::time::Instant>>>,
     subscription_deadlines: Arc<Mutex<Vec<Deadline>>>,
     snapshot_deadlines: Arc<Mutex<Vec<Deadline>>>,
 }
@@ -448,26 +448,26 @@ impl Accessibility for DeadlineRecordingAccessibility {
     }
 
     fn state_coverage(&self) -> AxStateCoverage {
+        *self.coverage_started.lock().unwrap() = Some(std::time::Instant::now());
         std::thread::sleep(self.coverage_delay);
-        *self.coverage_finished.lock().unwrap() = Some(std::time::Instant::now());
         full_state_coverage()
     }
 }
 
 fn deadline_recording_glass(coverage_delay: std::time::Duration) -> DeadlineRecordingFixture {
-    let coverage_finished = Arc::new(Mutex::new(None));
+    let coverage_started = Arc::new(Mutex::new(None));
     let subscription_deadlines = Arc::new(Mutex::new(Vec::new()));
     let snapshot_deadlines = Arc::new(Mutex::new(Vec::new()));
     let accessibility = DeadlineRecordingAccessibility {
         tree: named_button_tree("Save account"),
         coverage_delay,
-        coverage_finished: coverage_finished.clone(),
+        coverage_started: coverage_started.clone(),
         subscription_deadlines: subscription_deadlines.clone(),
         snapshot_deadlines: snapshot_deadlines.clone(),
     };
     (
         glass_with_backend(FakePlatform::new(100, 100), Box::new(accessibility)),
-        coverage_finished,
+        coverage_started,
         subscription_deadlines,
         snapshot_deadlines,
     )
@@ -1142,9 +1142,9 @@ fn selector_resolution_uses_the_reported_deadline_for_subscription_and_snapshot(
 
 #[test]
 fn selector_resolution_setup_consumes_the_reported_action_budget() {
-    let timeout = std::time::Duration::from_millis(300);
-    let (mut glass, coverage_finished, subscription_deadlines, snapshot_deadlines) =
-        deadline_recording_glass(std::time::Duration::from_millis(150));
+    let timeout = std::time::Duration::from_millis(SEMANTIC_ACTION_DEFAULT_TIMEOUT_MS);
+    let (mut glass, coverage_started, subscription_deadlines, snapshot_deadlines) =
+        deadline_recording_glass(std::time::Duration::from_millis(10));
     glass.start(&spec()).unwrap();
 
     let resolved = glass
@@ -1157,16 +1157,10 @@ fn selector_resolution_setup_consumes_the_reported_action_budget() {
         )
         .unwrap();
 
-    let coverage_finished = coverage_finished.lock().unwrap().unwrap();
-    let remaining_after_setup = resolved
-        .bound
-        .deadline
-        .instant()
-        .unwrap()
-        .saturating_duration_since(coverage_finished);
+    let coverage_started = coverage_started.lock().unwrap().unwrap();
     assert!(
-        remaining_after_setup < std::time::Duration::from_millis(225),
-        "pre-poll setup did not consume the action budget: {remaining_after_setup:?} remained"
+        resolved.bound.deadline.instant().unwrap() <= coverage_started + timeout,
+        "the action deadline must start before pre-poll setup"
     );
     assert_eq!(
         subscription_deadlines.lock().unwrap().as_slice(),
@@ -1452,6 +1446,7 @@ fn target_deadlines_preserve_id_and_selector_bound_ownership() {
     assert_eq!(batched.owner, Some(Whose::Caller));
     assert!(batched.allow_wait);
 
+    let before_default = std::time::Instant::now();
     let defaulted = target_deadline(
         &ActionTarget::Semantic(semantic_target("save")),
         None,
@@ -1459,9 +1454,10 @@ fn target_deadlines_preserve_id_and_selector_bound_ownership() {
         Deadline::UNBOUNDED,
     )
     .unwrap();
-    let remaining = defaulted.deadline.remaining().unwrap();
-    assert!(remaining <= std::time::Duration::from_millis(SEMANTIC_ACTION_DEFAULT_TIMEOUT_MS));
-    assert!(remaining > std::time::Duration::from_millis(SEMANTIC_ACTION_DEFAULT_TIMEOUT_MS - 100));
+    let after_default = std::time::Instant::now();
+    let duration = std::time::Duration::from_millis(SEMANTIC_ACTION_DEFAULT_TIMEOUT_MS);
+    assert!(defaulted.deadline.instant().unwrap() >= before_default + duration);
+    assert!(defaulted.deadline.instant().unwrap() <= after_default + duration);
     assert_eq!(defaulted.owner, Some(Whose::Callee));
     assert!(defaulted.allow_wait);
 
@@ -1513,7 +1509,7 @@ fn selector_pointer_waits_for_two_identical_samples_at_least_one_hundred_ms_apar
     let started = std::time::Instant::now();
     let outcome = glass
         .click_target_inner(
-            pointer_params(ActionTarget::Semantic(semantic_target("Save")), Some(500)),
+            pointer_params(ActionTarget::Semantic(semantic_target("Save")), None),
             Deadline::UNBOUNDED,
         )
         .unwrap();
@@ -1554,7 +1550,7 @@ fn moving_bounds_reset_the_stability_sample_until_the_target_stops() {
     let started = std::time::Instant::now();
     glass
         .click_target_inner(
-            pointer_params(ActionTarget::Semantic(semantic_target("Save")), Some(600)),
+            pointer_params(ActionTarget::Semantic(semantic_target("Save")), None),
             Deadline::UNBOUNDED,
         )
         .unwrap();
@@ -1588,7 +1584,7 @@ fn identity_change_resets_stability_even_when_bounds_are_equal() {
 
     glass
         .click_target_inner(
-            pointer_params(ActionTarget::Semantic(semantic_target("Save")), Some(600)),
+            pointer_params(ActionTarget::Semantic(semantic_target("Save")), None),
             Deadline::UNBOUNDED,
         )
         .unwrap();
@@ -1666,7 +1662,7 @@ fn selector_pointer_builds_each_stability_sample_from_its_refreshed_window() {
 
     glass
         .click_target_inner(
-            pointer_params(ActionTarget::Semantic(semantic_target("Save")), Some(600)),
+            pointer_params(ActionTarget::Semantic(semantic_target("Save")), None),
             Deadline::UNBOUNDED,
         )
         .unwrap();
@@ -1711,7 +1707,7 @@ fn selector_pointer_revalidates_the_exact_plan_against_the_dispatch_window() {
 
     let error = glass
         .click_target_inner(
-            pointer_params(ActionTarget::Semantic(semantic_target("Save")), Some(500)),
+            pointer_params(ActionTarget::Semantic(semantic_target("Save")), None),
             Deadline::UNBOUNDED,
         )
         .unwrap_err();
@@ -1978,7 +1974,7 @@ fn selector_pointer_known_occlusion_blocks_before_pointer_dispatch() {
 
     let error = glass
         .click_target_inner(
-            pointer_params(ActionTarget::Semantic(semantic_target("Save")), Some(500)),
+            pointer_params(ActionTarget::Semantic(semantic_target("Save")), None),
             Deadline::UNBOUNDED,
         )
         .unwrap_err();
@@ -2012,7 +2008,7 @@ fn selector_pointer_inconclusive_occlusion_dispatches_once_and_discloses_unprove
 
     let outcome = glass
         .click_target_inner(
-            pointer_params(ActionTarget::Semantic(semantic_target("Save")), Some(500)),
+            pointer_params(ActionTarget::Semantic(semantic_target("Save")), None),
             Deadline::UNBOUNDED,
         )
         .unwrap();
@@ -2048,7 +2044,7 @@ fn selector_pointer_hit_probe_and_dispatch_use_the_same_planned_point() {
 
     glass
         .click_target_inner(
-            pointer_params(ActionTarget::Semantic(semantic_target("Save")), Some(500)),
+            pointer_params(ActionTarget::Semantic(semantic_target("Save")), None),
             Deadline::UNBOUNDED,
         )
         .unwrap();
@@ -2135,7 +2131,7 @@ fn selector_pointer_rejects_a_trailing_toggle_with_a_boundary_endpoint() {
 
     let error = glass
         .click_target_inner(
-            pointer_params(ActionTarget::Semantic(semantic_target("Wi-Fi")), Some(500)),
+            pointer_params(ActionTarget::Semantic(semantic_target("Wi-Fi")), None),
             Deadline::UNBOUNDED,
         )
         .unwrap_err();
@@ -2251,7 +2247,7 @@ fn selector_pointer_popover_row_toggle_dispatches_the_translated_planned_segment
 }
 
 #[test]
-fn legacy_id_forced_pointer_dispatches_without_a_fresh_read_or_stability_sleep() {
+fn legacy_id_forced_pointer_dispatches_without_a_fresh_read_or_stability_poll() {
     let tree = fake_tree();
     let clicks = Arc::new(Mutex::new(Vec::new()));
     let platform = FakePlatform::new(100, 100).with_click_log(clicks.clone());
@@ -2263,7 +2259,6 @@ fn legacy_id_forced_pointer_dispatches_without_a_fresh_read_or_stability_sleep()
     hit_calls.store(0, Ordering::Relaxed);
     clicks.lock().unwrap().clear();
 
-    let started = std::time::Instant::now();
     let outcome = glass
         .click_target_inner(
             pointer_params(ActionTarget::Id(AxNodeId(1)), None),
@@ -2271,7 +2266,6 @@ fn legacy_id_forced_pointer_dispatches_without_a_fresh_read_or_stability_sleep()
         )
         .unwrap();
 
-    assert!(started.elapsed() < std::time::Duration::from_millis(75));
     assert_eq!(walks.load(Ordering::Relaxed), 0);
     assert_eq!(hit_calls.load(Ordering::Relaxed), 0);
     assert_eq!(clicks.lock().unwrap().len(), 1);
@@ -2314,7 +2308,7 @@ fn selector_pointer_hit_probe_errors_are_action_failed_before_dispatch() {
 
     let error = glass
         .click_target_inner(
-            pointer_params(ActionTarget::Semantic(semantic_target("Save")), Some(500)),
+            pointer_params(ActionTarget::Semantic(semantic_target("Save")), None),
             Deadline::UNBOUNDED,
         )
         .unwrap_err();

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -92,9 +92,6 @@ pub(crate) struct FakePlatform {
     /// The deadline `stop_app_by` was handed. `stop_app` is the provided half of the pair, so it
     /// records [`crate::Deadline::UNBOUNDED`] rather than nothing.
     stop_deadline: Option<Arc<Mutex<Option<crate::Deadline>>>>,
-    /// Makes `stop_app_by` spend its whole deadline, standing in for a device that stopped
-    /// answering.
-    stop_burns_deadline: bool,
     protected_path_mode: HostPathProtectionMode,
     fail_protected_path_configuration: bool,
     fail_start: bool,
@@ -246,11 +243,6 @@ impl FakePlatform {
         self.stop_count = Some(c);
         self
     }
-    /// Spend the whole deadline in `stop_app_by`.
-    pub(crate) fn burning_its_deadline(mut self) -> Self {
-        self.stop_burns_deadline = true;
-        self
-    }
     /// Record the deadline `stop_app_by` receives, for proving the teardown budget reaches the
     /// backend rather than stopping at `Glass`.
     pub(crate) fn recording_stop_deadline(
@@ -353,9 +345,6 @@ impl Platform for FakePlatform {
     fn stop_app_by(&mut self, deadline: crate::Deadline) -> Result<()> {
         if let Some(at) = &self.stop_deadline {
             *at.lock().unwrap() = Some(deadline);
-        }
-        if self.stop_burns_deadline {
-            std::thread::sleep(deadline.remaining().unwrap_or_default());
         }
         self.stop_app()
     }

--- a/crates/glass-macos/src/bin/sandbox_probe.rs
+++ b/crates/glass-macos/src/bin/sandbox_probe.rs
@@ -27,6 +27,25 @@ fn main() {
     let mut i = 0;
     while i < args.len() {
         match args[i].as_str() {
+            "--protected-file" => {
+                let path =
+                    std::env::var_os(&args[i + 1]).expect("protected file environment variable");
+                let path = std::path::Path::new(&path);
+                assert!(std::fs::read(path).is_err(), "protected file was readable");
+                assert!(
+                    std::fs::OpenOptions::new().write(true).open(path).is_err(),
+                    "protected file was writable"
+                );
+                assert!(
+                    std::fs::remove_file(path).is_err(),
+                    "protected file was removable"
+                );
+                assert!(
+                    std::fs::rename(path, path.with_extension("moved")).is_err(),
+                    "protected file was movable"
+                );
+                i += 2;
+            }
             "--print" => {
                 let line = args
                     .get(i + 1)

--- a/crates/glass-macos/src/menubar.rs
+++ b/crates/glass-macos/src/menubar.rs
@@ -61,6 +61,7 @@ struct Ivars {
     on_copy: Box<dyn Fn()>,
     on_restart: Box<dyn Fn()>,
     on_uninstall: Box<dyn Fn()>,
+    on_quit: Option<Box<dyn Fn()>>,
 }
 
 define_class!(
@@ -90,6 +91,12 @@ define_class!(
         #[unsafe(method(uninstall:))]
         fn uninstall(&self, _sender: Option<&AnyObject>) {
             (self.ivars().on_uninstall)();
+        }
+
+        #[unsafe(method(quit:))]
+        fn quit(&self, _sender: Option<&AnyObject>) {
+            if let Some(quit) = &self.ivars().on_quit { quit(); }
+            NSApplication::sharedApplication(self.mtm()).terminate(None);
         }
     }
 
@@ -146,6 +153,11 @@ fn action_item(
 /// precondition this crate can enforce; everything else (the status item appearing, the menu
 /// firing its actions, `terminate:` quitting cleanly) is main-thread AppKit runtime behavior.
 pub fn run(actions: MenuBarActions) -> Result<()> {
+    run_with_quit(actions, None)
+}
+
+/// Run the menu with an optional host cleanup callback before quitting.
+pub fn run_with_quit(actions: MenuBarActions, on_quit: Option<Box<dyn Fn()>>) -> Result<()> {
     let mtm = MainThreadMarker::new().ok_or_else(|| {
         GlassError::Backend("the menu-bar app must start on the main thread".into())
     })?;
@@ -168,6 +180,7 @@ pub fn run(actions: MenuBarActions) -> Result<()> {
             on_copy: actions.on_copy,
             on_restart: actions.on_restart,
             on_uninstall: actions.on_uninstall,
+            on_quit,
         },
     );
 
@@ -195,7 +208,11 @@ pub fn run(actions: MenuBarActions) -> Result<()> {
     menu.addItem(&sep2);
 
     // 4. Quit glass — nil target lets the responder chain deliver `terminate:` to `NSApp`.
-    let quit_item = action_item(mtm, "Quit glass", sel!(terminate:), "q", None);
+    let quit_item = if target.ivars().on_quit.is_some() {
+        action_item(mtm, "Quit glass", sel!(quit:), "q", Some(&target))
+    } else {
+        action_item(mtm, "Quit glass", sel!(terminate:), "q", None)
+    };
     menu.addItem(&quit_item);
 
     // 5. Uninstall glass… — routed to our custom target. The trailing ellipsis is the macOS

--- a/crates/glass-macos/src/process.rs
+++ b/crates/glass-macos/src/process.rs
@@ -736,7 +736,10 @@ mod tests {
                 std::process::id(),
                 CLIP_TOKEN.fetch_add(1, Ordering::Relaxed)
             );
-            let root = std::env::temp_dir().join("glass-macos-artifact-probe");
+            let root = std::env::temp_dir()
+                .canonicalize()
+                .unwrap()
+                .join("glass-macos-artifact-probe");
             let process_dir = root.join(&nonce);
             let lease = root.join(format!("{nonce}.lease"));
             let marker = process_dir.join("marker");
@@ -814,6 +817,53 @@ mod tests {
             fixture.marker_text
         );
         assert_eq!(std::fs::read_to_string(&fixture.lease).unwrap(), "lease");
+    }
+
+    #[test]
+    #[ignore = "requires macOS Seatbelt"]
+    #[cfg(target_os = "macos")]
+    fn protected_trace_root_denies_current_and_retained_history() {
+        let fixture = ArtifactProbeFixture::new();
+        let history = fixture.process_dir.join("retained");
+        std::fs::create_dir(&history).unwrap();
+        let old = history.join("old-evidence");
+        std::fs::write(&old, "retained evidence").unwrap();
+        let probe = sandbox_probe_path();
+        for level in [SandboxLevel::Default, SandboxLevel::Strict] {
+            let mut launch = spec(&[
+                probe.to_str().unwrap(),
+                "--protected-file",
+                "CURRENT",
+                "--protected-file",
+                "HISTORY",
+            ]);
+            launch.sandbox = level;
+            // Re-allowing the target's cwd must not override the protected subtree.
+            launch.cwd = fixture.process_dir.parent().map(Path::to_owned);
+            launch.env = vec![
+                ("CURRENT".into(), fixture.marker.to_str().unwrap().into()),
+                ("HISTORY".into(), old.to_str().unwrap().into()),
+            ];
+            let logs = empty_sink();
+            let mut launched = spawn(
+                &launch,
+                logs.clone(),
+                &[ProtectedHostPath::directory(&fixture.process_dir)],
+            )
+            .unwrap();
+            let status = launched.child.wait().unwrap();
+            drop(launched);
+            assert!(
+                status.success(),
+                "{level} probe failed: {:?}",
+                logs.lock().unwrap()
+            );
+        }
+        assert_eq!(
+            std::fs::read_to_string(&fixture.marker).unwrap(),
+            fixture.marker_text
+        );
+        assert_eq!(std::fs::read_to_string(old).unwrap(), "retained evidence");
     }
 
     /// glass#477: the launch's readers are the caller's to end, and the last thing the app said

--- a/crates/glass-mcp/Cargo.toml
+++ b/crates/glass-mcp/Cargo.toml
@@ -29,6 +29,9 @@ serde_json = "1"
 schemars = "1"
 base64 = "0.23"
 anyhow = "1"
+cap-std = "4"
+cap-fs-ext = "4"
+zip = { version = "8.6", default-features = false }
 clap = { version = "4", features = ["derive"] }
 axum = { version = "0.8", optional = true }
 tower = { version = "0.5", optional = true }

--- a/crates/glass-mcp/Cargo.toml
+++ b/crates/glass-mcp/Cargo.toml
@@ -98,7 +98,7 @@ tempfile.workspace = true
 image.workspace = true
 proptest.workspace = true
 rmcp = { version = "2.2", features = ["client", "transport-streamable-http-client", "transport-streamable-http-client-reqwest"] }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["full", "test-util"] }
 # Named directly in tests/network_roundtrip.rs (the client transport is generic over
 # the HTTP client). Pinned to rmcp's reqwest line so cargo unifies on one copy; plain
 # loopback HTTP needs no TLS provider, so keep default-features off.

--- a/crates/glass-mcp/src/artifact_resources_tests.rs
+++ b/crates/glass-mcp/src/artifact_resources_tests.rs
@@ -504,6 +504,7 @@ async fn oversized_snapshot_link_reads_exact_resource_over_http() {
                 addr,
                 token: None,
                 tool_profile: Default::default(),
+                trace: None,
             },
             server,
             async move { shutdown.cancelled().await },

--- a/crates/glass-mcp/src/cli.rs
+++ b/crates/glass-mcp/src/cli.rs
@@ -27,10 +27,23 @@ pub struct Cli {
     /// Tools exposed to agents: full (default) or lean (actions through glass_do).
     #[arg(long, global = true, value_enum, default_value_t)]
     pub tool_profile: crate::tool_profile::ToolProfile,
+
+    /// Retain tool inputs and requested app evidence (may contain sensitive content) in a new child of this existing absolute directory.
+    #[arg(long, global = true, value_name = "DIRECTORY")]
+    pub trace_dir: Option<std::path::PathBuf>,
+
+    /// Maximum retained trace bytes, including metadata (default 268435456).
+    #[arg(long, global = true, requires = "trace_dir", value_parser = clap::value_parser!(u64).range(1048576..=2147483648))]
+    pub trace_max_bytes: Option<u64>,
 }
 
 #[derive(Subcommand, Debug)]
 pub enum Command {
+    /// Inspect or export a stopped session trace without starting a backend.
+    Trace {
+        #[command(subcommand)]
+        command: TraceCommand,
+    },
     /// List the selected profile's MCP tools and schema cost without starting a session.
     Tools {
         /// Include complete definitions and server instructions as JSON.
@@ -133,6 +146,22 @@ pub enum Command {
     /// the window's rendering + buttons can be smoke-tested without building the .app. macOS-only.
     #[command(hide = true)]
     DebugChecklist,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum TraceCommand {
+    /// Validate evidence and show a bounded timeline. Exit 2 means valid but incomplete.
+    Inspect {
+        directory: std::path::PathBuf,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Export validated evidence to a new ZIP. Exit 2 leaves a usable incomplete bundle.
+    Export {
+        directory: std::path::PathBuf,
+        #[arg(long)]
+        out: std::path::PathBuf,
+    },
 }
 
 #[cfg(test)]

--- a/crates/glass-mcp/src/lib.rs
+++ b/crates/glass-mcp/src/lib.rs
@@ -50,6 +50,7 @@ pub(crate) mod shutdown;
 pub(crate) mod status;
 pub mod tool_profile;
 mod tools;
+pub mod trace;
 mod untrusted;
 #[cfg(feature = "self-update")]
 pub(crate) mod update;
@@ -416,6 +417,16 @@ pub(crate) async fn cleanup_artifacts(store: Option<crate::artifacts::ArtifactSt
     }
 }
 
+pub(crate) async fn cleanup_evidence(
+    trace: Option<crate::trace::TraceRecorder>,
+    store: Option<crate::artifacts::ArtifactStore>,
+) {
+    if let Some(trace) = trace {
+        trace.close().await;
+    }
+    cleanup_artifacts(store).await;
+}
+
 pub(crate) async fn finish_transport_lifecycle<T>(
     transport_result: T,
     teardown: impl std::future::Future<Output = ()>,
@@ -512,13 +523,29 @@ pub async fn run_stdio_with_profile(
     report: crate::audit::AuditReport,
     profile: tool_profile::ToolProfile,
 ) -> anyhow::Result<()> {
-    let server = GlassServer::new_with_profile(glass, report, profile);
+    run_stdio_configured(glass, report, profile, None).await
+}
+
+/// Serve stdio with optional persistent evidence recording.
+pub async fn run_stdio_configured(
+    glass: Glass,
+    report: crate::audit::AuditReport,
+    profile: tool_profile::ToolProfile,
+    config: Option<&trace::TraceConfig>,
+) -> anyhow::Result<()> {
+    let server = GlassServer::new_configured(glass, report, profile, config, "stdio")?;
     let sessions = server.sessions();
     let artifacts = server.artifact_store();
-    let service = server
-        .serve(stdio())
-        .await
-        .context("starting the MCP stdio service")?;
+    let trace = server.trace_recorder();
+    let service = match server.serve(stdio()).await {
+        Ok(service) => service,
+        Err(error) => {
+            shutdown::run_shutdown_with_trace(sessions, glass_core::TEARDOWN_BUDGET, trace.clone())
+                .await;
+            cleanup_evidence(trace, artifacts).await;
+            return Err(error).context("starting the MCP stdio service");
+        }
+    };
 
     let signal = async {
         shutdown::shutdown_signal().await;
@@ -528,8 +555,8 @@ pub async fn run_stdio_with_profile(
         service,
         signal,
         glass_core::TEARDOWN_BUDGET,
-        shutdown::run_shutdown(sessions, glass_core::TEARDOWN_BUDGET),
-        cleanup_artifacts(artifacts),
+        shutdown::run_shutdown_with_trace(sessions, glass_core::TEARDOWN_BUDGET, trace.clone()),
+        cleanup_evidence(trace, artifacts),
     )
     .await;
     match transport_outcome {

--- a/crates/glass-mcp/src/main.rs
+++ b/crates/glass-mcp/src/main.rs
@@ -1,29 +1,56 @@
 use clap::Parser;
-use glass_mcp::cli::{Cli, Command};
+use glass_mcp::cli::{Cli, Command, TraceCommand};
 use glass_mcp::launch::NoArgLaunch;
 use glass_mcp::{
     boot, launch, onboarding, run_debug_checklist, run_debug_grants, run_doctor, run_env,
-    run_status, run_stdio_with_profile, run_uninstall, setup,
+    run_status, run_stdio_configured, run_uninstall, setup,
 };
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // One-time AppKit/WindowServer init — must run on the process's real main thread
-    // ("thread 0"), exactly once, before anything spawns the `glass-platform` worker thread
-    // that `GlassServer::new` parents every `MacosPlatform` call to. This is the FIRST
-    // statement of `main()`, with no `.await` above it: `#[tokio::main]` calls
-    // `Runtime::block_on` on the thread that invoked `main()` and polls the async body on
-    // that same thread, so this runs synchronously on thread 0, strictly before
-    // `boot()`/`run_stdio()` construct a `GlassServer`.
-    #[cfg(target_os = "macos")]
-    glass_macos::init_main_thread();
-
     let cli = Cli::parse();
+    // AppKit setup precedes platform workers; offline evidence commands need none.
+    #[cfg(target_os = "macos")]
+    if !matches!(
+        cli.command,
+        Some(Command::Tools { .. } | Command::Trace { .. })
+    ) {
+        glass_macos::init_main_thread();
+    }
     let audit_log = cli.audit_log;
     let tool_profile = cli.tool_profile;
+    let trace = cli
+        .trace_dir
+        .map(|directory| glass_mcp::trace::TraceConfig::new(directory, cli.trace_max_bytes))
+        .transpose()?;
     // Resolve (and OPEN, fail-closed) the audit sink only in the serving arms below —
     // never for doctor/env/gen-token, so those never create the audit file as a side effect.
     match cli.command {
+        Some(Command::Trace { command }) => {
+            let report = match command {
+                TraceCommand::Inspect { directory, json } => {
+                    let report = glass_mcp::trace::inspect(&directory)?;
+                    glass_mcp::trace::print_inspection(&report, json)?;
+                    report
+                }
+                TraceCommand::Export { directory, out } => {
+                    let report = glass_mcp::trace::export(&directory, &out)?;
+                    eprintln!(
+                        "glass: exported {} trace to {out:?}",
+                        if report.complete {
+                            "complete"
+                        } else {
+                            "incomplete"
+                        }
+                    );
+                    report
+                }
+            };
+            if report.exit_code() != 0 {
+                std::process::exit(report.exit_code());
+            }
+            Ok(())
+        }
         Some(Command::Tools { json }) => glass_mcp::tool_profile::print_tools(tool_profile, json),
         // No subcommand: a LaunchServices double-click routes to onboarding; an MCP client's
         // stdio spawn (the default, and the only case off macOS) serves MCP over stdio.
@@ -32,7 +59,7 @@ async fn main() -> anyhow::Result<()> {
             NoArgLaunch::StdioServe => {
                 let (sink, report) =
                     glass_mcp::audit::resolve(audit_log.as_deref(), |k| std::env::var(k).ok())?;
-                run_stdio_with_profile(boot(sink), report, tool_profile).await
+                run_stdio_configured(boot(sink), report, tool_profile, trace.as_ref()).await
             }
         },
         Some(Command::Doctor { deep, json, color }) => {
@@ -76,6 +103,7 @@ async fn main() -> anyhow::Result<()> {
                         )
                         .map_err(|e| anyhow::anyhow!("glass serve --menubar: {e}"))?;
                         cfg.tool_profile = tool_profile;
+                        cfg.trace = trace;
                         glass_mcp::menubar::run(cfg)
                     }
                     #[cfg(not(target_os = "macos"))]
@@ -86,7 +114,16 @@ async fn main() -> anyhow::Result<()> {
                 } else {
                     let (sink, report) =
                         glass_mcp::audit::resolve(audit_log.as_deref(), |k| std::env::var(k).ok())?;
-                    glass_mcp::serve::run(http, addr, token_file, sink, report, tool_profile).await
+                    glass_mcp::serve::run_configured(
+                        http,
+                        addr,
+                        token_file,
+                        sink,
+                        report,
+                        tool_profile,
+                        trace,
+                    )
+                    .await
                 }
             }
             #[cfg(not(feature = "network"))]

--- a/crates/glass-mcp/src/menubar.rs
+++ b/crates/glass-mcp/src/menubar.rs
@@ -29,8 +29,8 @@
 //!    via `MainThreadMarker` (requires thread 0 — it is) and blocks thread 0 on
 //!    `NSApplication::run`. The server keeps serving on the workers while thread 0 pumps the
 //!    AppKit event loop.
-//! 4. "Quit glass" sends `terminate:` to `NSApp`, which exits the process (dropping the server
-//!    task with it).
+//! 4. With tracing enabled, "Quit glass" waits for bounded server teardown and evidence cleanup
+//!    before terminating AppKit. Trace-off mode retains the direct terminate action.
 
 use crate::serve::config::ServeConfig;
 
@@ -99,6 +99,10 @@ mod macos {
             Err(e) => return Err(anyhow::anyhow!("binding {}: {e}", cfg.addr)),
         };
 
+        let trace_enabled = cfg.trace.is_some() && listener.is_some();
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        let server_shutdown = shutdown.clone();
+        let (finished_tx, finished_rx) = std::sync::mpsc::sync_channel(1);
         if let Some(std_listener) = listener {
             // We're on the `#[tokio::main]` block_on thread, so the runtime context is
             // entered: `TcpListener::from_std` (reactor registration) and `tokio::spawn` both
@@ -117,14 +121,29 @@ mod macos {
             // CLI flag to thread through. Fail-closed: an unopenable audit log aborts here.
             let (sink, report) = crate::audit::resolve(None, |k| std::env::var(k).ok())?;
             let glass = crate::boot(sink);
+            let server = crate::server::GlassServer::new_configured(
+                glass,
+                report,
+                cfg.tool_profile,
+                cfg.trace.as_ref(),
+                "http",
+            )?;
 
             tokio::spawn(async move {
                 // Never swallow the server task's failure silently — surface it to the
                 // LaunchAgent's stderr log. (The menu bar stays up so the operator still has a
                 // Quit; wiring the failure into the status line is a future refinement.)
-                if let Err(e) = serve::run_on(listener, cfg, glass, report).await {
+                if let Err(e) = serve::run_server_on_until(listener, cfg, server, async move {
+                    tokio::select! {
+                        () = server_shutdown.cancelled() => {},
+                        () = crate::shutdown::shutdown_signal() => {},
+                    }
+                })
+                .await
+                {
                     eprintln!("glass: menu-bar server task exited with error: {e:#}");
                 }
+                let _ = finished_tx.send(());
             });
         }
 
@@ -133,46 +152,56 @@ mod macos {
         // LaunchAgent `kickstart -k`); their errors go loudly to stderr (the menu action
         // has no dialog surface), matching onboarding's best-effort osascript fallback.
         let endpoint_for_copy = endpoint;
-        glass_macos::menubar::run(glass_macos::menubar::MenuBarActions {
-            title: "glass \u{25CF}".to_string(),
-            status_line,
-            on_copy: Box::new(move || {
-                if let Err(e) = crate::onboarding::copy_to_clipboard(&endpoint_for_copy) {
-                    eprintln!("glass: menu 'Copy endpoint' failed: {e}");
-                }
-            }),
-            on_restart: Box::new(|| {
-                // This process *is* the LaunchAgent job, so `restart_launch_agent` uses
-                // `launchctl kickstart -k gui/<uid>/tech.fixedwidth.glass` rather than
-                // `bootout`+`bootstrap`: `kickstart -k` is a single request to launchd (a
-                // separate supervisor process) to kill-and-restart the job in place, so it's
-                // safe to call from inside the job being restarted and doesn't depend on
-                // `KeepAlive`. `bootout` would instead SIGTERM this very process, and with
-                // `KeepAlive=false` launchd would never bring it back.
-                if let Err(e) = crate::setup::restart_launch_agent() {
-                    eprintln!("glass: menu 'Restart' failed: {e}");
-                }
-            }),
-            on_uninstall: Box::new(|| {
-                // Confirm first, defaulting to Cancel so a stray click/Return never uninstalls.
-                // `uninstall_launch_agent` boots out (SIGTERM) this very process, so a dialog
-                // shown *after* it may not survive to be read — put the "drag to Trash" step in
-                // the confirmation itself. Only the exact "Uninstall" button proceeds.
-                let clicked = confirm_dialog(
-                    "Remove glass?\n\nThis stops glass from launching at login and shuts it \
-                     down now. To finish removing it, drag GlassMcp.app to the Trash.",
-                    "Uninstall",
-                );
-                if clicked == "Uninstall" {
-                    // Best-effort: a menu action has no further error surface, so log loudly to
-                    // stderr rather than crash the action if bootout/plist-removal fails. On
-                    // success this process is terminated as part of the uninstall.
-                    if let Err(e) = crate::setup::uninstall_launch_agent() {
-                        eprintln!("glass: menu 'Uninstall glass' failed: {e}");
+        let on_quit: Option<Box<dyn Fn()>> = trace_enabled.then(|| {
+            Box::new(move || {
+                shutdown.cancel();
+                let _ = finished_rx
+                    .recv_timeout(glass_core::TEARDOWN_BUDGET + std::time::Duration::from_secs(6));
+            }) as Box<dyn Fn()>
+        });
+        glass_macos::menubar::run_with_quit(
+            glass_macos::menubar::MenuBarActions {
+                title: "glass \u{25CF}".to_string(),
+                status_line,
+                on_copy: Box::new(move || {
+                    if let Err(e) = crate::onboarding::copy_to_clipboard(&endpoint_for_copy) {
+                        eprintln!("glass: menu 'Copy endpoint' failed: {e}");
                     }
-                }
-            }),
-        })?;
+                }),
+                on_restart: Box::new(|| {
+                    // This process *is* the LaunchAgent job, so `restart_launch_agent` uses
+                    // `launchctl kickstart -k gui/<uid>/tech.fixedwidth.glass` rather than
+                    // `bootout`+`bootstrap`: `kickstart -k` is a single request to launchd (a
+                    // separate supervisor process) to kill-and-restart the job in place, so it's
+                    // safe to call from inside the job being restarted and doesn't depend on
+                    // `KeepAlive`. `bootout` would instead SIGTERM this very process, and with
+                    // `KeepAlive=false` launchd would never bring it back.
+                    if let Err(e) = crate::setup::restart_launch_agent() {
+                        eprintln!("glass: menu 'Restart' failed: {e}");
+                    }
+                }),
+                on_uninstall: Box::new(|| {
+                    // Confirm first, defaulting to Cancel so a stray click/Return never uninstalls.
+                    // `uninstall_launch_agent` boots out (SIGTERM) this very process, so a dialog
+                    // shown *after* it may not survive to be read — put the "drag to Trash" step in
+                    // the confirmation itself. Only the exact "Uninstall" button proceeds.
+                    let clicked = confirm_dialog(
+                        "Remove glass?\n\nThis stops glass from launching at login and shuts it \
+                     down now. To finish removing it, drag GlassMcp.app to the Trash.",
+                        "Uninstall",
+                    );
+                    if clicked == "Uninstall" {
+                        // Best-effort: a menu action has no further error surface, so log loudly to
+                        // stderr rather than crash the action if bootout/plist-removal fails. On
+                        // success this process is terminated as part of the uninstall.
+                        if let Err(e) = crate::setup::uninstall_launch_agent() {
+                            eprintln!("glass: menu 'Uninstall glass' failed: {e}");
+                        }
+                    }
+                }),
+            },
+            on_quit,
+        )?;
         Ok(())
     }
 

--- a/crates/glass-mcp/src/output.rs
+++ b/crates/glass-mcp/src/output.rs
@@ -96,10 +96,9 @@ pub(crate) enum ArtifactDescriptorError {
 }
 
 impl ArtifactDescriptor {
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "Used by artifact verification tests.")
-    )]
+    pub(crate) fn bytes(&self) -> u64 {
+        self.bytes
+    }
     pub(crate) fn uri(&self) -> &str {
         &self.uri
     }

--- a/crates/glass-mcp/src/params.rs
+++ b/crates/glass-mcp/src/params.rs
@@ -3,12 +3,12 @@
 
 use glass_core::Region;
 use schemars::JsonSchema;
-use serde::{Deserialize, Deserializer, de::Error as _};
+use serde::{Deserialize, Deserializer, Serialize, de::Error as _};
 
 pub(crate) const MAX_CLICK_COUNT: u32 = glass_core::MAX_CLICK_COUNT;
 pub(crate) const MAX_SCROLL_NOTCHES: i32 = glass_core::MAX_SCROLL_NOTCHES as i32;
 
-#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct RegionArgs {
     /// Left edge in window-relative pixels.
     pub x: u32,
@@ -37,7 +37,7 @@ pub fn ignore_regions(args: Option<&[RegionArgs]>) -> Vec<Region> {
         .unwrap_or_default()
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct ScreenshotArgs {
     /// Optional window-relative sub-rectangle to capture; omit for the whole window.
     pub region: Option<RegionArgs>,
@@ -45,7 +45,7 @@ pub struct ScreenshotArgs {
     pub window_id: Option<u64>,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct WindowHintArgs {
     /// Case-insensitive title substring; can locate a window handed off to an unrelated process.
     pub title: Option<String>,
@@ -53,7 +53,7 @@ pub struct WindowHintArgs {
     pub class: Option<String>,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct StartArgs {
     /// Optional shell command to run (in `cwd`) before launching.
     pub build: Option<String>,
@@ -77,7 +77,7 @@ pub struct StartArgs {
     pub a11y: Option<bool>,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct WindowArgs {
     /// One of: "focus", "resize", "move", "geometry".
     pub op: String,
@@ -91,13 +91,13 @@ pub struct WindowArgs {
     pub height: Option<u32>,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct SelectWindowArgs {
     /// Current ID from glass_list_windows; re-list after window changes.
     pub id: u64,
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, JsonSchema)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ActionModeArg {
     Auto,
@@ -105,7 +105,7 @@ pub enum ActionModeArg {
     Pointer,
 }
 
-#[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ActionScopeArgs {
     pub query: Option<String>,
@@ -113,7 +113,7 @@ pub struct ActionScopeArgs {
     pub states: Option<Vec<String>>,
 }
 
-#[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ActionTargetArgs {
     pub query: Option<String>,
@@ -122,7 +122,7 @@ pub struct ActionTargetArgs {
     pub within: Option<ActionScopeArgs>,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct ClickElementArgs {
     /// Latest snapshot ID, exclusive with target; re-read after UI changes. Native action may focus text editors; fallback clicks the center. Popover actions restore the prior window.
     pub id: Option<u32>,
@@ -136,7 +136,7 @@ pub struct ClickElementArgs {
     pub return_: Option<String>,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct SetValueArgs {
     /// Latest snapshot ID, exclusive with target.
     pub id: Option<u32>,
@@ -152,7 +152,7 @@ pub struct SetValueArgs {
 }
 
 /// Arguments for `glass_find_elements` selector fields.
-#[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 #[allow(dead_code)]
 pub struct FindSelectorArgs {
     /// Case-insensitive substring searched across accessible name, description and non-secure value.
@@ -164,7 +164,7 @@ pub struct FindSelectorArgs {
 }
 
 /// Arguments for `glass_find_elements`.
-#[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 #[allow(dead_code)]
 pub struct FindElementsArgs {
     /// Approximate case-insensitive semantic text. Optional when role or states are supplied.
@@ -185,13 +185,13 @@ pub struct FindElementsArgs {
 }
 
 /// Arguments for `glass_a11y_snapshot`.
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct A11ySnapshotArgs {
     /// Node cap; omit for server default, 0 for unlimited. Changing the cap renumbers IDs; re-read them.
     pub max_nodes: Option<u32>,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct ClickArgs {
     /// Click x in window-relative pixels.
     pub x: i32,
@@ -206,7 +206,7 @@ pub struct ClickArgs {
     pub modifiers: Option<Vec<String>>,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct MoveArgs {
     /// Destination x in window-relative pixels.
     pub x: i32,
@@ -214,7 +214,7 @@ pub struct MoveArgs {
     pub y: i32,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct DragArgs {
     /// Press x in window-relative pixels.
     pub x1: i32,
@@ -232,7 +232,7 @@ pub struct DragArgs {
     pub duration_ms: Option<u64>,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct PointerArgs {
     /// Window-relative start point.
     pub from: PointArg,
@@ -240,7 +240,7 @@ pub struct PointerArgs {
     pub to: PointArg,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct PointArg {
     /// Window-relative x in pixels.
     pub x: i32,
@@ -248,7 +248,7 @@ pub struct PointArg {
     pub y: i32,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct GestureArgs {
     /// 2–10 simultaneous pointers; each a straight from→to segment. Pinch = two pointers
     /// moving toward/apart; rotate = two on an arc; two-finger swipe = two parallel segments.
@@ -257,7 +257,7 @@ pub struct GestureArgs {
     pub duration_ms: Option<u64>,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct ScrollArgs {
     /// Window-relative anchor x; selects the container under the pointer.
     pub x: i32,
@@ -273,7 +273,7 @@ pub struct ScrollArgs {
     pub modifiers: Option<Vec<String>>,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct TypeArgs {
     /// Synthetic keystrokes, not paste. When `target` is omitted: current keyboard focus. When `target` is supplied: resolves and focuses the target, confirms focus, then types. Newlines do not press Return.
     pub text: String,
@@ -287,19 +287,19 @@ pub struct TypeArgs {
     pub return_: Option<String>,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct KeyArgs {
     /// Modifiers plus one key: ctrl+s, Return, alt+F4. Modifiers: ctrl/shift/alt/super (cmd/win/meta aliases). Key: named key, F1-F12 or printable ASCII; case-insensitive names.
     pub chord: String,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct ClipboardSetArgs {
     /// The text to write to the clipboard.
     pub text: String,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct WaitStableArgs {
     /// How long to wait between capture ticks (default 100ms).
     pub interval_ms: Option<u64>,
@@ -322,7 +322,7 @@ pub struct WaitStableArgs {
     pub ignore: Option<Vec<RegionArgs>>,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct WaitForElementArgs {
     /// Substring of the element's accessible name (selector).
     pub name: Option<String>,
@@ -342,7 +342,7 @@ pub struct WaitForElementArgs {
     pub timeout_ms: Option<u64>,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct ScrollToElementArgs {
     /// Substring of the target element's accessible name (selector).
     pub name: Option<String>,
@@ -364,7 +364,7 @@ pub struct ScrollToElementArgs {
     pub timeout_ms: Option<u64>,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct WaitForRegionArgs {
     /// Saved baseline name to compare against; omit to use the frame at call start.
     pub baseline: Option<String>,
@@ -390,7 +390,7 @@ pub struct WaitForRegionArgs {
     pub ignore: Option<Vec<RegionArgs>>,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct WaitForLogArgs {
     /// Substring to wait for (required, non-empty).
     pub contains: String,
@@ -405,25 +405,25 @@ pub struct WaitForLogArgs {
     pub timeout_ms: Option<u64>,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct BaselineSaveArgs {
     /// ASCII letters/digits/-/_ only. Replaces an existing baseline silently; used by glass_diff and glass_wait_for_region.
     pub name: String,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct DoctorArgs {
     /// Start and tear down the default display to prove it starts (default false).
     pub deep: Option<bool>,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct CapabilitiesArgs {
     /// x11, wayland, windows, macos, android or ios. Default active/default backend. Valid but unbuilt backends report available:false.
     pub backend: Option<String>,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct DiffArgs {
     /// Saved baseline name; unsaved names error.
     pub name: String,
@@ -442,7 +442,7 @@ pub struct DiffArgs {
     pub ignore: Option<Vec<RegionArgs>>,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct LogsArgs {
     /// Resume from a prior returned cursor; omit for oldest buffered line.
     pub cursor: Option<u64>,
@@ -456,7 +456,7 @@ pub struct LogsArgs {
 
 /// One action in a `glass_do` sequence. Internally tagged by `action`; each
 /// variant carries the same fields as the standalone tool.
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(tag = "action", rename_all = "snake_case")]
 pub enum Action {
     Click(ClickArgs),
@@ -473,7 +473,7 @@ pub enum Action {
 }
 
 /// A mid-sequence or terminal settle — the `wait_stable` knobs, no image/return.
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct SettleArgs {
     /// How long to wait between capture ticks (default 100ms).
     pub interval_ms: Option<u64>,
@@ -492,7 +492,7 @@ pub struct SettleArgs {
 /// Optional terminal observe after a `glass_do` sequence (run settle → diff →
 /// screenshot). All text-first; only `screenshot` (or `diff` with its own
 /// `include_image`) returns an image.
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct ThenArgs {
     /// Wait for quiescence before diff/screenshot; otherwise they may observe a half-drawn frame.
     pub settle: Option<SettleArgs>,
@@ -503,7 +503,7 @@ pub struct ThenArgs {
 }
 
 /// Arguments for `glass_do`: an ordered, non-empty action sequence + optional observe.
-#[derive(Debug, JsonSchema)]
+#[derive(Debug, Serialize, JsonSchema)]
 pub struct DoArgs {
     /// Non-empty ordered actions; failure stops remaining steps. Completed mutations may already have landed.
     pub actions: Vec<Action>,
@@ -512,6 +512,7 @@ pub struct DoArgs {
     /// Overall budget in ms (default 30000, range 1..120000), shared by all actions and terminal observations.
     pub timeout_ms: Option<u64>,
     #[schemars(skip)]
+    #[serde(skip)]
     pub(crate) encoded_argument_bytes: usize,
 }
 

--- a/crates/glass-mcp/src/serve/config.rs
+++ b/crates/glass-mcp/src/serve/config.rs
@@ -8,6 +8,7 @@ pub struct ServeConfig {
     pub addr: SocketAddr,
     pub token: Option<String>,
     pub tool_profile: crate::tool_profile::ToolProfile,
+    pub trace: Option<crate::trace::TraceConfig>,
 }
 
 pub const DEFAULT_ADDR: &str = "127.0.0.1:7300";
@@ -88,6 +89,7 @@ pub fn parse_args(
         addr,
         token,
         tool_profile: Default::default(),
+        trace: None,
     })
 }
 
@@ -162,6 +164,7 @@ mod tests {
             addr: addr.parse().unwrap(),
             token: token.map(String::from),
             tool_profile: Default::default(),
+            trace: None,
         }
     }
 

--- a/crates/glass-mcp/src/serve/mod.rs
+++ b/crates/glass-mcp/src/serve/mod.rs
@@ -55,6 +55,18 @@ pub async fn run(
     report: crate::audit::AuditReport,
     tool_profile: crate::tool_profile::ToolProfile,
 ) -> anyhow::Result<()> {
+    run_configured(http, addr, token_file, sink, report, tool_profile, None).await
+}
+
+pub async fn run_configured(
+    http: bool,
+    addr: Option<String>,
+    token_file: Option<String>,
+    sink: Option<Box<dyn glass_core::AuditSink>>,
+    report: crate::audit::AuditReport,
+    tool_profile: crate::tool_profile::ToolProfile,
+    trace: Option<crate::trace::TraceConfig>,
+) -> anyhow::Result<()> {
     // Delegate to the audited resolver (token precedence + exposure rules + its tests stay
     // the single source of truth); just reconstruct its flag form from clap's typed args.
     let mut argv: Vec<String> = Vec::new();
@@ -74,6 +86,7 @@ pub async fn run(
     })
     .map_err(|e| anyhow::anyhow!("glass serve: {e}"))?;
     cfg.tool_profile = tool_profile;
+    cfg.trace = trace;
 
     // Fail-closed exposure rule (spec D4) — refuse a network-exposed bind without a token.
     check_exposure(&cfg)?;
@@ -120,7 +133,7 @@ fn build_router(cfg: &ServeConfig, server: GlassServer, cancel: &CancellationTok
         http_cfg = http_cfg.disable_allowed_hosts();
     }
     let service = StreamableHttpService::new(
-        move || Ok(server.clone()),
+        move || Ok(server.clone().for_client()),
         Arc::new(SingleSessionManager::default()),
         http_cfg,
     );
@@ -175,34 +188,11 @@ pub async fn run_on_until(
     report: crate::audit::AuditReport,
     shutdown: impl Future<Output = ()> + Send + 'static,
 ) -> anyhow::Result<()> {
-    let server = GlassServer::new_with_profile(glass, report, cfg.tool_profile);
-    let sessions = server.sessions();
-    let artifacts = server.artifact_store();
-    let cancel = CancellationToken::new();
-    let app = build_router(&cfg, server, &cancel);
-
-    let server_cancel = cancel.clone();
-    let serving = axum::serve(listener, app).with_graceful_shutdown(async move {
-        server_cancel.cancelled().await;
-    });
-    let transport_result = run_server_then_teardown(
-        async move { serving.await },
-        shutdown,
-        &cancel,
-        HTTP_GRACEFUL_DRAIN_BUDGET,
-        crate::shutdown::run_shutdown(sessions, glass_core::TEARDOWN_BUDGET),
-        crate::cleanup_artifacts(artifacts),
-    )
-    .await;
-    match transport_result {
-        Ok(result) => result.context("serving MCP over HTTP"),
-        Err(()) => Err(anyhow::anyhow!(
-            "MCP HTTP graceful drain exceeded {HTTP_GRACEFUL_DRAIN_BUDGET:?}"
-        )),
-    }
+    let server =
+        GlassServer::new_configured(glass, report, cfg.tool_profile, cfg.trace.as_ref(), "http")?;
+    run_server_on_until(listener, cfg, server, shutdown).await
 }
 
-#[cfg(test)]
 pub(crate) async fn run_server_on_until(
     listener: tokio::net::TcpListener,
     cfg: ServeConfig,
@@ -211,6 +201,7 @@ pub(crate) async fn run_server_on_until(
 ) -> anyhow::Result<()> {
     let sessions = server.sessions();
     let artifacts = server.artifact_store();
+    let trace = server.trace_recorder();
     let cancel = CancellationToken::new();
     let app = build_router(&cfg, server, &cancel);
     let server_cancel = cancel.clone();
@@ -222,8 +213,12 @@ pub(crate) async fn run_server_on_until(
         shutdown,
         &cancel,
         HTTP_GRACEFUL_DRAIN_BUDGET,
-        crate::shutdown::run_shutdown(sessions, glass_core::TEARDOWN_BUDGET),
-        crate::cleanup_artifacts(artifacts),
+        crate::shutdown::run_shutdown_with_trace(
+            sessions,
+            glass_core::TEARDOWN_BUDGET,
+            trace.clone(),
+        ),
+        crate::cleanup_evidence(trace, artifacts),
     )
     .await;
     match transport_result {
@@ -361,6 +356,7 @@ mod tests {
             addr: addr.parse().unwrap(),
             token: token.map(String::from),
             tool_profile: Default::default(),
+            trace: None,
         }
     }
 

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -27,6 +27,7 @@ use crate::tools::{self, BatchToolResult, ToolResult};
 type Job = (
     &'static str,
     ToolEffect,
+    Option<crate::trace::CallTrace>,
     Box<dyn FnOnce(&mut Glass) -> ToolCallOutcome + Send>,
     tokio::sync::oneshot::Sender<ToolCallOutcome>,
 );
@@ -43,6 +44,8 @@ pub struct GlassServer {
     output_policy: Arc<OutputPolicy>,
     tool_router: ToolRouter<GlassServer>,
     tool_profile: ToolProfile,
+    trace: Option<crate::trace::TraceRecorder>,
+    trace_client: u64,
 }
 
 fn tool_effect(tool: &str) -> ToolEffect {
@@ -73,8 +76,27 @@ fn target_access(access: HostPathAccess) -> TargetAccess {
     }
 }
 
+#[cfg(test)]
 fn applied_to_call_result(applied: AppliedOutcome, target_access: TargetAccess) -> CallToolResult {
+    traced_call_result(applied, target_access, None, None)
+}
+
+fn traced_call_result(
+    applied: AppliedOutcome,
+    target_access: TargetAccess,
+    trace: Option<&crate::trace::CallTrace>,
+    store: Option<&ArtifactStore>,
+) -> CallToolResult {
     let (output, is_error, _metadata, response_pin) = applied.into_parts();
+    if let Some(trace) = trace {
+        trace.output(
+            "response_constructed",
+            &output,
+            is_error,
+            target_access,
+            store,
+        );
+    }
     let content = output
         .0
         .into_iter()
@@ -179,6 +201,37 @@ impl GlassServer {
     }
 
     pub fn new(mut glass: Glass, report: AuditReport) -> Self {
+        let store = Self::prepare_artifacts(&mut glass);
+        Self::new_with_state(glass, report, store)
+    }
+
+    pub fn new_configured(
+        mut glass: Glass,
+        report: AuditReport,
+        profile: ToolProfile,
+        config: Option<&crate::trace::TraceConfig>,
+        transport: &str,
+    ) -> anyhow::Result<Self> {
+        let Some(config) = config else {
+            return Ok(Self::new_with_profile(glass, report, profile));
+        };
+        let trace = crate::trace::TraceRecorder::start(config, profile, transport)?;
+        let store = Self::prepare_artifacts(&mut glass);
+        let mut paths = vec![ProtectedHostPath::directory(trace.root())];
+        if let Some(store) = &store {
+            paths.push(ProtectedHostPath::directory(store.process_dir()));
+            paths.push(ProtectedHostPath::file(store.lease_path()));
+        }
+        glass.set_protected_host_paths(paths)?;
+        let mut server = Self::new_with_state(glass, report, store);
+        server.tool_router = configured_router(profile);
+        server.tool_profile = profile;
+        server.trace_client = trace.new_client();
+        server.trace = Some(trace);
+        Ok(server)
+    }
+
+    fn prepare_artifacts(glass: &mut Glass) -> Option<ArtifactStore> {
         const ARTIFACT_LIMIT_BYTES: u64 = 64 * 1024 * 1024;
         let store = match ArtifactStore::new(ARTIFACT_LIMIT_BYTES) {
             Ok(store) => {
@@ -206,7 +259,7 @@ impl GlassServer {
                 "glass: artifact storage unavailable; oversized responses will be bounded and incomplete"
             );
         }
-        Self::new_with_state(glass, report, store)
+        store
     }
 
     #[cfg(test)]
@@ -241,8 +294,14 @@ impl GlassServer {
             std::thread::Builder::new()
                 .name("glass-platform".into())
                 .spawn(move || {
-                    while let Ok((tool, effect, job, reply)) = rx.recv() {
+                    let mut execution = 0_u64;
+                    let mut session = None;
+                    while let Ok((tool, effect, trace, job, reply)) = rx.recv() {
                         let mut g = worker_glass.blocking_lock();
+                        execution += 1;
+                        if let Some(trace) = &trace {
+                            trace.record("execution_started", serde_json::json!({"execution_order": execution, "session": session, "backend": g.active_backend()}));
+                        }
                         let mut outcome =
                             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| job(&mut g)))
                                 .unwrap_or_else(|_| ToolCallOutcome {
@@ -255,6 +314,15 @@ impl GlassServer {
                                     )]),
                                 });
                         outcome.target_access = target_access(g.host_path_access());
+                        if g.active_backend().is_none() {
+                            session = None;
+                        } else if tool == "glass_start" && !outcome.is_error {
+                            session = Some(execution);
+                        }
+                        if let Some(trace) = &trace {
+                            trace.record("session_context", serde_json::json!({"session": session, "backend": g.active_backend()}));
+                            trace.logical_outcome(&outcome);
+                        }
                         let _ = reply.send(outcome);
                     }
                 })
@@ -271,11 +339,25 @@ impl GlassServer {
             output_policy,
             tool_router: Self::tool_router(),
             tool_profile: ToolProfile::Full,
+            trace: None,
+            trace_client: 0,
         }
     }
 
     pub fn sessions(&self) -> Arc<Mutex<Glass>> {
         self.glass.clone()
+    }
+
+    pub(crate) fn trace_recorder(&self) -> Option<crate::trace::TraceRecorder> {
+        self.trace.clone()
+    }
+
+    #[cfg(feature = "network")]
+    pub(crate) fn for_client(mut self) -> Self {
+        if let Some(trace) = &self.trace {
+            self.trace_client = trace.new_client();
+        }
+        self
     }
 
     #[cfg(test)]
@@ -339,6 +421,19 @@ impl GlassServer {
     where
         F: FnOnce(&mut Glass) -> (bool, ToolOutput) + Send + 'static,
     {
+        let trace = crate::trace::current_call();
+        if let Some(trace) = &trace
+            && !trace.has_valid_arguments()
+        {
+            if matches!(
+                tool,
+                "glass_stop" | "glass_clipboard_get" | "glass_list_windows" | "glass_a11y_marks"
+            ) {
+                trace.arguments(&serde_json::json!({}));
+            } else {
+                trace.arguments_unavailable();
+            }
+        }
         let job = move |g: &mut Glass| {
             let (is_error, output) = f(g);
             ToolCallOutcome {
@@ -360,26 +455,41 @@ impl GlassServer {
             )]),
         };
         let Some(jobs) = &self.jobs else {
-            return Ok(applied_to_call_result(
+            if let Some(trace) = &trace {
+                trace.record("worker_unavailable", serde_json::json!({}));
+            }
+            return Ok(traced_call_result(
                 self.output_policy.apply(fallback()),
                 TargetAccess::NoActiveTarget,
+                trace.as_ref(),
+                self.artifacts.as_ref(),
             ));
         };
-        if jobs.send((tool, effect, Box::new(job), reply_tx)).is_err() {
-            return Ok(applied_to_call_result(
+        if jobs
+            .send((tool, effect, trace.clone(), Box::new(job), reply_tx))
+            .is_err()
+        {
+            if let Some(trace) = &trace {
+                trace.record("worker_unavailable", serde_json::json!({}));
+            }
+            return Ok(traced_call_result(
                 self.output_policy.apply(fallback()),
                 TargetAccess::NoActiveTarget,
+                trace.as_ref(),
+                self.artifacts.as_ref(),
             ));
         }
         let outcome = reply_rx.await.unwrap_or_else(|_| fallback());
         let access = outcome.target_access;
         let policy = self.output_policy.clone();
-        let applied = tokio::task::spawn_blocking(move || policy.apply(outcome))
-            .await
-            .map_err(|_| {
-                McpError::new(ErrorCode::INTERNAL_ERROR, "output processing failed", None)
-            })?;
-        Ok(applied_to_call_result(applied, access))
+        let store = self.artifacts.clone();
+        let result = tokio::task::spawn_blocking(move || {
+            let applied = policy.apply(outcome);
+            traced_call_result(applied, access, trace.as_ref(), store.as_ref())
+        })
+        .await
+        .map_err(|_| McpError::new(ErrorCode::INTERNAL_ERROR, "output processing failed", None))?;
+        Ok(result)
     }
 
     #[cfg(test)]
@@ -407,8 +517,20 @@ impl GlassServer {
         &self,
         Parameters(a): Parameters<StartArgs>,
     ) -> Result<CallToolResult, McpError> {
+        crate::trace::start_arguments(&a);
         self.run("glass_start", tool_effect("glass_start"), move |g| {
             tools::start(g, &a)
+        })
+        .await
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn run_trace_test_job(
+        &self,
+        job: impl FnOnce(&mut Glass) -> ToolOutput + Send + 'static,
+    ) -> Result<CallToolResult, McpError> {
+        self.run_outcome("glass_test", ToolEffect::MayMutate, |glass| {
+            (false, job(glass))
         })
         .await
     }
@@ -439,6 +561,7 @@ impl GlassServer {
         &self,
         Parameters(a): Parameters<WindowArgs>,
     ) -> Result<CallToolResult, McpError> {
+        crate::trace::arguments(&a);
         self.run("glass_window", tool_effect("glass_window"), move |g| {
             tools::window(g, &a)
         })
@@ -453,6 +576,7 @@ impl GlassServer {
         &self,
         Parameters(a): Parameters<ScreenshotArgs>,
     ) -> Result<CallToolResult, McpError> {
+        crate::trace::arguments(&a);
         self.run(
             "glass_screenshot",
             tool_effect("glass_screenshot"),
@@ -469,6 +593,7 @@ impl GlassServer {
         &self,
         Parameters(a): Parameters<WaitStableArgs>,
     ) -> Result<CallToolResult, McpError> {
+        crate::trace::arguments(&a);
         self.run(
             "glass_wait_stable",
             tool_effect("glass_wait_stable"),
@@ -489,6 +614,7 @@ impl GlassServer {
         &self,
         Parameters(a): Parameters<ClickArgs>,
     ) -> Result<CallToolResult, McpError> {
+        crate::trace::arguments(&a);
         self.run("glass_click", tool_effect("glass_click"), move |g| {
             tools::click(g, &a)
         })
@@ -507,6 +633,7 @@ impl GlassServer {
         &self,
         Parameters(a): Parameters<MoveArgs>,
     ) -> Result<CallToolResult, McpError> {
+        crate::trace::arguments(&a);
         self.run("glass_move", tool_effect("glass_move"), move |g| {
             tools::mouse_move(g, &a)
         })
@@ -525,6 +652,7 @@ impl GlassServer {
         &self,
         Parameters(a): Parameters<DragArgs>,
     ) -> Result<CallToolResult, McpError> {
+        crate::trace::arguments(&a);
         self.run("glass_drag", tool_effect("glass_drag"), move |g| {
             tools::drag(g, &a)
         })
@@ -543,6 +671,7 @@ impl GlassServer {
         &self,
         Parameters(a): Parameters<ScrollArgs>,
     ) -> Result<CallToolResult, McpError> {
+        crate::trace::arguments(&a);
         self.run("glass_scroll", tool_effect("glass_scroll"), move |g| {
             tools::scroll(g, &a)
         })
@@ -566,6 +695,7 @@ impl GlassServer {
         &self,
         Parameters(a): Parameters<GestureArgs>,
     ) -> Result<CallToolResult, McpError> {
+        crate::trace::arguments(&a);
         self.run("glass_gesture", tool_effect("glass_gesture"), move |g| {
             tools::gesture(g, &a)
         })
@@ -584,6 +714,7 @@ impl GlassServer {
         &self,
         Parameters(a): Parameters<TypeArgs>,
     ) -> Result<CallToolResult, McpError> {
+        crate::trace::arguments(&a);
         self.run_batch("glass_type", tool_effect("glass_type"), move |g| {
             tools::type_text(g, &a)
         })
@@ -602,6 +733,7 @@ impl GlassServer {
         &self,
         Parameters(a): Parameters<KeyArgs>,
     ) -> Result<CallToolResult, McpError> {
+        crate::trace::arguments(&a);
         self.run("glass_key", tool_effect("glass_key"), move |g| {
             tools::key(g, &a)
         })
@@ -637,6 +769,7 @@ impl GlassServer {
         &self,
         Parameters(a): Parameters<ClipboardSetArgs>,
     ) -> Result<CallToolResult, McpError> {
+        crate::trace::arguments(&a);
         self.run(
             "glass_clipboard_set",
             tool_effect("glass_clipboard_set"),
@@ -657,6 +790,7 @@ impl GlassServer {
         &self,
         Parameters(a): Parameters<BaselineSaveArgs>,
     ) -> Result<CallToolResult, McpError> {
+        crate::trace::arguments(&a);
         self.run(
             "glass_baseline_save",
             tool_effect("glass_baseline_save"),
@@ -673,6 +807,7 @@ impl GlassServer {
         &self,
         Parameters(a): Parameters<DiffArgs>,
     ) -> Result<CallToolResult, McpError> {
+        crate::trace::arguments(&a);
         self.run("glass_diff", tool_effect("glass_diff"), move |g| {
             tools::diff(g, &a)
         })
@@ -691,15 +826,18 @@ impl GlassServer {
         &self,
         Parameters(a): Parameters<DoctorArgs>,
     ) -> Result<CallToolResult, McpError> {
+        crate::trace::arguments(&a);
         let backend = crate::default_backend(std::env::var("GLASS_BACKEND").ok().as_deref());
         let deep = a.deep.unwrap_or(false);
         let report = self.report.clone();
+        let trace = self.trace.clone();
         self.run("glass_doctor", tool_effect("glass_doctor"), move |_| {
             let diag = crate::doctor::diagnose_with_audit(deep, &report);
-            Ok(ToolOutput::result(
-                "glass_doctor",
-                doctor_result(&diag, backend),
-            ))
+            let mut result = doctor_result(&diag, backend);
+            if let Some(trace) = trace {
+                result["trace"] = trace.status();
+            }
+            Ok(ToolOutput::result("glass_doctor", result))
         })
         .await
     }
@@ -712,6 +850,7 @@ impl GlassServer {
         &self,
         Parameters(a): Parameters<CapabilitiesArgs>,
     ) -> Result<CallToolResult, McpError> {
+        crate::trace::arguments(&a);
         let profile = self.tool_profile;
         self.run(
             "glass_capabilities",
@@ -752,6 +891,7 @@ impl GlassServer {
         &self,
         Parameters(a): Parameters<SelectWindowArgs>,
     ) -> Result<CallToolResult, McpError> {
+        crate::trace::arguments(&a);
         self.run(
             "glass_select_window",
             tool_effect("glass_select_window"),
@@ -768,6 +908,7 @@ impl GlassServer {
         &self,
         Parameters(a): Parameters<FindElementsArgs>,
     ) -> Result<CallToolResult, McpError> {
+        crate::trace::arguments(&a);
         self.run(
             "glass_find_elements",
             tool_effect("glass_find_elements"),
@@ -784,6 +925,7 @@ impl GlassServer {
         &self,
         Parameters(a): Parameters<A11ySnapshotArgs>,
     ) -> Result<CallToolResult, McpError> {
+        crate::trace::arguments(&a);
         self.run(
             "glass_a11y_snapshot",
             tool_effect("glass_a11y_snapshot"),
@@ -804,6 +946,7 @@ impl GlassServer {
         &self,
         Parameters(a): Parameters<ClickElementArgs>,
     ) -> Result<CallToolResult, McpError> {
+        crate::trace::arguments(&a);
         self.run_batch(
             "glass_click_element",
             tool_effect("glass_click_element"),
@@ -824,6 +967,7 @@ impl GlassServer {
         &self,
         Parameters(a): Parameters<SetValueArgs>,
     ) -> Result<CallToolResult, McpError> {
+        crate::trace::arguments(&a);
         self.run_batch(
             "glass_set_value",
             tool_effect("glass_set_value"),
@@ -853,6 +997,7 @@ impl GlassServer {
         &self,
         Parameters(a): Parameters<LogsArgs>,
     ) -> Result<CallToolResult, McpError> {
+        crate::trace::arguments(&a);
         self.run("glass_logs", tool_effect("glass_logs"), move |g| {
             tools::logs(g, &a)
         })
@@ -867,6 +1012,7 @@ impl GlassServer {
         &self,
         Parameters(a): Parameters<WaitForElementArgs>,
     ) -> Result<CallToolResult, McpError> {
+        crate::trace::arguments(&a);
         self.run(
             "glass_wait_for_element",
             tool_effect("glass_wait_for_element"),
@@ -887,6 +1033,7 @@ impl GlassServer {
         &self,
         Parameters(a): Parameters<ScrollToElementArgs>,
     ) -> Result<CallToolResult, McpError> {
+        crate::trace::arguments(&a);
         self.run(
             "glass_scroll_to_element",
             tool_effect("glass_scroll_to_element"),
@@ -903,6 +1050,7 @@ impl GlassServer {
         &self,
         Parameters(a): Parameters<WaitForRegionArgs>,
     ) -> Result<CallToolResult, McpError> {
+        crate::trace::arguments(&a);
         self.run(
             "glass_wait_for_region",
             tool_effect("glass_wait_for_region"),
@@ -919,6 +1067,7 @@ impl GlassServer {
         &self,
         Parameters(a): Parameters<WaitForLogArgs>,
     ) -> Result<CallToolResult, McpError> {
+        crate::trace::arguments(&a);
         self.run(
             "glass_wait_for_log",
             tool_effect("glass_wait_for_log"),
@@ -939,6 +1088,7 @@ impl GlassServer {
         &self,
         Parameters(a): Parameters<DoArgs>,
     ) -> Result<CallToolResult, McpError> {
+        crate::trace::arguments(&a);
         self.run_batch("glass_do", tool_effect("glass_do"), move |g| {
             tools::do_actions(g, &a)
         })
@@ -961,6 +1111,41 @@ const SERVER_INSTRUCTIONS: &str = crate::tool_profile::SHARED_INSTRUCTIONS;
 
 #[tool_handler(router = self.tool_router)]
 impl ServerHandler for GlassServer {
+    async fn call_tool(
+        &self,
+        request: rmcp::model::CallToolRequestParams,
+        context: rmcp::service::RequestContext<rmcp::RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        let trace = self
+            .trace
+            .as_ref()
+            .and_then(|trace| trace.begin_call(&request.name, self.trace_client));
+        if let Some(trace) = &trace {
+            trace.record("argument_size", serde_json::json!({"compact_json_bytes": crate::trace::argument_bytes(&request.arguments)}));
+        }
+        let tcc = rmcp::handler::server::tool::ToolCallContext::new(self, request, context);
+        let mut result = if let Some(call) = trace {
+            let mut guard = crate::trace::RequestGuard::new(call.clone());
+            let result = crate::trace::ACTIVE_CALL
+                .scope(call.clone(), self.tool_router.call(tcc))
+                .await;
+            if !call.has_valid_arguments() {
+                call.record("router_rejection", serde_json::json!({"category": "tool_or_arguments_rejected", "raw_arguments": "excluded"}));
+            }
+            guard.complete();
+            result
+        } else {
+            self.tool_router.call(tcc).await
+        };
+        if let (Some(trace), Ok(result)) = (&self.trace, &mut result) {
+            let meta = result.meta.get_or_insert_with(Default::default);
+            meta.0
+                .entry("glass")
+                .or_insert_with(|| serde_json::json!({}))["trace"] = trace.status();
+        }
+        result
+    }
+
     fn get_info(&self) -> ServerInfo {
         let mut info = ServerInfo::new(
             ServerCapabilities::builder()
@@ -1008,10 +1193,18 @@ impl ServerHandler for GlassServer {
     ) -> impl Future<Output = Result<ReadResourceResult, McpError>> + Send + '_ {
         let store = self.artifacts.clone();
         let server_id = self.artifact_server_id.clone();
+        let trace = self
+            .trace
+            .as_ref()
+            .and_then(|trace| trace.begin_call("resources/read", self.trace_client));
         async move {
             let uri = request.uri;
             tokio::task::spawn_blocking(move || {
-                read_resource_result(store.as_ref(), &server_id, &uri)
+                let result = read_resource_result(store.as_ref(), &server_id, &uri);
+                if let Some(trace) = trace {
+                    trace.resource_read(&result);
+                }
+                result
             })
             .await
             .map_err(|_| resource_error(ArtifactReadError::ReadFailed, "artifact_read_failed"))?

--- a/crates/glass-mcp/src/shutdown.rs
+++ b/crates/glass-mcp/src/shutdown.rs
@@ -24,7 +24,16 @@ const LOCK_WAIT_WORTH_SAYING: Duration = Duration::from_millis(250);
 /// `bounded::KILL_REAP` past its deadline — still lands inside. This `timeout` is the backstop for
 /// a step that ignores the deadline: a `spawn_blocking` task cannot be cancelled, so that step is
 /// still running when the process exits, and its child is orphaned.
+#[cfg(test)]
 pub async fn run_shutdown(sessions: Arc<Mutex<Glass>>, budget: Duration) {
+    run_shutdown_with_trace(sessions, budget, None).await;
+}
+
+pub(crate) async fn run_shutdown_with_trace(
+    sessions: Arc<Mutex<Glass>>,
+    budget: Duration,
+    trace: Option<crate::trace::TraceRecorder>,
+) {
     let task = tokio::task::spawn_blocking(move || {
         // Started after the lock: a tool call in flight holds the session, and a deadline
         // measured across that wait arrives spent — reported downstream as every step skipped,
@@ -37,16 +46,26 @@ pub async fn run_shutdown(sessions: Arc<Mutex<Glass>>, budget: Duration) {
         if waited > LOCK_WAIT_WORTH_SAYING {
             eprintln!("glass: a tool call held the session for {waited:?} before teardown started");
         }
-        glass.shutdown(Deadline::at(
+        glass.shutdown_report(Deadline::at(
             Instant::now() + budget - glass_core::TEARDOWN_REAP_HEADROOM,
-        ));
+        ))
     });
-    match tokio::time::timeout(budget, task).await {
-        Ok(Ok(())) => {}
+    let status = match tokio::time::timeout(budget, task).await {
+        Ok(Ok(Ok(()))) => "completed",
+        Ok(Ok(Err(_))) => "target_stop_failed",
         // A panic inside teardown: the steps behind it did not run, and the process is about to
         // exit past it.
-        Ok(Err(e)) => eprintln!("glass: teardown panicked ({e}); exiting anyway"),
-        Err(_) => eprintln!("glass: shutdown exceeded {budget:?}; exiting anyway"),
+        Ok(Err(e)) => {
+            eprintln!("glass: teardown panicked ({e}); exiting anyway");
+            "panicked"
+        }
+        Err(_) => {
+            eprintln!("glass: shutdown exceeded {budget:?}; exiting anyway");
+            "timed_out"
+        }
+    };
+    if let Some(trace) = trace {
+        trace.shutdown_event(status);
     }
 }
 

--- a/crates/glass-mcp/src/tools/testutil.rs
+++ b/crates/glass-mcp/src/tools/testutil.rs
@@ -31,6 +31,7 @@ pub struct FakePlatform {
     pub specs: Arc<Mutex<Vec<AppSpec>>>,
     pub fail_text_dispatch_after_receiving: bool,
     pub trailing_toggle: bool,
+    pub protected_paths: Option<Arc<Mutex<Vec<glass_core::ProtectedHostPath>>>>,
 }
 
 impl FakePlatform {
@@ -93,6 +94,19 @@ pub fn frame_4x4_corner(corner: [u8; 4]) -> Frame {
 }
 
 impl Platform for FakePlatform {
+    fn configure_protected_host_paths(
+        &mut self,
+        paths: &[glass_core::ProtectedHostPath],
+    ) -> Result<glass_core::HostPathProtectionMode> {
+        if let Some(recorded) = &self.protected_paths {
+            *recorded.lock().unwrap() = paths.to_vec();
+        } else if !paths.is_empty() {
+            return Err(GlassError::SandboxUnavailable(
+                "fake backend has no protected-path support".into(),
+            ));
+        }
+        Ok(glass_core::HostPathProtectionMode::SandboxRules)
+    }
     fn start_app(&mut self, spec: &AppSpec) -> Result<WindowGeometry> {
         self.specs.lock().unwrap().push(spec.clone());
         self.started = true;

--- a/crates/glass-mcp/src/trace/capture.rs
+++ b/crates/glass-mcp/src/trace/capture.rs
@@ -1,0 +1,173 @@
+use serde::Serialize;
+use serde_json::json;
+
+use crate::artifacts::ArtifactStore;
+use crate::output::{OutContent, TargetAccess, TextRole, TextTrust, ToolOutput};
+use crate::output_policy::ToolCallOutcome;
+
+use super::CallTrace;
+use super::config::MAX_PAYLOAD_BYTES;
+use super::recorder::evidence;
+
+tokio::task_local! {
+    pub(crate) static ACTIVE_CALL: CallTrace;
+}
+
+pub(crate) fn current_call() -> Option<CallTrace> {
+    ACTIVE_CALL.try_with(Clone::clone).ok()
+}
+
+pub(crate) fn arguments(value: &impl Serialize) {
+    if let Some(call) = current_call() {
+        call.arguments(value);
+    }
+}
+
+pub(crate) fn start_arguments(args: &crate::params::StartArgs) {
+    #[derive(Serialize)]
+    struct Args<'a> {
+        build: &'a Option<String>,
+        run: &'a [String],
+        backend: &'a Option<String>,
+        sandbox: &'a Option<String>,
+        cwd: &'a Option<String>,
+        env_entry_count: usize,
+        window_hint: &'a Option<crate::params::WindowHintArgs>,
+        timeout_ms: Option<u64>,
+        a11y: Option<bool>,
+    }
+    arguments(&Args {
+        build: &args.build,
+        run: &args.run,
+        backend: &args.backend,
+        sandbox: &args.sandbox,
+        cwd: &args.cwd,
+        env_entry_count: args.env.len(),
+        window_hint: &args.window_hint,
+        timeout_ms: args.timeout_ms,
+        a11y: args.a11y,
+    });
+}
+
+impl CallTrace {
+    pub fn logical_outcome(&self, outcome: &ToolCallOutcome) {
+        self.output(
+            "logical_outcome",
+            &outcome.output,
+            outcome.is_error,
+            outcome.target_access,
+            None,
+        );
+    }
+
+    pub fn output(
+        &self,
+        kind: &str,
+        output: &ToolOutput,
+        is_error: bool,
+        access: TargetAccess,
+        store: Option<&ArtifactStore>,
+    ) {
+        self.capture(kind, json!({"is_error": is_error, "target_access": access, "content_blocks": output.0.len(), "client_delivery": "unknown"}), |capture| {
+            for (index, block) in output.0.iter().enumerate() {
+                let entries = if matches!(block, OutContent::ResourceLink(_)) { 2 } else { 1 };
+                if capture.entries() + entries >= 128 {
+                    capture.omission(evidence("remaining_content_blocks", "application/json", "mixed", Some(index)), "block_limit");
+                    break;
+                }
+                match block {
+                    OutContent::Envelope(envelope) => {
+                        #[derive(Serialize)]
+                        struct Envelope<'a> { ok: bool, result: &'a serde_json::Value, tool: &'a str }
+                        capture.json(evidence("envelope", "application/json", "glass", Some(index)), &Envelope { ok: true, tool: &envelope.tool, result: &envelope.result });
+                    }
+                    OutContent::Text(text) => {
+                        let trust = match text.trust { TextTrust::Trusted => "glass", TextTrust::UntrustedApplication => "untrusted_application" };
+                        let role = match text.role { TextRole::Envelope => "envelope", TextRole::Observation => "observation", TextRole::Guidance => "guidance", TextRole::ErrorDetail => "error_detail" };
+                        capture.bytes(evidence(role, "text/plain; charset=utf-8", trust, Some(index)), text.body.as_bytes());
+                    }
+                    OutContent::Image(bytes) => capture.bytes(evidence("image", "image/webp", "untrusted_application", Some(index)), bytes),
+                    OutContent::ResourceLink(descriptor) => {
+                        capture.json(evidence("resource_descriptor", "application/json", "glass", Some(index)), &rmcp::model::ContentBlock::ResourceLink(descriptor.to_resource(access)));
+                        let mut metadata = evidence("resource", descriptor.mime_type(), if descriptor.untrusted() { "untrusted_application" } else { "glass" }, Some(index));
+                        metadata.source_uri = Some(descriptor.uri().to_owned());
+                        metadata.original_bytes = Some(descriptor.bytes());
+                        if descriptor.bytes() > MAX_PAYLOAD_BYTES as u64 {
+                            capture.omission(metadata, "payload_limit");
+                        } else if let Some(store) = store {
+                            capture.read_bytes(metadata, descriptor.bytes() as usize, || store.read(descriptor.uri()).ok().map(|read| read.text.into_bytes()));
+                        } else { capture.omission(metadata, "artifact_unavailable"); }
+                    }
+                }
+            }
+        });
+    }
+
+    pub fn resource_read(&self, result: &Result<rmcp::model::ReadResourceResult, rmcp::ErrorData>) {
+        self.capture(
+            "resource_read",
+            json!({"is_error": result.is_err()}),
+            |capture| {
+                if let Ok(result) = result {
+                    for (index, content) in result.contents.iter().take(127).enumerate() {
+                        if let rmcp::model::ResourceContents::TextResourceContents {
+                            text,
+                            uri,
+                            mime_type,
+                            meta,
+                        } = content
+                        {
+                            let mut metadata = evidence(
+                                "resource",
+                                mime_type.as_deref().unwrap_or("text/plain"),
+                                if meta
+                                    .as_ref()
+                                    .and_then(|meta| meta.0.get("glass"))
+                                    .and_then(|glass| glass.get("untrusted"))
+                                    .and_then(serde_json::Value::as_bool)
+                                    == Some(false)
+                                {
+                                    "glass"
+                                } else {
+                                    "untrusted_application"
+                                },
+                                Some(index),
+                            );
+                            metadata.source_uri = Some(uri.clone());
+                            capture.bytes(metadata, text.as_bytes());
+                        }
+                    }
+                }
+            },
+        );
+        self.record("logical_outcome", json!({"is_error": result.is_err()}));
+    }
+}
+
+pub(crate) struct RequestGuard {
+    call: CallTrace,
+    completed: bool,
+}
+
+impl RequestGuard {
+    pub fn new(call: CallTrace) -> Self {
+        Self {
+            call,
+            completed: false,
+        }
+    }
+    pub fn complete(&mut self) {
+        self.completed = true;
+    }
+}
+
+impl Drop for RequestGuard {
+    fn drop(&mut self) {
+        if !self.completed {
+            self.call.record(
+                "request_abandoned",
+                json!({"execution_outcome": "observe_worker_outcome"}),
+            );
+        }
+    }
+}

--- a/crates/glass-mcp/src/trace/config.rs
+++ b/crates/glass-mcp/src/trace/config.rs
@@ -1,0 +1,39 @@
+use std::path::PathBuf;
+
+pub const DEFAULT_MAX_BYTES: u64 = 256 * 1024 * 1024;
+pub const MIN_MAX_BYTES: u64 = 1024 * 1024;
+pub const MAX_MAX_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+pub(super) const MAX_PAYLOAD_BYTES: usize = 16 * 1024 * 1024;
+pub(super) const MAX_PENDING_BYTES: usize = 32 * 1024 * 1024;
+pub(super) const MAX_PENDING_EVENTS: usize = 256;
+pub(super) const MAX_CALLS: u64 = 10_000;
+pub(super) const MAX_EVENTS: u64 = 100_000;
+pub(super) const MAX_BLOBS: usize = 25_000;
+pub(super) const MAX_EVENT_BYTES: usize = 64 * 1024;
+pub(super) const RESERVE_BYTES: u64 = 128 * 1024;
+
+/// Recording is enabled only when an explicit existing absolute directory is supplied.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TraceConfig {
+    pub directory: PathBuf,
+    pub max_bytes: u64,
+}
+
+impl TraceConfig {
+    pub fn new(directory: PathBuf, max_bytes: Option<u64>) -> anyhow::Result<Self> {
+        let max_bytes = max_bytes.unwrap_or(DEFAULT_MAX_BYTES);
+        anyhow::ensure!(directory.is_absolute(), "trace directory must be absolute");
+        anyhow::ensure!(
+            directory.parent().is_some(),
+            "trace directory cannot be a filesystem root"
+        );
+        anyhow::ensure!(
+            (MIN_MAX_BYTES..=MAX_MAX_BYTES).contains(&max_bytes),
+            "trace byte limit must be between {MIN_MAX_BYTES} and {MAX_MAX_BYTES}"
+        );
+        Ok(Self {
+            directory,
+            max_bytes,
+        })
+    }
+}

--- a/crates/glass-mcp/src/trace/format.rs
+++ b/crates/glass-mcp/src/trace/format.rs
@@ -1,0 +1,114 @@
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use super::config::*;
+
+pub(super) const SCHEMA: &str = "glass.trace.v1";
+
+pub(super) fn digest(bytes: &[u8]) -> String {
+    hex(&Sha256::digest(bytes))
+}
+
+pub(super) fn hex(bytes: &[u8]) -> String {
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        use std::fmt::Write as _;
+        let _ = write!(encoded, "{byte:02x}");
+    }
+    encoded
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct Payload {
+    pub path: String,
+    pub bytes: u64,
+    pub sha256: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct Evidence {
+    pub label: String,
+    pub mime_type: String,
+    pub trust: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub block: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_uri: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload: Option<Payload>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub omitted: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub original_bytes: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct Event {
+    pub seq: u64,
+    pub elapsed_us: u64,
+    pub kind: String,
+    pub call: Option<u64>,
+    pub client: u64,
+    pub data: serde_json::Value,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub evidence: Vec<Evidence>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct Limits {
+    pub bytes: u64,
+    pub payload_bytes: usize,
+    pub pending_bytes: usize,
+    pub pending_events: usize,
+    pub calls: u64,
+    pub events: u64,
+    pub event_bytes: usize,
+    pub blobs: usize,
+    pub blocks_per_event: usize,
+}
+
+impl Limits {
+    pub fn new(bytes: u64) -> Self {
+        Self {
+            bytes,
+            payload_bytes: MAX_PAYLOAD_BYTES,
+            pending_bytes: MAX_PENDING_BYTES,
+            pending_events: MAX_PENDING_EVENTS,
+            calls: MAX_CALLS,
+            events: MAX_EVENTS,
+            event_bytes: MAX_EVENT_BYTES,
+            blobs: MAX_BLOBS,
+            blocks_per_event: 128,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct Manifest {
+    pub schema: String,
+    pub id: String,
+    pub started_at: String,
+    pub server_version: String,
+    pub source_revision: Option<String>,
+    pub os: String,
+    pub architecture: String,
+    pub transport: String,
+    pub profile: String,
+    pub exclusions: Vec<String>,
+    pub limits: Limits,
+    pub state: String,
+    pub complete: bool,
+    pub events: u64,
+    pub calls: u64,
+    pub omissions: u64,
+    pub errors: u64,
+    pub stored_bytes: u64,
+    pub journal_bytes: u64,
+    pub journal_sha256: Option<String>,
+    pub finalization: Option<String>,
+}

--- a/crates/glass-mcp/src/trace/fs.rs
+++ b/crates/glass-mcp/src/trace/fs.rs
@@ -6,6 +6,22 @@ use anyhow::{Context, ensure};
 use cap_fs_ext::{DirExt, FollowSymlinks, OpenOptionsFollowExt};
 use cap_std::fs::{Dir, DirBuilder, OpenOptions};
 
+pub(super) struct Lease(File);
+
+impl Lease {
+    pub(super) fn try_lock(file: File) -> anyhow::Result<Self> {
+        fs4::FileExt::try_lock(&file)?;
+        Ok(Self(file))
+    }
+}
+
+impl Drop for Lease {
+    fn drop(&mut self) {
+        // A fork can retain the open file description until exec, even with CLOEXEC.
+        let _ = fs4::FileExt::unlock(&self.0);
+    }
+}
+
 pub(super) fn open_directory(path: &Path) -> anyhow::Result<Dir> {
     ensure!(path.is_absolute(), "expected an absolute directory");
     let mut base = std::path::PathBuf::new();
@@ -181,4 +197,25 @@ pub(super) fn write_atomic(dir: &Dir, name: &str, bytes: &[u8]) -> anyhow::Resul
         let _ = dir.remove_file(&temporary);
     }
     result
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lease_release_does_not_wait_for_an_inherited_descriptor_to_close() {
+        let root = tempfile::tempdir().unwrap();
+        let dir = open_directory(&root.path().canonicalize().unwrap()).unwrap();
+        let lease = Lease::try_lock(create_file(&dir, "writer.lease").unwrap()).unwrap();
+        let inherited = lease.0.try_clone().unwrap();
+        assert!(Lease::try_lock(open_file(&dir, "writer.lease", true).unwrap()).is_err());
+
+        drop(lease);
+
+        let next = Lease::try_lock(open_file(&dir, "writer.lease", true).unwrap())
+            .expect("the owner released its lock even while a fork-inherited descriptor survives");
+        assert_eq!(inherited.metadata().unwrap().len(), 0);
+        drop(next);
+    }
 }

--- a/crates/glass-mcp/src/trace/fs.rs
+++ b/crates/glass-mcp/src/trace/fs.rs
@@ -1,0 +1,184 @@
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::{Component, Path};
+
+use anyhow::{Context, ensure};
+use cap_fs_ext::{DirExt, FollowSymlinks, OpenOptionsFollowExt};
+use cap_std::fs::{Dir, DirBuilder, OpenOptions};
+
+pub(super) fn open_directory(path: &Path) -> anyhow::Result<Dir> {
+    ensure!(path.is_absolute(), "expected an absolute directory");
+    let mut base = std::path::PathBuf::new();
+    let mut directory = None;
+    for component in path.components() {
+        match component {
+            Component::Prefix(_) | Component::RootDir => base.push(component),
+            Component::Normal(name) => {
+                let parent = match directory.take() {
+                    Some(parent) => parent,
+                    None => Dir::open_ambient_dir(&base, cap_std::ambient_authority())?,
+                };
+                directory = Some(parent.open_dir_nofollow(name)?);
+            }
+            _ => anyhow::bail!("directory must not contain parent components"),
+        }
+    }
+    directory.context("a filesystem root is not an owned directory")
+}
+
+pub(super) fn check_owner(dir: &Dir) -> anyhow::Result<()> {
+    #[cfg(unix)]
+    {
+        use cap_std::fs::MetadataExt;
+        let metadata = dir.dir_metadata()?;
+        ensure!(
+            metadata.uid() == rustix::process::geteuid().as_raw(),
+            "trace directory is not owned by the current user"
+        );
+        ensure!(
+            metadata.mode() & 0o022 == 0,
+            "trace directory must not be writable by other users"
+        );
+    }
+    #[cfg(windows)]
+    {
+        ensure!(
+            glass_windows::file_is_private_to_current_user(&dir.try_clone()?.into_std_file())?,
+            "trace directory must be owned by the current user with a protected owner-and-SYSTEM DACL"
+        );
+    }
+    Ok(())
+}
+
+pub(super) fn same_directory(first: &Dir, second: &Dir) -> anyhow::Result<bool> {
+    #[cfg(unix)]
+    {
+        use cap_std::fs::MetadataExt;
+        let first = first.dir_metadata()?;
+        let second = second.dir_metadata()?;
+        Ok(first.dev() == second.dev() && first.ino() == second.ino())
+    }
+    #[cfg(windows)]
+    glass_windows::same_file_object(
+        &first.try_clone()?.into_std_file(),
+        &second.try_clone()?.into_std_file(),
+    )
+    .map_err(|_| anyhow::anyhow!("cannot compare directory identities"))
+}
+
+pub(super) fn create_directory(parent: &Dir, name: &str) -> anyhow::Result<Dir> {
+    valid_name(name)?;
+    let builder = DirBuilder::new();
+    #[cfg(unix)]
+    let builder = {
+        use cap_std::fs::DirBuilderExt;
+        let mut builder = builder;
+        builder.mode(0o700);
+        builder
+    };
+    parent.create_dir_with(name, &builder)?;
+    let child = parent.open_dir_nofollow(name)?;
+    #[cfg(windows)]
+    glass_windows::restrict_directory_child_to_current_user(
+        &parent.try_clone()?.into_std_file(),
+        std::ffi::OsStr::new(name),
+    )?;
+    Ok(child)
+}
+
+pub(super) fn valid_name(name: &str) -> anyhow::Result<()> {
+    ensure!(
+        !name.is_empty()
+            && name.len() <= 128
+            && name
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'.' || b == b'_'),
+        "invalid evidence filename"
+    );
+    ensure!(name != "." && name != "..", "invalid evidence filename");
+    Ok(())
+}
+
+pub(super) fn create_file(dir: &Dir, name: &str) -> anyhow::Result<File> {
+    valid_name(name)?;
+    let mut options = OpenOptions::new();
+    options
+        .read(true)
+        .write(true)
+        .create_new(true)
+        .follow(FollowSymlinks::No);
+    #[cfg(unix)]
+    {
+        use cap_std::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    #[cfg(windows)]
+    {
+        use cap_std::fs::OpenOptionsExt;
+        options.access_mode(windows::Win32::Storage::FileSystem::FILE_ALL_ACCESS.0);
+    }
+    let file = dir.open_with(name, &options)?.into_std();
+    #[cfg(windows)]
+    glass_windows::restrict_file_to_current_user(&file)?;
+    Ok(file)
+}
+
+pub(super) fn open_file(dir: &Dir, name: &str, writable: bool) -> anyhow::Result<File> {
+    valid_name(name)?;
+    let mut options = OpenOptions::new();
+    options
+        .read(true)
+        .write(writable)
+        .follow(FollowSymlinks::No);
+    #[cfg(unix)]
+    {
+        use cap_std::fs::OpenOptionsExt;
+        options.custom_flags(rustix::fs::OFlags::NONBLOCK.bits() as i32);
+    }
+    let file = dir.open_with(name, &options)?.into_std();
+    let metadata = file.metadata()?;
+    ensure!(metadata.is_file(), "evidence is not a regular file");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        ensure!(metadata.nlink() == 1, "hard-linked evidence is refused");
+    }
+    #[cfg(windows)]
+    ensure!(
+        glass_windows::file_has_single_link(&file)
+            .map_err(|_| anyhow::anyhow!("cannot inspect evidence links"))?,
+        "hard-linked evidence is refused"
+    );
+    Ok(file)
+}
+
+pub(super) fn read_bounded(dir: &Dir, name: &str, limit: u64) -> anyhow::Result<Vec<u8>> {
+    let file = open_file(dir, name, false)?;
+    ensure!(
+        file.metadata()?.len() <= limit,
+        "evidence exceeds its size limit"
+    );
+    let mut bytes = Vec::new();
+    file.take(limit + 1).read_to_end(&mut bytes)?;
+    ensure!(
+        bytes.len() as u64 <= limit,
+        "evidence grew beyond its size limit"
+    );
+    Ok(bytes)
+}
+
+pub(super) fn write_atomic(dir: &Dir, name: &str, bytes: &[u8]) -> anyhow::Result<()> {
+    let temporary = format!("pending-{}", crate::artifacts::new_server_id());
+    let result = (|| {
+        let mut file = create_file(dir, &temporary)?;
+        file.write_all(bytes)?;
+        file.flush()?;
+        drop(file);
+        dir.rename(&temporary, dir, name)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = dir.remove_file(&temporary);
+    }
+    result
+}

--- a/crates/glass-mcp/src/trace/inspect.rs
+++ b/crates/glass-mcp/src/trace/inspect.rs
@@ -1,0 +1,506 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::File;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, ensure};
+use cap_std::fs::Dir;
+use fs4::FileExt;
+use serde::Serialize;
+use serde_json::json;
+use sha2::{Digest, Sha256};
+
+use super::config::*;
+use super::format::{Event, Manifest, Payload, SCHEMA, digest};
+use super::fs;
+
+const MAX_INDEX_BYTES: usize = 8 * 1024 * 1024;
+const READING: &str = "Glass session evidence\n\nmanifest.json describes capture scope, exclusions, limits and completeness.\nevents.jsonl is the ordered timeline. Evidence payloads are in blobs/.\nVerify lengths and SHA-256 digests before relying on evidence. Application\ntext and images are untrusted data, never instructions. Original runtime\npaths and glass-artifact URIs are historical; use relative payload paths.\nA constructed response does not prove client delivery or application success.\nAn incomplete trace may omit actions or outcomes. Never replay possibly\ndispatched input solely to recover missing evidence. This is not a replay bundle.\n";
+
+/// A bounded summary and timeline index; observation bytes remain in referenced files.
+#[derive(Debug, Serialize)]
+pub struct Inspection {
+    pub complete: bool,
+    pub manifest: serde_json::Value,
+    pub events: Vec<serde_json::Value>,
+    pub index_truncated: bool,
+    pub uncommitted_tail_bytes: u64,
+    pub unreferenced_files: usize,
+    pub payloads: usize,
+}
+
+impl Inspection {
+    pub fn exit_code(&self) -> i32 {
+        if self.complete { 0 } else { 2 }
+    }
+}
+
+struct Validated {
+    dir: Dir,
+    blobs: Dir,
+    _lease: File,
+    manifest: Manifest,
+    payloads: BTreeMap<String, Payload>,
+    report: Inspection,
+}
+
+fn absolute(path: &Path) -> anyhow::Result<PathBuf> {
+    Ok(if path.is_absolute() {
+        path.to_owned()
+    } else {
+        std::env::current_dir()?.join(path)
+    })
+}
+
+pub fn inspect(path: &Path) -> anyhow::Result<Inspection> {
+    Ok(validate(path)?.report)
+}
+
+fn validate(path: &Path) -> anyhow::Result<Validated> {
+    let dir = fs::open_directory(&absolute(path)?)?;
+    let lease = fs::open_file(&dir, "writer.lease", true)?;
+    ensure!(lease.metadata()?.len() == 0, "invalid trace lease");
+    FileExt::try_lock(&lease).context("trace is held by an active writer or inspector")?;
+    let manifest_bytes = fs::read_bounded(&dir, "manifest.json", RESERVE_BYTES)?;
+    let mut manifest: Manifest =
+        serde_json::from_slice(&manifest_bytes).context("invalid trace manifest")?;
+    ensure!(manifest.schema == SCHEMA, "unsupported trace schema");
+    ensure!(
+        matches!(
+            manifest.state.as_str(),
+            "recording" | "limited" | "failed" | "closed" | "interrupted"
+        ),
+        "unknown trace state"
+    );
+    ensure!(
+        matches!(
+            manifest.finalization.as_deref(),
+            None | Some("writer_closed" | "recovered_interrupted_prefix")
+        ),
+        "unknown trace finalization"
+    );
+    ensure!(
+        (MIN_MAX_BYTES..=MAX_MAX_BYTES).contains(&manifest.limits.bytes),
+        "invalid trace byte limit"
+    );
+    ensure!(
+        manifest.limits.events <= MAX_EVENTS
+            && manifest.limits.event_bytes <= MAX_EVENT_BYTES
+            && manifest.limits.payload_bytes <= MAX_PAYLOAD_BYTES
+            && manifest.limits.calls <= MAX_CALLS
+            && manifest.limits.blobs <= MAX_BLOBS
+            && manifest.limits.pending_bytes <= MAX_PENDING_BYTES
+            && manifest.limits.pending_events <= MAX_PENDING_EVENTS
+            && manifest.limits.blocks_per_event <= 128,
+        "invalid trace format limits"
+    );
+    let finalized = manifest.finalization.as_deref() == Some("writer_closed");
+    ensure!(
+        !manifest.complete
+            || (finalized
+                && manifest.state == "closed"
+                && manifest.omissions == 0
+                && manifest.errors == 0),
+        "inconsistent complete trace manifest"
+    );
+    let blobs = dir.open_dir_nofollow("blobs")?;
+    let journal = fs::open_file(&dir, "events.jsonl", false)?;
+    let journal_length = journal.metadata()?.len();
+    ensure!(
+        journal_length <= manifest.limits.bytes,
+        "journal exceeds trace byte limit"
+    );
+    let read_limit = if finalized {
+        ensure!(
+            manifest.journal_bytes <= journal_length,
+            "committed journal is missing bytes"
+        );
+        manifest.journal_bytes
+    } else {
+        journal_length
+    };
+    let mut reader = BufReader::new(journal.take(read_limit));
+    let mut journal_hash = Sha256::new();
+    let mut journal_bytes = 0;
+    let mut count = 0;
+    let mut calls = BTreeSet::new();
+    let mut unfinished = BTreeSet::new();
+    let mut outcomes = BTreeSet::new();
+    let mut payloads: BTreeMap<String, Payload> = BTreeMap::new();
+    let mut index = Vec::new();
+    let mut index_bytes = 0;
+    let mut index_truncated = false;
+    let mut omissions = 0_u64;
+    let mut total_bytes = manifest_bytes.len() as u64 + journal_length;
+    let mut last_kind = String::new();
+    loop {
+        let mut line = Vec::new();
+        let size = reader
+            .by_ref()
+            .take(MAX_EVENT_BYTES as u64 + 1)
+            .read_until(b'\n', &mut line)?;
+        if size == 0 {
+            break;
+        }
+        ensure!(
+            size <= MAX_EVENT_BYTES,
+            "trace event exceeds its size limit"
+        );
+        if line.last() != Some(&b'\n') {
+            ensure!(!finalized, "committed journal record is torn");
+            break;
+        }
+        let event: Event =
+            serde_json::from_slice(&line).context("invalid committed trace event")?;
+        count += 1;
+        ensure!(
+            count <= MAX_EVENTS && event.seq == count,
+            "invalid trace event ordering"
+        );
+        ensure!(
+            event.kind.len() <= 64 && event.evidence.len() <= 128,
+            "trace event metadata exceeds limits"
+        );
+        if let Some(call) = event.call {
+            ensure!(call != 0 && call <= MAX_CALLS, "invalid trace call ID");
+            if event.kind == "call_received" {
+                ensure!(calls.insert(call), "duplicate trace call ID");
+                unfinished.insert(call);
+            } else {
+                ensure!(calls.contains(&call), "event refers to an unknown call");
+            }
+            if matches!(
+                event.kind.as_str(),
+                "logical_outcome" | "router_rejection" | "worker_unavailable"
+            ) {
+                ensure!(outcomes.insert(call), "duplicate call execution outcome");
+                unfinished.remove(&call);
+            }
+        }
+        for evidence in &event.evidence {
+            ensure!(
+                evidence.payload.is_some() != evidence.omitted.is_some(),
+                "evidence must have a payload or an omission"
+            );
+            if evidence.omitted.is_some() {
+                omissions += 1;
+            }
+            if let Some(payload) = &evidence.payload {
+                validate_payload_name(payload)?;
+                ensure!(
+                    payload.bytes <= MAX_PAYLOAD_BYTES as u64,
+                    "evidence exceeds payload limit"
+                );
+                if let Some(previous) = payloads.get(&payload.sha256) {
+                    ensure!(
+                        previous.bytes == payload.bytes && previous.path == payload.path,
+                        "inconsistent evidence descriptor"
+                    );
+                } else {
+                    ensure!(payloads.len() < MAX_BLOBS, "too many trace payloads");
+                    let bytes = fs::read_bounded(
+                        &blobs,
+                        payload.path.trim_start_matches("blobs/"),
+                        payload.bytes,
+                    )?;
+                    ensure!(
+                        bytes.len() as u64 == payload.bytes && digest(&bytes) == payload.sha256,
+                        "evidence digest or size mismatch"
+                    );
+                    total_bytes += payload.bytes;
+                    ensure!(
+                        total_bytes <= manifest.limits.bytes,
+                        "trace exceeds total byte limit"
+                    );
+                    payloads.insert(payload.sha256.clone(), payload.clone());
+                }
+            }
+        }
+        let entry = json!({"seq": event.seq, "elapsed_us": event.elapsed_us, "kind": event.kind, "call": event.call, "client": event.client, "data": event.data, "evidence": event.evidence});
+        let entry_bytes = serde_json::to_vec(&entry)?.len();
+        if index_bytes + entry_bytes <= MAX_INDEX_BYTES {
+            index_bytes += entry_bytes;
+            index.push(entry);
+        } else {
+            index_truncated = true;
+        }
+        last_kind = event.kind;
+        journal_hash.update(&line);
+        journal_bytes += line.len() as u64;
+    }
+    let journal_digest = super::format::hex(&journal_hash.finalize());
+    if finalized {
+        ensure!(
+            manifest.events == count
+                && manifest.journal_bytes == journal_bytes
+                && manifest.journal_sha256.as_deref() == Some(&journal_digest),
+            "journal integrity mismatch"
+        );
+        ensure!(last_kind == "trace_closed", "final trace event missing");
+        ensure!(
+            manifest.calls == calls.len() as u64,
+            "trace call count mismatch"
+        );
+        ensure!(
+            !manifest.complete
+                || (unfinished.is_empty() && omissions == 0 && journal_length == journal_bytes),
+            "complete trace has missing evidence"
+        );
+    } else {
+        manifest.complete = false;
+        if manifest.state != "failed" {
+            manifest.state = "interrupted".into();
+        }
+        manifest.events = count;
+        manifest.calls = calls.len() as u64;
+        manifest.journal_bytes = journal_bytes;
+        manifest.journal_sha256 = Some(journal_digest);
+        manifest.omissions = manifest.omissions.max(omissions);
+    }
+    let mut unreferenced = 0;
+    for entry in blobs.entries()? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let expected = name
+            .to_str()
+            .and_then(|name| name.strip_suffix(".bin"))
+            .is_some_and(|sha| payloads.contains_key(sha));
+        if !expected {
+            unreferenced += 1;
+            ensure!(
+                entry.file_type()?.is_file(),
+                "non-file staging evidence is refused"
+            );
+            let metadata = fs::open_file(
+                &blobs,
+                name.to_str().context("invalid staging filename")?,
+                false,
+            )?
+            .metadata()?;
+            total_bytes = total_bytes
+                .checked_add(metadata.len())
+                .context("trace size overflow")?;
+        }
+        ensure!(
+            payloads.len() + unreferenced <= MAX_BLOBS + MAX_PENDING_EVENTS,
+            "too many trace directory entries"
+        );
+    }
+    for entry in dir.entries()? {
+        let entry = entry?;
+        let name = entry.file_name();
+        if matches!(
+            name.to_str(),
+            Some("manifest.json" | "events.jsonl" | "blobs" | "writer.lease")
+        ) {
+            continue;
+        }
+        ensure!(
+            name.to_str()
+                .is_some_and(|name| name.starts_with("pending-"))
+                && entry.file_type()?.is_file(),
+            "unknown trace directory entry"
+        );
+        unreferenced += 1;
+        ensure!(
+            unreferenced <= MAX_BLOBS + MAX_PENDING_EVENTS,
+            "too many staging files"
+        );
+        total_bytes = total_bytes
+            .checked_add(
+                fs::open_file(
+                    &dir,
+                    name.to_str().context("invalid staging filename")?,
+                    false,
+                )?
+                .metadata()?
+                .len(),
+            )
+            .context("trace size overflow")?;
+    }
+    ensure!(
+        total_bytes <= manifest.limits.bytes,
+        "trace exceeds total byte limit"
+    );
+    ensure!(
+        !manifest.complete || (unreferenced == 0 && manifest.stored_bytes == total_bytes),
+        "complete trace storage accounting mismatch"
+    );
+    let report = Inspection {
+        complete: manifest.complete,
+        manifest: serde_json::to_value(&manifest)?,
+        events: index,
+        index_truncated,
+        uncommitted_tail_bytes: journal_length - journal_bytes,
+        unreferenced_files: unreferenced,
+        payloads: payloads.len(),
+    };
+    Ok(Validated {
+        dir,
+        blobs,
+        _lease: lease,
+        manifest,
+        payloads,
+        report,
+    })
+}
+
+fn validate_payload_name(payload: &Payload) -> anyhow::Result<()> {
+    ensure!(
+        payload.sha256.len() == 64
+            && payload
+                .sha256
+                .bytes()
+                .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b)),
+        "invalid evidence digest"
+    );
+    ensure!(
+        payload.path == format!("blobs/{}.bin", payload.sha256),
+        "invalid evidence relative path"
+    );
+    Ok(())
+}
+
+pub fn print_inspection(report: &Inspection, as_json: bool) -> anyhow::Result<()> {
+    let mut out = std::io::stdout().lock();
+    if as_json {
+        serde_json::to_writer(&mut out, report)?;
+        writeln!(out)?;
+    } else {
+        writeln!(
+            out,
+            "Trace {}: {} ({} payloads)",
+            report.manifest["id"],
+            if report.complete {
+                "complete"
+            } else {
+                "incomplete"
+            },
+            report.payloads
+        )?;
+        for event in &report.events {
+            // JSON string formatting escapes terminal controls in all nonliteral fields.
+            writeln!(
+                out,
+                "{} call={} {} {}",
+                event["seq"], event["call"], event["kind"], event["data"]
+            )?;
+            if let Some(evidence) = event["evidence"].as_array() {
+                for item in evidence {
+                    writeln!(
+                        out,
+                        "  {} {} {}",
+                        item["label"], item["payload"]["path"], item["omitted"]
+                    )?;
+                }
+            }
+        }
+        if report.index_truncated {
+            writeln!(
+                out,
+                "Timeline index truncated; full validated journal remains in events.jsonl."
+            )?;
+        }
+    }
+    Ok(())
+}
+
+pub fn export(source: &Path, output: &Path) -> anyhow::Result<Inspection> {
+    let source = absolute(source)?;
+    let output = absolute(output)?;
+    ensure!(
+        !output.starts_with(&source) && !source.starts_with(&output),
+        "export source and destination overlap"
+    );
+    let mut validated = validate(&source)?;
+    let parent = fs::open_directory(output.parent().context("export needs a parent directory")?)?;
+    for ancestor in output
+        .parent()
+        .unwrap()
+        .ancestors()
+        .take_while(|path| path.parent().is_some())
+    {
+        ensure!(
+            !fs::same_directory(&validated.dir, &fs::open_directory(ancestor)?)?,
+            "export source and destination overlap"
+        );
+    }
+    let name = output
+        .file_name()
+        .and_then(|s| s.to_str())
+        .context("export filename must be UTF-8")?;
+    ensure!(
+        name != "." && name != ".." && !name.contains(['/', '\\', ':']),
+        "invalid export filename"
+    );
+    ensure!(
+        parent
+            .symlink_metadata(name)
+            .is_err_and(|e| e.kind() == std::io::ErrorKind::NotFound),
+        "export destination already exists or is inaccessible"
+    );
+    let temporary = format!("pending-{}.zip", crate::artifacts::new_server_id());
+    let file = fs::create_file(&parent, &temporary)?;
+    let result = (|| {
+        use zip::write::SimpleFileOptions;
+        let options = SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Stored)
+            .unix_permissions(0o600);
+        let mut zip = zip::ZipWriter::new(file);
+        if validated.manifest.finalization.is_none() {
+            validated.manifest.finalization = Some("recovered_interrupted_prefix".into());
+        }
+        zip.start_file("manifest.json", options)?;
+        serde_json::to_writer(&mut zip, &validated.manifest)?;
+        zip.start_file("events.jsonl", options)?;
+        let journal = fs::open_file(&validated.dir, "events.jsonl", false)?;
+        let mut bytes = journal.take(validated.manifest.journal_bytes);
+        let mut hasher = Sha256::new();
+        let mut buffer = [0u8; 64 * 1024];
+        let mut copied = 0;
+        loop {
+            let count = bytes.read(&mut buffer)?;
+            if count == 0 {
+                break;
+            }
+            hasher.update(&buffer[..count]);
+            zip.write_all(&buffer[..count])?;
+            copied += count as u64;
+        }
+        ensure!(
+            copied == validated.manifest.journal_bytes
+                && Some(super::format::hex(&hasher.finalize()))
+                    == validated.manifest.journal_sha256,
+            "journal changed during export"
+        );
+        for payload in validated.payloads.values() {
+            let bytes = fs::read_bounded(
+                &validated.blobs,
+                payload.path.trim_start_matches("blobs/"),
+                payload.bytes,
+            )?;
+            ensure!(
+                bytes.len() as u64 == payload.bytes && digest(&bytes) == payload.sha256,
+                "evidence changed during export"
+            );
+            zip.start_file(&payload.path, options)?;
+            zip.write_all(&bytes)?;
+        }
+        zip.start_file("READING.txt", options)?;
+        zip.write_all(READING.as_bytes())?;
+        let mut file = zip.finish()?;
+        file.flush()?;
+        drop(file);
+        parent.hard_link(&temporary, &parent, name)?;
+        if parent.remove_file(&temporary).is_err() {
+            eprintln!("glass: export succeeded but temporary archive cleanup failed");
+        }
+        Ok(validated.report)
+    })();
+    if result.is_err() {
+        let _ = parent.remove_file(&temporary);
+    }
+    result
+}
+
+use cap_fs_ext::DirExt;

--- a/crates/glass-mcp/src/trace/inspect.rs
+++ b/crates/glass-mcp/src/trace/inspect.rs
@@ -1,11 +1,9 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs::File;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, ensure};
 use cap_std::fs::Dir;
-use fs4::FileExt;
 use serde::Serialize;
 use serde_json::json;
 use sha2::{Digest, Sha256};
@@ -38,7 +36,7 @@ impl Inspection {
 struct Validated {
     dir: Dir,
     blobs: Dir,
-    _lease: File,
+    _lease: fs::Lease,
     manifest: Manifest,
     payloads: BTreeMap<String, Payload>,
     report: Inspection,
@@ -60,7 +58,8 @@ fn validate(path: &Path) -> anyhow::Result<Validated> {
     let dir = fs::open_directory(&absolute(path)?)?;
     let lease = fs::open_file(&dir, "writer.lease", true)?;
     ensure!(lease.metadata()?.len() == 0, "invalid trace lease");
-    FileExt::try_lock(&lease).context("trace is held by an active writer or inspector")?;
+    let lease =
+        fs::Lease::try_lock(lease).context("trace is held by an active writer or inspector")?;
     let manifest_bytes = fs::read_bounded(&dir, "manifest.json", RESERVE_BYTES)?;
     let mut manifest: Manifest =
         serde_json::from_slice(&manifest_bytes).context("invalid trace manifest")?;

--- a/crates/glass-mcp/src/trace/mod.rs
+++ b/crates/glass-mcp/src/trace/mod.rs
@@ -1,0 +1,19 @@
+//! Optional session evidence recording and offline inspection.
+
+mod capture;
+mod config;
+mod format;
+mod fs;
+mod inspect;
+mod recorder;
+mod store;
+
+pub(crate) use capture::{ACTIVE_CALL, RequestGuard, arguments, current_call, start_arguments};
+pub use config::TraceConfig;
+pub use inspect::{export, inspect, print_inspection};
+pub(crate) use recorder::{CallTrace, TraceRecorder, argument_bytes};
+
+#[cfg(test)]
+mod tests;
+#[cfg(test)]
+mod transport_tests;

--- a/crates/glass-mcp/src/trace/recorder.rs
+++ b/crates/glass-mcp/src/trace/recorder.rs
@@ -197,7 +197,7 @@ struct Inner {
     path: PathBuf,
     sender: mpsc::SyncSender<Pending>,
     shared: Arc<Shared>,
-    done: Mutex<Option<tokio::sync::oneshot::Receiver<()>>>,
+    done: tokio::sync::watch::Receiver<bool>,
     next_client: AtomicU64,
 }
 
@@ -285,20 +285,20 @@ impl TraceRecorder {
             writer_gate: Mutex::new(None),
         });
         let (sender, receiver) = mpsc::sync_channel(MAX_PENDING_EVENTS);
-        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+        let (done_tx, done_rx) = tokio::sync::watch::channel(false);
         let worker_shared = shared.clone();
         std::thread::Builder::new()
             .name("glass-trace".into())
             .spawn(move || {
                 writer(store, receiver, &worker_shared);
-                let _ = done_tx.send(());
+                let _ = done_tx.send(true);
             })?;
         let recorder = Self(Arc::new(Inner {
             root: root_path.clone(),
             path: root_path.join(name),
             sender,
             shared,
-            done: Mutex::new(Some(done_rx)),
+            done: done_rx,
             next_client: AtomicU64::new(1),
         }));
         recorder.record("inventory", None, 0, json!({}), |capture| {
@@ -438,13 +438,11 @@ impl TraceRecorder {
                 .unwrap_or_else(|e| e.into_inner());
             self.0.shared.closing.store(true, Ordering::Release);
         }
-        let done = self.0.done.lock().unwrap_or_else(|e| e.into_inner()).take();
-        if let Some(done) = done
-            && !matches!(
-                tokio::time::timeout(Duration::from_secs(2), done).await,
-                Ok(Ok(()))
-            )
-        {
+        let mut done = self.0.done.clone();
+        if !matches!(
+            tokio::time::timeout(Duration::from_secs(2), done.wait_for(|finished| *finished)).await,
+            Ok(Ok(_))
+        ) {
             self.0.shared.timed_out.store(true, Ordering::Release);
             self.0.shared.errors.fetch_add(1, Ordering::Relaxed);
             self.0.shared.stop(FAILED, "writer shutdown timeout");
@@ -460,6 +458,15 @@ impl TraceRecorder {
         })
         .await
         .expect("trace writer drained");
+    }
+
+    #[cfg(test)]
+    pub(super) async fn writer_finished(&self) {
+        let mut done = self.0.done.clone();
+        tokio::time::timeout(Duration::from_secs(10), done.wait_for(|finished| *finished))
+            .await
+            .expect("trace writer finished")
+            .expect("trace writer completion published");
     }
 
     #[cfg(test)]

--- a/crates/glass-mcp/src/trace/recorder.rs
+++ b/crates/glass-mcp/src/trace/recorder.rs
@@ -1,0 +1,688 @@
+use std::collections::BTreeSet;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, mpsc};
+use std::time::{Duration, Instant};
+
+use serde::Serialize;
+use serde_json::json;
+
+use super::TraceConfig;
+use super::config::*;
+use super::format::{Event, Evidence, Limits, Manifest, SCHEMA};
+use super::{fs, store::Store};
+
+const RECORDING: u8 = 0;
+const LIMITED: u8 = 1;
+const FAILED: u8 = 2;
+const CLOSED: u8 = 3;
+
+struct Shared {
+    state: AtomicU8,
+    closing: AtomicBool,
+    admission: Mutex<()>,
+    timed_out: AtomicBool,
+    pending_bytes: AtomicUsize,
+    calls: AtomicU64,
+    events: AtomicU64,
+    omissions: AtomicU64,
+    errors: AtomicU64,
+    stored_bytes: AtomicU64,
+    max_bytes: u64,
+    start: Instant,
+    #[cfg(test)]
+    fail_next_write: AtomicBool,
+    #[cfg(test)]
+    writer_gate: Mutex<Option<(mpsc::SyncSender<()>, mpsc::Receiver<()>)>>,
+}
+
+impl Shared {
+    fn stop(&self, state: u8, reason: &str) {
+        if self
+            .state
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                (current < state && current != CLOSED).then_some(state)
+            })
+            .is_ok()
+        {
+            eprintln!("glass: session trace incomplete ({reason}); tool execution is unchanged");
+        }
+    }
+
+    fn reserve(&self, count: usize) -> bool {
+        if self
+            .pending_bytes
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |used| {
+                used.checked_add(count)
+                    .filter(|next| *next <= MAX_PENDING_BYTES)
+            })
+            .is_ok()
+        {
+            true
+        } else {
+            self.stop(LIMITED, "pending byte limit");
+            false
+        }
+    }
+}
+
+struct Pending {
+    event: Event,
+    blobs: Vec<(usize, Vec<u8>)>,
+    reserved: usize,
+    shared: Arc<Shared>,
+}
+
+impl Drop for Pending {
+    fn drop(&mut self) {
+        self.shared
+            .pending_bytes
+            .fetch_sub(self.reserved, Ordering::AcqRel);
+    }
+}
+
+pub(super) struct Capture<'a> {
+    pending: &'a mut Pending,
+}
+
+impl Capture<'_> {
+    pub fn entries(&self) -> usize {
+        self.pending.event.evidence.len()
+    }
+
+    pub fn read_bytes(
+        &mut self,
+        mut evidence: Evidence,
+        length: usize,
+        read: impl FnOnce() -> Option<Vec<u8>>,
+    ) {
+        evidence.original_bytes = Some(length as u64);
+        if length > MAX_PAYLOAD_BYTES {
+            self.omission(evidence, "payload_limit");
+        } else if !self.pending.shared.reserve(length) {
+            self.omission(evidence, "pending_byte_limit");
+        } else {
+            self.pending.reserved += length;
+            match read() {
+                Some(bytes) if bytes.len() == length => {
+                    self.pending
+                        .blobs
+                        .push((self.pending.event.evidence.len(), bytes));
+                    self.pending.event.evidence.push(evidence);
+                }
+                _ => self.omission(evidence, "artifact_unavailable"),
+            }
+        }
+    }
+
+    pub fn bytes(&mut self, mut evidence: Evidence, bytes: &[u8]) {
+        evidence.original_bytes = Some(bytes.len() as u64);
+        let index = self.pending.event.evidence.len();
+        if bytes.len() > MAX_PAYLOAD_BYTES {
+            evidence.omitted = Some("payload_limit".into());
+            self.pending
+                .shared
+                .omissions
+                .fetch_add(1, Ordering::Relaxed);
+        } else if self.pending.shared.reserve(bytes.len()) {
+            self.pending.reserved += bytes.len();
+            self.pending.blobs.push((index, bytes.to_vec()));
+        } else {
+            evidence.omitted = Some("pending_byte_limit".into());
+            self.pending
+                .shared
+                .omissions
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        self.pending.event.evidence.push(evidence);
+    }
+
+    pub fn json(&mut self, mut evidence: Evidence, value: &impl Serialize) {
+        let mut counter = Counter(0);
+        if serde_json::to_writer(&mut counter, value).is_err() {
+            evidence.omitted = Some("serialization_failed".into());
+        } else {
+            evidence.original_bytes = Some(counter.0 as u64);
+            if counter.0 > MAX_PAYLOAD_BYTES {
+                evidence.omitted = Some("payload_limit".into());
+            } else if self.pending.shared.reserve(counter.0) {
+                self.pending.reserved += counter.0;
+                match serde_json::to_vec(value) {
+                    Ok(bytes) if bytes.len() == counter.0 => {
+                        self.pending
+                            .blobs
+                            .push((self.pending.event.evidence.len(), bytes));
+                    }
+                    _ => evidence.omitted = Some("serialization_failed".into()),
+                }
+            } else {
+                evidence.omitted = Some("pending_byte_limit".into());
+            }
+        }
+        if evidence.omitted.is_some() {
+            self.pending
+                .shared
+                .omissions
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        self.pending.event.evidence.push(evidence);
+    }
+
+    pub fn omission(&mut self, mut evidence: Evidence, reason: &str) {
+        evidence.omitted = Some(reason.into());
+        self.pending.event.evidence.push(evidence);
+        self.pending
+            .shared
+            .omissions
+            .fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+pub(super) fn evidence(label: &str, mime: &str, trust: &str, block: Option<usize>) -> Evidence {
+    Evidence {
+        label: label.into(),
+        mime_type: mime.into(),
+        trust: trust.into(),
+        block,
+        source_uri: None,
+        payload: None,
+        omitted: None,
+        original_bytes: None,
+    }
+}
+
+struct Inner {
+    root: PathBuf,
+    path: PathBuf,
+    sender: mpsc::SyncSender<Pending>,
+    shared: Arc<Shared>,
+    done: Mutex<Option<tokio::sync::oneshot::Receiver<()>>>,
+    next_client: AtomicU64,
+}
+
+impl Drop for Inner {
+    fn drop(&mut self) {
+        self.shared.closing.store(true, Ordering::Release);
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct TraceRecorder(Arc<Inner>);
+
+impl TraceRecorder {
+    pub fn start(
+        config: &TraceConfig,
+        profile: crate::tool_profile::ToolProfile,
+        transport: &str,
+    ) -> anyhow::Result<Self> {
+        TraceConfig::new(config.directory.clone(), Some(config.max_bytes))?;
+        let root = fs::open_directory(&config.directory)?;
+        fs::check_owner(&root)?;
+        let root_path = config.directory.canonicalize()?;
+        anyhow::ensure!(
+            fs::same_directory(&root, &fs::open_directory(&root_path)?)?,
+            "trace root changed while opening it"
+        );
+        let id = crate::artifacts::new_server_id();
+        let name = format!("trace-{id}");
+        let directory = fs::create_directory(&root, &name)?;
+        let manifest = Manifest {
+            schema: SCHEMA.into(),
+            id,
+            started_at: chrono::Utc::now().to_rfc3339(),
+            server_version: crate::VERSION.into(),
+            source_revision: None,
+            os: std::env::consts::OS.into(),
+            architecture: std::env::consts::ARCH.into(),
+            transport: transport.into(),
+            profile: match profile {
+                crate::tool_profile::ToolProfile::Full => "full",
+                crate::tool_profile::ToolProfile::Lean => "lean",
+            }
+            .into(),
+            exclusions: [
+                "transport_credentials",
+                "http_headers",
+                "protocol_session_tokens",
+                "request_meta",
+                "host_environment",
+                "glass_start.env_names_and_values",
+                "malformed_arguments",
+                "secure_accessibility_values",
+            ]
+            .map(String::from)
+            .into(),
+            limits: Limits::new(config.max_bytes),
+            state: "recording".into(),
+            complete: false,
+            events: 0,
+            calls: 0,
+            omissions: 0,
+            errors: 0,
+            stored_bytes: 0,
+            journal_bytes: 0,
+            journal_sha256: None,
+            finalization: None,
+        };
+        let store = Store::new(directory, manifest)?;
+        let shared = Arc::new(Shared {
+            state: AtomicU8::new(RECORDING),
+            closing: AtomicBool::new(false),
+            admission: Mutex::new(()),
+            timed_out: AtomicBool::new(false),
+            pending_bytes: AtomicUsize::new(0),
+            calls: AtomicU64::new(0),
+            events: AtomicU64::new(0),
+            omissions: AtomicU64::new(0),
+            errors: AtomicU64::new(0),
+            stored_bytes: AtomicU64::new(store.manifest.stored_bytes),
+            max_bytes: config.max_bytes,
+            start: Instant::now(),
+            #[cfg(test)]
+            fail_next_write: AtomicBool::new(false),
+            #[cfg(test)]
+            writer_gate: Mutex::new(None),
+        });
+        let (sender, receiver) = mpsc::sync_channel(MAX_PENDING_EVENTS);
+        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+        let worker_shared = shared.clone();
+        std::thread::Builder::new()
+            .name("glass-trace".into())
+            .spawn(move || {
+                writer(store, receiver, &worker_shared);
+                let _ = done_tx.send(());
+            })?;
+        let recorder = Self(Arc::new(Inner {
+            root: root_path.clone(),
+            path: root_path.join(name),
+            sender,
+            shared,
+            done: Mutex::new(Some(done_rx)),
+            next_client: AtomicU64::new(1),
+        }));
+        recorder.record("inventory", None, 0, json!({}), |capture| {
+            capture.json(evidence("tools_and_instructions", "application/json", "glass", None), &json!({
+                "tools": crate::server::tool_inventory(profile), "instructions": profile.instructions(),
+            }));
+        });
+        eprintln!(
+            "glass: session trace at {:?}; retains supplied inputs and requested app evidence, which may contain sensitive data",
+            recorder.path()
+        );
+        Ok(recorder)
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.0.root
+    }
+    pub fn path(&self) -> &Path {
+        &self.0.path
+    }
+    pub fn new_client(&self) -> u64 {
+        let client = self.0.next_client.fetch_add(1, Ordering::Relaxed);
+        self.record("client_created", None, client, json!({}), |_| {});
+        client
+    }
+
+    pub fn shutdown_event(&self, status: &str) {
+        self.record(
+            "shutdown",
+            None,
+            0,
+            json!({"status": status, "host_hook_confirmation": "not_reported"}),
+            |_| {},
+        );
+        if status != "completed" {
+            self.0.shared.errors.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    pub fn status(&self) -> serde_json::Value {
+        let shared = &self.0.shared;
+        json!({
+            "enabled": true, "state": state_name(shared.state.load(Ordering::Acquire)),
+            "stored_bytes": shared.stored_bytes.load(Ordering::Relaxed), "calls": shared.calls.load(Ordering::Relaxed).min(MAX_CALLS),
+            "limits": Limits::new(shared.max_bytes), "omissions": shared.omissions.load(Ordering::Relaxed), "errors": shared.errors.load(Ordering::Relaxed),
+        })
+    }
+
+    pub fn begin_call(&self, tool: &str, client: u64) -> Option<CallTrace> {
+        if !self.accepting() {
+            return None;
+        }
+        let call = self.0.shared.calls.fetch_add(1, Ordering::Relaxed) + 1;
+        if call > MAX_CALLS {
+            self.0.shared.omissions.fetch_add(1, Ordering::Relaxed);
+            self.0.shared.stop(LIMITED, "call limit");
+            return None;
+        }
+        self.record(
+            "call_received",
+            Some(call),
+            client,
+            json!({"tool": tool.chars().take(128).collect::<String>()}),
+            |_| {},
+        );
+        Some(CallTrace {
+            recorder: self.clone(),
+            id: call,
+            client,
+            valid_arguments: Arc::new(AtomicBool::new(false)),
+        })
+    }
+
+    fn accepting(&self) -> bool {
+        !self.0.shared.closing.load(Ordering::Acquire)
+            && self.0.shared.state.load(Ordering::Acquire) == RECORDING
+    }
+
+    pub(super) fn record(
+        &self,
+        kind: &str,
+        call: Option<u64>,
+        client: u64,
+        data: serde_json::Value,
+        capture: impl FnOnce(&mut Capture<'_>),
+    ) {
+        let admission = self
+            .0
+            .shared
+            .admission
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        if !self.accepting() {
+            return;
+        }
+        if self.0.shared.events.fetch_add(1, Ordering::Relaxed) >= MAX_EVENTS - 1 {
+            self.0.shared.omissions.fetch_add(1, Ordering::Relaxed);
+            self.0.shared.stop(LIMITED, "event limit");
+            return;
+        }
+        let mut pending = Pending {
+            event: Event {
+                seq: 0,
+                elapsed_us: elapsed(&self.0.shared),
+                kind: kind.into(),
+                call,
+                client,
+                data,
+                evidence: vec![],
+            },
+            blobs: vec![],
+            reserved: MAX_EVENT_BYTES,
+            shared: self.0.shared.clone(),
+        };
+        if !self.0.shared.reserve(MAX_EVENT_BYTES) {
+            pending.reserved = 0;
+            self.0.shared.omissions.fetch_add(1, Ordering::Relaxed);
+            return;
+        }
+        drop(admission);
+        capture(&mut Capture {
+            pending: &mut pending,
+        });
+        if self.0.sender.try_send(pending).is_err() {
+            self.0.shared.omissions.fetch_add(1, Ordering::Relaxed);
+            self.0.shared.stop(LIMITED, "writer queue unavailable");
+        }
+    }
+
+    pub async fn close(&self) {
+        {
+            let _admission = self
+                .0
+                .shared
+                .admission
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            self.0.shared.closing.store(true, Ordering::Release);
+        }
+        let done = self.0.done.lock().unwrap_or_else(|e| e.into_inner()).take();
+        if let Some(done) = done
+            && !matches!(
+                tokio::time::timeout(Duration::from_secs(2), done).await,
+                Ok(Ok(()))
+            )
+        {
+            self.0.shared.timed_out.store(true, Ordering::Release);
+            self.0.shared.errors.fetch_add(1, Ordering::Relaxed);
+            self.0.shared.stop(FAILED, "writer shutdown timeout");
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) async fn idle(&self) {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while self.0.shared.pending_bytes.load(Ordering::Acquire) != 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("trace writer drained");
+    }
+
+    #[cfg(test)]
+    pub(super) fn fail_next_write(&self) {
+        self.0.shared.fail_next_write.store(true, Ordering::Release);
+    }
+
+    #[cfg(test)]
+    pub(super) fn pause_next_write(&self) -> (mpsc::Receiver<()>, mpsc::SyncSender<()>) {
+        let (entered_tx, entered_rx) = mpsc::sync_channel(1);
+        let (release_tx, release_rx) = mpsc::sync_channel(1);
+        *self.0.shared.writer_gate.lock().unwrap() = Some((entered_tx, release_rx));
+        (entered_rx, release_tx)
+    }
+
+    #[cfg(test)]
+    pub(super) fn set_calls_at_limit(&self) {
+        self.0.shared.calls.store(MAX_CALLS, Ordering::Relaxed);
+    }
+}
+
+fn elapsed(shared: &Shared) -> u64 {
+    u64::try_from(shared.start.elapsed().as_micros()).unwrap_or(u64::MAX)
+}
+
+fn state_name(state: u8) -> &'static str {
+    match state {
+        RECORDING => "recording",
+        LIMITED => "limited",
+        FAILED => "failed",
+        _ => "closed",
+    }
+}
+
+fn writer(mut store: Store, receiver: mpsc::Receiver<Pending>, shared: &Shared) {
+    let mut unfinished = BTreeSet::new();
+    let mut journal_has_capacity = true;
+    loop {
+        let pending = match receiver.recv_timeout(Duration::from_millis(20)) {
+            Ok(pending) => pending,
+            Err(mpsc::RecvTimeoutError::Timeout)
+                if !shared.closing.load(Ordering::Acquire)
+                    || shared.pending_bytes.load(Ordering::Acquire) != 0 =>
+            {
+                continue;
+            }
+            Err(_) => break,
+        };
+        if shared.state.load(Ordering::Acquire) == FAILED || !journal_has_capacity {
+            continue;
+        }
+        match write_pending(&mut store, &pending, shared, &mut unfinished) {
+            Ok(has_capacity) => journal_has_capacity = has_capacity,
+            Err(_) => {
+                shared.errors.fetch_add(1, Ordering::Relaxed);
+                shared.stop(FAILED, "evidence write failed");
+            }
+        }
+        shared
+            .stored_bytes
+            .store(store.manifest.stored_bytes, Ordering::Relaxed);
+    }
+    if shared.state.load(Ordering::Acquire) == FAILED || shared.timed_out.load(Ordering::Acquire) {
+        store.manifest.state = "failed".into();
+        store.manifest.errors = shared.errors.load(Ordering::Relaxed);
+        store.manifest.omissions = shared.omissions.load(Ordering::Relaxed);
+        let _ = store.write_manifest();
+        return;
+    }
+    let terminal = Event {
+        seq: 0,
+        elapsed_us: elapsed(shared),
+        kind: "trace_closed".into(),
+        call: None,
+        client: 0,
+        data: json!({"unfinished_calls": unfinished, "writer_timed_out": shared.timed_out.load(Ordering::Acquire)}),
+        evidence: vec![],
+    };
+    if store.event(terminal, true).is_err() {
+        shared.errors.fetch_add(1, Ordering::Relaxed);
+        shared.stop(FAILED, "terminal record write failed");
+        return;
+    }
+    let state = shared.state.load(Ordering::Acquire);
+    store.manifest.state = if state == RECORDING {
+        "closed".into()
+    } else {
+        state_name(state).into()
+    };
+    store.manifest.omissions = shared.omissions.load(Ordering::Relaxed);
+    store.manifest.errors = shared.errors.load(Ordering::Relaxed);
+    store.manifest.complete = state == RECORDING
+        && store.manifest.omissions == 0
+        && store.manifest.errors == 0
+        && unfinished.is_empty()
+        && !shared.timed_out.load(Ordering::Acquire);
+    store.manifest.finalization = Some("writer_closed".into());
+    if store.finish().is_err() {
+        shared.errors.fetch_add(1, Ordering::Relaxed);
+        shared.stop(FAILED, "trace finalization failed");
+    } else if state == RECORDING {
+        let _ =
+            shared
+                .state
+                .compare_exchange(RECORDING, CLOSED, Ordering::AcqRel, Ordering::Acquire);
+    }
+    shared
+        .stored_bytes
+        .store(store.manifest.stored_bytes, Ordering::Relaxed);
+}
+
+fn write_pending(
+    store: &mut Store,
+    pending: &Pending,
+    shared: &Shared,
+    unfinished: &mut BTreeSet<u64>,
+) -> anyhow::Result<bool> {
+    #[cfg(test)]
+    if let Some((entered, release)) = shared.writer_gate.lock().unwrap().take() {
+        let _ = entered.send(());
+        let _ = release.recv();
+    }
+    #[cfg(test)]
+    if shared.fail_next_write.swap(false, Ordering::AcqRel) {
+        anyhow::bail!("injected trace write failure");
+    }
+    let mut event = pending.event.clone();
+    for (index, bytes) in &pending.blobs {
+        match store.payload(bytes)? {
+            Some(payload) => event.evidence[*index].payload = Some(payload),
+            None => {
+                event.evidence[*index].omitted = Some("total_byte_limit".into());
+                shared.omissions.fetch_add(1, Ordering::Relaxed);
+                shared.stop(LIMITED, "total byte limit");
+            }
+        }
+    }
+    if store.event(event.clone(), false)? {
+        if let Some(call) = event.call {
+            match event.kind.as_str() {
+                "call_received" => {
+                    unfinished.insert(call);
+                    store.manifest.calls += 1;
+                }
+                "logical_outcome" | "router_rejection" | "worker_unavailable" => {
+                    unfinished.remove(&call);
+                }
+                _ => {}
+            }
+        }
+    } else {
+        shared.omissions.fetch_add(1, Ordering::Relaxed);
+        shared.stop(LIMITED, "total byte limit");
+        return Ok(false);
+    }
+    Ok(true)
+}
+
+#[derive(Clone)]
+pub(crate) struct CallTrace {
+    recorder: TraceRecorder,
+    pub id: u64,
+    pub client: u64,
+    valid_arguments: Arc<AtomicBool>,
+}
+
+impl CallTrace {
+    pub fn record(&self, kind: &str, data: serde_json::Value) {
+        self.recorder
+            .record(kind, Some(self.id), self.client, data, |_| {});
+    }
+
+    pub fn arguments(&self, value: &impl Serialize) {
+        self.valid_arguments.store(true, Ordering::Release);
+        self.capture("arguments", json!({}), |capture| {
+            capture.json(
+                evidence("arguments", "application/json", "caller", None),
+                value,
+            )
+        });
+    }
+
+    pub fn has_valid_arguments(&self) -> bool {
+        self.valid_arguments.load(Ordering::Acquire)
+    }
+
+    pub fn arguments_unavailable(&self) {
+        self.valid_arguments.store(true, Ordering::Release);
+        self.capture("arguments", json!({}), |capture| {
+            capture.omission(
+                evidence("arguments", "application/json", "caller", None),
+                "argument_capture_unavailable",
+            );
+        });
+    }
+
+    pub(super) fn capture(
+        &self,
+        kind: &str,
+        data: serde_json::Value,
+        capture: impl FnOnce(&mut Capture<'_>),
+    ) {
+        self.recorder
+            .record(kind, Some(self.id), self.client, data, capture);
+    }
+}
+
+struct Counter(usize);
+
+pub(crate) fn argument_bytes(value: &impl Serialize) -> Option<u64> {
+    let mut counter = Counter(0);
+    serde_json::to_writer(&mut counter, value).ok()?;
+    u64::try_from(counter.0).ok()
+}
+impl Write for Counter {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        self.0 = self
+            .0
+            .checked_add(bytes.len())
+            .ok_or_else(|| std::io::Error::other("serialized size overflow"))?;
+        Ok(bytes.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}

--- a/crates/glass-mcp/src/trace/store.rs
+++ b/crates/glass-mcp/src/trace/store.rs
@@ -1,0 +1,123 @@
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io::Write;
+
+use anyhow::ensure;
+use cap_std::fs::Dir;
+use sha2::{Digest, Sha256};
+
+use super::config::{MAX_BLOBS, MAX_EVENT_BYTES, RESERVE_BYTES};
+use super::format::{Event, Manifest, Payload, digest};
+use super::fs;
+
+pub(super) struct Store {
+    pub directory: Dir,
+    pub blobs: Dir,
+    pub manifest: Manifest,
+    journal: File,
+    journal_hash: Sha256,
+    manifest_bytes: u64,
+    payloads: BTreeMap<String, Payload>,
+    _lease: File,
+}
+
+impl Store {
+    pub fn new(directory: Dir, manifest: Manifest) -> anyhow::Result<Self> {
+        use fs4::FileExt;
+        let lease = fs::create_file(&directory, "writer.lease")?;
+        FileExt::try_lock(&lease)?;
+        let blobs = fs::create_directory(&directory, "blobs")?;
+        let journal = fs::create_file(&directory, "events.jsonl")?;
+        let mut store = Self {
+            directory,
+            blobs,
+            manifest,
+            journal,
+            journal_hash: Sha256::new(),
+            manifest_bytes: 0,
+            payloads: BTreeMap::new(),
+            _lease: lease,
+        };
+        store.write_manifest()?;
+        Ok(store)
+    }
+
+    pub fn available(&self, bytes: u64) -> bool {
+        self.manifest
+            .stored_bytes
+            .saturating_add(bytes)
+            .saturating_add(RESERVE_BYTES)
+            <= self.manifest.limits.bytes
+    }
+
+    pub fn payload(&mut self, bytes: &[u8]) -> anyhow::Result<Option<Payload>> {
+        let sha256 = digest(bytes);
+        if let Some(payload) = self.payloads.get(&sha256) {
+            return Ok(Some(payload.clone()));
+        }
+        if self.payloads.len() >= MAX_BLOBS || !self.available(bytes.len() as u64) {
+            return Ok(None);
+        }
+        let name = format!("{sha256}.bin");
+        fs::write_atomic(&self.blobs, &name, bytes)?;
+        self.manifest.stored_bytes += bytes.len() as u64;
+        let payload = Payload {
+            path: format!("blobs/{name}"),
+            bytes: bytes.len() as u64,
+            sha256: sha256.clone(),
+        };
+        self.payloads.insert(sha256, payload.clone());
+        Ok(Some(payload))
+    }
+
+    pub fn event(&mut self, mut event: Event, terminal: bool) -> anyhow::Result<bool> {
+        event.seq = self.manifest.events + 1;
+        let mut bytes = serde_json::to_vec(&event)?;
+        bytes.push(b'\n');
+        ensure!(
+            bytes.len() <= MAX_EVENT_BYTES,
+            "trace event exceeds its size limit"
+        );
+        if !terminal && !self.available(bytes.len() as u64) {
+            return Ok(false);
+        }
+        ensure!(
+            self.manifest.stored_bytes + bytes.len() as u64 <= self.manifest.limits.bytes,
+            "trace terminal record exceeds byte limit"
+        );
+        self.journal.write_all(&bytes)?;
+        self.journal.flush()?;
+        self.journal_hash.update(&bytes);
+        self.manifest.events += 1;
+        self.manifest.journal_bytes += bytes.len() as u64;
+        self.manifest.stored_bytes += bytes.len() as u64;
+        Ok(true)
+    }
+
+    pub fn write_manifest(&mut self) -> anyhow::Result<()> {
+        // Fixed-width accounting converges after at most a few decimal-length changes.
+        let without = self
+            .manifest
+            .stored_bytes
+            .saturating_sub(self.manifest_bytes);
+        let mut bytes = serde_json::to_vec(&self.manifest)?;
+        for _ in 0..4 {
+            self.manifest.stored_bytes = without + bytes.len() as u64;
+            bytes = serde_json::to_vec(&self.manifest)?;
+        }
+        ensure!(
+            self.manifest.stored_bytes + bytes.len() as u64 <= self.manifest.limits.bytes,
+            "trace manifest exceeds byte limit"
+        );
+        fs::write_atomic(&self.directory, "manifest.json", &bytes)?;
+        self.manifest_bytes = bytes.len() as u64;
+        Ok(())
+    }
+
+    pub fn finish(&mut self) -> anyhow::Result<()> {
+        self.journal.flush()?;
+        self.manifest.journal_sha256 =
+            Some(super::format::hex(&self.journal_hash.clone().finalize()));
+        self.write_manifest()
+    }
+}

--- a/crates/glass-mcp/src/trace/store.rs
+++ b/crates/glass-mcp/src/trace/store.rs
@@ -18,14 +18,12 @@ pub(super) struct Store {
     journal_hash: Sha256,
     manifest_bytes: u64,
     payloads: BTreeMap<String, Payload>,
-    _lease: File,
+    _lease: fs::Lease,
 }
 
 impl Store {
     pub fn new(directory: Dir, manifest: Manifest) -> anyhow::Result<Self> {
-        use fs4::FileExt;
-        let lease = fs::create_file(&directory, "writer.lease")?;
-        FileExt::try_lock(&lease)?;
+        let lease = fs::Lease::try_lock(fs::create_file(&directory, "writer.lease")?)?;
         let blobs = fs::create_directory(&directory, "blobs")?;
         let journal = fs::create_file(&directory, "events.jsonl")?;
         let mut store = Self {

--- a/crates/glass-mcp/src/trace/tests.rs
+++ b/crates/glass-mcp/src/trace/tests.rs
@@ -1,0 +1,476 @@
+use super::*;
+use serde_json::json;
+
+fn start_recorder(root: &tempfile::TempDir) -> TraceRecorder {
+    TraceRecorder::start(
+        &TraceConfig::new(root.path().to_owned(), None).unwrap(),
+        crate::tool_profile::ToolProfile::Full,
+        "test",
+    )
+    .unwrap()
+}
+
+#[cfg(windows)]
+#[tokio::test]
+async fn windows_private_files_junction_refusal_and_case_alias_overlap() {
+    let root = private_root();
+    let outside = private_root();
+    let junction = root.path().join("redirected");
+    assert!(
+        std::process::Command::new("cmd.exe")
+            .args(["/c", "mklink", "/J"])
+            .arg(&junction)
+            .arg(outside.path())
+            .output()
+            .unwrap()
+            .status
+            .success()
+    );
+    let config = TraceConfig::new(junction, None).unwrap();
+    assert!(TraceRecorder::start(&config, crate::tool_profile::ToolProfile::Full, "test").is_err());
+    assert_eq!(std::fs::read_dir(outside.path()).unwrap().count(), 0);
+    let recorder = start_recorder(&root);
+    recorder.close().await;
+    for directory in [recorder.path().to_owned(), recorder.path().join("blobs")] {
+        for entry in std::fs::read_dir(directory).unwrap() {
+            let entry = entry.unwrap();
+            if entry.file_type().unwrap().is_file() {
+                let file = std::fs::File::open(entry.path()).unwrap();
+                assert!(glass_windows::file_is_private_to_current_user(&file).unwrap());
+            }
+        }
+    }
+    let alias =
+        std::path::PathBuf::from(recorder.path().to_str().unwrap().to_uppercase()).join("bad.zip");
+    assert!(export(recorder.path(), &alias).is_err());
+    assert!(!alias.exists());
+}
+
+#[tokio::test]
+async fn shutdown_failure_and_hard_linked_evidence_are_not_complete() {
+    let root = private_root();
+    let recorder = start_recorder(&root);
+    recorder.shutdown_event("timed_out");
+    recorder.close().await;
+    assert_eq!(inspect(recorder.path()).unwrap().exit_code(), 2);
+    std::fs::hard_link(
+        recorder.path().join("manifest.json"),
+        root.path().join("external-manifest"),
+    )
+    .unwrap();
+    assert!(inspect(recorder.path()).is_err());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn shutdown_waits_for_admitted_capture_before_closing_the_journal() {
+    let root = private_root();
+    let recorder = start_recorder(&root);
+    recorder.idle().await;
+    let (entered_tx, entered) = std::sync::mpsc::sync_channel(1);
+    let (release, release_rx) = std::sync::mpsc::sync_channel(1);
+    let producer = recorder.clone();
+    let thread = std::thread::spawn(move || {
+        producer.record("capture_in_progress", None, 0, json!({}), |capture| {
+            entered_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
+            capture.bytes(
+                super::recorder::evidence("late", "text/plain", "glass", None),
+                b"completed capture",
+            );
+        })
+    });
+    entered
+        .recv_timeout(std::time::Duration::from_secs(2))
+        .unwrap();
+    let closing = recorder.clone();
+    let closed = tokio::spawn(async move { closing.close().await });
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert!(
+        !closed.is_finished(),
+        "writer closed ahead of admitted evidence"
+    );
+    release.send(()).unwrap();
+    thread.join().unwrap();
+    closed.await.unwrap();
+    let report = inspect(recorder.path()).unwrap();
+    assert!(report.complete);
+    assert!(
+        report
+            .events
+            .iter()
+            .any(|event| event["kind"] == "capture_in_progress")
+    );
+}
+
+#[tokio::test]
+async fn queue_and_call_limits_preserve_inspectable_prefixes() {
+    for queue_limit in [true, false] {
+        let root = private_root();
+        let recorder = start_recorder(&root);
+        recorder.idle().await;
+        if queue_limit {
+            let (entered, release) = recorder.pause_next_write();
+            recorder.record("queue_probe", None, 0, json!({}), |_| {});
+            entered
+                .recv_timeout(std::time::Duration::from_secs(2))
+                .unwrap();
+            for _ in 0..super::config::MAX_PENDING_EVENTS + 2 {
+                recorder.record("queue_probe", None, 0, json!({}), |_| {});
+            }
+            assert_eq!(recorder.status()["state"], "limited");
+            release.send(()).unwrap();
+        } else {
+            recorder.set_calls_at_limit();
+            assert!(recorder.begin_call("glass_type", 1).is_none());
+        }
+        recorder.close().await;
+        let report = inspect(recorder.path()).unwrap();
+        assert_eq!(report.exit_code(), 2);
+        assert_eq!(report.manifest["state"], "limited");
+        assert!(report.manifest["omissions"].as_u64().unwrap() > 0);
+    }
+}
+
+#[tokio::test]
+async fn stalled_writer_shutdown_is_bounded_and_never_claims_completeness() {
+    let root = private_root();
+    let recorder = start_recorder(&root);
+    recorder.idle().await;
+    let (entered, release) = recorder.pause_next_write();
+    recorder.record("stall_probe", None, 0, json!({}), |_| {});
+    entered
+        .recv_timeout(std::time::Duration::from_secs(2))
+        .unwrap();
+    tokio::time::timeout(std::time::Duration::from_secs(3), recorder.close())
+        .await
+        .unwrap();
+    assert_eq!(recorder.status()["state"], "failed");
+    release.send(()).unwrap();
+    let report = tokio::time::timeout(std::time::Duration::from_secs(3), async {
+        loop {
+            if let Ok(report) = inspect(recorder.path()) {
+                break report;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .unwrap();
+    assert_eq!(report.exit_code(), 2);
+    assert_eq!(report.manifest["state"], "failed");
+}
+
+#[tokio::test]
+async fn retained_trace_exports_after_writer_stops() {
+    let root = private_root();
+    let config = TraceConfig::new(root.path().to_owned(), None).unwrap();
+    let recorder =
+        TraceRecorder::start(&config, crate::tool_profile::ToolProfile::Full, "test").unwrap();
+    let call = recorder.begin_call("glass_type", 1).unwrap();
+    call.arguments(&json!({"text": "hello"}));
+    call.record("logical_outcome", json!({"is_error": false}));
+    assert!(inspect(recorder.path()).is_err());
+    recorder.close().await;
+    let report = inspect(recorder.path()).unwrap();
+    assert!(report.complete, "{report:?}");
+    let output = root.path().join("trace.zip");
+    assert!(export(recorder.path(), &output).unwrap().complete);
+    let mut archive = zip::ZipArchive::new(std::fs::File::open(output).unwrap()).unwrap();
+    assert!(archive.by_name("events.jsonl").is_ok());
+    assert!(archive.by_name("READING.txt").is_ok());
+}
+
+#[tokio::test]
+async fn missing_committed_evidence_refuses_export() {
+    let root = private_root();
+    let recorder = TraceRecorder::start(
+        &TraceConfig::new(root.path().to_owned(), None).unwrap(),
+        crate::tool_profile::ToolProfile::Lean,
+        "test",
+    )
+    .unwrap();
+    recorder.close().await;
+    let blob = std::fs::read_dir(recorder.path().join("blobs"))
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .path();
+    std::fs::write(blob, b"corrupt").unwrap();
+    let out = root.path().join("bad.zip");
+    assert!(export(recorder.path(), &out).is_err());
+    assert!(!out.exists());
+}
+
+pub(super) fn private_root() -> tempfile::TempDir {
+    let root = tempfile::tempdir_in(std::env::temp_dir().canonicalize().unwrap()).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(root.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        use windows::Win32::Storage::FileSystem::{FILE_ALL_ACCESS, FILE_FLAG_BACKUP_SEMANTICS};
+        let file = std::fs::OpenOptions::new()
+            .access_mode(FILE_ALL_ACCESS.0)
+            .custom_flags(FILE_FLAG_BACKUP_SEMANTICS.0)
+            .open(root.path())
+            .unwrap();
+        glass_windows::restrict_file_to_current_user(&file).unwrap();
+    }
+    root
+}
+
+#[tokio::test]
+async fn total_limit_preserves_prefix_and_exports_an_incomplete_bundle() {
+    let root = private_root();
+    let limit = super::config::MIN_MAX_BYTES;
+    let recorder = TraceRecorder::start(
+        &TraceConfig::new(root.path().to_owned(), Some(limit)).unwrap(),
+        crate::tool_profile::ToolProfile::Full,
+        "test",
+    )
+    .unwrap();
+    recorder.idle().await;
+    let call = recorder.begin_call("glass_screenshot", 1).unwrap();
+    call.arguments(&json!({}));
+    call.capture("logical_outcome", json!({"is_error": false}), |capture| {
+        capture.bytes(
+            super::recorder::evidence("image", "image/webp", "untrusted_application", Some(0)),
+            &vec![3; limit as usize],
+        );
+    });
+    recorder.idle().await;
+    assert_eq!(recorder.status()["state"], "limited");
+    recorder.close().await;
+    let report = inspect(recorder.path()).unwrap();
+    assert!(!report.complete);
+    assert_eq!(report.exit_code(), 2);
+    assert!(report.events.iter().any(|e| e["kind"] == "call_received"));
+    assert!(
+        report
+            .events
+            .iter()
+            .flat_map(|e| e["evidence"].as_array().into_iter().flatten())
+            .any(|e| e["omitted"] == "total_byte_limit")
+    );
+    let total: u64 = [recorder.path().to_owned(), recorder.path().join("blobs")]
+        .iter()
+        .flat_map(|dir| std::fs::read_dir(dir).unwrap())
+        .map(|entry| entry.unwrap().metadata().unwrap())
+        .filter(|meta| meta.is_file())
+        .map(|meta| meta.len())
+        .sum();
+    assert!(total <= limit, "stored {total}, cap {limit}");
+    assert_eq!(
+        export(recorder.path(), &root.path().join("limited.zip"))
+            .unwrap()
+            .exit_code(),
+        2
+    );
+}
+
+#[tokio::test]
+async fn oversized_payload_is_omitted_whole_and_later_small_evidence_survives() {
+    let root = private_root();
+    let recorder = TraceRecorder::start(
+        &TraceConfig::new(root.path().to_owned(), None).unwrap(),
+        crate::tool_profile::ToolProfile::Full,
+        "test",
+    )
+    .unwrap();
+    let call = recorder.begin_call("glass_test", 1).unwrap();
+    call.arguments(&json!({}));
+    call.capture("logical_outcome", json!({"is_error": false}), |capture| {
+        capture.bytes(
+            super::recorder::evidence("large", "text/plain", "untrusted_application", Some(0)),
+            &vec![b'x'; super::config::MAX_PAYLOAD_BYTES + 1],
+        );
+        capture.bytes(
+            super::recorder::evidence("small", "text/plain", "untrusted_application", Some(1)),
+            b"later evidence",
+        );
+    });
+    recorder.close().await;
+    let report = inspect(recorder.path()).unwrap();
+    assert_eq!(report.exit_code(), 2);
+    let event = report
+        .events
+        .iter()
+        .find(|e| e["kind"] == "logical_outcome")
+        .unwrap();
+    assert_eq!(event["evidence"][0]["omitted"], "payload_limit");
+    assert!(event["evidence"][0].get("payload").is_none());
+    assert_eq!(
+        std::fs::read(
+            recorder
+                .path()
+                .join(event["evidence"][1]["payload"]["path"].as_str().unwrap())
+        )
+        .unwrap(),
+        b"later evidence"
+    );
+}
+
+#[tokio::test]
+async fn writer_failure_keeps_an_inspectable_interrupted_prefix() {
+    let root = private_root();
+    let recorder = TraceRecorder::start(
+        &TraceConfig::new(root.path().to_owned(), None).unwrap(),
+        crate::tool_profile::ToolProfile::Full,
+        "test",
+    )
+    .unwrap();
+    recorder.idle().await;
+    recorder.fail_next_write();
+    let call = recorder.begin_call("glass_test", 1).unwrap();
+    call.arguments(&json!({}));
+    recorder.idle().await;
+    assert_eq!(recorder.status()["state"], "failed");
+    recorder.close().await;
+    let report = inspect(recorder.path()).unwrap();
+    assert!(!report.complete);
+    assert!(report.manifest["errors"].as_u64().unwrap() > 0);
+    assert_eq!(
+        export(recorder.path(), &root.path().join("failed.zip"))
+            .unwrap()
+            .exit_code(),
+        2
+    );
+}
+
+#[tokio::test]
+async fn interrupted_tail_recovers_but_tampered_committed_journal_refuses() {
+    let root = private_root();
+    let recorder = TraceRecorder::start(
+        &TraceConfig::new(root.path().to_owned(), None).unwrap(),
+        crate::tool_profile::ToolProfile::Full,
+        "test",
+    )
+    .unwrap();
+    recorder.close().await;
+    let path = recorder.path();
+    let manifest_path = path.join("manifest.json");
+    let mut manifest: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&manifest_path).unwrap()).unwrap();
+    manifest["complete"] = json!(false);
+    manifest["finalization"] = serde_json::Value::Null;
+    std::fs::write(manifest_path, serde_json::to_vec(&manifest).unwrap()).unwrap();
+    use std::io::Write;
+    std::fs::OpenOptions::new()
+        .append(true)
+        .open(path.join("events.jsonl"))
+        .unwrap()
+        .write_all(b"{torn")
+        .unwrap();
+    let report = inspect(path).unwrap();
+    assert_eq!(report.uncommitted_tail_bytes, 5);
+    assert_eq!(report.exit_code(), 2);
+    assert_eq!(
+        export(path, &root.path().join("recovered.zip"))
+            .unwrap()
+            .exit_code(),
+        2
+    );
+    let mut journal = std::fs::read(path.join("events.jsonl")).unwrap();
+    journal[0] = b'!';
+    std::fs::write(path.join("events.jsonl"), journal).unwrap();
+    assert!(inspect(path).is_err());
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn symlinked_root_and_payload_are_refused_without_following_them() {
+    use std::os::unix::fs::symlink;
+    let root = private_root();
+    let other = private_root();
+    symlink(other.path(), root.path().join("redirected")).unwrap();
+    let config = TraceConfig::new(root.path().join("redirected"), None).unwrap();
+    assert!(TraceRecorder::start(&config, crate::tool_profile::ToolProfile::Full, "test").is_err());
+    assert_eq!(std::fs::read_dir(other.path()).unwrap().count(), 0);
+    let recorder = TraceRecorder::start(
+        &TraceConfig::new(root.path().to_owned(), None).unwrap(),
+        crate::tool_profile::ToolProfile::Full,
+        "test",
+    )
+    .unwrap();
+    recorder.close().await;
+    let blob = std::fs::read_dir(recorder.path().join("blobs"))
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .path();
+    let outside = other.path().join("outside");
+    std::fs::rename(&blob, &outside).unwrap();
+    symlink(&outside, &blob).unwrap();
+    assert!(inspect(recorder.path()).is_err());
+}
+
+#[tokio::test]
+async fn export_refuses_existing_destinations_and_source_overlap() {
+    let root = private_root();
+    let recorder = TraceRecorder::start(
+        &TraceConfig::new(root.path().to_owned(), None).unwrap(),
+        crate::tool_profile::ToolProfile::Full,
+        "test",
+    )
+    .unwrap();
+    recorder.close().await;
+    let existing = root.path().join("existing.zip");
+    std::fs::write(&existing, b"keep").unwrap();
+    assert!(export(recorder.path(), &existing).is_err());
+    assert_eq!(std::fs::read(existing).unwrap(), b"keep");
+    assert!(export(recorder.path(), &recorder.path().join("overlap.zip")).is_err());
+}
+
+#[test]
+fn trace_cli_bounds_and_offline_commands_parse_without_creating_storage() {
+    use crate::cli::{Cli, Command, TraceCommand};
+    use clap::Parser;
+    let root = private_root();
+    let path = root.path().to_str().unwrap();
+    assert!(
+        Cli::try_parse_from(["glass-mcp"])
+            .unwrap()
+            .trace_dir
+            .is_none()
+    );
+    assert!(Cli::try_parse_from(["glass-mcp", "--trace-max-bytes", "1048576"]).is_err());
+    for invalid in ["0", "1048575", "2147483649"] {
+        assert!(
+            Cli::try_parse_from([
+                "glass-mcp",
+                "--trace-dir",
+                path,
+                "--trace-max-bytes",
+                invalid
+            ])
+            .is_err()
+        );
+    }
+    for valid in ["1048576", "2147483648"] {
+        assert!(
+            Cli::try_parse_from([
+                "glass-mcp",
+                "serve",
+                "--http",
+                "--trace-dir",
+                path,
+                "--trace-max-bytes",
+                valid
+            ])
+            .is_ok()
+        );
+    }
+    let cli = Cli::try_parse_from(["glass-mcp", "trace", "inspect", path, "--json"]).unwrap();
+    assert!(matches!(
+        cli.command,
+        Some(Command::Trace {
+            command: TraceCommand::Inspect { json: true, .. }
+        })
+    ));
+    assert_eq!(std::fs::read_dir(root.path()).unwrap().count(), 0);
+}

--- a/crates/glass-mcp/src/trace/tests.rs
+++ b/crates/glass-mcp/src/trace/tests.rs
@@ -132,6 +132,34 @@ async fn queue_and_call_limits_preserve_inspectable_prefixes() {
 }
 
 #[tokio::test]
+async fn concurrent_and_cancelled_close_wait_for_the_writer() {
+    use std::future::Future;
+    use std::task::{Context, Waker};
+
+    let root = private_root();
+    let recorder = start_recorder(&root);
+    recorder.idle().await;
+    let (entered, release) = recorder.pause_next_write();
+    recorder.record("close_probe", None, 0, json!({}), |_| {});
+    entered
+        .recv_timeout(std::time::Duration::from_secs(5))
+        .unwrap();
+
+    let mut first = Box::pin(recorder.close());
+    let mut second = Box::pin(recorder.close());
+    let mut context = Context::from_waker(Waker::noop());
+    assert!(first.as_mut().poll(&mut context).is_pending());
+    assert!(second.as_mut().poll(&mut context).is_pending());
+    drop(first);
+    assert!(inspect(recorder.path()).is_err());
+
+    release.send(()).unwrap();
+    second.await;
+    assert!(inspect(recorder.path()).unwrap().complete);
+    recorder.close().await;
+}
+
+#[tokio::test]
 async fn stalled_writer_shutdown_is_bounded_and_never_claims_completeness() {
     let root = private_root();
     let recorder = start_recorder(&root);
@@ -141,21 +169,15 @@ async fn stalled_writer_shutdown_is_bounded_and_never_claims_completeness() {
     entered
         .recv_timeout(std::time::Duration::from_secs(2))
         .unwrap();
+    tokio::time::pause();
     tokio::time::timeout(std::time::Duration::from_secs(3), recorder.close())
         .await
         .unwrap();
+    tokio::time::resume();
     assert_eq!(recorder.status()["state"], "failed");
     release.send(()).unwrap();
-    let report = tokio::time::timeout(std::time::Duration::from_secs(3), async {
-        loop {
-            if let Ok(report) = inspect(recorder.path()) {
-                break report;
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-        }
-    })
-    .await
-    .unwrap();
+    recorder.writer_finished().await;
+    let report = inspect(recorder.path()).unwrap();
     assert_eq!(report.exit_code(), 2);
     assert_eq!(report.manifest["state"], "failed");
 }

--- a/crates/glass-mcp/src/trace/transport_tests.rs
+++ b/crates/glass-mcp/src/trace/transport_tests.rs
@@ -99,8 +99,13 @@ impl Harness {
         )
         .await;
         let path = self.recorder.path().to_owned();
-        crate::cleanup_evidence(Some(self.recorder), self.server.artifact_store()).await;
-        let report = inspect(&path).unwrap();
+        crate::cleanup_evidence(Some(self.recorder.clone()), self.server.artifact_store()).await;
+        let report = inspect(&path).unwrap_or_else(|error| {
+            panic!(
+                "trace inspection after cleanup: {error:#}; recorder: {}",
+                self.recorder.status()
+            )
+        });
         (self.root, path, report)
     }
 }

--- a/crates/glass-mcp/src/trace/transport_tests.rs
+++ b/crates/glass-mcp/src/trace/transport_tests.rs
@@ -1,0 +1,451 @@
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use glass_core::{Frame, ProtectedHostPath};
+use rmcp::{ServiceExt, model::CallToolRequestParams};
+use serde_json::{Value, json};
+
+use crate::server::GlassServer;
+use crate::tool_profile::ToolProfile;
+use crate::tools::testutil::{FakePlatform, fake_tree, glass_with_a11y};
+
+use super::{TraceConfig, TraceRecorder, inspect};
+
+struct Harness {
+    root: tempfile::TempDir,
+    server: GlassServer,
+    task: tokio::task::JoinHandle<()>,
+    client: rmcp::service::RunningService<rmcp::RoleClient, ()>,
+    recorder: TraceRecorder,
+    captures: Arc<Mutex<usize>>,
+    paths: Arc<Mutex<Vec<ProtectedHostPath>>>,
+    inputs: Arc<Mutex<Vec<String>>>,
+}
+
+impl Harness {
+    async fn stdio(profile: ToolProfile, max_bytes: Option<u64>) -> Self {
+        let root = super::tests::private_root();
+        let captures = Arc::new(Mutex::new(0));
+        let paths = Arc::new(Mutex::new(vec![]));
+        let inputs = Arc::new(Mutex::new(vec![]));
+        let mut platform = FakePlatform::new(100, 100)
+            .with_frames(vec![Frame::solid(100, 100, [1, 2, 3, 255])])
+            .with_capture_log(captures.clone())
+            .with_event_log(inputs.clone());
+        platform.protected_paths = Some(paths.clone());
+        let glass = glass_with_a11y(platform, fake_tree());
+        let config = TraceConfig::new(root.path().to_owned(), max_bytes).unwrap();
+        let server = GlassServer::new_configured(
+            glass,
+            crate::audit::report_from_config(None, |_| None),
+            profile,
+            Some(&config),
+            "stdio",
+        )
+        .unwrap();
+        let recorder = server.trace_recorder().unwrap();
+        let (server_io, client_io) = tokio::io::duplex(64 * 1024);
+        let service = server.clone();
+        let task = tokio::spawn(async move {
+            service
+                .serve(server_io)
+                .await
+                .unwrap()
+                .waiting()
+                .await
+                .unwrap();
+        });
+        let client = ().serve(client_io).await.unwrap();
+        Self {
+            root,
+            server,
+            task,
+            client,
+            recorder,
+            captures,
+            paths,
+            inputs,
+        }
+    }
+
+    async fn call(&self, tool: &str, args: Value) -> rmcp::model::CallToolResult {
+        self.client
+            .call_tool(
+                CallToolRequestParams::new(tool.to_owned())
+                    .with_arguments(args.as_object().unwrap().clone()),
+            )
+            .await
+            .unwrap()
+    }
+
+    async fn start(&self) {
+        let result = self.call("glass_start", json!({"run": ["app"], "sandbox": "off", "env": {"SECRET_ENV_NAME": "SECRET_ENV_VALUE"}})).await;
+        assert!(!result.is_error.unwrap_or(false), "{result:?}");
+    }
+
+    async fn finish(
+        self,
+    ) -> (
+        tempfile::TempDir,
+        std::path::PathBuf,
+        super::inspect::Inspection,
+    ) {
+        self.client.cancel().await.unwrap();
+        self.task.await.unwrap();
+        crate::shutdown::run_shutdown_with_trace(
+            self.server.sessions(),
+            glass_core::TEARDOWN_BUDGET,
+            Some(self.recorder.clone()),
+        )
+        .await;
+        let path = self.recorder.path().to_owned();
+        crate::cleanup_evidence(Some(self.recorder), self.server.artifact_store()).await;
+        let report = inspect(&path).unwrap();
+        (self.root, path, report)
+    }
+}
+
+#[tokio::test]
+async fn writer_failure_does_not_change_or_repeat_input() {
+    let harness = Harness::stdio(ToolProfile::Full, None).await;
+    harness.start().await;
+    harness.recorder.idle().await;
+    harness.recorder.fail_next_write();
+    let result = harness
+        .call("glass_type", json!({"text": "one dispatch"}))
+        .await;
+    assert!(!result.is_error.unwrap_or(false));
+    assert_eq!(*harness.inputs.lock().unwrap(), ["type(one dispatch)"]);
+    harness.recorder.idle().await;
+    assert_eq!(harness.recorder.status()["state"], "failed");
+    let (_root, _path, report) = harness.finish().await;
+    assert_eq!(report.exit_code(), 2);
+}
+
+#[tokio::test]
+async fn failed_replacement_clears_the_previous_session_context() {
+    let harness = Harness::stdio(ToolProfile::Full, None).await;
+    harness.start().await;
+    let failed = harness
+        .call(
+            "glass_start",
+            json!({"run": ["replacement"], "sandbox": "off"}),
+        )
+        .await;
+    assert!(failed.is_error.unwrap_or(false));
+    assert!(
+        harness
+            .call("glass_logs", json!({}))
+            .await
+            .is_error
+            .unwrap_or(false)
+    );
+    let (_root, _path, report) = harness.finish().await;
+    assert!(report.complete);
+    let contexts: Vec<_> = report
+        .events
+        .iter()
+        .filter(|event| event["kind"] == "session_context")
+        .collect();
+    assert_eq!(contexts.len(), 3);
+    assert_eq!(contexts[0]["data"]["backend"], "x11");
+    assert!(contexts[0]["data"]["session"].is_number());
+    for context in &contexts[1..] {
+        assert!(context["data"]["backend"].is_null());
+        assert!(context["data"]["session"].is_null());
+    }
+}
+
+#[cfg(feature = "network")]
+#[tokio::test]
+async fn http_takeover_retains_distinct_clients_and_does_not_record_transport_secrets() {
+    use rmcp::transport::StreamableHttpClientTransport;
+    use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
+    let root = super::tests::private_root();
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let config = crate::serve::config::ServeConfig {
+        addr,
+        token: Some("HTTP_TOKEN_CANARY".into()),
+        tool_profile: ToolProfile::Lean,
+        trace: Some(TraceConfig::new(root.path().to_owned(), None).unwrap()),
+    };
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let stopping = cancel.clone();
+    let server = tokio::spawn(crate::serve::run_on_until(
+        listener,
+        config,
+        crate::boot(None),
+        crate::audit::report_from_config(None, |_| None),
+        async move { stopping.cancelled().await },
+    ));
+    let connect = || {
+        StreamableHttpClientTransport::from_config(
+            StreamableHttpClientTransportConfig::with_uri(format!("http://{addr}/"))
+                .auth_header("HTTP_TOKEN_CANARY"),
+        )
+    };
+    let first = ().serve(connect()).await.unwrap();
+    let mut request = CallToolRequestParams::new("glass_do")
+        .with_arguments(json!({"actions": []}).as_object().unwrap().clone());
+    request.meta = Some(rmcp::model::Meta(
+        json!({"secret":"META_CANARY"}).as_object().unwrap().clone(),
+    ));
+    assert!(
+        first
+            .call_tool(request)
+            .await
+            .unwrap()
+            .is_error
+            .unwrap_or(false)
+    );
+    let second = ().serve(connect()).await.unwrap();
+    assert!(
+        second
+            .call_tool(CallToolRequestParams::new("glass_logs"))
+            .await
+            .unwrap()
+            .is_error
+            .unwrap_or(false)
+    );
+    second.cancel().await.unwrap();
+    let _ = first.cancel().await;
+    cancel.cancel();
+    server.await.unwrap().unwrap();
+    let path = std::fs::read_dir(root.path())
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .path();
+    let report = inspect(&path).unwrap();
+    assert!(report.complete, "{report:?}");
+    let clients: std::collections::BTreeSet<_> = report
+        .events
+        .iter()
+        .filter(|e| e["kind"] == "call_received")
+        .map(|e| e["client"].as_u64().unwrap())
+        .collect();
+    assert_eq!(clients.len(), 2);
+    let body = String::from_utf8_lossy(&all_content(&path)).into_owned();
+    assert!(!body.contains("HTTP_TOKEN_CANARY"));
+    assert!(!body.contains("META_CANARY"));
+}
+
+#[tokio::test]
+async fn oversized_text_is_portable_after_artifact_cleanup() {
+    let harness = Harness::stdio(ToolProfile::Full, None).await;
+    harness.start().await;
+    let expected = "unicode observation 🌍\n".repeat(2000);
+    let call = harness.recorder.begin_call("glass_test", 1).unwrap();
+    call.arguments(&json!({}));
+    let output_text = expected.clone();
+    let response = super::ACTIVE_CALL
+        .scope(
+            call,
+            harness.server.run_trace_test_job(move |_| {
+                crate::output::ToolOutput(vec![crate::output::OutContent::untrusted_observation(
+                    &output_text,
+                )])
+            }),
+        )
+        .await
+        .unwrap();
+    let link = response
+        .content
+        .iter()
+        .find_map(|block| match block {
+            rmcp::model::ContentBlock::ResourceLink(link) => Some(link),
+            _ => None,
+        })
+        .unwrap();
+    let artifact_path = link.meta.as_ref().unwrap().0["glass"]["localPath"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+    let original = std::fs::read(&artifact_path).unwrap();
+    let (_root, path, report) = harness.finish().await;
+    assert!(!std::path::Path::new(&artifact_path).exists());
+    assert!(report.complete, "{report:?}");
+    let resource = report
+        .events
+        .iter()
+        .flat_map(|event| event["evidence"].as_array().into_iter().flatten())
+        .find(|e| e["source_uri"] == link.uri)
+        .unwrap();
+    assert_eq!(
+        std::fs::read(path.join(resource["payload"]["path"].as_str().unwrap())).unwrap(),
+        original
+    );
+    let descriptor = report
+        .events
+        .iter()
+        .flat_map(|event| event["evidence"].as_array().into_iter().flatten())
+        .find(|e| e["label"] == "resource_descriptor")
+        .unwrap();
+    let recorded: Value = serde_json::from_slice(
+        &std::fs::read(path.join(descriptor["payload"]["path"].as_str().unwrap())).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        recorded,
+        serde_json::to_value(rmcp::model::ContentBlock::ResourceLink(link.clone())).unwrap()
+    );
+}
+
+fn all_content(path: &std::path::Path) -> Vec<u8> {
+    let mut result = std::fs::read(path.join("events.jsonl")).unwrap();
+    for entry in std::fs::read_dir(path.join("blobs")).unwrap() {
+        result.extend(std::fs::read(entry.unwrap().path()).unwrap());
+    }
+    result
+}
+
+#[tokio::test]
+async fn stdio_preserves_requested_evidence_and_excludes_environment_and_invalid_arguments() {
+    let harness = Harness::stdio(ToolProfile::Full, None).await;
+    harness.start().await;
+    let configured = harness.paths.lock().unwrap().clone();
+    assert!(
+        configured
+            .iter()
+            .any(|path| path.path == harness.root.path())
+    );
+    assert_eq!(
+        configured.len(),
+        3,
+        "trace root and both artifact paths must be composed"
+    );
+    let before = *harness.captures.lock().unwrap();
+    let screenshot = harness.call("glass_screenshot", json!({})).await;
+    assert!(!screenshot.is_error.unwrap_or(false));
+    assert_eq!(*harness.captures.lock().unwrap(), before + 1);
+    let invalid = harness
+        .call(
+            "glass_type",
+            json!({"text": {"bad": "INVALID_INPUT_SECRET"}}),
+        )
+        .await;
+    assert!(invalid.is_error.unwrap_or(false));
+    let text = harness
+        .call(
+            "glass_type",
+            json!({"text": "retained text", "ignored_unknown": "UNKNOWN_FIELD_SECRET"}),
+        )
+        .await;
+    assert!(!text.is_error.unwrap_or(false));
+    assert_eq!(
+        *harness.captures.lock().unwrap(),
+        before + 1,
+        "tracing adds no screenshots"
+    );
+    let (_root, path, report) = harness.finish().await;
+    assert!(report.complete, "{report:?}");
+    let content = String::from_utf8_lossy(&all_content(&path)).into_owned();
+    for secret in [
+        "SECRET_ENV_NAME",
+        "SECRET_ENV_VALUE",
+        "INVALID_INPUT_SECRET",
+        "UNKNOWN_FIELD_SECRET",
+    ] {
+        assert!(!content.contains(secret), "leaked {secret}");
+    }
+    assert!(content.contains("retained text"));
+    let image = report
+        .events
+        .iter()
+        .flat_map(|event| event["evidence"].as_array().into_iter().flatten())
+        .find(|e| e["mime_type"] == "image/webp")
+        .unwrap();
+    let bytes = std::fs::read(path.join(image["payload"]["path"].as_str().unwrap())).unwrap();
+    let returned = screenshot
+        .content
+        .iter()
+        .find_map(|b| b.as_image())
+        .unwrap();
+    use base64::Engine;
+    assert_eq!(
+        bytes,
+        base64::engine::general_purpose::STANDARD
+            .decode(&returned.data)
+            .unwrap()
+    );
+}
+
+#[tokio::test]
+async fn lean_batch_keeps_fail_fast_outcomes_and_refused_tool_body_private() {
+    let harness = Harness::stdio(ToolProfile::Lean, None).await;
+    harness.start().await;
+    let missing = harness
+        .client
+        .call_tool(
+            CallToolRequestParams::new("glass_type").with_arguments(
+                json!({"text":"OMITTED_TOOL_SECRET"})
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+            ),
+        )
+        .await;
+    assert!(missing.is_err());
+    let batch = harness.call("glass_do", json!({"actions":[{"action":"type", "text":"first"}, {"action":"wait_for_element", "name":"missing", "timeout_ms":0}, {"action":"type","text":"unexecuted"}]})).await;
+    assert!(batch.is_error.unwrap_or(false));
+    let (_root, path, report) = harness.finish().await;
+    assert!(report.complete, "{report:?}");
+    let content = String::from_utf8_lossy(&all_content(&path)).into_owned();
+    assert!(!content.contains("OMITTED_TOOL_SECRET"));
+    assert!(content.contains("unexecuted"));
+    assert!(content.contains("predicate_not_matched"));
+}
+
+#[tokio::test]
+async fn cancelled_request_keeps_the_workers_later_outcome() {
+    let harness = Harness::stdio(ToolProfile::Full, None).await;
+    let call = harness.recorder.begin_call("glass_test", 1).unwrap();
+    let call_id = call.id;
+    call.arguments(&json!({}));
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+    let (finish_tx, finish_rx) = std::sync::mpsc::channel();
+    let server = harness.server.clone();
+    let operation = tokio::spawn(super::ACTIVE_CALL.scope(call.clone(), async move {
+        let mut guard = super::RequestGuard::new(call);
+        let result = server
+            .run_trace_test_job(move |_| {
+                let _ = started_tx.send(());
+                finish_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+                crate::output::ToolOutput::result("glass_test", json!({"mutations":1}))
+            })
+            .await;
+        guard.complete();
+        result
+    }));
+    started_rx.await.unwrap();
+    operation.abort();
+    let _ = operation.await;
+    finish_tx.send(()).unwrap();
+    // A following worker job is a barrier for the cancelled job's completion.
+    harness.call("glass_logs", json!({})).await;
+    let (_root, _path, report) = harness.finish().await;
+    let events: Vec<_> = report
+        .events
+        .iter()
+        .filter(|event| event["call"] == call_id)
+        .collect();
+    assert!(
+        events
+            .iter()
+            .any(|event| event["kind"] == "request_abandoned")
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| event["kind"] == "logical_outcome")
+            .count(),
+        1
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| event["kind"] == "response_constructed")
+    );
+}

--- a/crates/glass-mcp/tests/common/mcp_http.rs
+++ b/crates/glass-mcp/tests/common/mcp_http.rs
@@ -140,6 +140,7 @@ impl InProcessMcpHarness {
                 addr,
                 token: Some(server_token),
                 tool_profile: Default::default(),
+                trace: None,
             };
             glass_mcp::serve::run_on_until(listener, cfg, glass, report, async move {
                 shutdown.cancelled().await;

--- a/crates/glass-mcp/tests/network_roundtrip.rs
+++ b/crates/glass-mcp/tests/network_roundtrip.rs
@@ -45,6 +45,7 @@ async fn start_server_with_profile(
         addr,
         token: token.map(String::from),
         tool_profile: profile,
+        trace: None,
     };
     let glass = glass_mcp::boot(None);
     let report = glass_mcp::audit::report_from_config(None, |_| None);

--- a/crates/glass-sandbox-linux/tests/trace_root.rs
+++ b/crates/glass-sandbox-linux/tests/trace_root.rs
@@ -1,0 +1,59 @@
+#![cfg(target_os = "linux")]
+
+use std::ffi::OsStr;
+use std::process::Command;
+
+use glass_core::{ProtectedHostPath, SandboxLevel};
+use glass_sandbox_linux::{WrapOpts, wrap_argv};
+
+#[test]
+#[ignore = "requires Bubblewrap user and PID namespaces"]
+fn protected_trace_root_denies_current_history_and_proc_aliases() {
+    let root = tempfile::tempdir().unwrap();
+    let traces = root.path().join("traces");
+    let current = traces.join("current");
+    let history = traces.join("retained");
+    std::fs::create_dir_all(&current).unwrap();
+    std::fs::create_dir(&history).unwrap();
+    let files = [current.join("evidence"), history.join("evidence")];
+    for file in &files {
+        std::fs::write(file, "host evidence").unwrap();
+    }
+    let script = r#"
+set -eu
+for file in "$CURRENT" "$HISTORY"; do
+  for alias in "$file" "/proc/self/root$file" "/proc/1/root$file"; do
+    if cat "$alias" 2>/dev/null; then exit 1; fi
+    if (printf tamper > "$alias") 2>/dev/null; then exit 2; fi
+    if rm "$alias" 2>/dev/null; then exit 3; fi
+  done
+done
+"#;
+    for level in [SandboxLevel::Default, SandboxLevel::Strict] {
+        let options = WrapOpts {
+            level,
+            home: std::env::var_os("HOME").unwrap(),
+            cwd: Some(root.path().to_owned()),
+            ro_binds: vec![],
+            rw_binds: vec![root.path().to_owned()],
+            status_fd: None,
+            protected_paths: vec![ProtectedHostPath::directory(&traces)],
+        };
+        let argv = wrap_argv(
+            OsStr::new("/bin/sh"),
+            &["-c".into(), script.into()],
+            &options,
+        )
+        .unwrap();
+        let output = Command::new(&argv[0])
+            .args(&argv[1..])
+            .env("CURRENT", &files[0])
+            .env("HISTORY", &files[1])
+            .output()
+            .unwrap();
+        assert!(output.status.success(), "{level}: {output:?}");
+    }
+    for file in files {
+        assert_eq!(std::fs::read_to_string(file).unwrap(), "host evidence");
+    }
+}

--- a/crates/glass-testapp/tests/common/mcp_cost.rs
+++ b/crates/glass-testapp/tests/common/mcp_cost.rs
@@ -58,6 +58,7 @@ pub async fn boot_mcp() -> RunningService<RoleClient, ()> {
             addr,
             token: Some("vcost".into()),
             tool_profile: Default::default(),
+            trace: None,
         };
         let _ = glass_mcp::serve::run_on(listener, cfg, glass, report).await;
     });

--- a/crates/glass-testapp/tests/common/mcp_ignore.rs
+++ b/crates/glass-testapp/tests/common/mcp_ignore.rs
@@ -97,6 +97,7 @@ pub async fn assert_blink_region_e2e(testapp: &str, backend: &str, start_timeout
             addr,
             token: Some("e2e".into()),
             tool_profile: Default::default(),
+            trace: None,
         };
         let _ = glass_mcp::serve::run_on(listener, cfg, glass, report).await;
     });

--- a/crates/glass-testapp/tests/host_conformance.rs
+++ b/crates/glass-testapp/tests/host_conformance.rs
@@ -339,6 +339,7 @@ async fn boot_http_client(display: &str) -> RunningService<RoleClient, ()> {
             addr,
             token: Some("conf".into()),
             tool_profile: Default::default(),
+            trace: None,
         };
         let _ = glass_mcp::serve::run_on(listener, cfg, glass, report).await;
     });

--- a/crates/glass-testapp/tests/network.rs
+++ b/crates/glass-testapp/tests/network.rs
@@ -38,6 +38,7 @@ async fn network_screenshot_over_http() {
             addr,
             token: Some("e2e".into()),
             tool_profile: Default::default(),
+            trace: None,
         };
         let _ = glass_mcp::serve::run_on(listener, cfg, glass, report).await;
     });

--- a/crates/glass-windows/src/containment/artifact_onbox.rs
+++ b/crates/glass-windows/src/containment/artifact_onbox.rs
@@ -22,6 +22,7 @@ enum AccessResult {
 #[derive(Debug, PartialEq, Eq)]
 struct ProbeResult {
     marker_read: AccessResult,
+    marker_write: AccessResult,
     lease_write: AccessResult,
 }
 
@@ -57,6 +58,7 @@ fn parse_probe_logs(text: &str) -> Result<ProbeResult, ProbeParseError> {
     }
     Ok(ProbeResult {
         marker_read: parse_access(text, "MARKER"),
+        marker_write: parse_access(text, "MARKER_WRITE"),
         lease_write: parse_access(text, "LEASE"),
     })
 }
@@ -68,7 +70,6 @@ struct ArtifactOnboxFixture {
     marker: PathBuf,
     marker_text: String,
     lease: Option<File>,
-    box_prefix: String,
 }
 
 impl ArtifactOnboxFixture {
@@ -99,7 +100,6 @@ impl ArtifactOnboxFixture {
             marker,
             marker_text,
             lease: Some(lease),
-            box_prefix: format!("glass_artifact_{nonce}"),
         }
     }
 
@@ -113,7 +113,7 @@ impl ArtifactOnboxFixture {
     fn run_probe_in_sandboxie(&self, level: SandboxLevel) -> Result<ProbeResult, ProbeParseError> {
         let dir = sandboxie_dir();
         assert!(available(&dir), "Sandboxie not available at {dir}");
-        let box_name = format!("{}_{level}", self.box_prefix);
+        let box_name = super::sandboxie::unique_box_name();
         let sandboxie = Sandboxie::new(dir, box_name);
         sandboxie
             .configure_with_paths(level, &self.protected_paths())
@@ -121,7 +121,12 @@ impl ArtifactOnboxFixture {
 
         let marker = path_string(&self.marker);
         let lease = path_string(&self.lease_path);
-        let script = "$ErrorActionPreference='Stop'; try { [void][IO.File]::ReadAllText($env:ARTIFACT_MARKER); Write-Output 'MARKER_SUCCESS' } catch { Write-Output ('MARKER_ERROR:'+ $_.Exception.HResult) }; try { [IO.File]::AppendAllText($env:ARTIFACT_LEASE,'tamper'); Write-Output 'LEASE_SUCCESS' } catch { Write-Output ('LEASE_ERROR:'+ $_.Exception.HResult) }; Write-Output 'PROBE_COMPLETE'".to_string();
+        let probe = "$ErrorActionPreference='Stop'; try { [void][IO.File]::ReadAllText($env:ARTIFACT_MARKER); Write-Output 'MARKER_SUCCESS' } catch { Write-Output ('MARKER_ERROR:'+ $_.Exception.GetBaseException().HResult) }; try { [IO.File]::AppendAllText($env:ARTIFACT_MARKER,'tamper'); Write-Output 'MARKER_WRITE_SUCCESS' } catch { Write-Output ('MARKER_WRITE_ERROR:'+ $_.Exception.GetBaseException().HResult) }; try { [IO.File]::AppendAllText($env:ARTIFACT_LEASE,'tamper'); Write-Output 'LEASE_SUCCESS' } catch { Write-Output ('LEASE_ERROR:'+ $_.Exception.GetBaseException().HResult) }; Write-Output 'PROBE_COMPLETE'";
+        let script = format!(
+            "$env:ARTIFACT_MARKER='{}'; $env:ARTIFACT_LEASE='{}'; {probe}",
+            marker.replace('\'', "''"),
+            lease.replace('\'', "''")
+        );
         let spec = AppSpec {
             build: None,
             run: vec![
@@ -215,6 +220,7 @@ fn sandboxie_denies_artifact_read_and_lease_tampering() {
             .run_probe_in_sandboxie(level)
             .expect("probe reached completion sentinel");
         assert_eq!(result.marker_read, AccessResult::Denied);
+        assert_eq!(result.marker_write, AccessResult::Denied);
         assert_eq!(result.lease_write, AccessResult::Denied);
     }
     assert_eq!(
@@ -222,6 +228,43 @@ fn sandboxie_denies_artifact_read_and_lease_tampering() {
         fixture.marker_text
     );
     assert_eq!(fixture.conflicting_lease_open_error(), SHARING_VIOLATION);
+}
+
+#[test]
+#[ignore = "requires Windows Sandboxie Plus"]
+fn protected_trace_root_denies_current_and_retained_history() {
+    let mut fixture = ArtifactOnboxFixture::new();
+    let current = fixture.marker.clone();
+    let history = fixture.process_dir.join("retained");
+    std::fs::create_dir(&history).unwrap();
+    let old = history.join("old-evidence");
+    std::fs::write(&old, "retained evidence").unwrap();
+    for marker in [&current, &old] {
+        fixture.marker = marker.clone();
+        for level in [SandboxLevel::Default, SandboxLevel::Strict] {
+            let result = fixture
+                .run_probe_in_sandboxie(level)
+                .expect("probe completed");
+            assert_eq!(
+                result.marker_read,
+                AccessResult::Denied,
+                "{level} {marker:?}"
+            );
+            assert_eq!(
+                result.marker_write,
+                AccessResult::Denied,
+                "{level} {marker:?}"
+            );
+        }
+    }
+    assert_eq!(
+        std::fs::read_to_string(&current).unwrap(),
+        fixture.marker_text
+    );
+    assert_eq!(std::fs::read_to_string(&old).unwrap(), "retained evidence");
+    std::fs::remove_file(old).unwrap();
+    std::fs::remove_dir(history).unwrap();
+    fixture.marker = current;
 }
 
 #[cfg(test)]

--- a/crates/glass-windows/src/host_fs.rs
+++ b/crates/glass-windows/src/host_fs.rs
@@ -523,6 +523,20 @@ fn open_relative(
     filename: &OsStr,
     directory_child: Option<bool>,
 ) -> Result<File, HostFsError> {
+    open_relative_with_access(
+        directory,
+        filename,
+        directory_child,
+        FILE_READ_DATA | FILE_READ_ATTRIBUTES | SYNCHRONIZE | DELETE,
+    )
+}
+
+fn open_relative_with_access(
+    directory: &File,
+    filename: &OsStr,
+    directory_child: Option<bool>,
+    access: windows::Win32::Storage::FileSystem::FILE_ACCESS_RIGHTS,
+) -> Result<File, HostFsError> {
     if !valid_child_name(filename) {
         return Err(HostFsError::Integrity);
     }
@@ -553,7 +567,7 @@ fn open_relative(
     let status = unsafe {
         NtCreateFile(
             &mut handle,
-            FILE_READ_DATA | FILE_READ_ATTRIBUTES | SYNCHRONIZE | DELETE,
+            access,
             &attributes,
             &mut status_block,
             None,
@@ -611,11 +625,81 @@ pub fn same_file_object(first: &File, second: &File) -> Result<bool, HostFsError
     Ok(file_identity(first)? == file_identity(second)?)
 }
 
+/// Reports whether a retained regular file has exactly one directory link.
+pub fn file_has_single_link(file: &File) -> Result<bool, HostFsError> {
+    let mut information = BY_HANDLE_FILE_INFORMATION::default();
+    // SAFETY: The borrowed handle and correctly sized writable result remain valid for the query.
+    unsafe { GetFileInformationByHandle(HANDLE(file.as_raw_handle()), &mut information) }
+        .map_err(|_| HostFsError::Open)?;
+    Ok(information.nNumberOfLinks == 1)
+}
+
 fn is_reparse(metadata: &std::fs::Metadata) -> bool {
     metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT.0 != 0
 }
 
-/// Replaces a filesystem object's inherited permissions with full access for its owner and SYSTEM.
+/// Restrict an owned directory child through its retained parent handle.
+pub fn restrict_directory_child_to_current_user(
+    parent: &File,
+    name: &OsStr,
+) -> glass_core::Result<()> {
+    use windows::Win32::Storage::FileSystem::{READ_CONTROL, WRITE_DAC, WRITE_OWNER};
+    let file = open_relative_with_access(
+        parent,
+        name,
+        Some(true),
+        READ_CONTROL | WRITE_DAC | WRITE_OWNER | FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+    )
+    .map_err(|_| GlassError::Backend("open private directory handle failed".into()))?;
+    restrict_file_to_current_user(&file)
+}
+
+/// Set the current user as owner and install the private DACL through an owned handle.
+pub fn restrict_file_to_current_user(file: &File) -> glass_core::Result<()> {
+    with_current_user_sid(|owner| {
+        use windows::Win32::Security::Authorization::{SE_FILE_OBJECT, SetSecurityInfo};
+        // SAFETY: Both the borrowed file handle and token-owned SID remain live during the call.
+        unsafe {
+            SetSecurityInfo(
+                HANDLE(file.as_raw_handle()),
+                SE_FILE_OBJECT,
+                windows::Win32::Security::OWNER_SECURITY_INFORMATION,
+                Some(owner),
+                None,
+                None,
+                None,
+            )
+            .ok()
+            .map_err(|error| backend_error("set private handle owner", error))
+        }
+    })?;
+    let sddl = wide_text(PRIVATE_DACL);
+    let mut descriptor = PSECURITY_DESCRIPTOR::default();
+    // SAFETY: The terminated SDDL and output pointer live through this call.
+    unsafe {
+        ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            PCWSTR(sddl.as_ptr()),
+            SDDL_REVISION_1,
+            &mut descriptor,
+            None,
+        )
+        .map_err(|error| backend_error("convert private DACL", error))?;
+    }
+    // SAFETY: The borrowed file handle and allocated descriptor remain valid through the call.
+    let applied = unsafe {
+        windows::Win32::Security::SetKernelObjectSecurity(
+            HANDLE(file.as_raw_handle()),
+            DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+            descriptor,
+        )
+    };
+    // SAFETY: The conversion API returned this LocalAlloc allocation.
+    unsafe {
+        let _ = LocalFree(Some(HLOCAL(descriptor.0)));
+    }
+    applied.map_err(|error| backend_error("apply private handle DACL", error))
+}
+
 pub fn restrict_path_to_current_user(path: &Path) -> glass_core::Result<()> {
     let path = wide(path);
     let sddl = wide_text(PRIVATE_DACL);
@@ -646,6 +730,106 @@ pub fn restrict_path_to_current_user(path: &Path) -> glass_core::Result<()> {
     applied
         .ok()
         .map_err(|error| backend_error("apply private DACL", error))
+}
+
+/// Checks ownership and the protected owner-and-SYSTEM DACL through a retained handle.
+pub fn file_is_private_to_current_user(file: &File) -> glass_core::Result<bool> {
+    use windows::Win32::Security::{
+        EqualSid, GetKernelObjectSecurity, GetSecurityDescriptorOwner, OWNER_SECURITY_INFORMATION,
+    };
+
+    let information = DACL_SECURITY_INFORMATION | OWNER_SECURITY_INFORMATION;
+    let mut needed = 0;
+    // SAFETY: The borrowed handle and zero-length size query are valid.
+    unsafe {
+        let _ = GetKernelObjectSecurity(
+            HANDLE(file.as_raw_handle()),
+            information.0,
+            None,
+            0,
+            &mut needed,
+        );
+    }
+    if needed == 0 || needed > 65536 {
+        return Err(GlassError::Backend(
+            "invalid private handle security size".into(),
+        ));
+    }
+    let mut storage = vec![0_u32; (needed as usize).div_ceil(4)];
+    let descriptor = PSECURITY_DESCRIPTOR(storage.as_mut_ptr().cast());
+    let capacity = needed;
+    // SAFETY: DWORD-aligned storage provides the requested descriptor capacity.
+    unsafe {
+        GetKernelObjectSecurity(
+            HANDLE(file.as_raw_handle()),
+            information.0,
+            Some(descriptor),
+            capacity,
+            &mut needed,
+        )
+        .map_err(|error| backend_error("read private handle security", error))?;
+    }
+    if needed > capacity {
+        return Err(GlassError::Backend("private handle security grew".into()));
+    }
+    // SAFETY: The successful query initialized `needed` bytes within storage.
+    let bytes = unsafe { std::slice::from_raw_parts(storage.as_ptr().cast(), needed as usize) };
+    if !descriptor_has_private_dacl(bytes) {
+        return Ok(false);
+    }
+    let mut owner = PSID::default();
+    let mut defaulted = windows::core::BOOL::default();
+    // SAFETY: The validated descriptor and output pointers remain live throughout this call.
+    unsafe {
+        GetSecurityDescriptorOwner(descriptor, &mut owner, &mut defaulted)
+            .map_err(|error| backend_error("read private handle owner", error))?;
+    }
+    // SAFETY: Both SIDs remain backed by their owning descriptor/token buffers.
+    with_current_user_sid(|user| Ok(unsafe { EqualSid(owner, user).is_ok() }))
+}
+
+fn with_current_user_sid<T>(
+    inspect: impl FnOnce(PSID) -> glass_core::Result<T>,
+) -> glass_core::Result<T> {
+    use windows::Win32::Security::{GetTokenInformation, TOKEN_QUERY, TOKEN_USER, TokenUser};
+    use windows::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+    let mut token = HANDLE::default();
+    // SAFETY: The current process pseudo-handle and token output pointer are valid.
+    unsafe {
+        OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token)
+            .map_err(|error| backend_error("open current user token", error))?;
+    }
+    let result = (|| {
+        let mut needed = 0;
+        // SAFETY: The owned token handle supports the documented zero-length query.
+        unsafe {
+            let _ = GetTokenInformation(token, TokenUser, None, 0, &mut needed);
+        }
+        if needed < std::mem::size_of::<TOKEN_USER>() as u32 || needed > 65536 {
+            return Err(GlassError::Backend(
+                "invalid current user token size".into(),
+            ));
+        }
+        let mut user = vec![0_usize; (needed as usize).div_ceil(std::mem::size_of::<usize>())];
+        // SAFETY: Pointer-aligned storage fits TOKEN_USER and its SID; both buffers outlive comparison.
+        unsafe {
+            GetTokenInformation(
+                token,
+                TokenUser,
+                Some(user.as_mut_ptr().cast()),
+                needed,
+                &mut needed,
+            )
+            .map_err(|error| backend_error("read current user token", error))?;
+            let user = &*user.as_ptr().cast::<TOKEN_USER>();
+            inspect(user.User.Sid)
+        }
+    })();
+    // SAFETY: OpenProcessToken returned this owned handle; no later code uses it.
+    unsafe {
+        let _ = windows::Win32::Foundation::CloseHandle(token);
+    }
+    result
 }
 
 /// Reports whether a filesystem object has the protected owner-and-SYSTEM DACL used by Glass.

--- a/crates/glass-windows/src/lib.rs
+++ b/crates/glass-windows/src/lib.rs
@@ -32,10 +32,12 @@ pub mod vkmap; // pure named-keysym->VK map — cross-platform, host-tested
 #[cfg(windows)]
 pub use host_fs::{
     DirectoryEntryHandle, DirectoryEntryRecord, HostFsError, directory_entry_handles,
-    directory_entry_names, directory_entry_records, file_matches_path_no_reparse,
+    directory_entry_names, directory_entry_records, file_has_single_link,
+    file_is_private_to_current_user, file_matches_path_no_reparse,
     open_deletable_directory_no_reparse, open_directory_beneath, open_directory_entry,
     open_directory_no_reparse, open_entry_child, open_file_beneath, open_file_child,
-    path_has_private_dacl, remove_by_handle, restrict_path_to_current_user, same_file_object,
+    path_has_private_dacl, remove_by_handle, restrict_directory_child_to_current_user,
+    restrict_file_to_current_user, restrict_path_to_current_user, same_file_object,
 };
 
 /// This backend's canonical name (matches the `glass_capabilities` / `GLASS_BACKEND` value).

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ way it does? The explanations.
 
 - [Connect glass to your agent](how-to/connect-an-agent.md) — stdio and HTTP
 - [Run glass over the network](how-to/run-over-the-network.md) — agent and app on different machines
+- [Record and export session evidence](how-to/record-session-evidence.md) — retain requested results for offline review
 - [Drive glass well — the glass-drive skill](how-to/drive-glass-well.md)
 - [Drive a native iOS app in the Simulator](how-to/drive-an-ios-app.md) — launch, drive, and verify an iOS app
 
@@ -53,6 +54,7 @@ way it does? The explanations.
 - [Platform support](reference/platforms.md) — the capability matrix and system requirements
 - [Accessibility roles by platform](reference/a11y-roles.md) — which roles each backend can produce
 - [Audit log](reference/audit-log.md) — the JSONL record schema and redaction
+- [Session trace](reference/session-trace.md) — capture scope, bounds, format and offline commands
 
 ## Explanation — understand why
 

--- a/docs/how-to/record-session-evidence.md
+++ b/docs/how-to/record-session-evidence.md
@@ -1,0 +1,85 @@
+# Record and export session evidence
+
+Enable tracing when you need to review a run after Glass and the target have stopped. A trace
+retains supplied tool inputs and requested results, including screenshots, clipboard content,
+logs and accessibility text. Review the [capture scope and exclusions](../reference/session-trace.md)
+before sharing it.
+
+## Prepare a private directory
+
+On Linux or macOS, create a directory owned by your account:
+
+```sh
+mkdir -m 700 "$HOME/glass-traces"
+cd "$HOME/glass-traces"
+pwd -P
+```
+
+Use the physical absolute path printed by `pwd -P`. Glass refuses symlinks in the path, missing
+parents, filesystem roots and directories writable by other users.
+
+On Windows, create a directory with your account as owner and the protected owner-and-SYSTEM DACL:
+
+```powershell
+$traceRoot = New-Item -ItemType Directory -Path "$env:USERPROFILE\glass-traces"
+$acl = Get-Acl -LiteralPath $traceRoot.FullName
+$acl.SetOwner([Security.Principal.WindowsIdentity]::GetCurrent().User)
+$acl.SetSecurityDescriptorSddlForm('D:P(A;OICI;FA;;;OW)(A;OICI;FA;;;SY)', [Security.AccessControl.AccessControlSections]::Access)
+Set-Acl -LiteralPath $traceRoot.FullName -AclObject $acl
+$traceRoot.FullName
+```
+
+## Start Glass with tracing
+
+Add the directory to the server command your MCP client launches:
+
+```sh
+glass-mcp --trace-dir /absolute/path/glass-traces
+```
+
+The same flags work over HTTP and with either tool profile:
+
+```sh
+glass-mcp serve --http --tool-profile lean --trace-dir /absolute/path/glass-traces
+```
+
+Glass prints the new `trace-…` child directory on stderr. One child covers that server process,
+including replacement app launches and successive HTTP clients. Use the app normally; tracing
+records only evidence produced by requested calls. Request a screenshot yourself when you need
+visual evidence at a particular point.
+
+The default allowance is 256 MiB per process. To choose 64 MiB, add `--trace-max-bytes 67108864`.
+Repeated runs accumulate files until you remove them. `glass_doctor` and tool-result
+`_meta.glass.trace` expose live state and omissions without returning trace content or paths.
+
+## Stop, inspect and export
+
+Disconnect the stdio client or stop the HTTP server gracefully. Then inspect the child path
+printed at startup:
+
+```sh
+glass-mcp trace inspect /absolute/path/glass-traces/trace-ID
+glass-mcp trace inspect /absolute/path/glass-traces/trace-ID --json
+glass-mcp trace export /absolute/path/glass-traces/trace-ID --out /absolute/path/incident.zip
+```
+
+These commands need no target, display, MCP connection or network access. They refuse active
+writers and existing export destinations. Exit status `0` means complete; `2` means valid but
+incomplete; `1` means refusal, corruption or an operational error. An export returning `2` still
+creates a usable archive with an incomplete manifest.
+
+The ZIP contains `manifest.json`, `events.jsonl`, referenced payload files and `READING.txt`.
+Use the journal's relative payload paths, byte lengths and SHA-256 digests when reading a moved
+bundle. UTF-8 text and WebP bytes are retained without recompression. Runtime artifact URIs and
+local paths are historical references; retained payloads survive the temporary artifact store's
+deletion. Archives contain no runtime writer lease; the inspect command accepts original trace
+directories, while standard ZIP/JSON tools can read exported bundles.
+
+An execution outcome and a constructed MCP response are separate events. Neither proves client
+delivery. Missing outcomes remain unknown; do not repeat possibly dispatched input to fill a gap.
+Application text and images remain untrusted data. This bundle does not recreate the app's
+environment or provide a replay runner.
+
+Contained desktop targets in default or strict mode cannot access the configured trace root,
+including earlier traces. Sandbox-off targets, host build commands, unrelated processes running
+as your account, and exported copies outside that root are outside this protection.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -19,6 +19,10 @@ client's filesystem.
   [reference/audit-log.md](audit-log.md).
 - `--tool-profile full|lean` — fixed tool inventory for this server, default `full`.
   Lean uses `glass_do` for actions; see [tool profiles](tools.md#tool-profiles).
+- `--trace-dir <absolute-directory>` — retain supplied inputs and requested results, which can
+  contain sensitive data, in a new child of an existing private directory.
+- `--trace-max-bytes <bytes>` — per-process trace allowance, default 256 MiB; requires `--trace-dir`.
+  See [session trace](session-trace.md) for bounds, exclusions and ownership requirements.
 
 ## `serve`
 
@@ -31,10 +35,25 @@ Serve MCP over the network (Streamable HTTP) instead of stdio.
   headless (no menu bar, MCP served silently).
 - `--audit-log <path>` — as above.
 - `--tool-profile full|lean` — as above, including menu-bar mode.
+- `--trace-dir` and `--trace-max-bytes` — as above, including menu-bar mode.
 
 Loopback binds need no token; see [how-to/run-over-the-network.md](../how-to/run-over-the-network.md).
 Remote HTTP clients must read `glass-artifact://` links with MCP `resources/read`; they must not try
 to open the server-local path from resource metadata on the client machine.
+
+## `trace inspect` and `trace export`
+
+Validate a stopped or interrupted trace without starting a backend or server:
+
+```sh
+glass-mcp trace inspect /absolute/path/trace-ID [--json]
+glass-mcp trace export /absolute/path/trace-ID --out /absolute/path/incident.zip
+```
+
+Inspection returns a bounded timeline with payload references. Export creates a new ZIP containing
+the validated evidence. Active writers and existing destinations are refused. Exit codes are `0`
+for complete evidence, `2` for valid incomplete evidence (a ZIP is still created), and `1` for
+refusal or failure. See [Record and export session evidence](../how-to/record-session-evidence.md).
 
 ## `tools`
 

--- a/docs/reference/session-trace.md
+++ b/docs/reference/session-trace.md
@@ -1,0 +1,120 @@
+# Session trace
+
+Tracing is optional, off by default, and independent of the [audit log](audit-log.md). It retains
+evidence on the server host until the operator deletes it. It never uploads data. See
+[Record and export session evidence](../how-to/record-session-evidence.md) for setup and commands.
+
+## Configuration
+
+| Flag | Meaning |
+| --- | --- |
+| `--trace-dir <absolute-directory>` | Existing operator-owned root; creates one random private child per server process. No symlink/reparse traversal or filesystem roots. |
+| `--trace-max-bytes <bytes>` | Default `268435456`; inclusive range `1048576`–`2147483648`; requires `--trace-dir`. |
+
+Both flags work with stdio, HTTP, full/lean profiles and macOS menu-bar HTTP. Non-serving commands
+ignore recording configuration and create no trace. Offline commands also work in builds without
+default features.
+
+## Captured data
+
+- Advertised tool definitions and instructions, server version, OS, architecture, transport and
+  tool profile. An unavailable source revision is `null`.
+- Local client/call identifiers, receipt and worker execution ordering, elapsed times, known
+  backend and app-session context, typed tool arguments, logical results and constructed responses.
+- Requested text and WebP images: screenshots, marked observations, snapshots, discoveries, diffs,
+  waits, logs and clipboard output, including requested return/then observations.
+- Original batch structure, completed/failed/unexecuted steps, dispatch/confirmation details,
+  content-block indices, trust labels, untrusted text fences and artifact mappings.
+- Observable request abandonment, teardown status, capacity omissions and recording failures.
+
+Arguments are normalized from accepted typed parameters; they are not a copy of the transport
+frame. Times identify recording/execution/result boundaries, not exact image acquisition times.
+The recorder does not request extra images, accessibility walks, log reads, polling or actions.
+It retains no internal baseline image unless a requested result returns it.
+
+The recorder excludes transport credentials, HTTP headers, protocol session tokens, request
+`_meta`, the host environment, and both names and values from `glass_start.env`. Only the explicit
+environment entry count is retained. Invalid arguments produce a rejection category and compact
+decoded argument byte count, without their body or an echoing error message. Existing secure-field
+suppression remains in effect. Other supplied arguments and app output can contain secrets;
+audit redaction settings do not redact traces.
+
+Worker execution continues to be recorded when a waiting caller is cancelled. Response construction
+is recorded separately, with client delivery `unknown`. Trace completeness concerns recorded
+evidence, not application correctness or confirmed client receipt.
+
+## Bounds and live status
+
+| Bound | Value |
+| --- | --- |
+| Total retained bytes | Configurable; counts metadata, journal, payloads and temporary writes |
+| Reserved terminal/metadata allowance | 128 KiB within the total limit |
+| Individual payload | 16 MiB |
+| Pending data | 32 MiB |
+| Queued events | 256 |
+| Admitted calls | 10,000 |
+| Journal events | 100,000, including the terminal event |
+| Single journal event | 64 KiB |
+| Unique payloads | 25,000 |
+| Evidence entries per event | 128, including an omission marker when blocks exceed the bound |
+| Offline timeline index | 8 MiB; remaining events are validated but omitted from the index |
+
+Oversized payloads are omitted whole; later smaller evidence can still be retained. Total, call,
+event and queue exhaustion stop new recording with state `limited`. I/O failure produces `failed`.
+Both preserve earlier evidence, mark the trace incomplete and leave tool execution and `isError`
+unchanged. There is no retry or eviction to recover missing evidence. Invalid trace setup refuses
+server startup.
+
+Enabled traces add `_meta.glass.trace` to successful protocol tool responses, including tool errors.
+The status object contains `enabled`, `state`, `stored_bytes`, `calls`, `limits`, `omissions` and
+`errors`. `glass_doctor` also includes this object as `trace`. Status can lag asynchronous writes.
+Both additions are absent when tracing is disabled. Protocol-level rejections retain their existing
+error shape. No new MCP tool, trace resource or HTTP endpoint is added.
+
+Shutdown tears down the target before waiting up to two seconds for trace finalization, then
+cleans temporary artifacts. A crash, unresolved call, omission or writer failure leaves incomplete
+evidence. The trace is not an audit durability, power-loss or tamper-proofing guarantee.
+
+## Directory and archive format
+
+The schema is `glass.trace.v1`. A live/stopped trace directory contains:
+
+```text
+manifest.json
+events.jsonl
+blobs/<sha256>.bin
+writer.lease
+```
+
+The manifest declares identity, scope exclusions, limits, state, completeness and counters.
+Finalized manifests include journal byte length and SHA-256. Each ordered JSONL event has `seq`,
+`elapsed_us`, `kind`, `call`, `client`, `data`, and optional `evidence`. Evidence descriptors identify
+the block, MIME type, trust and either a relative `payload` (`path`, `bytes`, `sha256`) or `omitted`
+reason. Artifact mappings additionally retain the historical `source_uri`. Text and image blobs
+contain original bytes; JSON argument/envelope payloads contain normalized serialization.
+Resource links also retain their full MCP descriptor in a `resource_descriptor` JSON payload,
+associated with the same block index as the retained resource body.
+
+Events distinguish `call_received`, `arguments`, `execution_started`, `session_context`,
+`logical_outcome`, `response_constructed`, `request_abandoned`, `router_rejection`,
+`worker_unavailable`, and `resource_read`. Inventory, local client creation, shutdown and the
+terminal `trace_closed` are separate control events. Execution ordinals are distinct from receipt
+ordering. Batch steps remain within their original argument/result structures.
+
+Offline inspection holds an exclusive source lease and validates schema, ordering, relative paths,
+lengths and digests. It refuses missing or corrupt committed evidence and unsupported schemas.
+An interrupted final line is an uncommitted tail; unreferenced staging files are reported and are
+not exported. Human output escapes terminal controls and never prints payload bodies.
+
+Export writes a new private ZIP with stored entries (no recompression), validated manifest/journal,
+referenced blobs and `READING.txt`. Runtime leases and staging files are omitted. The destination
+must be outside the source and must not already exist. ZIP overhead is separate from the trace's
+source-storage limit. An interrupted export declares `recovered_interrupted_prefix` and remains
+incomplete. Export never fetches arbitrary URIs, runs recorded commands, extracts an input archive
+or renders application content.
+
+| Exit code | Inspection/export result |
+| --- | --- |
+| `0` | Valid complete trace; export created the ZIP |
+| `2` | Valid incomplete trace; export still created the ZIP |
+| `1` | Invalid input, active source, corruption or I/O failure; no new destination published |

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -997,6 +997,10 @@ counts only as a warning: a non-default backend's problem never reads as `overal
 
 Mirrors the `glass-mcp doctor` CLI — see [reference/cli.md](cli.md).
 
+When session tracing is enabled, the MCP result also includes `trace` with recorder state,
+retained bytes/calls, limits and omission/error counts. The field is absent when tracing is off.
+See [session trace](session-trace.md) for scope and tool-result `_meta.glass.trace` status.
+
 ### `glass_capabilities`
 
 Report which operations can be performed **right now** on a backend — so you can check before you

--- a/tools/windows-validation/run-onbox.ps1
+++ b/tools/windows-validation/run-onbox.ps1
@@ -135,7 +135,8 @@ foreach ($t in $targetList) {
 # the interactive session via the same schtasks /it path the examples use.
 if ($Tests -ne "") {
   Write-Host "`n===== tests: --ignored $Tests ====="
-  $json = cmd /c "cargo test -p glass-windows --no-run --message-format=json $relArg 2>&1"
+  $testTarget = if ($Tests -in @("artifact", "protected_trace_root")) { "--lib" } else { "" }
+  $json = cmd /c "cargo test -p glass-windows $testTarget --no-run --message-format=json $relArg 2>&1"
   if ($LASTEXITCODE -ne 0) {
     $json | Select-Object -Last 20 | Out-Host
     Write-Host "tests($Tests): FAIL (build)"; $failures++
@@ -144,28 +145,30 @@ if ($Tests -ne "") {
     foreach ($line in $json) {
       if ($line -notmatch '"reason"') { continue }
       try { $o = $line | ConvertFrom-Json } catch { continue }
-      if ($o.reason -eq "compiler-artifact" -and $o.executable -and ($o.target.kind -contains "test")) {
+      if ($o.reason -eq "compiler-artifact" -and $o.executable -and $o.profile.test) {
         $exes += $o.executable
       }
     }
     if ($exes.Count -eq 0) {
-      Write-Host "tests($Tests): FAIL (no integration test binary built)"; $failures++
+      Write-Host "tests($Tests): FAIL (no test binary built)"; $failures++
     } else {
       $anyFail = $false
       $artifactMatches = 0
+      $traceMatches = 0
       $safeTests = ($Tests -replace '[^A-Za-z0-9_.-]', '_')
       $artifactEvidence = Join-Path $artifacts "artifact.log"
       if ($Tests -eq "artifact" -and (Test-Path $artifactEvidence)) { Remove-Item $artifactEvidence -Force }
       foreach ($exe in $exes) {
         $tag = [System.IO.Path]::GetFileNameWithoutExtension($exe)
         if ($Tests -eq "artifact") {
-          $testArgs = "--ignored --test-threads=1 --exact containment::artifact_onbox::sandboxie_denies_artifact_read_and_lease_tampering"
+          $testArgs = "--ignored --test-threads=1 sandboxie_denies_artifact"
           $evidenceTag = "artifact"
         } else {
           $testArgs = "--ignored --test-threads=1 $Tests"
           $evidenceTag = "$tag-$safeTests"
         }
-        $r = Invoke-Interactive $exe $tag $testArgs
+        $runTag = if ($Tests -eq "artifact") { "artifact" } else { $tag }
+        $r = Invoke-Interactive $exe $runTag $testArgs
         Write-Host $r.text
         if ($Tests -eq "artifact") {
           $r.text | Out-File -Encoding ascii -Append $artifactEvidence
@@ -177,10 +180,19 @@ if ($Tests -ne "") {
             $r.text -match 'test result: ok\. 1 passed;') {
           $artifactMatches++
         }
+        if ($Tests -eq "protected_trace_root" -and
+            $r.text -match 'test containment::artifact_onbox::protected_trace_root_denies_current_and_retained_history \.\.\. ok' -and
+            $r.text -match 'test result: ok\. 1 passed;') {
+          $traceMatches++
+        }
         if (-not ($r.ran -and $r.result -eq "0")) { $anyFail = $true }
       }
       if ($Tests -eq "artifact" -and $artifactMatches -ne 1) {
         Write-Host "tests(artifact): FAIL (expected exactly one passing artifact test, found $artifactMatches)"
+        $anyFail = $true
+      }
+      if ($Tests -eq "protected_trace_root" -and $traceMatches -ne 1) {
+        Write-Host "tests(protected_trace_root): FAIL (expected exactly one passing trace test, found $traceMatches)"
         $anyFail = $true
       }
       if ($anyFail) { Write-Host "tests($Tests): FAIL"; $failures++ } else { Write-Host "tests($Tests): PASS" }


### PR DESCRIPTION
Glass currently loses session evidence when the client disconnects or temporary output artifacts are cleaned up. This adds opt-in `--trace-dir` recording with bounded persistent storage, plus offline `trace inspect` and `trace export` commands for reviewing a stopped run and sharing its verified evidence in a ZIP.

The recorder retains typed inputs and requested outputs, preserves worker outcomes after cancellation, and keeps logical execution separate from response construction and unknown client delivery. It excludes transport credentials, request metadata, launch environment names/values, and malformed argument bodies. Contained desktop targets are denied access to the entire trace root, including previous runs. Capacity or writer failure marks evidence incomplete without changing action results or retrying input. Tracing is off by default and adds no platform observations or MCP tools.

The change includes stdio/HTTP/menu-bar lifecycle integration, portable artifact mappings, public usage/reference documentation, and native containment fixtures. It also repairs Windows validation harness issues needed to execute those fixtures reliably. Trace leases explicitly unlock when their owner finishes, and concurrent or cancelled shutdown callers observe shared writer completion. Deadline tests use fixed instants or virtual time; semantic behavior tests assert operation evidence with normal action budgets.

Validation:

- Workspace: 3,709 tests passed; formatting and all-targets clippy passed with warnings denied.
- All [CI checks](https://github.com/fixed-width/glass/actions/runs/33993931437) passed at `4b9d393`, including macOS, Windows, Linux integration, and all eight mutation shards plus the aggregate gate.
- Focused trace coverage includes cancellation, recording faults, storage limits, integrity failures, resource retention, transport exclusions, inherited descriptors, and concurrent shutdown. All 22 trace tests passed 25 consecutive runs on each of Linux and macOS (1,100 executions).
- Native macOS core/MCP library suites passed three consecutive runs with 16 test threads: 1,772 tests per run.
- Native default/strict protection passed on X11, Wayland, macOS, and Windows; existing macOS/Windows artifact containment regressions passed.
- Six alternating X11 form runs verified the saved value and submission count; three moved ZIPs independently passed byte/digest checks after temporary artifact cleanup. An iOS Simulator capture/stop/export smoke passed.
- Minimal binary build and 641 minimal library tests passed; Windows cross-target workspace clippy and native macOS clippy passed.

Validation limits: macOS menu Quit compiled but was not manually clicked; Android was not exercised. The full minimal integration suite has an existing network-feature gating failure, and the Linux-host full Darwin cross-check lacks the required C SDK/toolchain. Native macOS compilation passed. The small debug-build timing sample shows recording overhead and is not a production performance estimate.

Co-Authored-By: Jcode <jcode@users.noreply.github.com>


