### PR TITLE
Own remaining Windows token and pipe handles

### DIFF
--- a/crates/glass-clip-shim-windows/src/hook.rs
+++ b/crates/glass-clip-shim-windows/src/hook.rs
@@ -11,9 +11,10 @@
 //! finalized on a real Windows box; the detour table is authored complete so that on-box
 //! work is debugging, not authoring.
 
+use std::os::windows::io::{AsHandle, AsRawHandle, BorrowedHandle, FromRawHandle, OwnedHandle};
 use std::sync::OnceLock;
 
-use windows::Win32::Foundation::{CloseHandle, GENERIC_READ, GENERIC_WRITE, HANDLE, HGLOBAL};
+use windows::Win32::Foundation::{GENERIC_READ, GENERIC_WRITE, HANDLE, HGLOBAL};
 use windows::Win32::Security::RevertToSelf;
 use windows::Win32::Storage::FileSystem::{
     CreateFileW, FILE_FLAGS_AND_ATTRIBUTES, FILE_SHARE_NONE, OPEN_EXISTING, ReadFile, WriteFile,
@@ -31,6 +32,9 @@ use crate::proto::{self, FormatKey, Request, Response};
 mod dataobject;
 mod detour_impl;
 mod ole;
+
+#[cfg(test)]
+mod tests;
 
 // Standard Win32 clipboard format ids (stable ABI).
 pub(crate) const CF_TEXT: u32 = 1;
@@ -102,18 +106,13 @@ pub(crate) fn init() {
 
 /// Open the pipe, write `frame(req.encode())`, read one framed `Response`. `None` on any failure.
 fn rpc(req: Request) -> Option<Response> {
-    let pipe = PIPE.get()?;
-    let h = open_pipe(pipe)?;
-    let resp = (|| {
-        let body = proto::frame(&req.encode());
-        write_all(h, &body)?;
-        read_response(h)
-    })();
-    // SAFETY: `h` is a valid handle returned by CreateFileW and not used after this call.
-    unsafe {
-        let _ = CloseHandle(h);
-    }
-    resp
+    exchange(open_pipe(PIPE.get()?)?, req)
+}
+
+fn exchange(pipe: OwnedHandle, req: Request) -> Option<Response> {
+    let body = proto::frame(&req.encode());
+    write_all(pipe.as_handle(), &body)?;
+    read_response(pipe.as_handle())
 }
 
 /// `CreateFileW` the named pipe for read+write, retrying briefly. Returns `None` if it cannot be
@@ -125,7 +124,7 @@ fn rpc(req: Request) -> Option<Response> {
 /// fail. We use the standard named-pipe client pattern: on failure, `WaitNamedPipe` for an instance
 /// (and back off briefly if the pipe is momentarily absent), then retry — bounded so a genuinely
 /// down server still fails soft rather than hanging.
-fn open_pipe(path: &str) -> Option<HANDLE> {
+fn open_pipe(path: &str) -> Option<OwnedHandle> {
     // Connect to the host as THIS PROCESS, not a thread impersonation. clipboard-win (arboard) wraps
     // the app's `CloseClipboard` in `ImpersonateAnonymousToken`/`RevertToSelf` (a crbug/441834
     // mitigation), and our `CloseClipboard` detour — which ships the copy via this pipe — runs inside
@@ -153,7 +152,8 @@ fn open_pipe(path: &str) -> Option<HANDLE> {
             )
         };
         if let Ok(h) = opened {
-            return Some(h);
+            // SAFETY: CreateFileW succeeded, transferring a new pipe handle to its sole owner.
+            return Some(unsafe { OwnedHandle::from_raw_handle(h.0) });
         }
         // Instance busy → WaitNamedPipe blocks until one frees (up to 100ms). Instance momentarily
         // absent → it returns Err fast, so back off ~10ms to avoid a tight spin, then retry.
@@ -167,13 +167,19 @@ fn open_pipe(path: &str) -> Option<HANDLE> {
 }
 
 /// Write the whole buffer, looping over partial writes. `Some(())` on success.
-fn write_all(h: HANDLE, buf: &[u8]) -> Option<()> {
+fn write_all(h: BorrowedHandle<'_>, buf: &[u8]) -> Option<()> {
     let mut off = 0usize;
     while off < buf.len() {
         let mut written: u32 = 0;
         // SAFETY: `h` is valid; the slice is in-bounds; `written` is a live out-param.
         unsafe {
-            WriteFile(h, Some(&buf[off..]), Some(&mut written), None).ok()?;
+            WriteFile(
+                HANDLE(h.as_raw_handle()),
+                Some(&buf[off..]),
+                Some(&mut written),
+                None,
+            )
+            .ok()?;
         }
         if written == 0 {
             return None; // pipe closed mid-write
@@ -184,7 +190,7 @@ fn write_all(h: HANDLE, buf: &[u8]) -> Option<()> {
 }
 
 /// Read a 4-byte LE length prefix, then that many bytes, then `Response::decode`.
-fn read_response(h: HANDLE) -> Option<Response> {
+fn read_response(h: BorrowedHandle<'_>) -> Option<Response> {
     let mut len_buf = [0u8; 4];
     read_exact(h, &mut len_buf)?;
     let len = u32::from_le_bytes(len_buf) as usize;
@@ -197,13 +203,19 @@ fn read_response(h: HANDLE) -> Option<Response> {
 }
 
 /// Loop `ReadFile` until `buf` is full. `None` on short read (EOF) or error.
-fn read_exact(h: HANDLE, buf: &mut [u8]) -> Option<()> {
+fn read_exact(h: BorrowedHandle<'_>, buf: &mut [u8]) -> Option<()> {
     let mut off = 0usize;
     while off < buf.len() {
         let mut read: u32 = 0;
         // SAFETY: `h` is valid; the destination slice is in-bounds; `read` is a live out-param.
         unsafe {
-            ReadFile(h, Some(&mut buf[off..]), Some(&mut read), None).ok()?;
+            ReadFile(
+                HANDLE(h.as_raw_handle()),
+                Some(&mut buf[off..]),
+                Some(&mut read),
+                None,
+            )
+            .ok()?;
         }
         if read == 0 {
             return None; // EOF before the buffer was filled

--- a/crates/glass-clip-shim-windows/src/hook/tests.rs
+++ b/crates/glass-clip-shim-windows/src/hook/tests.rs
@@ -1,0 +1,95 @@
+use super::*;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use windows::Win32::Foundation::{ERROR_BROKEN_PIPE, ERROR_PIPE_CONNECTED, INVALID_HANDLE_VALUE};
+use windows::Win32::Storage::FileSystem::{FlushFileBuffers, PIPE_ACCESS_DUPLEX};
+use windows::Win32::System::Pipes::{
+    ConnectNamedPipe, CreateNamedPipeW, PIPE_READMODE_BYTE, PIPE_TYPE_BYTE, PIPE_WAIT,
+    PeekNamedPipe,
+};
+
+fn connected_pipe() -> (OwnedHandle, File) {
+    static NEXT_PIPE: AtomicUsize = AtomicUsize::new(0);
+    let name = format!(
+        r"\\.\pipe\glass-client-test-{}-{}",
+        std::process::id(),
+        NEXT_PIPE.fetch_add(1, Ordering::Relaxed),
+    );
+    let wide: Vec<u16> = name.encode_utf16().chain(Some(0)).collect();
+    // SAFETY: the name stays live through the call; all remaining arguments are scalar or absent.
+    let server = unsafe {
+        CreateNamedPipeW(
+            PCWSTR(wide.as_ptr()),
+            PIPE_ACCESS_DUPLEX,
+            PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
+            1,
+            4096,
+            4096,
+            0,
+            None,
+        )
+    };
+    assert_ne!(server, INVALID_HANDLE_VALUE);
+    // SAFETY: CreateNamedPipeW returned a new valid handle owned only by this fixture.
+    let server = unsafe { OwnedHandle::from_raw_handle(server.0) };
+    let client = open_pipe(&name).expect("connect fixture client");
+    // SAFETY: the server is owned and the client connected before this call.
+    let connected = unsafe { ConnectNamedPipe(HANDLE(server.as_raw_handle()), None) };
+    assert!(
+        connected.is_ok()
+            || connected.unwrap_err().code()
+                == windows::core::HRESULT::from_win32(ERROR_PIPE_CONNECTED.0)
+    );
+    (client, File::from(server))
+}
+
+fn response_round_trip(response: Vec<u8>) -> (Option<Response>, File) {
+    let (client, mut server) = connected_pipe();
+    let worker = std::thread::spawn(move || {
+        let mut request = vec![0; proto::frame(&Request::Seq.encode()).len()];
+        server.read_exact(&mut request).unwrap();
+        assert_eq!(request, proto::frame(&Request::Seq.encode()));
+        server.write_all(&response).unwrap();
+        // SAFETY: the owned server is connected; flush keeps the response alive until the client reads it.
+        let _ = unsafe { FlushFileBuffers(HANDLE(server.as_raw_handle())) };
+        server
+    });
+    let response = exchange(client, Request::Seq);
+    (response, worker.join().unwrap())
+}
+
+fn assert_client_closed(server: &File) {
+    // SAFETY: the server remains owned; a zero-buffer peek only queries connection state.
+    let error = unsafe { PeekNamedPipe(HANDLE(server.as_raw_handle()), None, 0, None, None, None) }
+        .expect_err("the exchange must close its client handle");
+    assert_eq!(
+        error.code(),
+        windows::core::HRESULT::from_win32(ERROR_BROKEN_PIPE.0)
+    );
+}
+
+#[test]
+fn exchange_closes_pipe_after_successful_response() {
+    let (response, server) = response_round_trip(proto::frame(&Response::Seq(42).encode()));
+
+    assert_eq!(response, Some(Response::Seq(42)));
+    assert_client_closed(&server);
+}
+
+#[test]
+fn exchange_closes_pipe_after_invalid_response() {
+    let (response, server) = response_round_trip(proto::frame(&[255]));
+
+    assert_eq!(response, None);
+    assert_client_closed(&server);
+}
+
+#[test]
+fn exchange_closes_pipe_after_oversized_response() {
+    let size = u32::try_from(proto::MAX_TOTAL_BYTES + 4097).unwrap();
+    let (response, server) = response_round_trip(size.to_le_bytes().to_vec());
+
+    assert_eq!(response, None);
+    assert_client_closed(&server);
+}

--- a/crates/glass-mcp/src/env.rs
+++ b/crates/glass-mcp/src/env.rs
@@ -360,6 +360,8 @@ pub(crate) const INTERNAL_ENV: &[&str] = &[
     "GLASS_LISTPIDS_TEST_DELAY_MS",
     "GLASS_LISTPIDS_TEST_OUTPUT",
     "GLASS_LISTPIDS_TEST_PID_FILE",
+    // Runs the Windows token-handle leak probe in its own process, isolated from parallel tests.
+    "GLASS_TOKEN_HANDLE_PROBE",
     // The three the glass-wayland test harness passes to the app it launches
     // (glass-wayland/src/testw.rs): which windows to map, whether to ignore a close request, and
     // whether to be an X11 client. Read only by that fixture, never by glass.

--- a/crates/glass-windows/src/containment/clip_onbox.rs
+++ b/crates/glass-windows/src/containment/clip_onbox.rs
@@ -1,7 +1,8 @@
 //! On-box deterministic validation of the private-clipboard hook. `#[ignore]`d — it needs
 //! Sandboxie running, the built `glass_clip_shim_windows.dll` (path in `GLASS_CLIP_SHIM_DLL`), and the built
-//! `clipprobe` example. No GUI / interactive desktop is needed: the probe only calls user32
-//! clipboard APIs, so it runs over SSH. Run on the box with:
+//! `clipprobe` example. Run in the logged-in user's interactive Windows session. From SSH,
+//! use a scheduled task with an interactive logon, as in `tools/windows-validation/run-onbox.ps1`;
+//! direct execution in SSH session 0 can produce no boxed probe output. In the interactive session:
 //! ```text
 //!   set GLASS_CLIP_SHIM_DLL=C:\Users\<user>\glass\target\release\glass_clip_shim_windows.dll
 //!   cargo test -p glass-windows --release private_clipboard_isolation -- --ignored --nocapture

--- a/crates/glass-windows/src/containment/clip_server.rs
+++ b/crates/glass-windows/src/containment/clip_server.rs
@@ -6,6 +6,7 @@
 //! we [`PrivateClipboard::apply`] and answer. The boxed `glass_clip_shim_windows` DLL is the client.
 //! Sandboxie's `OpenPipePath` lets the box reach this host pipe (always applied).
 
+use std::os::windows::io::{AsHandle, AsRawHandle, BorrowedHandle, FromRawHandle, OwnedHandle};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::JoinHandle;
@@ -15,7 +16,7 @@ use glass_clip_shim_windows::proto::{self, Request, Response};
 use glass_clip_shim_windows::store::PrivateClipboard;
 use glass_core::{GlassError, Result};
 
-use windows::Win32::Foundation::{CloseHandle, ERROR_PIPE_CONNECTED, HANDLE, INVALID_HANDLE_VALUE};
+use windows::Win32::Foundation::{ERROR_PIPE_CONNECTED, HANDLE, INVALID_HANDLE_VALUE};
 use windows::Win32::Security::Authorization::ConvertStringSecurityDescriptorToSecurityDescriptorW;
 use windows::Win32::Security::{PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES};
 use windows::Win32::Storage::FileSystem::{FlushFileBuffers, ReadFile, WriteFile};
@@ -25,6 +26,9 @@ use windows::Win32::System::Pipes::{
 };
 use windows::core::BOOL;
 use windows::core::PCWSTR;
+
+#[cfg(test)]
+mod tests;
 
 /// SDDL for the pipe DACL: Everyone (WD) + SYSTEM generic-all. Everyone is required merely so the
 /// box's client can *connect*: with `KeepTokenIntegrity=y` the Sandboxie token's access check is
@@ -83,7 +87,7 @@ impl ClipServer {
     fn shutdown(&mut self) {
         self.stop.store(true, Ordering::Relaxed);
         let wide = to_wide(&self.pipe_path);
-        // SAFETY: opening our own pipe by name to release the accept loop; handle closed immediately.
+        // SAFETY: the name stays live through the call; a successful self-connect is owned and closed immediately.
         unsafe {
             use windows::Win32::Foundation::{GENERIC_READ, GENERIC_WRITE};
             use windows::Win32::Storage::FileSystem::{
@@ -98,7 +102,7 @@ impl ClipServer {
                 FILE_FLAGS_AND_ATTRIBUTES(0),
                 None,
             ) {
-                let _ = CloseHandle(h);
+                drop(OwnedHandle::from_raw_handle(h.0));
             }
         }
         if let Some(t) = self.thread.take() {
@@ -177,6 +181,8 @@ fn accept_loop(
         if pipe == INVALID_HANDLE_VALUE {
             break;
         }
+        // SAFETY: CreateNamedPipeW returned a valid new handle, transferred to its sole owner.
+        let pipe = unsafe { OwnedHandle::from_raw_handle(pipe.0) };
         // SAFETY: blocks until a client connects (or our self-poke in stop()).
         // A client that connects in the gap between CreateNamedPipeW and
         // ConnectNamedPipe makes the call return FALSE + ERROR_PIPE_CONNECTED —
@@ -184,15 +190,14 @@ fn accept_loop(
         // `.is_ok()` alone would silently drop the client (its read-back then
         // comes back empty — the flaky-empty-readback class). Treat it as
         // connected.
-        let connected = match unsafe { ConnectNamedPipe(pipe, None) } {
+        let connected = match unsafe { ConnectNamedPipe(HANDLE(pipe.as_raw_handle()), None) } {
             Ok(()) => true,
             Err(e) => e.code() == windows::core::HRESULT::from_win32(ERROR_PIPE_CONNECTED.0),
         };
         if stop.load(Ordering::Relaxed) {
-            // SAFETY: closing the instance handle we own.
+            // SAFETY: the server owns this instance; it closes when the loop scope ends.
             unsafe {
-                let _ = DisconnectNamedPipe(pipe);
-                let _ = CloseHandle(pipe);
+                let _ = DisconnectNamedPipe(HANDLE(pipe.as_raw_handle()));
             }
             break;
         }
@@ -200,12 +205,11 @@ fn accept_loop(
             if pids.1.is_empty() || pids.0.elapsed() > Duration::from_millis(500) {
                 pids = (Instant::now(), box_pids(&dir, &box_name));
             }
-            serve_one(pipe, &store, &pids.1);
+            serve_one(pipe.as_handle(), &store, &pids.1);
         }
         // SAFETY: done with this instance.
         unsafe {
-            let _ = DisconnectNamedPipe(pipe);
-            let _ = CloseHandle(pipe);
+            let _ = DisconnectNamedPipe(HANDLE(pipe.as_raw_handle()));
         }
     }
     // SAFETY: free the SD allocated by ConvertStringSecurityDescriptor…; psd.0 is the pointer
@@ -235,17 +239,19 @@ fn box_pids(dir: &str, box_name: &str) -> Vec<u32> {
 /// owner-only DACL); this membership check is the real boundary. We look up the client PID
 /// (`GetNamedPipeClientProcessId`) and require it to be in the box's `/listpids` set — so an
 /// ordinary local process that guessed the per-box pipe name is rejected. Fail closed on any error.
-fn client_in_box(pipe: HANDLE, box_pids: &[u32]) -> bool {
+fn client_in_box(pipe: BorrowedHandle<'_>, box_pids: &[u32]) -> bool {
     let mut pid = 0u32;
     // SAFETY: writes the connected client's PID into `pid`; returns Err if there is no client.
-    if unsafe { GetNamedPipeClientProcessId(pipe, &mut pid) }.is_err() || pid == 0 {
+    if unsafe { GetNamedPipeClientProcessId(HANDLE(pipe.as_raw_handle()), &mut pid) }.is_err()
+        || pid == 0
+    {
         return false;
     }
     box_pids.contains(&pid)
 }
 
 /// Read one length-prefixed request, apply it, write the length-prefixed response.
-fn serve_one(pipe: HANDLE, store: &PrivateClipboard, box_pids: &[u32]) {
+fn serve_one(pipe: BorrowedHandle<'_>, store: &PrivateClipboard, box_pids: &[u32]) {
     let Some(body) = read_frame(pipe) else { return };
     // Authorization: only a process inside our Sandboxie box is served — the DACL merely lets the
     // box connect; this is the boundary against any other local process (see [`client_in_box`]).
@@ -262,13 +268,18 @@ fn serve_one(pipe: HANDLE, store: &PrivateClipboard, box_pids: &[u32]) {
     // the bytes. Without it, the caller's DisconnectNamedPipe can fire first and DISCARD the unread
     // response (the read-back then comes back empty), which is timing-dependent and flaky.
     unsafe {
-        let _ = WriteFile(pipe, Some(&out), Some(&mut written as *mut u32), None);
-        let _ = FlushFileBuffers(pipe);
+        let _ = WriteFile(
+            HANDLE(pipe.as_raw_handle()),
+            Some(&out),
+            Some(&mut written as *mut u32),
+            None,
+        );
+        let _ = FlushFileBuffers(HANDLE(pipe.as_raw_handle()));
     }
 }
 
 /// Read a 4-byte LE length then exactly that many bytes. None on any short/failed read.
-fn read_frame(pipe: HANDLE) -> Option<Vec<u8>> {
+fn read_frame(pipe: BorrowedHandle<'_>) -> Option<Vec<u8>> {
     let mut len_buf = [0u8; 4];
     if !read_exact(pipe, &mut len_buf) {
         return None;
@@ -284,14 +295,14 @@ fn read_frame(pipe: HANDLE) -> Option<Vec<u8>> {
     Some(body)
 }
 
-fn read_exact(pipe: HANDLE, buf: &mut [u8]) -> bool {
+fn read_exact(pipe: BorrowedHandle<'_>, buf: &mut [u8]) -> bool {
     let mut off = 0usize;
     while off < buf.len() {
         let mut read = 0u32;
         // SAFETY: reading into buf[off..] on a connected pipe instance we own.
         let ok = unsafe {
             ReadFile(
-                pipe,
+                HANDLE(pipe.as_raw_handle()),
                 Some(&mut buf[off..]),
                 Some(&mut read as *mut u32),
                 None,

--- a/crates/glass-windows/src/containment/clip_server/tests.rs
+++ b/crates/glass-windows/src/containment/clip_server/tests.rs
@@ -1,0 +1,103 @@
+use super::*;
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Write};
+use std::sync::atomic::AtomicUsize;
+use windows::Win32::Foundation::{ERROR_FILE_NOT_FOUND, ERROR_PIPE_NOT_CONNECTED};
+use windows::Win32::System::Pipes::WaitNamedPipeW;
+
+fn start_server() -> ClipServer {
+    static NEXT_PIPE: AtomicUsize = AtomicUsize::new(0);
+    let name = format!(
+        "glass-server-test-{}-{}",
+        std::process::id(),
+        NEXT_PIPE.fetch_add(1, Ordering::Relaxed),
+    );
+    let server = ClipServer::start(
+        &name,
+        PrivateClipboard::new(),
+        std::env::temp_dir()
+            .join(&name)
+            .to_string_lossy()
+            .into_owned(),
+        name.clone(),
+    )
+    .unwrap();
+    let wide = to_wide(&server.pipe_path);
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        // SAFETY: the pipe name stays live through the bounded readiness query.
+        if unsafe { WaitNamedPipeW(PCWSTR(wide.as_ptr()), 50) }.as_bool() {
+            return server;
+        }
+        assert!(Instant::now() < deadline, "server did not create its pipe");
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn connect(server: &ClipServer) -> File {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Ok(file) = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&server.pipe_path)
+        {
+            return file;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "server did not accept another client"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn assert_pipe_closed(path: &str) {
+    let error = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)
+        .expect_err("server retained its pipe after shutdown");
+    assert_eq!(
+        error.raw_os_error(),
+        Some(ERROR_FILE_NOT_FOUND.0 as i32),
+        "pipe must be removed, rather than busy or inaccessible",
+    );
+}
+
+#[test]
+fn stop_releases_pipe_while_waiting_for_connection() {
+    let server = start_server();
+    let path = server.pipe_path.clone();
+
+    server.stop();
+
+    assert_pipe_closed(&path);
+}
+
+#[test]
+fn drop_releases_pipe_after_incomplete_and_unauthorized_requests() {
+    let server = start_server();
+    let path = server.pipe_path.clone();
+    let mut client = connect(&server);
+    client.write_all(&[1]).unwrap();
+    drop(client);
+
+    let mut client = connect(&server);
+    client
+        .write_all(&proto::frame(&Request::Seq.encode()))
+        .unwrap();
+    match client.read(&mut [0]) {
+        Ok(0) => {}
+        Err(error) => assert_eq!(
+            error.raw_os_error(),
+            Some(ERROR_PIPE_NOT_CONNECTED.0 as i32),
+        ),
+        result => panic!("unboxed client was served: {result:?}"),
+    }
+    drop(client);
+
+    drop(server);
+
+    assert_pipe_closed(&path);
+}

--- a/crates/glass-windows/src/containment/pid_discovery.rs
+++ b/crates/glass-windows/src/containment/pid_discovery.rs
@@ -314,20 +314,19 @@ mod tests {
             .trim()
             .parse()
             .unwrap();
-        // SAFETY: OpenProcess receives a numeric PID written by the child. Any returned handle is
-        // closed immediately and is used only to ask whether the process is still active.
+        // SAFETY: the child's numeric PID is queried through an owned process handle and a live output buffer.
         let still_active = unsafe {
-            use windows::Win32::Foundation::{CloseHandle, STILL_ACTIVE};
+            use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle};
+            use windows::Win32::Foundation::{HANDLE, STILL_ACTIVE};
             use windows::Win32::System::Threading::{
                 GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
             };
             match OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) {
                 Ok(handle) => {
+                    let handle = OwnedHandle::from_raw_handle(handle.0);
                     let mut exit_code = 0;
-                    let active = GetExitCodeProcess(handle, &mut exit_code).is_ok()
-                        && exit_code == STILL_ACTIVE.0 as u32;
-                    let _ = CloseHandle(handle);
-                    active
+                    GetExitCodeProcess(HANDLE(handle.as_raw_handle()), &mut exit_code).is_ok()
+                        && exit_code == STILL_ACTIVE.0 as u32
                 }
                 Err(_) => false,
             }

--- a/crates/glass-windows/src/host_fs.rs
+++ b/crates/glass-windows/src/host_fs.rs
@@ -3,8 +3,7 @@ use std::ffi::OsStr;
 use std::fs::{File, OpenOptions};
 use std::os::windows::ffi::{OsStrExt, OsStringExt};
 use std::os::windows::fs::{MetadataExt, OpenOptionsExt};
-use std::os::windows::io::AsRawHandle;
-use std::os::windows::io::FromRawHandle;
+use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle};
 use std::path::Component;
 use std::path::Path;
 use windows::Wdk::Foundation::OBJECT_ATTRIBUTES;
@@ -793,43 +792,43 @@ fn with_current_user_sid<T>(
 ) -> glass_core::Result<T> {
     use windows::Win32::Security::{GetTokenInformation, TOKEN_QUERY, TOKEN_USER, TokenUser};
     use windows::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
-    let mut token = HANDLE::default();
-    // SAFETY: The current process pseudo-handle and token output pointer are valid.
-    unsafe {
-        OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token)
+    // SAFETY: the pseudo-handle and output are valid; success transfers a new token handle to its sole owner.
+    let token = unsafe {
+        let mut handle = HANDLE::default();
+        OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut handle)
             .map_err(|error| backend_error("open current user token", error))?;
-    }
-    let result = (|| {
-        let mut needed = 0;
-        // SAFETY: The owned token handle supports the documented zero-length query.
-        unsafe {
-            let _ = GetTokenInformation(token, TokenUser, None, 0, &mut needed);
-        }
-        if needed < std::mem::size_of::<TOKEN_USER>() as u32 || needed > 65536 {
-            return Err(GlassError::Backend(
-                "invalid current user token size".into(),
-            ));
-        }
-        let mut user = vec![0_usize; (needed as usize).div_ceil(std::mem::size_of::<usize>())];
-        // SAFETY: Pointer-aligned storage fits TOKEN_USER and its SID; both buffers outlive comparison.
-        unsafe {
-            GetTokenInformation(
-                token,
-                TokenUser,
-                Some(user.as_mut_ptr().cast()),
-                needed,
-                &mut needed,
-            )
-            .map_err(|error| backend_error("read current user token", error))?;
-            let user = &*user.as_ptr().cast::<TOKEN_USER>();
-            inspect(user.User.Sid)
-        }
-    })();
-    // SAFETY: OpenProcessToken returned this owned handle; no later code uses it.
+        OwnedHandle::from_raw_handle(handle.0)
+    };
+    let mut needed = 0;
+    // SAFETY: The owned token handle supports the documented zero-length query.
     unsafe {
-        let _ = windows::Win32::Foundation::CloseHandle(token);
+        let _ = GetTokenInformation(
+            HANDLE(token.as_raw_handle()),
+            TokenUser,
+            None,
+            0,
+            &mut needed,
+        );
     }
-    result
+    if needed < std::mem::size_of::<TOKEN_USER>() as u32 || needed > 65536 {
+        return Err(GlassError::Backend(
+            "invalid current user token size".into(),
+        ));
+    }
+    let mut user = vec![0_usize; (needed as usize).div_ceil(std::mem::size_of::<usize>())];
+    // SAFETY: pointer-aligned storage fits TOKEN_USER and its SID and remains live through inspection.
+    let sid = unsafe {
+        GetTokenInformation(
+            HANDLE(token.as_raw_handle()),
+            TokenUser,
+            Some(user.as_mut_ptr().cast()),
+            needed,
+            &mut needed,
+        )
+        .map_err(|error| backend_error("read current user token", error))?;
+        (*user.as_ptr().cast::<TOKEN_USER>()).User.Sid
+    };
+    inspect(sid)
 }
 
 /// Reports whether a filesystem object has the protected owner-and-SYSTEM DACL used by Glass.
@@ -1155,6 +1154,52 @@ mod tests {
     use super::*;
     use std::io::Read;
 
+    #[test]
+    fn current_user_token_is_closed_on_error_and_unwind() {
+        const PROBE_ENV: &str = "GLASS_TOKEN_HANDLE_PROBE";
+        if std::env::var_os(PROBE_ENV).is_none() {
+            let output = std::process::Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "--exact",
+                    "host_fs::tests::current_user_token_is_closed_on_error_and_unwind",
+                    "--nocapture",
+                ])
+                .env(PROBE_ENV, "1")
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "token handle probe failed:\n{}\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr),
+            );
+            return;
+        }
+
+        fn handle_count() -> u32 {
+            use windows::Win32::System::Threading::{GetCurrentProcess, GetProcessHandleCount};
+            let mut count = 0;
+            // SAFETY: the current-process pseudo-handle and writable count are valid for the query.
+            unsafe { GetProcessHandleCount(GetCurrentProcess(), &mut count) }.unwrap();
+            count
+        }
+
+        // Isolate the count from parallel tests and warm up token queries and panic reporting.
+        with_current_user_sid(|_| Ok(())).unwrap();
+        let _ = std::panic::catch_unwind(|| panic!("warm up panic reporting"));
+        let before = handle_count();
+
+        let result: glass_core::Result<()> =
+            with_current_user_sid(|_| Err(GlassError::Backend("inspection failed".into())));
+        assert!(result.is_err());
+        assert_eq!(handle_count(), before, "error return leaked a token handle");
+
+        let result = std::panic::catch_unwind(|| {
+            with_current_user_sid::<()>(|_| panic!("inspection panicked"))
+        });
+        assert!(result.is_err());
+        assert_eq!(handle_count(), before, "unwinding leaked a token handle");
+    }
     fn descriptor_bytes(sddl: &str) -> Vec<u8> {
         let sddl = wide_text(sddl);
         let mut descriptor = PSECURITY_DESCRIPTOR::default();

--- a/docs/how-to/verify-a-change.md
+++ b/docs/how-to/verify-a-change.md
@@ -114,6 +114,12 @@ cargo test -p glass-wayland -- --include-ignored   # 61 tests; needs sway >= 1.1
 | Windows on-box validation (Sandboxie, clipboard shim) | a Windows box, driven by `scripts/test-windows.sh` |
 | Mutation testing | CI only; it is sharded there, and a local sweep saturates the machine |
 
+The Sandboxie clipboard tests also need the logged-in user's **interactive Windows session**,
+even though the probe has no GUI. From SSH, use the scheduled-task bridge in
+`tools/windows-validation/run-onbox.ps1`; running the test executable directly in SSH session 0
+can leave the boxed probe silent. Build `glass-clip-shim-windows` and its `clipprobe` example in
+the test's profile, and set `GLASS_CLIP_SHIM_DLL` in the scheduled process to that DLL.
+
 ## The scripts
 
 Fourteen run locally. One drives another machine.


### PR DESCRIPTION
An inspection panic in `with_current_user_sid` leaked the process token handle. Adopt tokens, clipboard pipe instances and clients, and the remaining process handle in a test helper with `OwnedHandle` immediately after successful acquisition. Pipe helpers accept `BorrowedHandle`, so their callers retain ownership throughout I/O and cleanup also runs during unwinding.

Preserve response flushing before disconnection, `ERROR_PIPE_CONNECTED` handling, and the shutdown self-connect that wakes the accept loop. This removes the remaining manual `CloseHandle` calls from `glass-windows` and `glass-clip-shim-windows`; it does not change dependencies.

Add six Windows tests covering token cleanup on error/unwind, client closure after successful and malformed responses, incomplete/rejected requests, and idle server shutdown. The token regression failed against the merged baseline with one leaked handle and passes with this change.

Validation:

- Native Windows/MSVC: clippy with warnings denied and library tests for both affected Windows crates; **237 passed, 8 ignored**.
- Sandboxie clipboard integration: **all four ignored tests passed** in interactive Windows session 1 through a scheduled task, using the rebuilt native MSVC debug shim and probe. Covers text, multiple formats, OLE/user32 coherence, CF_HDROP, and preservation of the ambient clipboard sentinel.
- Linux: workspace formatting, clippy with warnings denied, and tests; **3,741 passed, 363 ignored**.
- Windows GNU target: workspace/all-targets clippy with warnings denied; GNU-built pipe tests also passed on native Windows.
- `git diff --check` passed.

Correct the test instructions to require an interactive Windows session. The earlier no-output failures came from running directly in SSH session 0; rerunning the same current implementation through the scheduled task passed all four tests in 4.18s.
