### PR TITLE
Keep semantic execution evidence in core results

### DIFF
--- a/crates/glass-core/src/session/semantic_action.rs
+++ b/crates/glass-core/src/session/semantic_action.rs
@@ -126,6 +126,14 @@ pub struct MutationReport {
     pub confirmation: ConfirmationStatus,
 }
 
+fn mutations_may_have_dispatched(
+    focus: Option<&MutationReport>,
+    action_dispatch: DispatchStatus,
+) -> bool {
+    action_dispatch != DispatchStatus::NotDispatched
+        || focus.is_some_and(|report| report.dispatch != DispatchStatus::NotDispatched)
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ActionDeadline {
     pub deadline: Deadline,
@@ -153,6 +161,13 @@ pub struct SemanticActionOutcome {
     pub focus: Option<MutationReport>,
     pub action: MutationReport,
     pub bound: ActionDeadline,
+}
+
+impl SemanticActionOutcome {
+    /// Whether focus or the requested action dispatched or may have dispatched.
+    pub fn side_effects_may_have_occurred(&self) -> bool {
+        mutations_may_have_dispatched(self.focus.as_ref(), self.action.dispatch)
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -218,6 +233,8 @@ pub struct SemanticActionError {
     pub resolution: Option<ResolutionReport>,
     pub actionability: ActionabilityReport,
     pub focus: Option<MutationReport>,
+    /// Selected method for the requested action, independent of whether it dispatched.
+    pub action_method: Option<ActionMethod>,
     pub action_dispatch: DispatchStatus,
     pub candidates: Vec<SemanticMatch>,
     /// The resolved element for failures that occur after unique target resolution.
@@ -238,6 +255,16 @@ impl std::fmt::Display for SemanticActionError {
 impl std::error::Error for SemanticActionError {}
 
 impl SemanticActionError {
+    /// Whether focus or the requested action dispatched or may have dispatched.
+    pub fn side_effects_may_have_occurred(&self) -> bool {
+        mutations_may_have_dispatched(self.focus.as_ref(), self.action_dispatch)
+    }
+
+    fn with_action_method(mut self: Box<Self>, method: ActionMethod) -> Box<Self> {
+        self.action_method = Some(method);
+        self
+    }
+
     fn with_target(mut self: Box<Self>, target: ElementInfo) -> Box<Self> {
         self.target = Some(Box::new(target));
         self
@@ -389,6 +416,7 @@ fn empty_error(
         resolution: None,
         actionability: ActionabilityReport::default(),
         focus: None,
+        action_method: None,
         action_dispatch: DispatchStatus::NotDispatched,
         candidates: Vec::new(),
         target: None,
@@ -528,6 +556,7 @@ fn classified_resolution_error(
         resolution: Some(report),
         actionability: ActionabilityReport::default(),
         focus: None,
+        action_method: None,
         action_dispatch: DispatchStatus::NotDispatched,
         candidates: observation.result.matches,
         target: None,
@@ -703,6 +732,7 @@ fn key_source_error(source: GlassError, focused: ConfirmedFocus) -> Box<Semantic
         source.bound_dispatch() == Some(crate::BoundDispatch::NotDispatched);
     let mut error = source_error(source, focused.bound);
     error.summary = "semantic targeted typing failed";
+    error.action_method = Some(ActionMethod::Keyboard);
     error.target = Some(Box::new(focused.element.clone()));
     error.resolution = Some(focused.resolution);
     error.actionability = focused.actionability;
@@ -741,6 +771,7 @@ fn actionability_error(
         resolution,
         actionability,
         focus: None,
+        action_method: None,
         action_dispatch: dispatch,
         candidates: Vec::new(),
         target: None,
@@ -842,6 +873,7 @@ fn set_value_source_error(
     };
     let mut error = source_error(source, bound);
     error.summary = "semantic set-value action failed";
+    error.action_method = Some(ActionMethod::AccessibilityValue);
     error.target = target.map(Box::new);
     error.resolution = resolution;
     error.actionability = actionability;
@@ -859,17 +891,6 @@ fn native_fallback_reason(source: &GlassError) -> String {
         GlassError::AxUnsupported => "backend has no native action path".into(),
         GlassError::AxActionUnavailable(_) => "element exposes no activation action".into(),
         _ => "native accessibility action did not dispatch".into(),
-    }
-}
-
-#[derive(Default)]
-struct ClickAuditContext {
-    method: Option<ActionMethod>,
-}
-
-impl ClickAuditContext {
-    fn selected(&mut self, method: ActionMethod) {
-        self.method = Some(method);
     }
 }
 
@@ -1506,16 +1527,15 @@ impl Glass {
         max_nodes: Option<usize>,
         sequence_deadline: Deadline,
         bound: ActionDeadline,
-        audit: &mut ClickAuditContext,
     ) -> SemanticActionResult<SemanticActionOutcome> {
         match target {
             ActionTarget::Id(id) => {
                 let actionability = self.legacy_click_actionability(*id, false);
-                audit.selected(ActionMethod::NativeAction { actuated: None });
                 let actuated = self
                     .try_native_invoke(*id, bound.deadline)
                     .map_err(|source| {
                         action_source_error(source, None, None, actionability, bound, true)
+                            .with_action_method(ActionMethod::NativeAction { actuated: None })
                     })?;
                 Ok(self.legacy_click_outcome(
                     *id,
@@ -1549,8 +1569,9 @@ impl Glass {
                         .is_none()
                     },
                 )?;
-                audit.selected(ActionMethod::NativeAction { actuated: None });
-                self.dispatch_native_click(resolved)
+                self.dispatch_native_click(resolved).map_err(|error| {
+                    error.with_action_method(ActionMethod::NativeAction { actuated: None })
+                })
             }
         }
     }
@@ -1562,17 +1583,16 @@ impl Glass {
         sequence_deadline: Deadline,
         bound: ActionDeadline,
         native_fallback: Option<String>,
-        audit: &mut ClickAuditContext,
     ) -> SemanticActionResult<SemanticActionOutcome> {
         match target {
             ActionTarget::Id(id) => {
                 let actionability = self.legacy_click_actionability(*id, true);
-                audit.selected(ActionMethod::Pointer {
-                    native_fallback: native_fallback.clone(),
-                });
                 self.click_element_pointer_only(*id, None, bound.deadline)
                     .map_err(|source| {
                         action_source_error(source, None, None, actionability, bound, true)
+                            .with_action_method(ActionMethod::Pointer {
+                                native_fallback: native_fallback.clone(),
+                            })
                     })?;
                 Ok(self.legacy_click_outcome(
                     *id,
@@ -1588,10 +1608,10 @@ impl Glass {
                     sequence_deadline,
                     bound,
                 )?;
-                audit.selected(ActionMethod::Pointer {
-                    native_fallback: native_fallback.clone(),
-                });
-                self.dispatch_pointer_click(resolved, native_fallback)
+                self.dispatch_pointer_click(resolved, native_fallback.clone())
+                    .map_err(|error| {
+                        error.with_action_method(ActionMethod::Pointer { native_fallback })
+                    })
             }
         }
     }
@@ -1630,9 +1650,7 @@ impl Glass {
         sequence_deadline: Deadline,
     ) -> SemanticActionResult<SemanticActionOutcome> {
         let started = std::time::Instant::now();
-        let mut audit = ClickAuditContext::default();
-        let result =
-            self.click_target_inner_with_audit(params.clone(), sequence_deadline, &mut audit);
+        let result = self.click_target_inner(params.clone(), sequence_deadline);
         let element = self.semantic_action_audit_element(&result, &params.target);
         let (method, native_fallback, actuated_id, dispatch, confirmation) = match &result {
             Ok(outcome) => {
@@ -1647,7 +1665,7 @@ impl Glass {
                 )
             }
             Err(error) => {
-                let (method, native_fallback, _) = click_audit_fields(audit.method.as_ref());
+                let (method, native_fallback, _) = click_audit_fields(error.action_method.as_ref());
                 (
                     method,
                     native_fallback,
@@ -1678,19 +1696,6 @@ impl Glass {
         params: ClickTargetParams,
         sequence_deadline: Deadline,
     ) -> SemanticActionResult<SemanticActionOutcome> {
-        self.click_target_inner_with_audit(
-            params,
-            sequence_deadline,
-            &mut ClickAuditContext::default(),
-        )
-    }
-
-    fn click_target_inner_with_audit(
-        &mut self,
-        params: ClickTargetParams,
-        sequence_deadline: Deadline,
-        audit: &mut ClickAuditContext,
-    ) -> SemanticActionResult<SemanticActionOutcome> {
         let bound = target_deadline(
             &params.target,
             params.timeout_ms,
@@ -1698,42 +1703,37 @@ impl Glass {
             sequence_deadline,
         )?;
         match params.mode {
-            ActionMode::Native => self.click_native_once(
-                &params.target,
-                params.max_nodes,
-                sequence_deadline,
-                bound,
-                audit,
-            ),
+            ActionMode::Native => {
+                self.click_native_once(&params.target, params.max_nodes, sequence_deadline, bound)
+            }
             ActionMode::Pointer => self.click_pointer_once(
                 &params.target,
                 params.max_nodes,
                 sequence_deadline,
                 bound,
                 None,
-                audit,
             ),
             ActionMode::Auto => match self.click_native_once(
                 &params.target,
                 params.max_nodes,
                 sequence_deadline,
                 bound,
-                audit,
             ) {
                 Ok(done) => Ok(done),
                 Err(error) if error.proves_pre_dispatch_native_unavailable() => {
                     let reason = error.safe_fallback_reason();
-                    audit.selected(ActionMethod::Pointer {
-                        native_fallback: Some(reason.clone()),
-                    });
                     self.click_pointer_once(
                         &params.target,
                         params.max_nodes,
                         sequence_deadline,
                         bound,
-                        Some(reason),
-                        audit,
+                        Some(reason.clone()),
                     )
+                    .map_err(|error| {
+                        error.with_action_method(ActionMethod::Pointer {
+                            native_fallback: Some(reason),
+                        })
+                    })
                 }
                 Err(error) => Err(error),
             },

--- a/crates/glass-core/src/session/semantic_action/tests.rs
+++ b/crates/glass-core/src/session/semantic_action/tests.rs
@@ -572,6 +572,64 @@ fn public_semantic_action_enums_have_stable_snake_case_labels() {
 }
 
 #[test]
+fn semantic_outcomes_and_errors_combine_both_mutation_phases() {
+    use DispatchStatus::{Dispatched, MayHaveDispatched, NotDispatched};
+
+    for (focus_dispatch, action_dispatch, expected) in [
+        (None, NotDispatched, false),
+        (Some(NotDispatched), NotDispatched, false),
+        (Some(Dispatched), NotDispatched, true),
+        (Some(MayHaveDispatched), NotDispatched, true),
+        (None, Dispatched, true),
+        (Some(NotDispatched), Dispatched, true),
+        (Some(Dispatched), Dispatched, true),
+        (Some(MayHaveDispatched), Dispatched, true),
+        (None, MayHaveDispatched, true),
+        (Some(NotDispatched), MayHaveDispatched, true),
+        (Some(Dispatched), MayHaveDispatched, true),
+        (Some(MayHaveDispatched), MayHaveDispatched, true),
+    ] {
+        let focus = focus_dispatch.map(|dispatch| MutationReport {
+            method: ActionMethod::NativeAction { actuated: None },
+            dispatch,
+            confirmation: ConfirmationStatus::Unconfirmed,
+        });
+        let outcome = SemanticActionOutcome {
+            target: ElementInfo::from_node(&fake_tree().root),
+            resolution: None,
+            actionability: ActionabilityReport::default(),
+            focus: focus.clone(),
+            action: MutationReport {
+                method: ActionMethod::Keyboard,
+                dispatch: action_dispatch,
+                confirmation: ConfirmationStatus::Unconfirmed,
+            },
+            bound: unbounded_action_deadline(None),
+        };
+        let mut error = empty_error(
+            SemanticActionFailureKind::ActionFailed,
+            "semantic action failed",
+            outcome.bound,
+            RetryGuidance::Reobserve,
+            None,
+        );
+        error.focus = focus;
+        error.action_dispatch = action_dispatch;
+
+        assert_eq!(
+            outcome.side_effects_may_have_occurred(),
+            expected,
+            "outcome: focus={focus_dispatch:?}, action={action_dispatch:?}"
+        );
+        assert_eq!(
+            error.side_effects_may_have_occurred(),
+            expected,
+            "error: focus={focus_dispatch:?}, action={action_dispatch:?}"
+        );
+    }
+}
+
+#[test]
 fn semantic_action_error_display_never_exposes_retained_payloads() {
     let error = SemanticActionError {
         kind: SemanticActionFailureKind::ActionFailed,
@@ -585,6 +643,7 @@ fn semantic_action_error_display_never_exposes_retained_payloads() {
             dispatch: DispatchStatus::MayHaveDispatched,
             confirmation: ConfirmationStatus::Unconfirmed,
         }),
+        action_method: Some(ActionMethod::Keyboard),
         action_dispatch: DispatchStatus::MayHaveDispatched,
         candidates: Vec::new(),
         target: None,
@@ -1876,6 +1935,13 @@ fn selector_pointer_known_occlusion_blocks_before_pointer_dispatch() {
 
     assert_eq!(error.kind, SemanticActionFailureKind::NotActionable);
     assert_eq!(error.action_dispatch, DispatchStatus::NotDispatched);
+    assert_eq!(
+        error.action_method,
+        Some(ActionMethod::Pointer {
+            native_fallback: None
+        })
+    );
+    assert!(!error.side_effects_may_have_occurred());
     assert_eq!(hit_calls.load(Ordering::Relaxed), 1);
     assert!(clicks.lock().unwrap().is_empty());
 }
@@ -2245,6 +2311,10 @@ fn native_mode_unsupported_is_proven_not_dispatched() {
     assert!(matches!(error.source, Some(GlassError::AxUnsupported)));
     assert_eq!(error.action_dispatch, DispatchStatus::NotDispatched);
     assert!(clicks.lock().unwrap().is_empty());
+    assert_eq!(
+        error.action_method,
+        Some(ActionMethod::NativeAction { actuated: None })
+    );
 }
 
 #[test]
@@ -2586,6 +2656,10 @@ fn semantic_auto_click_never_falls_back_after_possible_native_dispatch() {
     assert_eq!(native_calls.load(Ordering::Relaxed), 1);
     assert_eq!(native_calls.load(Ordering::Relaxed).saturating_sub(1), 0);
     assert!(clicks.lock().unwrap().is_empty());
+    assert_eq!(
+        error.action_method,
+        Some(ActionMethod::NativeAction { actuated: None })
+    );
     assert_eq!(error.action_dispatch, DispatchStatus::MayHaveDispatched);
     assert_eq!(error.retry, RetryGuidance::DoNotRetry);
 }
@@ -2614,6 +2688,10 @@ fn semantic_native_mode_never_dispatches_pointer() {
 
     assert_eq!(native_calls.load(Ordering::Relaxed), 1);
     assert!(clicks.lock().unwrap().is_empty());
+    assert_eq!(
+        error.action_method,
+        Some(ActionMethod::NativeAction { actuated: None })
+    );
     assert_eq!(error.action_dispatch, DispatchStatus::NotDispatched);
 }
 
@@ -2729,22 +2807,23 @@ fn semantic_pointer_click_refuses_the_same_known_hidden_target() {
 
 #[test]
 fn duplicate_semantic_click_dispatches_neither_native_nor_pointer() {
-    let tree = duplicate_button_tree("Save", 2);
-    let (mut glass, native_calls, clicks, _) =
-        click_mode_glass(vec![tree], InvokeBehavior::Succeed);
-    glass.start(&spec()).unwrap();
+    for mode in [ActionMode::Auto, ActionMode::Native, ActionMode::Pointer] {
+        let tree = duplicate_button_tree("Save", 2);
+        let (mut glass, native_calls, clicks, _) =
+            click_mode_glass(vec![tree], InvokeBehavior::Succeed);
+        glass.start(&spec()).unwrap();
 
-    let error = glass
-        .click_target_by(
-            &semantic_click_params(ActionMode::Auto, 0),
-            Deadline::UNBOUNDED,
-        )
-        .unwrap_err();
+        let error = glass
+            .click_target_by(&semantic_click_params(mode, 0), Deadline::UNBOUNDED)
+            .unwrap_err();
 
-    assert_eq!(native_calls.load(Ordering::Relaxed), 0);
-    assert!(clicks.lock().unwrap().is_empty());
-    assert_eq!(error.kind, SemanticActionFailureKind::AmbiguousTarget);
-    assert_eq!(error.action_dispatch, DispatchStatus::NotDispatched);
+        assert_eq!(native_calls.load(Ordering::Relaxed), 0);
+        assert!(clicks.lock().unwrap().is_empty());
+        assert_eq!(error.kind, SemanticActionFailureKind::AmbiguousTarget);
+        assert_eq!(error.action_dispatch, DispatchStatus::NotDispatched);
+        assert_eq!(error.action_method, None);
+        assert!(!error.side_effects_may_have_occurred());
+    }
 }
 
 #[test]
@@ -2948,6 +3027,52 @@ fn semantic_public_click_audit_emits_exactly_one_record_on_native_fallback_and_f
 }
 
 #[test]
+fn auto_fallback_resolution_failure_retains_pointer_selection_without_dispatch() {
+    let tree = actionable_button_tree(
+        "Save",
+        AxRect {
+            x: 10,
+            y: 10,
+            width: 20,
+            height: 20,
+        },
+    );
+    let (mut glass, native_calls, clicks, _) = click_mode_glass(
+        vec![tree, duplicate_button_tree("Save", 2)],
+        InvokeBehavior::Unsupported,
+    );
+    let sink = RecordingSink::default();
+    glass.set_audit_sink(Box::new(sink.clone()));
+    glass.start(&spec()).unwrap();
+
+    let error = glass
+        .click_target(&semantic_click_params(ActionMode::Auto, 0))
+        .unwrap_err();
+
+    assert_eq!(error.kind, SemanticActionFailureKind::AmbiguousTarget);
+    assert_eq!(
+        error.action_method,
+        Some(ActionMethod::Pointer {
+            native_fallback: Some("backend has no native action path".into()),
+        })
+    );
+    assert_eq!(error.action_dispatch, DispatchStatus::NotDispatched);
+    assert!(!error.side_effects_may_have_occurred());
+    assert_eq!(native_calls.load(Ordering::Relaxed), 1);
+    assert!(clicks.lock().unwrap().is_empty());
+    let audits = sink.1.lock().unwrap();
+    assert_eq!(audits.len(), 1);
+    assert_eq!(audits[0].method.as_deref(), Some("pointer"));
+    assert_eq!(
+        audits[0].native_fallback.as_deref(),
+        Some("backend has no native action path")
+    );
+    assert_eq!(audits[0].dispatch, "not_dispatched");
+    assert_eq!(audits[0].confirmation, "unconfirmed");
+    assert_eq!(audits[0].actuated_id, None);
+}
+
+#[test]
 fn failure_audit_auto_pointer_fallback_retains_the_resolved_target_and_selected_path() {
     let tree = actionable_button_tree(
         "Save account",
@@ -2980,6 +3105,13 @@ fn failure_audit_auto_pointer_fallback_retains_the_resolved_target_and_selected_
     assert_eq!(native_calls.load(Ordering::Relaxed), 1);
     assert_eq!(clicks.lock().unwrap().len(), 1);
     assert_eq!(error.action_dispatch, DispatchStatus::MayHaveDispatched);
+    assert_eq!(
+        error.action_method,
+        Some(ActionMethod::Pointer {
+            native_fallback: Some("backend has no native action path".into()),
+        })
+    );
+    assert!(error.side_effects_may_have_occurred());
     assert_eq!(
         error.target.as_ref().map(|target| target.id),
         Some(AxNodeId(1))
@@ -3295,6 +3427,8 @@ fn semantic_set_value_does_not_retry_after_a_may_have_dispatched_transport_failu
     assert_eq!(walks.load(Ordering::Relaxed), 1);
     assert_eq!(set_log.lock().unwrap().len(), 1);
     assert_eq!(error.action_dispatch, DispatchStatus::MayHaveDispatched);
+    assert_eq!(error.action_method, Some(ActionMethod::AccessibilityValue));
+    assert!(error.side_effects_may_have_occurred());
     assert_eq!(error.retry, RetryGuidance::DoNotRetry);
 }
 
@@ -3742,6 +3876,8 @@ fn targeted_type_never_types_when_focus_cannot_be_confirmed() {
     assert!(fixture.key_log.lock().unwrap().is_empty());
     assert_eq!(error.kind, SemanticActionFailureKind::FocusUnconfirmed);
     assert_eq!(error.action_dispatch, DispatchStatus::NotDispatched);
+    assert_eq!(error.action_method, None);
+    assert!(error.side_effects_may_have_occurred());
     assert_eq!(error.retry, RetryGuidance::Reobserve);
     assert_eq!(
         error.focus,
@@ -3795,6 +3931,8 @@ fn targeted_type_never_dispatches_a_second_text_batch_after_possible_key_deliver
 
     assert_eq!(fixture.key_log.lock().unwrap().len(), 1);
     assert_eq!(error.action_dispatch, DispatchStatus::MayHaveDispatched);
+    assert_eq!(error.action_method, Some(ActionMethod::Keyboard));
+    assert!(error.side_effects_may_have_occurred());
     assert_eq!(error.retry, RetryGuidance::DoNotRetry);
     assert_eq!(
         error.focus.as_ref().map(|focus| focus.confirmation),

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -803,23 +803,20 @@ pub(crate) fn semantic_return_error(
     annotation: &str,
 ) -> ContextualError {
     let disclosure = semantic_action::success_output(tool, outcome, None, Vec::new());
+    let side_effects_may_have_occurred = outcome.side_effects_may_have_occurred();
     let mut contents = disclosure.0.into_iter();
     if let Some(OutContent::Envelope(envelope)) = contents.next() {
         let mut result = envelope.result;
-        let (_, side_effects_may_have_occurred) =
-            semantic_action::mutation_provenance(outcome.focus.as_ref(), outcome.action.dispatch);
         result["dispatch"] = json!(outcome.action.dispatch.as_str());
         result["side_effects_may_have_occurred"] = json!(side_effects_may_have_occurred);
         result["retry"] = json!("do_not_retry");
         error.result = Some(result);
     }
     error.siblings = contents.collect();
-    let (bound_dispatch, side_effects_may_have_occurred) =
-        semantic_action::mutation_provenance(outcome.focus.as_ref(), outcome.action.dispatch);
     error = if side_effects_may_have_occurred {
         error.after_dispatch()
     } else {
-        error.bound_dispatch = Some(bound_dispatch);
+        error.bound_dispatch = Some(BoundDispatch::NotDispatched);
         error
     };
     error.annotate(annotation)

--- a/crates/glass-mcp/src/tools/semantic_action.rs
+++ b/crates/glass-mcp/src/tools/semantic_action.rs
@@ -1,6 +1,6 @@
 use glass_core::{
     ActionMethod, ActionMode, ActionTarget, ActionabilityReport, AxNodeId, ClickTargetParams,
-    DispatchStatus, ElementInfo, MatchField, MatchTier, MutationReport, ResolutionReport,
+    ElementInfo, MatchField, MatchTier, MutationReport, ResolutionReport,
     SEMANTIC_ACTION_DEFAULT_TIMEOUT_MS, SEMANTIC_ACTION_MAX_TIMEOUT_MS, ScopeResolution,
     SemanticActionError, SemanticActionFailureKind, SemanticActionOutcome, SemanticMatch,
     SetValueTargetParams, TypeTargetParams, Whose,
@@ -354,22 +354,6 @@ fn merge_object(target: &mut Value, source: Value) {
     target.extend(source);
 }
 
-pub(crate) fn mutation_provenance(
-    focus: Option<&MutationReport>,
-    action_dispatch: DispatchStatus,
-) -> (glass_core::BoundDispatch, bool) {
-    let may_have_dispatched = action_dispatch != DispatchStatus::NotDispatched
-        || focus.is_some_and(|report| report.dispatch != DispatchStatus::NotDispatched);
-    (
-        if may_have_dispatched {
-            glass_core::BoundDispatch::MayHaveDispatched
-        } else {
-            glass_core::BoundDispatch::NotDispatched
-        },
-        may_have_dispatched,
-    )
-}
-
 pub(crate) fn success_output(
     tool: &'static str,
     outcome: &SemanticActionOutcome,
@@ -440,11 +424,9 @@ fn semantic_category(error: &SemanticActionError) -> SafeErrorCategory {
 }
 
 fn failure_result(error: &SemanticActionError) -> Value {
-    let (_, side_effects_may_have_occurred) =
-        mutation_provenance(error.focus.as_ref(), error.action_dispatch);
     let mut result = json!({
         "dispatch": error.action_dispatch.as_str(),
-        "side_effects_may_have_occurred": side_effects_may_have_occurred,
+        "side_effects_may_have_occurred": error.side_effects_may_have_occurred(),
         "retry": error.retry.as_str(),
         "actionability": actionability_json(&error.actionability),
         "candidate_count": error.candidates.len(),
@@ -475,7 +457,11 @@ pub(crate) fn semantic_error(
             &json!({ "target": element_json(target, include_text) }).to_string(),
         ));
     }
-    let (bound_dispatch, _) = mutation_provenance(error.focus.as_ref(), error.action_dispatch);
+    let bound_dispatch = if error.side_effects_may_have_occurred() {
+        glass_core::BoundDispatch::MayHaveDispatched
+    } else {
+        glass_core::BoundDispatch::NotDispatched
+    };
     ContextualError {
         code: category.code(),
         message: category.summary().into(),

--- a/crates/glass-mcp/src/tools/semantic_action/tests.rs
+++ b/crates/glass-mcp/src/tools/semantic_action/tests.rs
@@ -809,6 +809,7 @@ fn semantic_failure(
         resolution: Some(resolution_report(timed_out_by)),
         actionability: actionability_report(),
         focus: None,
+        action_method: None,
         action_dispatch: DispatchStatus::NotDispatched,
         candidates,
         target: None,


### PR DESCRIPTION
Failed clicks kept their selected method in an audit-only context, while MCP reconstructed whether focus or the requested action might have dispatched. Core outcomes and errors now provide that evidence directly, so audit and MCP consume the same facts.

Adds `SemanticActionError.action_method` and a shared query for possible side effects on outcomes and errors. Removes `ClickAuditContext`, its execution plumbing, and MCP's `mutation_provenance` helper. Preserves selected-method attribution through failed pointer fallback resolution, phase-specific dispatch certainty, retry behavior, deadlines, and existing MCP/audit output.

Rust source compatibility: callers constructing `SemanticActionError` or matching it exhaustively must account for the new field. Existing fields and MCP schemas retain their meaning.

Validation on Linux:

- `cargo build --workspace --all-targets --locked` passed.
- `cargo clippy --workspace --all-targets --locked -- -D warnings` passed.
- `cargo fmt --all --check` passed.
- `cargo test --workspace --locked -- --quiet`: 3,735 passed, 363 ignored. The first run hit an unchanged Wayland fixture `ETXTBSY`; the isolated test and full rerun passed.
- Coverage includes all focus/action dispatch combinations, native and pointer failure attribution, fallback resolution failure, and existing MCP/batch disclosure tests.
- Independent review found no material issues.

Co-Authored-By: Codex <noreply@openai.com>
