### PR TITLE
refactor(trace): centralize event construction and lifecycle roles

### DIFF
--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -89,13 +89,7 @@ fn traced_call_result(
 ) -> CallToolResult {
     let (output, is_error, _metadata, response_pin) = applied.into_parts();
     if let Some(trace) = trace {
-        trace.output(
-            "response_constructed",
-            &output,
-            is_error,
-            target_access,
-            store,
-        );
+        trace.response_constructed(&output, is_error, target_access, store);
     }
     let content = output
         .0
@@ -300,7 +294,7 @@ impl GlassServer {
                         let mut g = worker_glass.blocking_lock();
                         execution += 1;
                         if let Some(trace) = &trace {
-                            trace.record("execution_started", serde_json::json!({"execution_order": execution, "session": session, "backend": g.active_backend()}));
+                            trace.execution_started(execution, session, g.active_backend());
                         }
                         let mut outcome =
                             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| job(&mut g)))
@@ -320,7 +314,7 @@ impl GlassServer {
                             session = Some(execution);
                         }
                         if let Some(trace) = &trace {
-                            trace.record("session_context", serde_json::json!({"session": session, "backend": g.active_backend()}));
+                            trace.session_context(session, g.active_backend());
                             trace.logical_outcome(&outcome);
                         }
                         let _ = reply.send(outcome);
@@ -456,7 +450,7 @@ impl GlassServer {
         };
         let Some(jobs) = &self.jobs else {
             if let Some(trace) = &trace {
-                trace.record("worker_unavailable", serde_json::json!({}));
+                trace.worker_unavailable();
             }
             return Ok(traced_call_result(
                 self.output_policy.apply(fallback()),
@@ -470,7 +464,7 @@ impl GlassServer {
             .is_err()
         {
             if let Some(trace) = &trace {
-                trace.record("worker_unavailable", serde_json::json!({}));
+                trace.worker_unavailable();
             }
             return Ok(traced_call_result(
                 self.output_policy.apply(fallback()),
@@ -1121,7 +1115,7 @@ impl ServerHandler for GlassServer {
             .as_ref()
             .and_then(|trace| trace.begin_call(&request.name, self.trace_client));
         if let Some(trace) = &trace {
-            trace.record("argument_size", serde_json::json!({"compact_json_bytes": crate::trace::argument_bytes(&request.arguments)}));
+            trace.argument_size(&request.arguments);
         }
         let tcc = rmcp::handler::server::tool::ToolCallContext::new(self, request, context);
         let mut result = if let Some(call) = trace {
@@ -1130,7 +1124,7 @@ impl ServerHandler for GlassServer {
                 .scope(call.clone(), self.tool_router.call(tcc))
                 .await;
             if !call.has_valid_arguments() {
-                call.record("router_rejection", serde_json::json!({"category": "tool_or_arguments_rejected", "raw_arguments": "excluded"}));
+                call.router_rejection();
             }
             guard.complete();
             result

--- a/crates/glass-mcp/src/trace/capture.rs
+++ b/crates/glass-mcp/src/trace/capture.rs
@@ -7,6 +7,7 @@ use crate::output_policy::ToolCallOutcome;
 
 use super::CallTrace;
 use super::config::MAX_PAYLOAD_BYTES;
+use super::format::EventKind;
 use super::recorder::evidence;
 
 tokio::task_local! {
@@ -52,7 +53,7 @@ pub(crate) fn start_arguments(args: &crate::params::StartArgs) {
 impl CallTrace {
     pub fn logical_outcome(&self, outcome: &ToolCallOutcome) {
         self.output(
-            "logical_outcome",
+            EventKind::LogicalOutcome,
             &outcome.output,
             outcome.is_error,
             outcome.target_access,
@@ -60,9 +61,25 @@ impl CallTrace {
         );
     }
 
-    pub fn output(
+    pub fn response_constructed(
         &self,
-        kind: &str,
+        output: &ToolOutput,
+        is_error: bool,
+        access: TargetAccess,
+        store: Option<&ArtifactStore>,
+    ) {
+        self.output(
+            EventKind::ResponseConstructed,
+            output,
+            is_error,
+            access,
+            store,
+        );
+    }
+
+    fn output(
+        &self,
+        kind: EventKind,
         output: &ToolOutput,
         is_error: bool,
         access: TargetAccess,
@@ -105,7 +122,7 @@ impl CallTrace {
 
     pub fn resource_read(&self, result: &Result<rmcp::model::ReadResourceResult, rmcp::ErrorData>) {
         self.capture(
-            "resource_read",
+            EventKind::ResourceRead,
             json!({"is_error": result.is_err()}),
             |capture| {
                 if let Ok(result) = result {
@@ -140,7 +157,10 @@ impl CallTrace {
                 }
             },
         );
-        self.record("logical_outcome", json!({"is_error": result.is_err()}));
+        self.record(
+            EventKind::LogicalOutcome,
+            json!({"is_error": result.is_err()}),
+        );
     }
 }
 
@@ -165,7 +185,7 @@ impl Drop for RequestGuard {
     fn drop(&mut self) {
         if !self.completed {
             self.call.record(
-                "request_abandoned",
+                EventKind::RequestAbandoned,
                 json!({"execution_outcome": "observe_worker_outcome"}),
             );
         }

--- a/crates/glass-mcp/src/trace/event_tests.rs
+++ b/crates/glass-mcp/src/trace/event_tests.rs
@@ -1,0 +1,325 @@
+use std::io::Read;
+use std::path::Path;
+
+use serde_json::{Value, json};
+
+use crate::output::{TargetAccess, ToolEffect, ToolOutput};
+use crate::output_policy::ToolCallOutcome;
+
+use super::format::{CallRole, Event, EventKind, digest};
+use super::tests::{private_root, start_recorder};
+use super::{RequestGuard, export, inspect};
+
+#[test]
+fn event_kinds_preserve_v1_strings_and_call_roles() {
+    for (kind, name, role) in [
+        (EventKind::Inventory, "inventory", CallRole::Other),
+        (EventKind::ClientCreated, "client_created", CallRole::Other),
+        (EventKind::Shutdown, "shutdown", CallRole::Other),
+        (EventKind::CallReceived, "call_received", CallRole::Start),
+        (EventKind::ArgumentSize, "argument_size", CallRole::Other),
+        (EventKind::Arguments, "arguments", CallRole::Other),
+        (
+            EventKind::ExecutionStarted,
+            "execution_started",
+            CallRole::Other,
+        ),
+        (
+            EventKind::SessionContext,
+            "session_context",
+            CallRole::Other,
+        ),
+        (
+            EventKind::LogicalOutcome,
+            "logical_outcome",
+            CallRole::Outcome,
+        ),
+        (
+            EventKind::ResponseConstructed,
+            "response_constructed",
+            CallRole::Other,
+        ),
+        (
+            EventKind::RequestAbandoned,
+            "request_abandoned",
+            CallRole::Other,
+        ),
+        (
+            EventKind::RouterRejection,
+            "router_rejection",
+            CallRole::Outcome,
+        ),
+        (
+            EventKind::WorkerUnavailable,
+            "worker_unavailable",
+            CallRole::Outcome,
+        ),
+        (EventKind::ResourceRead, "resource_read", CallRole::Other),
+        (EventKind::TraceClosed, "trace_closed", CallRole::Other),
+        (
+            EventKind::Unknown("future_event".into()),
+            "future_event",
+            CallRole::Other,
+        ),
+    ] {
+        let wire = format!(
+            r#"{{"seq":1,"elapsed_us":2,"kind":"{name}","call":3,"client":4,"data":{{}}}}"#
+        );
+        let event: Event = serde_json::from_str(&wire).unwrap();
+        assert_eq!(event.kind, kind);
+        assert_eq!(event.kind.call_role(), role, "{name}");
+        assert_eq!(serde_json::to_string(&event).unwrap(), wire);
+    }
+}
+
+#[test]
+fn v1_event_kind_rejects_non_strings() {
+    for kind in [
+        Value::Null,
+        json!(1),
+        json!(true),
+        json!([]),
+        json!({"call_received": null}),
+    ] {
+        let event = json!({"seq":1, "elapsed_us":2, "kind":kind, "call":3, "client":4, "data":{}});
+        assert!(serde_json::from_value::<Event>(event).is_err(), "{kind}");
+    }
+}
+
+#[tokio::test]
+async fn call_events_preserve_payloads_and_finish_each_execution_path() {
+    let root = private_root();
+    let recorder = start_recorder(&root);
+    let client = recorder.new_client();
+    let call = recorder.begin_call("glass_test", client).unwrap();
+    call.argument_size(&json!({}));
+    call.arguments(&json!({}));
+    call.execution_started(7, None, None);
+    call.session_context(Some(7), Some("x11"));
+    let outcome = ToolCallOutcome {
+        tool: "glass_test",
+        effect: ToolEffect::ReadOnly,
+        is_error: false,
+        target_access: TargetAccess::NoActiveTarget,
+        output: ToolOutput(vec![]),
+    };
+    call.logical_outcome(&outcome);
+    call.response_constructed(&outcome.output, false, outcome.target_access, None);
+    let rejected = recorder.begin_call("glass_test", client).unwrap();
+    rejected.router_rejection();
+    let unavailable = recorder.begin_call("glass_test", client).unwrap();
+    unavailable.worker_unavailable();
+    unavailable.response_constructed(&outcome.output, true, outcome.target_access, None);
+    let resource = recorder.begin_call("resources/read", client).unwrap();
+    resource.resource_read(&Ok(rmcp::model::ReadResourceResult::new(vec![])));
+    recorder.close().await;
+
+    let report = inspect(recorder.path()).unwrap();
+    assert!(report.complete, "{report:?}");
+    assert_eq!(report.manifest["calls"], 4);
+    let call_events: Vec<_> = report
+        .events
+        .iter()
+        .filter(|event| !event["call"].is_null())
+        .map(|event| {
+            assert_eq!(event["client"], client);
+            json!({"call":event["call"], "kind":event["kind"], "data":event["data"]})
+        })
+        .collect();
+    let output = json!({"is_error":false, "target_access":"no_active_target", "content_blocks":0, "client_delivery":"unknown"});
+    assert_eq!(
+        call_events,
+        vec![
+            json!({"call":1, "kind":"call_received", "data":{"tool":"glass_test"}}),
+            json!({"call":1, "kind":"argument_size", "data":{"compact_json_bytes":2}}),
+            json!({"call":1, "kind":"arguments", "data":{}}),
+            json!({"call":1, "kind":"execution_started", "data":{"execution_order":7, "session":null, "backend":null}}),
+            json!({"call":1, "kind":"session_context", "data":{"session":7, "backend":"x11"}}),
+            json!({"call":1, "kind":"logical_outcome", "data":output}),
+            json!({"call":1, "kind":"response_constructed", "data":output}),
+            json!({"call":2, "kind":"call_received", "data":{"tool":"glass_test"}}),
+            json!({"call":2, "kind":"router_rejection", "data":{"category":"tool_or_arguments_rejected", "raw_arguments":"excluded"}}),
+            json!({"call":3, "kind":"call_received", "data":{"tool":"glass_test"}}),
+            json!({"call":3, "kind":"worker_unavailable", "data":{}}),
+            json!({"call":3, "kind":"response_constructed", "data":{"is_error":true, "target_access":"no_active_target", "content_blocks":0, "client_delivery":"unknown"}}),
+            json!({"call":4, "kind":"call_received", "data":{"tool":"resources/read"}}),
+            json!({"call":4, "kind":"resource_read", "data":{"is_error":false}}),
+            json!({"call":4, "kind":"logical_outcome", "data":{"is_error":false}}),
+        ]
+    );
+    assert!(
+        export(recorder.path(), &root.path().join("complete.zip"))
+            .unwrap()
+            .complete
+    );
+}
+
+#[tokio::test]
+async fn abandoned_request_without_execution_outcome_stays_incomplete() {
+    let root = private_root();
+    let recorder = start_recorder(&root);
+    let call = recorder.begin_call("glass_test", 1).unwrap();
+    drop(RequestGuard::new(call));
+    recorder.close().await;
+    let report = inspect(recorder.path()).unwrap();
+    assert!(!report.complete);
+    let abandoned = report
+        .events
+        .iter()
+        .find(|event| event["kind"] == "request_abandoned")
+        .unwrap();
+    assert_eq!(
+        abandoned["data"],
+        json!({"execution_outcome":"observe_worker_outcome"})
+    );
+    assert_eq!(
+        report.events.last().unwrap()["data"]["unfinished_calls"],
+        json!([1])
+    );
+    assert_eq!(
+        export(recorder.path(), &root.path().join("incomplete.zip"))
+            .unwrap()
+            .exit_code(),
+        2
+    );
+}
+
+// Refresh accounting so malformed fixtures exercise semantic checks, not stale hashes.
+fn rewrite_journal(path: &Path, mut events: Vec<Value>, mut manifest: Value) -> Vec<u8> {
+    let mut journal = Vec::new();
+    for (index, event) in events.iter_mut().enumerate() {
+        event["seq"] = json!(index + 1);
+        serde_json::to_writer(&mut journal, event).unwrap();
+        journal.push(b'\n');
+    }
+    manifest["events"] = json!(events.len());
+    manifest["journal_bytes"] = json!(journal.len());
+    manifest["journal_sha256"] = json!(digest(&journal));
+    let blobs: u64 = std::fs::read_dir(path.join("blobs"))
+        .unwrap()
+        .map(|entry| entry.unwrap().metadata().unwrap().len())
+        .sum();
+    let manifest_bytes = loop {
+        let bytes = serde_json::to_vec(&manifest).unwrap();
+        let total = blobs + journal.len() as u64 + bytes.len() as u64;
+        if manifest["stored_bytes"] == total {
+            break bytes;
+        }
+        manifest["stored_bytes"] = json!(total);
+    };
+    std::fs::write(path.join("events.jsonl"), &journal).unwrap();
+    std::fs::write(path.join("manifest.json"), manifest_bytes).unwrap();
+    journal
+}
+
+#[tokio::test]
+async fn unknown_events_remain_opaque_and_export_unchanged() {
+    for has_outcome in [false, true] {
+        let root = private_root();
+        let recorder = start_recorder(&root);
+        let call = recorder.begin_call("glass_test", 1).unwrap();
+        call.worker_unavailable();
+        recorder.close().await;
+        let report = inspect(recorder.path()).unwrap();
+        let mut events = report.events;
+        let mut unknown = events[2].clone();
+        unknown["kind"] = json!("future_event");
+        unknown["data"] = json!({"future_field":[1,2,3]});
+        events.insert(2, unknown.clone());
+        if !has_outcome {
+            events.remove(3);
+        }
+        let mut manifest = report.manifest;
+        manifest["complete"] = json!(has_outcome);
+        let journal = rewrite_journal(recorder.path(), events.clone(), manifest.clone());
+        let inspected = inspect(recorder.path()).unwrap();
+        assert_eq!(inspected.complete, has_outcome);
+        assert_eq!(inspected.events[2], unknown);
+        let output = root.path().join("unknown.zip");
+        assert_eq!(
+            export(recorder.path(), &output).unwrap().complete,
+            has_outcome
+        );
+        let mut archive = zip::ZipArchive::new(std::fs::File::open(output).unwrap()).unwrap();
+        let mut exported = Vec::new();
+        archive
+            .by_name("events.jsonl")
+            .unwrap()
+            .read_to_end(&mut exported)
+            .unwrap();
+        assert_eq!(exported, journal);
+
+        events[2]["kind"] = json!("x".repeat(65));
+        rewrite_journal(recorder.path(), events, manifest);
+        assert_eq!(
+            inspect(recorder.path()).unwrap_err().to_string(),
+            "trace event metadata exceeds limits"
+        );
+    }
+}
+
+#[tokio::test]
+async fn inspection_independently_rejects_inconsistent_call_lifecycles() {
+    let root = private_root();
+    let recorder = start_recorder(&root);
+    recorder
+        .begin_call("glass_test", 1)
+        .unwrap()
+        .worker_unavailable();
+    recorder.close().await;
+    let report = inspect(recorder.path()).unwrap();
+    assert!(report.complete);
+    for case in [
+        "duplicate_start",
+        "unknown_call",
+        "duplicate_outcome",
+        "unfinished",
+        "missing_close",
+        "call_count",
+    ] {
+        let mut events = report.events.clone();
+        let mut manifest = report.manifest.clone();
+        let expected = match case {
+            "duplicate_start" => {
+                events.insert(2, events[1].clone());
+                "duplicate trace call ID"
+            }
+            "unknown_call" => {
+                events[2]["call"] = json!(2);
+                "event refers to an unknown call"
+            }
+            "duplicate_outcome" => {
+                let mut duplicate = events[2].clone();
+                duplicate["kind"] = json!("logical_outcome");
+                events.insert(3, duplicate);
+                "duplicate call execution outcome"
+            }
+            "unfinished" => {
+                events.remove(2);
+                "complete trace has missing evidence"
+            }
+            "missing_close" => {
+                events.pop();
+                "final trace event missing"
+            }
+            "call_count" => {
+                manifest["calls"] = json!(2);
+                "trace call count mismatch"
+            }
+            _ => unreachable!(),
+        };
+        rewrite_journal(recorder.path(), events, manifest);
+        assert_eq!(
+            inspect(recorder.path()).unwrap_err().to_string(),
+            expected,
+            "{case}"
+        );
+        let output = root.path().join(format!("{case}.zip"));
+        assert_eq!(
+            export(recorder.path(), &output).unwrap_err().to_string(),
+            expected,
+            "{case}"
+        );
+        assert!(!output.exists());
+    }
+}

--- a/crates/glass-mcp/src/trace/format.rs
+++ b/crates/glass-mcp/src/trace/format.rs
@@ -5,6 +5,66 @@ use super::config::*;
 
 pub(super) const SCHEMA: &str = "glass.trace.v1";
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum EventKind {
+    Inventory,
+    ClientCreated,
+    Shutdown,
+    CallReceived,
+    ArgumentSize,
+    Arguments,
+    ExecutionStarted,
+    SessionContext,
+    LogicalOutcome,
+    ResponseConstructed,
+    RequestAbandoned,
+    RouterRejection,
+    WorkerUnavailable,
+    ResourceRead,
+    TraceClosed,
+    #[serde(untagged)]
+    Unknown(String),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum CallRole {
+    Start,
+    Outcome,
+    Other,
+}
+
+impl EventKind {
+    pub fn call_role(&self) -> CallRole {
+        match self {
+            Self::CallReceived => CallRole::Start,
+            Self::LogicalOutcome | Self::RouterRejection | Self::WorkerUnavailable => {
+                CallRole::Outcome
+            }
+            Self::Inventory
+            | Self::ClientCreated
+            | Self::Shutdown
+            | Self::ArgumentSize
+            | Self::Arguments
+            | Self::ExecutionStarted
+            | Self::SessionContext
+            | Self::ResponseConstructed
+            | Self::RequestAbandoned
+            | Self::ResourceRead
+            | Self::TraceClosed
+            | Self::Unknown(_) => CallRole::Other,
+        }
+    }
+}
+
+fn deserialize_event_kind<'de, D: serde::Deserializer<'de>>(
+    deserializer: D,
+) -> Result<EventKind, D::Error> {
+    // v1 accepts string kinds only, including unknown names.
+    let name = String::deserialize(deserializer)?;
+    EventKind::deserialize(serde::de::value::StrDeserializer::new(&name))
+}
+
 pub(super) fn digest(bytes: &[u8]) -> String {
     hex(&Sha256::digest(bytes))
 }
@@ -49,7 +109,8 @@ pub(super) struct Evidence {
 pub(super) struct Event {
     pub seq: u64,
     pub elapsed_us: u64,
-    pub kind: String,
+    #[serde(deserialize_with = "deserialize_event_kind")]
+    pub kind: EventKind,
     pub call: Option<u64>,
     pub client: u64,
     pub data: serde_json::Value,

--- a/crates/glass-mcp/src/trace/inspect.rs
+++ b/crates/glass-mcp/src/trace/inspect.rs
@@ -9,7 +9,7 @@ use serde_json::json;
 use sha2::{Digest, Sha256};
 
 use super::config::*;
-use super::format::{Event, Manifest, Payload, SCHEMA, digest};
+use super::format::{CallRole, Event, EventKind, Manifest, Payload, SCHEMA, digest};
 use super::fs;
 
 const MAX_INDEX_BYTES: usize = 8 * 1024 * 1024;
@@ -131,7 +131,7 @@ fn validate(path: &Path) -> anyhow::Result<Validated> {
     let mut index_truncated = false;
     let mut omissions = 0_u64;
     let mut total_bytes = manifest_bytes.len() as u64 + journal_length;
-    let mut last_kind = String::new();
+    let mut last_kind = None;
     loop {
         let mut line = Vec::new();
         let size = reader
@@ -157,21 +157,20 @@ fn validate(path: &Path) -> anyhow::Result<Validated> {
             "invalid trace event ordering"
         );
         ensure!(
-            event.kind.len() <= 64 && event.evidence.len() <= 128,
+            !matches!(&event.kind, EventKind::Unknown(name) if name.len() > 64)
+                && event.evidence.len() <= 128,
             "trace event metadata exceeds limits"
         );
         if let Some(call) = event.call {
             ensure!(call != 0 && call <= MAX_CALLS, "invalid trace call ID");
-            if event.kind == "call_received" {
+            let role = event.kind.call_role();
+            if role == CallRole::Start {
                 ensure!(calls.insert(call), "duplicate trace call ID");
                 unfinished.insert(call);
             } else {
                 ensure!(calls.contains(&call), "event refers to an unknown call");
             }
-            if matches!(
-                event.kind.as_str(),
-                "logical_outcome" | "router_rejection" | "worker_unavailable"
-            ) {
+            if role == CallRole::Outcome {
                 ensure!(outcomes.insert(call), "duplicate call execution outcome");
                 unfinished.remove(&call);
             }
@@ -223,7 +222,7 @@ fn validate(path: &Path) -> anyhow::Result<Validated> {
         } else {
             index_truncated = true;
         }
-        last_kind = event.kind;
+        last_kind = Some(event.kind);
         journal_hash.update(&line);
         journal_bytes += line.len() as u64;
     }
@@ -235,7 +234,10 @@ fn validate(path: &Path) -> anyhow::Result<Validated> {
                 && manifest.journal_sha256.as_deref() == Some(&journal_digest),
             "journal integrity mismatch"
         );
-        ensure!(last_kind == "trace_closed", "final trace event missing");
+        ensure!(
+            last_kind == Some(EventKind::TraceClosed),
+            "final trace event missing"
+        );
         ensure!(
             manifest.calls == calls.len() as u64,
             "trace call count mismatch"

--- a/crates/glass-mcp/src/trace/mod.rs
+++ b/crates/glass-mcp/src/trace/mod.rs
@@ -11,8 +11,10 @@ mod store;
 pub(crate) use capture::{ACTIVE_CALL, RequestGuard, arguments, current_call, start_arguments};
 pub use config::TraceConfig;
 pub use inspect::{export, inspect, print_inspection};
-pub(crate) use recorder::{CallTrace, TraceRecorder, argument_bytes};
+pub(crate) use recorder::{CallTrace, TraceRecorder};
 
+#[cfg(test)]
+mod event_tests;
 #[cfg(test)]
 mod tests;
 #[cfg(test)]

--- a/crates/glass-mcp/src/trace/recorder.rs
+++ b/crates/glass-mcp/src/trace/recorder.rs
@@ -10,7 +10,7 @@ use serde_json::json;
 
 use super::TraceConfig;
 use super::config::*;
-use super::format::{Event, Evidence, Limits, Manifest, SCHEMA};
+use super::format::{CallRole, Event, EventKind, Evidence, Limits, Manifest, SCHEMA};
 use super::{fs, store::Store};
 
 const RECORDING: u8 = 0;
@@ -301,7 +301,7 @@ impl TraceRecorder {
             done: done_rx,
             next_client: AtomicU64::new(1),
         }));
-        recorder.record("inventory", None, 0, json!({}), |capture| {
+        recorder.record(EventKind::Inventory, None, 0, json!({}), |capture| {
             capture.json(evidence("tools_and_instructions", "application/json", "glass", None), &json!({
                 "tools": crate::server::tool_inventory(profile), "instructions": profile.instructions(),
             }));
@@ -321,13 +321,13 @@ impl TraceRecorder {
     }
     pub fn new_client(&self) -> u64 {
         let client = self.0.next_client.fetch_add(1, Ordering::Relaxed);
-        self.record("client_created", None, client, json!({}), |_| {});
+        self.record(EventKind::ClientCreated, None, client, json!({}), |_| {});
         client
     }
 
     pub fn shutdown_event(&self, status: &str) {
         self.record(
-            "shutdown",
+            EventKind::Shutdown,
             None,
             0,
             json!({"status": status, "host_hook_confirmation": "not_reported"}),
@@ -358,7 +358,7 @@ impl TraceRecorder {
             return None;
         }
         self.record(
-            "call_received",
+            EventKind::CallReceived,
             Some(call),
             client,
             json!({"tool": tool.chars().take(128).collect::<String>()}),
@@ -379,7 +379,7 @@ impl TraceRecorder {
 
     pub(super) fn record(
         &self,
-        kind: &str,
+        kind: EventKind,
         call: Option<u64>,
         client: u64,
         data: serde_json::Value,
@@ -403,7 +403,7 @@ impl TraceRecorder {
             event: Event {
                 seq: 0,
                 elapsed_us: elapsed(&self.0.shared),
-                kind: kind.into(),
+                kind,
                 call,
                 client,
                 data,
@@ -539,7 +539,7 @@ fn writer(mut store: Store, receiver: mpsc::Receiver<Pending>, shared: &Shared) 
     let terminal = Event {
         seq: 0,
         elapsed_us: elapsed(shared),
-        kind: "trace_closed".into(),
+        kind: EventKind::TraceClosed,
         call: None,
         client: 0,
         data: json!({"unfinished_calls": unfinished, "writer_timed_out": shared.timed_out.load(Ordering::Acquire)}),
@@ -606,15 +606,15 @@ fn write_pending(
     }
     if store.event(event.clone(), false)? {
         if let Some(call) = event.call {
-            match event.kind.as_str() {
-                "call_received" => {
+            match event.kind.call_role() {
+                CallRole::Start => {
                     unfinished.insert(call);
                     store.manifest.calls += 1;
                 }
-                "logical_outcome" | "router_rejection" | "worker_unavailable" => {
+                CallRole::Outcome => {
                     unfinished.remove(&call);
                 }
-                _ => {}
+                CallRole::Other => {}
             }
         }
     } else {
@@ -634,14 +634,51 @@ pub(crate) struct CallTrace {
 }
 
 impl CallTrace {
-    pub fn record(&self, kind: &str, data: serde_json::Value) {
+    pub fn execution_started(
+        &self,
+        execution_order: u64,
+        session: Option<u64>,
+        backend: Option<&str>,
+    ) {
+        self.record(
+            EventKind::ExecutionStarted,
+            json!({"execution_order": execution_order, "session": session, "backend": backend}),
+        );
+    }
+
+    pub fn session_context(&self, session: Option<u64>, backend: Option<&str>) {
+        self.record(
+            EventKind::SessionContext,
+            json!({"session": session, "backend": backend}),
+        );
+    }
+
+    pub fn argument_size(&self, arguments: &impl Serialize) {
+        self.record(
+            EventKind::ArgumentSize,
+            json!({"compact_json_bytes": argument_bytes(arguments)}),
+        );
+    }
+
+    pub fn router_rejection(&self) {
+        self.record(
+            EventKind::RouterRejection,
+            json!({"category": "tool_or_arguments_rejected", "raw_arguments": "excluded"}),
+        );
+    }
+
+    pub fn worker_unavailable(&self) {
+        self.record(EventKind::WorkerUnavailable, json!({}));
+    }
+
+    pub(super) fn record(&self, kind: EventKind, data: serde_json::Value) {
         self.recorder
             .record(kind, Some(self.id), self.client, data, |_| {});
     }
 
     pub fn arguments(&self, value: &impl Serialize) {
         self.valid_arguments.store(true, Ordering::Release);
-        self.capture("arguments", json!({}), |capture| {
+        self.capture(EventKind::Arguments, json!({}), |capture| {
             capture.json(
                 evidence("arguments", "application/json", "caller", None),
                 value,
@@ -655,7 +692,7 @@ impl CallTrace {
 
     pub fn arguments_unavailable(&self) {
         self.valid_arguments.store(true, Ordering::Release);
-        self.capture("arguments", json!({}), |capture| {
+        self.capture(EventKind::Arguments, json!({}), |capture| {
             capture.omission(
                 evidence("arguments", "application/json", "caller", None),
                 "argument_capture_unavailable",
@@ -665,7 +702,7 @@ impl CallTrace {
 
     pub(super) fn capture(
         &self,
-        kind: &str,
+        kind: EventKind,
         data: serde_json::Value,
         capture: impl FnOnce(&mut Capture<'_>),
     ) {
@@ -676,7 +713,7 @@ impl CallTrace {
 
 struct Counter(usize);
 
-pub(crate) fn argument_bytes(value: &impl Serialize) -> Option<u64> {
+fn argument_bytes(value: &impl Serialize) -> Option<u64> {
     let mut counter = Counter(0);
     serde_json::to_writer(&mut counter, value).ok()?;
     u64::try_from(counter.0).ok()

--- a/crates/glass-mcp/src/trace/tests.rs
+++ b/crates/glass-mcp/src/trace/tests.rs
@@ -1,7 +1,8 @@
+use super::format::EventKind;
 use super::*;
 use serde_json::json;
 
-fn start_recorder(root: &tempfile::TempDir) -> TraceRecorder {
+pub(super) fn start_recorder(root: &tempfile::TempDir) -> TraceRecorder {
     TraceRecorder::start(
         &TraceConfig::new(root.path().to_owned(), None).unwrap(),
         crate::tool_profile::ToolProfile::Full,
@@ -70,14 +71,20 @@ async fn shutdown_waits_for_admitted_capture_before_closing_the_journal() {
     let (release, release_rx) = std::sync::mpsc::sync_channel(1);
     let producer = recorder.clone();
     let thread = std::thread::spawn(move || {
-        producer.record("capture_in_progress", None, 0, json!({}), |capture| {
-            entered_tx.send(()).unwrap();
-            release_rx.recv().unwrap();
-            capture.bytes(
-                super::recorder::evidence("late", "text/plain", "glass", None),
-                b"completed capture",
-            );
-        })
+        producer.record(
+            EventKind::Unknown("capture_in_progress".into()),
+            None,
+            0,
+            json!({}),
+            |capture| {
+                entered_tx.send(()).unwrap();
+                release_rx.recv().unwrap();
+                capture.bytes(
+                    super::recorder::evidence("late", "text/plain", "glass", None),
+                    b"completed capture",
+                );
+            },
+        )
     });
     entered
         .recv_timeout(std::time::Duration::from_secs(2))
@@ -110,12 +117,24 @@ async fn queue_and_call_limits_preserve_inspectable_prefixes() {
         recorder.idle().await;
         if queue_limit {
             let (entered, release) = recorder.pause_next_write();
-            recorder.record("queue_probe", None, 0, json!({}), |_| {});
+            recorder.record(
+                EventKind::Unknown("queue_probe".into()),
+                None,
+                0,
+                json!({}),
+                |_| {},
+            );
             entered
                 .recv_timeout(std::time::Duration::from_secs(2))
                 .unwrap();
             for _ in 0..super::config::MAX_PENDING_EVENTS + 2 {
-                recorder.record("queue_probe", None, 0, json!({}), |_| {});
+                recorder.record(
+                    EventKind::Unknown("queue_probe".into()),
+                    None,
+                    0,
+                    json!({}),
+                    |_| {},
+                );
             }
             assert_eq!(recorder.status()["state"], "limited");
             release.send(()).unwrap();
@@ -140,7 +159,13 @@ async fn concurrent_and_cancelled_close_wait_for_the_writer() {
     let recorder = start_recorder(&root);
     recorder.idle().await;
     let (entered, release) = recorder.pause_next_write();
-    recorder.record("close_probe", None, 0, json!({}), |_| {});
+    recorder.record(
+        EventKind::Unknown("close_probe".into()),
+        None,
+        0,
+        json!({}),
+        |_| {},
+    );
     entered
         .recv_timeout(std::time::Duration::from_secs(5))
         .unwrap();
@@ -165,7 +190,13 @@ async fn stalled_writer_shutdown_is_bounded_and_never_claims_completeness() {
     let recorder = start_recorder(&root);
     recorder.idle().await;
     let (entered, release) = recorder.pause_next_write();
-    recorder.record("stall_probe", None, 0, json!({}), |_| {});
+    recorder.record(
+        EventKind::Unknown("stall_probe".into()),
+        None,
+        0,
+        json!({}),
+        |_| {},
+    );
     entered
         .recv_timeout(std::time::Duration::from_secs(2))
         .unwrap();
@@ -190,7 +221,7 @@ async fn retained_trace_exports_after_writer_stops() {
         TraceRecorder::start(&config, crate::tool_profile::ToolProfile::Full, "test").unwrap();
     let call = recorder.begin_call("glass_type", 1).unwrap();
     call.arguments(&json!({"text": "hello"}));
-    call.record("logical_outcome", json!({"is_error": false}));
+    call.record(EventKind::LogicalOutcome, json!({"is_error": false}));
     assert!(inspect(recorder.path()).is_err());
     recorder.close().await;
     let report = inspect(recorder.path()).unwrap();
@@ -258,12 +289,16 @@ async fn total_limit_preserves_prefix_and_exports_an_incomplete_bundle() {
     recorder.idle().await;
     let call = recorder.begin_call("glass_screenshot", 1).unwrap();
     call.arguments(&json!({}));
-    call.capture("logical_outcome", json!({"is_error": false}), |capture| {
-        capture.bytes(
-            super::recorder::evidence("image", "image/webp", "untrusted_application", Some(0)),
-            &vec![3; limit as usize],
-        );
-    });
+    call.capture(
+        EventKind::LogicalOutcome,
+        json!({"is_error": false}),
+        |capture| {
+            capture.bytes(
+                super::recorder::evidence("image", "image/webp", "untrusted_application", Some(0)),
+                &vec![3; limit as usize],
+            );
+        },
+    );
     recorder.idle().await;
     assert_eq!(recorder.status()["state"], "limited");
     recorder.close().await;
@@ -305,16 +340,20 @@ async fn oversized_payload_is_omitted_whole_and_later_small_evidence_survives() 
     .unwrap();
     let call = recorder.begin_call("glass_test", 1).unwrap();
     call.arguments(&json!({}));
-    call.capture("logical_outcome", json!({"is_error": false}), |capture| {
-        capture.bytes(
-            super::recorder::evidence("large", "text/plain", "untrusted_application", Some(0)),
-            &vec![b'x'; super::config::MAX_PAYLOAD_BYTES + 1],
-        );
-        capture.bytes(
-            super::recorder::evidence("small", "text/plain", "untrusted_application", Some(1)),
-            b"later evidence",
-        );
-    });
+    call.capture(
+        EventKind::LogicalOutcome,
+        json!({"is_error": false}),
+        |capture| {
+            capture.bytes(
+                super::recorder::evidence("large", "text/plain", "untrusted_application", Some(0)),
+                &vec![b'x'; super::config::MAX_PAYLOAD_BYTES + 1],
+            );
+            capture.bytes(
+                super::recorder::evidence("small", "text/plain", "untrusted_application", Some(1)),
+                b"later evidence",
+            );
+        },
+    );
     recorder.close().await;
     let report = inspect(recorder.path()).unwrap();
     assert_eq!(report.exit_code(), 2);

--- a/crates/glass-mcp/src/trace/transport_tests.rs
+++ b/crates/glass-mcp/src/trace/transport_tests.rs
@@ -585,6 +585,7 @@ async fn cancelled_request_keeps_the_workers_later_outcome() {
     // A following worker job is a barrier for the cancelled job's completion.
     harness.call("glass_logs", json!({})).await;
     let (_root, _path, report) = harness.finish().await;
+    assert!(report.complete, "{report:?}");
     let events: Vec<_> = report
         .events
         .iter()

--- a/docs/reference/session-trace.md
+++ b/docs/reference/session-trace.md
@@ -95,7 +95,7 @@ contain original bytes; JSON argument/envelope payloads contain normalized seria
 Resource links also retain their full MCP descriptor in a `resource_descriptor` JSON payload,
 associated with the same block index as the retained resource body.
 
-Events distinguish `call_received`, `arguments`, `execution_started`, `session_context`,
+Events distinguish `call_received`, `argument_size`, `arguments`, `execution_started`, `session_context`,
 `logical_outcome`, `response_constructed`, `request_abandoned`, `router_rejection`,
 `worker_unavailable`, and `resource_read`. Inventory, local client creation, shutdown and the
 terminal `trace_closed` are separate control events. Execution ordinals are distinct from receipt


### PR DESCRIPTION
Trace callers currently construct event names and payloads by hand, while the writer and offline inspector each classify call completion separately. Centralize event kinds and lifecycle roles inside the trace module, and give callers named methods for execution, session context, argument size, rejection, worker availability, and response construction.

Preserve the `glass.trace.v1` format and existing inspection rules. Request abandonment remains separate from execution completion, responses may follow outcomes, and unknown event names remain opaque. The writer and inspector retain independent call accounting and integrity checks.

Validation: workspace build, clippy with warnings denied, formatting, and workspace tests; 30 focused trace tests cover v1 serialization and payloads, all completion paths, cancellation, unknown-event export, and independent rejection of inconsistent call lifecycles with valid journal hashes and byte counts.

Co-Authored-By: Codex <noreply@openai.com>
