### PR TITLE
refactor(bench): share attempt timing and result finalization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Test mutation gate wrapper
         run: python3 -m unittest discover -s scripts/tests
+      - name: Test interaction benchmark
+        run: python3 -m unittest discover -s tools/interaction-bench/tests
       # rustup auto-installs the pinned toolchain + components from
       # rust-toolchain.toml (single source of truth for the nightly).
       - name: Install pinned toolchain

--- a/tools/interaction-bench/application_run.py
+++ b/tools/interaction-bench/application_run.py
@@ -5,6 +5,7 @@ import time
 
 import application_cases as cases
 from android_session import Android
+from attempt_record import AttemptRecord
 import ios_publication
 from drivers.glass import Driver as Glass
 from evidence import Evidence, EvidenceError
@@ -12,11 +13,9 @@ from measurement import (
     canonical,
     digest,
     file_identity,
-    phase_totals,
     verify_files,
-    write_json,
 )
-from protocol import Client, ProtocolError
+from protocol import Client
 from native_sessions import create_session, prepare_display
 from validation import read_channel, validate_totals
 
@@ -285,14 +284,14 @@ class Fleet:
             )
             self.members[name] = UI(self, name, kind, session, client, evidence)
 
-    def phase(self, name):
-        for owned in self.owned.values():
-            if owned["client"]:
-                owned["client"].phase = name
+    @property
+    def clients(self):
+        return [owned["client"] for owned in self.owned.values() if owned["client"]]
 
     def close(self):
         errors = []
-        self.phase("cleanup")
+        for client in self.clients:
+            client.phase = "cleanup"
         for name, owned in reversed(list(self.owned.items())):
             client = owned["client"]
             if client:
@@ -331,41 +330,15 @@ class Fleet:
 
 
 def attempt(config, cell, directory):
-    directory.mkdir()
-    started = time.monotonic()
-    fleet = Fleet(
-        config, cell, directory, started + config["attempt_timeout_ms"] / 1000
+    record = AttemptRecord(
+        config, cell, directory, participants={}, file_reads=[], interrupted=False
     )
-    result = {
-        "schema_version": 1,
-        **cell,
-        "outcome": "harness_error",
-        "error": "attempt incomplete",
-        "cleanup_ok": False,
-        "evidence_ok": False,
-        "participants": {},
-        "events": [],
-        "files": {},
-        "phases": {},
-        "artifacts": {},
-        "file_reads": [],
-        "wall_ms": 0,
-        "interrupted": False,
-    }
-    write_json(directory / "result.json", result)
-    durations = {}
-    current_phase, phase_start = "server_start", started
-
-    def phase(name):
-        nonlocal current_phase, phase_start
-        now = time.monotonic()
-        durations[current_phase] = (now - phase_start) * 1000
-        current_phase, phase_start = name, now
-        fleet.phase(name)
+    result = record.result
+    fleet = Fleet(config, cell, directory, record.deadline)
 
     try:
         fleet.prepare()
-        phase("app_start")
+        record.advance("app_start", fleet.clients)
         for name, member in fleet.members.items():
             member.launch_application()
             fleet.records[name][
@@ -376,7 +349,7 @@ def attempt(config, cell, directory):
         )
         if setup_errors:
             raise EvidenceError("; ".join(setup_errors))
-        phase("task")
+        record.advance("task", fleet.clients)
         cases.execute(cell["case"], fleet)
         if cell["case"] == "ios-publication":
             result["outcome"], result["assertion_errors"] = ios_publication.evaluate(
@@ -387,27 +360,19 @@ def attempt(config, cell, directory):
             result["outcome"] = (
                 "failed" if result["assertion_errors"] else "task_completed"
             )
-        phase("evidence")
+        record.advance("evidence", fleet.clients)
         result.update(evidence_ok=True, error=None)
     except BaseException as exc:
-        result.update(
-            outcome=(
-                "harness_error"
-                if isinstance(exc, (ProtocolError, OSError))
-                else "failed"
-            ),
-            error=f"{type(exc).__name__}: {exc}",
-            interrupted=isinstance(exc, KeyboardInterrupt),
-        )
+        record.fail(exc)
     finally:
-        phase("cleanup")
+        record.advance("cleanup", fleet.clients)
         result["cleanup_errors"] = fleet.close()
         result["cleanup_ok"] = not result["cleanup_errors"]
-        durations["cleanup"] = (time.monotonic() - phase_start) * 1000
+        record.advance(None)
         calls = []
-        for name, record in fleet.records.items():
+        for name, participant in fleet.records.items():
             member = fleet.members.get(name)
-            record.update(
+            participant.update(
                 events=member.events if member else [],
                 artifacts=member.evidence.artifacts if member else {},
                 artifact_references=member.evidence.references if member else [],
@@ -417,21 +382,21 @@ def attempt(config, cell, directory):
             client = fleet.owned[name]["client"]
             if client:
                 calls.extend(client.calls)
-                record["process_cleanup"] = client.cleanup
+                participant["process_cleanup"] = client.cleanup
                 if client.fault:
                     result["evidence_ok"] = False
-                    record["evidence_error"] = client.fault
-                    record["evidence_ok"] = False
+                    participant["evidence_error"] = client.fault
+                    participant["evidence_ok"] = False
             for path in (directory / name).rglob("*"):
                 if path.is_file():
-                    record["files"][path.relative_to(directory / name).as_posix()] = (
-                        file_identity(path)
-                    )
+                    participant["files"][
+                        path.relative_to(directory / name).as_posix()
+                    ] = file_identity(path)
+        record.record_calls(calls)
+        record.capture_wall()
         result.update(
             participants=fleet.records,
             events=fleet.events,
-            phases=phase_totals(calls, durations),
-            wall_ms=(time.monotonic() - started) * 1000,
             tool_definitions_bytes=sum(
                 r.get("tool_definitions_bytes", 0) for r in fleet.records.values()
             ),
@@ -442,24 +407,7 @@ def attempt(config, cell, directory):
                 }
             ),
         )
-        write_json(
-            directory / "timing.json",
-            {"wall_ms": result["wall_ms"], "durations": durations},
-        )
-        for path in directory.rglob("*"):
-            if path.is_file() and path.name != "result.json":
-                result["files"][path.relative_to(directory).as_posix()] = file_identity(
-                    path
-                )
-        if (
-            sum(v["bytes"] for v in result["files"].values())
-            > config["evidence_limit_bytes"]
-        ):
-            result.update(
-                evidence_ok=False,
-                error="attempt evidence exceeds configured storage limit",
-            )
-        write_json(directory / "result.json", result)
+        record.finalize()
     return result
 
 

--- a/tools/interaction-bench/attempt_record.py
+++ b/tools/interaction-bench/attempt_record.py
@@ -1,0 +1,89 @@
+"""Attempt timing and persisted results, independent of resource ownership."""
+
+from contextlib import contextmanager
+import time
+
+from measurement import file_identity, phase_totals, write_json
+from protocol import ProtocolError
+
+
+class AttemptRecord:
+    def __init__(self, config, cell, directory, **fields):
+        directory.mkdir()
+        self.started = time.monotonic()
+        self.deadline = self.started + config["attempt_timeout_ms"] / 1000
+        self.directory = directory
+        self.evidence_limit = config["evidence_limit_bytes"]
+        self.durations = {}
+        self.current_phase, self.phase_start = "server_start", self.started
+        self.result = {
+            "schema_version": 1,
+            **cell,
+            "outcome": "harness_error",
+            "error": "attempt incomplete",
+            "cleanup_ok": False,
+            "evidence_ok": False,
+            "events": [],
+            "files": {},
+            "phases": {},
+            "artifacts": {},
+            "wall_ms": 0,
+            **fields,
+        }
+        write_json(directory / "result.json", self.result)
+
+    def advance(self, name, clients=()):
+        now = time.monotonic()
+        if self.current_phase is not None:
+            self.durations[self.current_phase] = (now - self.phase_start) * 1000
+        self.current_phase, self.phase_start = name, now
+        for client in clients:
+            client.phase = name
+
+    @contextmanager
+    def phase(self, name, clients=()):
+        self.advance(name, clients)
+        try:
+            yield
+        finally:
+            self.advance(None)
+
+    def fail(self, exc):
+        self.result.update(
+            outcome=(
+                "harness_error"
+                if isinstance(exc, (ProtocolError, OSError))
+                else "failed"
+            ),
+            error=f"{type(exc).__name__}: {exc}",
+            interrupted=isinstance(exc, KeyboardInterrupt),
+        )
+
+    def capture_wall(self):
+        # Callers retain their measured boundary relative to participant hashing.
+        self.result["wall_ms"] = (time.monotonic() - self.started) * 1000
+
+    def record_calls(self, calls):
+        self.result["phases"] = phase_totals(
+            calls + self.result.get("file_reads", []), self.durations
+        )
+
+    def finalize(self):
+        result = self.result
+        result.setdefault("interrupted", False)
+        write_json(
+            self.directory / "timing.json",
+            {"wall_ms": result["wall_ms"], "durations": self.durations},
+        )
+        for path in self.directory.rglob("*"):
+            if path.is_file() and path.name != "result.json":
+                result["files"][path.relative_to(self.directory).as_posix()] = (
+                    file_identity(path)
+                )
+        if sum(v["bytes"] for v in result["files"].values()) > self.evidence_limit:
+            result.update(
+                evidence_ok=False,
+                error="attempt evidence exceeds configured storage limit",
+            )
+        write_json(self.directory / "result.json", result)
+        return result

--- a/tools/interaction-bench/run.py
+++ b/tools/interaction-bench/run.py
@@ -11,7 +11,6 @@ import subprocess
 import sys
 import time
 import uuid
-from contextlib import contextmanager
 from pathlib import Path
 
 from application_cases import CASES as APPLICATION_CASES
@@ -20,6 +19,7 @@ from application_config import frozen_paths as application_frozen_paths
 from application_config import prerequisites as application_prerequisites
 from application_config import runtime_metadata
 from application_run import attempt as application_attempt
+from attempt_record import AttemptRecord
 from cases import CASES as WEB_CASES
 from cases import evaluate, evaluate_setup, execute
 
@@ -30,13 +30,12 @@ from measurement import (
     canonical,
     digest,
     file_identity,
-    phase_totals,
     schedule,
     summarize,
     verify_files,
     write_json,
 )
-from protocol import Client, ProtocolError
+from protocol import Client
 from native_sessions import create_session, prepare_display
 from validation import read_channel, validate_totals
 
@@ -254,40 +253,13 @@ def preflight(config):
     }
 
 
-@contextmanager
-def phase(client, durations, name):
-    client.phase = name
-    started = time.monotonic()
-    try:
-        yield
-    finally:
-        durations[name] = (time.monotonic() - started) * 1000
-
-
 def attempt(config, cell, directory, fixtures, adapter):
-    directory.mkdir()
-    began = time.monotonic()
-    result = {
-        "schema_version": 1,
-        **cell,
-        "outcome": "harness_error",
-        "cleanup_ok": False,
-        "evidence_ok": False,
-        "error": "attempt incomplete",
-        "wall_ms": 0,
-        "events": [],
-        "phases": {},
-        "artifacts": {},
-        "artifact_references": [],
-        "files": {},
-    }
-    write_json(directory / "result.json", result)
+    record = AttemptRecord(config, cell, directory, artifact_references=[])
+    result = record.result
     client = session = driver = evidence = None
-    durations = {}
-    interrupted = False
     errors = []
     spec = next(d for d in config["drivers"] if d["id"] == cell["driver"])
-    total_deadline = began + config["attempt_timeout_ms"] / 1000
+    total_deadline = record.deadline
     try:
         session = create_session(config.get("backend", "x11"))
         display = prepare_display(session, config, directory)
@@ -322,45 +294,39 @@ def attempt(config, cell, directory, fixtures, adapter):
         missing = adapter.required_tools - {t["name"] for t in inventory}
         if missing:
             raise EvidenceError(f"required tools missing: {sorted(missing)}")
-        durations["server_start"] = (time.monotonic() - began) * 1000
+        record.advance(None)
         evidence = Evidence(
             directory / "evidence", client, limit=config["evidence_limit_bytes"]
         )
         driver = adapter(config, session, client, evidence, total_deadline - 10)
         url = fixtures.url(cell["case"], config)
         result["fixture_url"] = url
-        with phase(client, durations, "app_start"):
+        with record.phase("app_start", (client,)):
             driver.launch(url)
             setup_errors = evaluate_setup(driver.events, config["viewport"])
             if setup_errors:
                 raise EvidenceError("; ".join(setup_errors))
             result["owned_process_commands"] = session.process_commands()
-        with phase(client, durations, "task"):
+        with record.phase("task", (client,)):
             execute(cell["case"], driver)
             errors = evaluate(cell["case"], driver.events, evidence.artifacts)
             result["outcome"] = "failed" if errors else CASES[cell["case"]]
-        with phase(client, durations, "evidence"):
+        with record.phase("evidence", (client,)):
             if hasattr(driver, "collect"):
                 driver.collect()
         result["evidence_ok"] = True
         result["error"] = None
     except BaseException as exc:
-        interrupted = isinstance(exc, KeyboardInterrupt)
-        result["outcome"] = (
-            "harness_error" if isinstance(exc, (ProtocolError, OSError)) else "failed"
-        )
-        result["error"] = f"{type(exc).__name__}: {exc}"
+        record.fail(exc)
     finally:
         if driver and not result["evidence_ok"] and hasattr(driver, "collect"):
             try:
-                with phase(client, durations, "evidence"):
+                with record.phase("evidence", (client,)):
                     driver.collect()
                 result["evidence_ok"] = True
             except Exception as exc:
                 result["evidence_error"] = str(exc)
-        cleanup_start = time.monotonic()
-        if "server_start" not in durations:
-            durations["server_start"] = (cleanup_start - began) * 1000
+        record.advance("cleanup")
         cleanup_errors = []
         if client:
             client.phase = "cleanup"
@@ -388,36 +354,18 @@ def attempt(config, cell, directory, fixtures, adapter):
                     )
             except Exception as exc:
                 cleanup_errors.append(str(exc))
-        durations["cleanup"] = (time.monotonic() - cleanup_start) * 1000
+        record.advance(None)
         result["cleanup_ok"] = not cleanup_errors
         result["cleanup_errors"] = cleanup_errors
         result["assertion_errors"] = errors
-        result["wall_ms"] = (time.monotonic() - began) * 1000
+        record.capture_wall()
         result["events"] = driver.events if driver else []
         result["artifacts"] = evidence.artifacts if evidence else {}
         result["artifact_references"] = evidence.references if evidence else []
         file_reads = getattr(driver, "file_reads", [])
         result["file_reads"] = file_reads
-        result["phases"] = phase_totals(
-            (client.calls if client else []) + file_reads, durations
-        )
-        result["interrupted"] = interrupted
-        write_json(
-            directory / "timing.json",
-            {"wall_ms": result["wall_ms"], "durations": durations},
-        )
-        for path in directory.rglob("*"):
-            if path.is_file() and path.name != "result.json":
-                result["files"][path.relative_to(directory).as_posix()] = file_identity(
-                    path
-                )
-        if (
-            sum(v["bytes"] for v in result["files"].values())
-            > config["evidence_limit_bytes"]
-        ):
-            result["evidence_ok"] = False
-            result["error"] = "attempt evidence exceeds configured storage limit"
-        write_json(directory / "result.json", result)
+        record.record_calls(client.calls if client else [])
+        record.finalize()
     return result
 
 

--- a/tools/interaction-bench/tests/test_attempt_lifecycle.py
+++ b/tools/interaction-bench/tests/test_attempt_lifecycle.py
@@ -1,0 +1,289 @@
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import application_run
+import attempt_record
+import run
+from evidence import EvidenceError
+from measurement import file_identity
+from protocol import ProtocolError
+
+
+class AttemptLifecycleTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.directory = Path(temporary.name) / "attempt"
+        self.now = 100
+        self.closed = []
+        self.config = {
+            "attempt_timeout_ms": 60000,
+            "evidence_limit_bytes": 100000,
+            "frame_limit_bytes": 100000,
+            "viewport": [1000, 700],
+            "backend": "x11",
+            "drivers": [{"id": "glass", "adapter": "glass", "command": ["unused"]}],
+        }
+        self.cell = {
+            "driver": "glass",
+            "case": "disabled",
+            "iteration": 0,
+            "warmup": False,
+        }
+        self.replace(attempt_record.time, "monotonic", side_effect=lambda: self.now)
+        self.replace(attempt_record, "file_identity", side_effect=self.hash_file)
+
+    def replace(self, owner, name, **kwargs):
+        replacement = patch.object(owner, name, **kwargs)
+        self.addCleanup(replacement.stop)
+        return replacement.start()
+
+    def tick(self, seconds):
+        self.now += seconds
+
+    def hash_file(self, path):
+        self.tick(10)
+        return file_identity(path)
+
+    def prepare_display(self, session, config, directory):
+        self.tick(2)
+        (directory / "note.txt").write_text("retained evidence")
+
+    def session(self, name):
+        session = Mock(env={}, root=self.directory, token=name)
+        session.process_commands.return_value = []
+
+        def close():
+            self.tick(1)
+            self.closed.append(f"{name}:session")
+            return {"ok": True}
+
+        session.close.side_effect = close
+        return session
+
+    def client(self, name):
+        client = Mock(
+            calls=[], phase="server_start", poisoned=False, fault=None, cleanup={}
+        )
+
+        def initialize():
+            self.tick(1)
+            client.calls.append({"phase": client.phase, "rpc_calls": 1})
+            required = run.GlassDriver.required_tools | {
+                "glass_list_windows",
+                "glass_select_window",
+                "glass_key",
+            }
+            return {}, [{"name": name} for name in sorted(required)]
+
+        def close(grace):
+            self.assertEqual(grace, 1)
+            self.tick(1)
+            self.closed.append(f"{name}:client")
+            return True
+
+        client.initialize.side_effect = initialize
+        client.close.side_effect = close
+        return client
+
+    def configure_web(self):
+        self.web_client = self.client("web")
+        self.web_session = self.session("web")
+        self.web_driver = Mock(events=[], file_reads=[])
+        self.web_driver.launch.side_effect = lambda url: self.tick(4)
+        self.web_driver.collect.side_effect = lambda: self.tick(5)
+
+        def stop():
+            self.tick(1)
+            self.closed.append("web:stop")
+
+        self.web_driver.stop.side_effect = stop
+
+        def construct(config, session, client, evidence, deadline):
+            self.assertEqual(deadline, 150)
+            self.tick(2)  # Web driver construction is outside phase durations.
+            return self.web_driver
+
+        self.adapter = Mock(side_effect=construct, required_tools=set())
+        self.adapter.command.return_value = ["unused"]
+        self.replace(run, "create_session", return_value=self.web_session)
+        self.replace(run, "prepare_display", side_effect=self.prepare_display)
+        self.launch_client = self.replace(run, "Client", return_value=self.web_client)
+        self.replace(run, "evaluate_setup", return_value=[])
+        self.replace(run, "evaluate", return_value=[])
+        self.execute = self.replace(
+            run, "execute", side_effect=lambda *args: self.tick(3)
+        )
+
+    def web_attempt(self):
+        fixtures = Mock()
+        fixtures.url.return_value = "http://fixture.invalid/disabled"
+        result = run.attempt(
+            self.config, self.cell, self.directory, fixtures, self.adapter
+        )
+        self.assertEqual(
+            json.loads((self.directory / "result.json").read_bytes()), result
+        )
+        return result
+
+    def test_web_preserves_phase_gaps_cleanup_allowances_and_wall_boundary(self):
+        self.configure_web()
+        result = self.web_attempt()
+        self.assertEqual(self.launch_client.call_args.kwargs["deadline"], 150)
+        self.assertEqual(self.web_client.deadline, 122)
+        self.assertEqual(self.closed, ["web:stop", "web:client", "web:session"])
+        self.assertEqual(result["wall_ms"], 20000)
+        self.assertEqual(
+            {name: phase["elapsed_ms"] for name, phase in result["phases"].items()},
+            {
+                "server_start": 3000,
+                "app_start": 4000,
+                "task": 3000,
+                "evidence": 5000,
+                "cleanup": 3000,
+            },
+        )
+        self.assertTrue(result["cleanup_ok"] and result["evidence_ok"])
+        self.assertNotIn("participants", result)
+        self.assertGreater(
+            self.now, 120
+        )  # Final file hashing is excluded from wall time.
+
+    def test_web_partial_startup_failure_still_closes_client_and_session(self):
+        self.configure_web()
+        self.web_client.initialize.side_effect = ProtocolError("initialize")
+        result = self.web_attempt()
+        self.assertEqual(result["outcome"], "harness_error")
+        self.assertEqual(self.closed, ["web:client", "web:session"])
+        self.assertEqual(result["phases"]["server_start"]["elapsed_ms"], 2000)
+        self.assertEqual(result["phases"]["task"]["elapsed_ms"], 0)
+        self.assertFalse(result["evidence_ok"])
+
+    def test_web_interruption_recovers_evidence_and_preserves_cleanup_failure(self):
+        self.configure_web()
+        self.execute.side_effect = KeyboardInterrupt()
+        self.web_client.poisoned = True
+        self.web_session.close.return_value = {"ok": False}
+        self.web_session.close.side_effect = None
+        result = self.web_attempt()
+        self.assertEqual(result["outcome"], "failed")
+        self.assertTrue(result["interrupted"] and result["evidence_ok"])
+        self.assertFalse(result["cleanup_ok"])
+        self.web_driver.collect.assert_called_once()
+        self.web_driver.stop.assert_not_called()
+        self.web_client.close.assert_called_once()
+        self.web_session.close.assert_called_once()
+        self.assertEqual(
+            result["cleanup_errors"],
+            ["owned session processes required forced cleanup"],
+        )
+
+    def test_web_repeated_collection_retains_only_last_evidence_duration(self):
+        self.configure_web()
+
+        def collect():
+            self.tick(5 if self.web_driver.collect.call_count == 1 else 2)
+            if self.web_driver.collect.call_count == 1:
+                raise EvidenceError("archive")
+
+        self.web_driver.collect.side_effect = collect
+        result = self.web_attempt()
+        self.assertEqual(self.web_driver.collect.call_count, 2)
+        self.assertEqual(result["phases"]["evidence"]["elapsed_ms"], 2000)
+        self.assertEqual(result["outcome"], "failed")
+        self.assertTrue(result["evidence_ok"])
+
+    def configure_applications(self):
+        self.cell["case"] = "cross-application"
+        self.app_clients = [self.client(name) for name in ("source", "destination")]
+        self.app_sessions = [self.session(name) for name in ("source", "destination")]
+        self.replace(application_run, "create_session", side_effect=self.app_sessions)
+        self.replace(
+            application_run, "prepare_display", side_effect=self.prepare_display
+        )
+        self.launch_clients = self.replace(
+            application_run, "Client", side_effect=self.app_clients
+        )
+        self.replace(application_run, "file_identity", side_effect=self.hash_file)
+        self.replace(
+            application_run.UI, "launch_application", side_effect=lambda: self.tick(4)
+        )
+
+        def stop(member):
+            self.tick(1)
+            self.closed.append(f"{member.name}:stop")
+
+        self.replace(application_run.UI, "stop", autospec=True, side_effect=stop)
+        self.replace(application_run.cases, "evaluate_setup", return_value=[])
+        self.replace(application_run.cases, "evaluate", return_value=[])
+
+        def execute(case, fleet):
+            self.tick(3)
+            for member in fleet.members.values():
+                self.assertEqual(member.deadline, 130)
+                member.client.calls.append(
+                    {"phase": member.client.phase, "rpc_calls": 1, "tool_calls": 1}
+                )
+
+        self.replace(application_run.cases, "execute", side_effect=execute)
+
+    def test_application_wall_includes_participant_hashing_and_sums_both_channels(self):
+        self.configure_applications()
+        result = application_run.attempt(self.config, self.cell, self.directory)
+        self.assertEqual(
+            [call.kwargs["deadline"] for call in self.launch_clients.call_args_list],
+            [130, 130],
+        )
+        self.assertEqual(
+            self.closed,
+            [
+                "destination:stop",
+                "destination:client",
+                "destination:session",
+                "source:stop",
+                "source:client",
+                "source:session",
+            ],
+        )
+        self.assertEqual([client.deadline for client in self.app_clients], [128, 125])
+        self.assertEqual(result["wall_ms"], 43000)
+        self.assertEqual(result["phases"]["task"]["tool_calls"], 2)
+        self.assertEqual(result["phases"]["task"]["elapsed_ms"], 3000)
+        self.assertEqual(set(result["participants"]), {"source", "destination"})
+        self.assertEqual(
+            json.loads((self.directory / "result.json").read_bytes()), result
+        )
+
+    def test_application_partial_startup_cleans_all_owned_participants_in_reverse(self):
+        self.configure_applications()
+        self.app_clients[1].initialize.side_effect = ProtocolError(
+            "destination initialize"
+        )
+        result = application_run.attempt(self.config, self.cell, self.directory)
+        self.assertEqual(result["outcome"], "harness_error")
+        self.assertTrue(result["cleanup_ok"])
+        self.assertFalse(result["evidence_ok"])
+        self.assertEqual(
+            self.closed,
+            [
+                "destination:client",
+                "destination:session",
+                "source:stop",
+                "source:client",
+                "source:session",
+            ],
+        )
+        self.assertEqual(result["phases"]["task"]["elapsed_ms"], 0)
+        self.assertEqual(result["participants"]["destination"]["events"], [])
+        self.assertEqual(
+            json.loads((self.directory / "result.json").read_bytes()), result
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/interaction-bench/tests/test_attempt_record.py
+++ b/tools/interaction-bench/tests/test_attempt_record.py
@@ -1,0 +1,141 @@
+import json
+from pathlib import Path
+import sys
+import tempfile
+from types import SimpleNamespace
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from attempt_record import AttemptRecord
+from evidence import EvidenceError
+from measurement import verify_files
+from protocol import ProtocolError
+from validation import validate_totals
+
+
+class AttemptRecordTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.directory = Path(temporary.name) / "attempt"
+        clock_patch = patch("attempt_record.time.monotonic", return_value=100)
+        self.clock = clock_patch.start()
+        self.addCleanup(clock_patch.stop)
+        self.record = AttemptRecord(
+            {"attempt_timeout_ms": 60000, "evidence_limit_bytes": 4096},
+            {"case": "disabled", "driver": "glass", "iteration": 0, "warmup": False},
+            self.directory,
+            artifact_references=[],
+        )
+
+    def test_initial_record_is_incomplete_and_existing_attempt_is_not_overwritten(self):
+        saved = (self.directory / "result.json").read_bytes()
+        result = json.loads(saved)
+        self.assertEqual(result["outcome"], "harness_error")
+        self.assertEqual(result["error"], "attempt incomplete")
+        self.assertFalse(result["cleanup_ok"])
+        self.assertFalse(result["evidence_ok"])
+        self.assertEqual(self.record.deadline, 160)
+        with self.assertRaises(FileExistsError):
+            AttemptRecord({}, {}, self.directory)
+        self.assertEqual((self.directory / "result.json").read_bytes(), saved)
+
+    def test_failure_classification_preserves_interruption_and_timeout_semantics(self):
+        for exc, outcome in [
+            (ProtocolError("wire"), "harness_error"),
+            (OSError("storage"), "harness_error"),
+            (TimeoutError("deadline"), "harness_error"),
+            (EvidenceError("missing body"), "failed"),
+            (ValueError("assertion"), "failed"),
+            (KeyboardInterrupt(), "failed"),
+            (SystemExit(2), "failed"),
+        ]:
+            with self.subTest(exception=type(exc).__name__):
+                self.record.fail(exc)
+                self.assertEqual(self.record.result["outcome"], outcome)
+                self.assertEqual(
+                    self.record.result["error"], f"{type(exc).__name__}: {exc}"
+                )
+                self.assertEqual(
+                    self.record.result["interrupted"],
+                    isinstance(exc, KeyboardInterrupt),
+                )
+
+    def test_phase_clock_excludes_gaps_and_overwrites_repeated_evidence(self):
+        client = SimpleNamespace(phase="server_start")
+        self.clock.return_value = 102
+        self.record.advance(None)
+        self.clock.return_value = 107
+        with self.assertRaises(EvidenceError):
+            with self.record.phase("evidence", (client,)):
+                self.assertEqual(client.phase, "evidence")
+                self.clock.return_value = 110
+                raise EvidenceError("first collection failed")
+        self.clock.return_value = 120
+        with self.record.phase("evidence", (client,)):
+            self.clock.return_value = 121
+        self.assertEqual(
+            self.record.durations, {"server_start": 2000, "evidence": 1000}
+        )
+
+    def test_continuous_phases_share_one_clock_and_sum_all_channels_and_reads(self):
+        clients = [SimpleNamespace(phase="server_start") for _ in range(2)]
+        self.clock.return_value = 103
+        self.record.advance("task", clients)
+        self.assertEqual([client.phase for client in clients], ["task", "task"])
+        calls = [{"phase": "task", "rpc_calls": 1, "tool_calls": 1} for _ in clients]
+        self.record.result["file_reads"] = [{"phase": "evidence", "file_reads": 1}]
+        self.clock.return_value = 108
+        self.record.advance("cleanup", clients)
+        self.clock.return_value = 109
+        self.record.advance(None)
+        self.record.record_calls(calls)
+        self.record.capture_wall()
+        self.clock.return_value = 200
+        self.record.finalize()
+        result = self.record.result
+        self.assertEqual(result["wall_ms"], 9000)
+        self.assertEqual(result["phases"]["task"]["elapsed_ms"], 5000)
+        self.assertEqual(result["phases"]["task"]["tool_calls"], 2)
+        self.assertEqual(result["phases"]["evidence"]["file_reads"], 1)
+        self.assertEqual(validate_totals(self.directory, result, calls), [])
+
+    def test_early_failure_keeps_startup_time_and_zero_unentered_phases(self):
+        self.clock.return_value = 103
+        self.record.fail(ProtocolError("initialize"))
+        self.record.advance("cleanup")
+        self.clock.return_value = 104
+        self.record.advance(None)
+        self.record.record_calls([])
+        self.record.capture_wall()
+        self.record.finalize()
+        phases = self.record.result["phases"]
+        self.assertEqual(phases["server_start"]["elapsed_ms"], 3000)
+        self.assertEqual(phases["cleanup"]["elapsed_ms"], 1000)
+        self.assertEqual(phases["task"]["elapsed_ms"], 0)
+
+    def test_finalization_inventories_timing_and_rejects_aggregate_overflow(self):
+        body = self.directory / "evidence.bin"
+        body.write_bytes(b"x" * 4096)
+        self.record.result.update(
+            outcome="task_completed", evidence_ok=True, cleanup_ok=True
+        )
+        self.record.capture_wall()
+        self.record.record_calls([])
+        result = self.record.finalize()
+        self.assertEqual(set(result["files"]), {"evidence.bin", "timing.json"})
+        self.assertEqual(verify_files(self.directory, result["files"]), [])
+        self.assertFalse(result["evidence_ok"])
+        self.assertTrue(result["cleanup_ok"])
+        self.assertEqual(result["outcome"], "task_completed")
+        self.assertEqual(
+            result["error"], "attempt evidence exceeds configured storage limit"
+        )
+        self.assertEqual(
+            json.loads((self.directory / "result.json").read_bytes()), result
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Web and application benchmark runners duplicate attempt timing, failure classification, and result finalization. Share those responsibilities through `AttemptRecord`, including the initial incomplete record, phase totals, timing file, evidence inventory, storage cap, and final result write.

Preserve version-1 record shapes, existing cleanup owners and allowances, optional web evidence recovery, and each runner's wall-time boundary relative to file hashing. Resource cleanup and independent offline validation remain in their existing modules.

Add the benchmark suite to CI. Validation passed:

- 52 benchmark tests run: 51 passed, one platform-specific skip.
- Six lifecycle tests also passed against the original runners, covering timing boundaries, partial startup, interruption, recovery, and cleanup order.
- Ruff checks, Black formatting, and Python 3.9 syntax compatibility.
- Existing CI-wrapper tests, Cargo formatting, and workspace clippy with warnings denied.

Co-Authored-By: Codex <noreply@openai.com>
