### PR TITLE
Bind Windows clipboard data to resource lifetimes

### DIFF
--- a/crates/glass-clip-shim-windows/Cargo.toml
+++ b/crates/glass-clip-shim-windows/Cargo.toml
@@ -39,5 +39,8 @@ windows-core = "0.62"
 # `nightly` feature — fine, the workspace is pinned to nightly (rust-toolchain.toml).
 retour = { version = "0.3", features = ["static-detour"] }
 
+[target.'cfg(windows)'.dev-dependencies]
+windows = { version = "0.62", features = ["Win32_System_WindowsProgramming"] }
+
 [lints]
 workspace = true

--- a/crates/glass-clip-shim-windows/src/hglobal.rs
+++ b/crates/glass-clip-shim-windows/src/hglobal.rs
@@ -4,29 +4,36 @@
 //! cross-compiles to `x86_64-pc-windows-gnu` so this is compile-checked on any host.
 
 use core::ffi::c_void;
+use std::marker::PhantomData;
 
 use windows::Win32::Foundation::{GlobalFree, HGLOBAL};
 use windows::Win32::System::Memory::{
-    GMEM_MOVEABLE, GlobalAlloc, GlobalLock, GlobalSize, GlobalUnlock,
+    GMEM_MOVEABLE, GMEM_ZEROINIT, GlobalAlloc, GlobalLock, GlobalSize, GlobalUnlock,
 };
+
+#[cfg(test)]
+mod tests;
 
 /// RAII lock over a moveable `HGLOBAL`: `GlobalLock` on construction, `GlobalUnlock` on drop. The
 /// byte view is bounded by `GlobalSize`, so reads cannot run past the allocation.
 ///
 /// Borrows — does not own — the handle; freeing is a separate concern (see [`OwnedHGlobal`], or the
 /// system taking ownership after `SetClipboardData`).
-pub struct HGlobalLock {
+pub struct HGlobalLock<'a> {
     h: HGLOBAL,
     ptr: *mut c_void,
     len: usize,
+    _borrow: PhantomData<&'a [u8]>,
 }
 
-impl HGlobalLock {
+impl<'a> HGlobalLock<'a> {
     /// Lock `h`, returning `None` if `GlobalLock` fails (null).
     ///
     /// # Safety
-    /// `h` must be a valid `HGLOBAL` (from `GlobalAlloc`, or a clipboard data handle for a global
-    /// format) that stays valid for the lifetime of the returned guard.
+    /// `h` must be a valid `HGLOBAL` whose entire `GlobalSize` is initialized. Its owner must
+    /// keep it alive for `'a` and prevent mutation while byte views are live, including through
+    /// other locks: `GlobalLock` pins memory but does not provide exclusive access. Prefer [`OwnedHGlobal::lock`] for
+    /// allocations owned by Rust; borrowed clipboard data must be tied to the open clipboard.
     pub unsafe fn new(h: HGLOBAL) -> Option<Self> {
         // SAFETY: caller guarantees `h` is valid. GlobalLock pins the moveable block, returning a
         // pointer to it or null on failure.
@@ -36,27 +43,27 @@ impl HGlobalLock {
         }
         // SAFETY: `h` is locked; GlobalSize reports its allocated byte length (0 on error).
         let len = unsafe { GlobalSize(h) };
-        Some(Self { h, ptr, len })
+        let lock = Self {
+            h,
+            ptr,
+            len,
+            _borrow: PhantomData,
+        };
+        // Rust slices cannot exceed isize::MAX, even if the allocator accepts a larger block.
+        (len <= isize::MAX as usize).then_some(lock)
     }
 
     /// The locked block as a byte slice, bounded by `GlobalSize`.
     pub fn as_bytes(&self) -> &[u8] {
-        // SAFETY: `ptr` is the locked, non-null base; `len` is the GlobalSize byte length. The slice
-        // borrows `self`, so it cannot outlive the lock that keeps the block pinned.
+        // SAFETY: construction guarantees initialized, immutable storage of `len <= isize::MAX`
+        // bytes at the locked non-null base; the slice cannot outlive this lock or its owner.
         unsafe { std::slice::from_raw_parts(self.ptr as *const u8, self.len) }
-    }
-
-    /// The locked block as a mutable byte slice. Internal: only [`OwnedHGlobal::from_bytes`] writes.
-    pub(crate) fn as_mut_bytes(&mut self) -> &mut [u8] {
-        // SAFETY: as `as_bytes`; `&mut self` proves we hold the only reference to the block.
-        unsafe { std::slice::from_raw_parts_mut(self.ptr as *mut u8, self.len) }
     }
 }
 
-impl Drop for HGlobalLock {
+impl Drop for HGlobalLock<'_> {
     fn drop(&mut self) {
-        // SAFETY: we took the matching lock in `new`. For a GMEM_MOVEABLE block the result is
-        // informational (Err only when the lock count reaches 0), so we ignore it.
+        // SAFETY: this guard took one lock in `new`; dropping it releases that lock.
         let _ = unsafe { GlobalUnlock(self.h) };
     }
 }
@@ -68,21 +75,39 @@ pub struct OwnedHGlobal {
 }
 
 impl OwnedHGlobal {
-    /// Allocate a `GMEM_MOVEABLE` block holding exactly `bytes`. `None` on alloc/lock failure (any
-    /// partial allocation is freed before returning).
+    /// Allocate a `GMEM_MOVEABLE` block containing `bytes`, with any allocator padding zeroed.
+    /// `None` on alloc/lock failure (any partial allocation is freed before returning).
     pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
-        // SAFETY: GlobalAlloc(GMEM_MOVEABLE, n) is the canonical moveable allocation; Err on failure.
-        let h = unsafe { GlobalAlloc(GMEM_MOVEABLE, bytes.len()) }.ok()?;
+        // SAFETY: the flags request moveable, initialized storage; Err on failure.
+        let h = unsafe { GlobalAlloc(GMEM_MOVEABLE | GMEM_ZEROINIT, bytes.len()) }.ok()?;
         let owned = Self { h };
         {
-            // SAFETY: `h` was just returned by GlobalAlloc, so it is valid.
-            let mut lock = unsafe { HGlobalLock::new(owned.h) }?; // on None, `owned` drops -> free
-            // GlobalAlloc may round the block UP, so the locked slice can be longer than requested;
-            // copy into the exact prefix (a whole-slice copy_from_slice would panic on a mismatch).
-            lock.as_mut_bytes()[..bytes.len()].copy_from_slice(bytes);
-            // `lock` drops here -> GlobalUnlock.
+            // SAFETY: this fresh allocation is initialized and has no aliases. This private lock
+            // exposes no byte references while we fill it, and drops before the owner escapes.
+            let lock = unsafe { HGlobalLock::new(owned.h) }?;
+            if bytes.len() > lock.len {
+                return None;
+            }
+            // SAFETY: the new allocation is disjoint from `bytes`, uniquely accessed, and large
+            // enough for this prefix; zero-initialized padding remains unchanged.
+            unsafe { std::ptr::copy_nonoverlapping(bytes.as_ptr(), lock.ptr.cast(), bytes.len()) };
         }
         Some(owned)
+    }
+
+    /// Borrow the initialized allocation for reading, keeping it alive until the lock drops.
+    ///
+    /// ```compile_fail
+    /// use glass_clip_shim_windows::OwnedHGlobal;
+    /// let memory = OwnedHGlobal::from_bytes(b"clipboard").unwrap();
+    /// let lock = memory.lock().unwrap();
+    /// drop(memory);
+    /// assert_eq!(&lock.as_bytes()[..9], b"clipboard");
+    /// ```
+    pub fn lock(&self) -> Option<HGlobalLock<'_>> {
+        // SAFETY: from_bytes initializes the whole allocation; the shared borrow prevents
+        // dropping or transferring it, and safe APIs expose no mutable access.
+        unsafe { HGlobalLock::new(self.h) }
     }
 
     /// The raw handle, for APIs that need it (e.g. `HANDLE(h.0)` for `SetClipboardData`).

--- a/crates/glass-clip-shim-windows/src/hglobal/tests.rs
+++ b/crates/glass-clip-shim-windows/src/hglobal/tests.rs
@@ -1,0 +1,58 @@
+use super::*;
+use windows::Win32::System::Memory::GlobalFlags;
+use windows::Win32::System::WindowsProgramming::{GMEM_INVALID_HANDLE, GMEM_LOCKCOUNT};
+
+fn lock_count(memory: &OwnedHGlobal) -> u32 {
+    // SAFETY: the allocation remains owned while its lock count is queried.
+    let flags = unsafe { GlobalFlags(memory.handle()) };
+    assert_ne!(flags, GMEM_INVALID_HANDLE);
+    flags & GMEM_LOCKCOUNT
+}
+
+#[test]
+fn allocation_initializes_payload_and_padding() {
+    for size in [1, 3, 13, 31, 4097] {
+        let bytes = vec![0xa5; size];
+        let memory = OwnedHGlobal::from_bytes(&bytes).unwrap();
+        let lock = memory.lock().unwrap();
+        assert_eq!(&lock.as_bytes()[..size], bytes);
+        assert!(lock.as_bytes()[size..].iter().all(|&byte| byte == 0));
+    }
+}
+
+#[test]
+fn read_locks_release_independently() {
+    let memory = OwnedHGlobal::from_bytes(b"clipboard").unwrap();
+    assert_eq!(lock_count(&memory), 0);
+    let first = memory.lock().unwrap();
+    let second = memory.lock().unwrap();
+    assert_eq!(lock_count(&memory), 2);
+    drop(first);
+    assert_eq!(lock_count(&memory), 1);
+    assert_eq!(&second.as_bytes()[..9], b"clipboard");
+    drop(second);
+    assert_eq!(lock_count(&memory), 0);
+}
+
+#[test]
+fn unwinding_unlocks_without_freeing_the_owner() {
+    let memory = OwnedHGlobal::from_bytes(b"clipboard").unwrap();
+    let result = std::panic::catch_unwind(|| {
+        let _lock = memory.lock().unwrap();
+        assert_eq!(lock_count(&memory), 1);
+        panic!("unwind with locked memory");
+    });
+    assert!(result.is_err());
+    assert_eq!(lock_count(&memory), 0);
+    assert_eq!(&memory.lock().unwrap().as_bytes()[..9], b"clipboard");
+}
+
+#[test]
+fn ownership_transfer_keeps_the_allocation_alive() {
+    let memory = OwnedHGlobal::from_bytes(b"transferred").unwrap();
+    let raw = memory.into_raw();
+    // Reclaim the sole ownership transferred above, so the fixture frees the allocation.
+    let reclaimed = OwnedHGlobal { h: raw };
+    assert_eq!(lock_count(&reclaimed), 0);
+    assert_eq!(&reclaimed.lock().unwrap().as_bytes()[..11], b"transferred");
+}

--- a/crates/glass-clip-shim-windows/src/hook.rs
+++ b/crates/glass-clip-shim-windows/src/hook.rs
@@ -276,13 +276,16 @@ pub(crate) fn store_get_all() -> Vec<(FormatKey, Vec<u8>)> {
 // ---------------------------------------------------------------------------------------------
 
 /// Copy the full contents of an app-provided `HGLOBAL` to a `Vec<u8>` (bounded by `GlobalSize`).
-pub(crate) fn read_bytes_from_hglobal(h: HGLOBAL) -> Option<Vec<u8>> {
-    // SAFETY: `h` is an app-provided clipboard data handle, valid for this call.
+///
+/// # Safety
+/// The caller must keep `h` and its initialized contents valid and immutable for this call.
+pub(crate) unsafe fn read_bytes_from_hglobal(h: HGLOBAL) -> Option<Vec<u8>> {
+    // SAFETY: the caller guarantees the allocation and its contents remain valid during the copy.
     let lock = unsafe { HGlobalLock::new(h) }?;
     Some(lock.as_bytes().to_vec())
 }
 
-/// Allocate a `GMEM_MOVEABLE` `HGLOBAL` holding exactly `bytes`. Caller caches + frees it.
+/// Allocate a `GMEM_MOVEABLE` `HGLOBAL` containing `bytes` and zeroed padding. Caller caches + frees it.
 pub(crate) fn alloc_hglobal_bytes(bytes: &[u8]) -> Option<HGLOBAL> {
     // Caller owns + frees the returned handle, so relinquish ownership with `into_raw`.
     Some(OwnedHGlobal::from_bytes(bytes)?.into_raw())

--- a/crates/glass-clip-shim-windows/src/hook/detour_impl.rs
+++ b/crates/glass-clip-shim-windows/src/hook/detour_impl.rs
@@ -238,7 +238,8 @@ fn set_clipboard_data(fmt: u32, h: HANDLE) -> HANDLE {
         if h.0.is_null() {
             return HANDLE::default(); // delayed rendering unsupported
         }
-        if let Some(bytes) = read_bytes_from_hglobal(HGLOBAL(h.0)) {
+        // SAFETY: the intercepted call lends its initialized clipboard data for this synchronous copy.
+        if let Some(bytes) = unsafe { read_bytes_from_hglobal(HGLOBAL(h.0)) } {
             let key = key_of(fmt);
             PENDING.with(|p| {
                 let mut v = p.borrow_mut();

--- a/crates/glass-windows/src/clipboard.rs
+++ b/crates/glass-windows/src/clipboard.rs
@@ -1,8 +1,7 @@
 //! Win32 clipboard get/set via `CF_UNICODETEXT`.
-//!
-//! The Windows clipboard is global OS storage — there is no owner thread and nothing
-//! to tear down. Both functions are safe wrappers around `unsafe` Win32 calls; every
-//! `unsafe` block is guarded by a `// SAFETY:` comment per the repo policy.
+
+use std::marker::PhantomData;
+use std::sync::{Mutex, MutexGuard, TryLockError};
 
 use windows::Win32::Foundation::{HANDLE, HGLOBAL};
 use windows::Win32::System::DataExchange::{
@@ -13,108 +12,102 @@ use windows::Win32::System::Ole::CF_UNICODETEXT;
 use glass_clip_shim_windows::{HGlobalLock, OwnedHGlobal};
 use glass_core::{GlassError, Result};
 
+#[cfg(test)]
+mod tests;
+
+// OpenClipboard(None) can succeed again on another thread in this process.
+static CLIPBOARD_ACCESS: Mutex<()> = Mutex::new(());
+
 /// Read the clipboard as UTF-8 text.
 ///
 /// Returns `Ok("")` when the clipboard is empty or contains no text (no
 /// `CF_UNICODETEXT` owner). Maps Win32 failures to [`GlassError::Backend`].
 pub fn get() -> Result<String> {
-    // SAFETY: OpenClipboard(None) is safe to call from any thread; None means
-    // "associate with no window" which is the documented practice for non-GUI code.
-    unsafe { OpenClipboard(None) }
-        .map_err(|e| GlassError::Backend(format!("OpenClipboard failed: {e}")))?;
-
-    // Always close, even on the empty/error paths — use a scope guard via a local
-    // wrapper.  We handle the close manually at each return site to keep the
-    // `unsafe` blocks minimal.
-
-    let result = read_clipboard_text();
-
-    // SAFETY: We successfully opened the clipboard above; CloseClipboard must be
-    // called exactly once to release the lock.  We call it unconditionally here
-    // (after the read) so it always runs.
-    let _ = unsafe { CloseClipboard() };
-
-    result
-}
-
-/// Inner: reads `CF_UNICODETEXT` while the clipboard is open.  Called only
-/// after a successful `OpenClipboard`; the caller owns the close.
-fn read_clipboard_text() -> Result<String> {
-    // SAFETY: The clipboard is open (caller guarantee).  GetClipboardData returns
-    // a handle owned by the clipboard — we must NOT free it.  A null/error result
-    // means no CF_UNICODETEXT data is available, which is `Ok("")`.
-    let handle = unsafe { GetClipboardData(CF_UNICODETEXT.0 as u32) };
-
-    let handle = match handle {
-        Ok(h) if !h.is_invalid() => h,
-        // No text data on the clipboard — this is not an error.
-        _ => return Ok(String::new()),
-    };
-
-    // Reinterpret the clipboard HANDLE as an HGLOBAL (both wrap `*mut c_void`;
-    // GetClipboardData returns an HGLOBAL for CF_UNICODETEXT).
-    let hglobal = HGLOBAL(handle.0);
-
-    // SAFETY: `hglobal` is the HGLOBAL GetClipboardData returned for CF_UNICODETEXT;
-    // it stays valid until the caller closes the clipboard, which outlives this `lock`.
-    let lock = unsafe { HGlobalLock::new(hglobal) }
-        .ok_or_else(|| GlassError::Backend("GlobalLock failed on clipboard handle".into()))?;
-
-    // The clipboard owner is an arbitrary (possibly buggy/malicious) app, so CF_UNICODETEXT
-    // may not be NUL-terminated. Bound the scan by the locked block size; `chunks_exact` drops
-    // any stray trailing odd byte (valid UTF-16 is even-length). `lock` unlocks on drop.
-    let units: Vec<u16> = lock
-        .as_bytes()
-        .chunks_exact(2)
-        .map(|c| u16::from_ne_bytes([c[0], c[1]]))
-        .take_while(|&u| u != 0)
-        .collect();
-    Ok(String::from_utf16_lossy(&units))
+    Clipboard::open()?.read_text()
 }
 
 /// Write UTF-8 text to the clipboard (encoded as NUL-terminated UTF-16).
-///
-/// On success the system owns the allocated global memory — we must NOT free it. On any failure the
-/// `OwnedHGlobal` frees the allocation as it drops.
 pub fn set(text: &str) -> Result<()> {
-    // Encode as native-endian (Windows = little-endian) UTF-16 + NUL terminator, as raw bytes.
-    let utf16: Vec<u16> = text.encode_utf16().chain(std::iter::once(0u16)).collect();
-    let mut bytes = Vec::with_capacity(utf16.len() * 2);
-    for unit in utf16 {
-        bytes.extend_from_slice(&unit.to_le_bytes());
-    }
-
-    // `mem` frees itself on drop until we relinquish it to the system via `into_raw` below.
-    let mem = OwnedHGlobal::from_bytes(&bytes)
+    let bytes: Vec<u8> = text
+        .encode_utf16()
+        .chain(std::iter::once(0))
+        .flat_map(u16::to_le_bytes)
+        .collect();
+    let memory = OwnedHGlobal::from_bytes(&bytes)
         .ok_or_else(|| GlassError::Backend("GlobalAlloc/GlobalLock failed for clipboard".into()))?;
+    Clipboard::open()?.write_text(memory)
+}
 
-    // SAFETY: OpenClipboard(None) is safe from any thread. On the `?` early-return `mem` drops -> free.
-    unsafe { OpenClipboard(None) }
-        .map_err(|e| GlassError::Backend(format!("OpenClipboard failed: {e}")))?;
+/// Holds the clipboard open on this thread; borrowed data must be unlocked before it closes.
+struct Clipboard {
+    _access: MutexGuard<'static, ()>,
+    _thread_bound: PhantomData<*mut ()>,
+}
 
-    // SAFETY: the clipboard is open; EmptyClipboard clears it and transfers ownership to us.
-    if let Err(e) = unsafe { EmptyClipboard() } {
-        // SAFETY: we opened the clipboard above. `mem` drops after this -> GlobalFree.
-        let _ = unsafe { CloseClipboard() };
-        return Err(GlassError::Backend(format!("EmptyClipboard failed: {e}")));
+impl Clipboard {
+    fn open() -> Result<Self> {
+        let access = match CLIPBOARD_ACCESS.try_lock() {
+            Ok(access) => access,
+            // There is no protected data to repair; the previous guard closed during unwinding.
+            Err(TryLockError::Poisoned(error)) => error.into_inner(),
+            Err(TryLockError::WouldBlock) => {
+                return Err(GlassError::Backend(
+                    "OpenClipboard failed: clipboard already open in this process".into(),
+                ));
+            }
+        };
+        // SAFETY: no window is associated with this task's clipboard access.
+        unsafe { OpenClipboard(None) }
+            .map_err(|e| GlassError::Backend(format!("OpenClipboard failed: {e}")))?;
+        Ok(Self {
+            _access: access,
+            _thread_bound: PhantomData,
+        })
     }
 
-    // HGLOBAL -> HANDLE for SetClipboardData (both wrap `*mut c_void`).
-    let hmem = HANDLE(mem.handle().0);
+    fn lock_text(&self) -> Result<Option<HGlobalLock<'_>>> {
+        // SAFETY: this guard holds the clipboard open; CF_UNICODETEXT data is a borrowed HGLOBAL.
+        let handle = match unsafe { GetClipboardData(CF_UNICODETEXT.0 as u32) } {
+            Ok(handle) if !handle.is_invalid() => handle,
+            _ => return Ok(None),
+        };
+        // SAFETY: the clipboard owns the text bytes and prevents concurrent modification while
+        // open; the returned lock borrows this guard, preventing closure or write_text until drop.
+        unsafe { HGlobalLock::new(HGLOBAL(handle.0)) }
+            .map(Some)
+            .ok_or_else(|| GlassError::Backend("GlobalLock failed on clipboard handle".into()))
+    }
 
-    // SAFETY: the clipboard is open and empty. On success SetClipboardData transfers ownership of the
-    // block to the system (so we must NOT free it — `into_raw`); on failure it stays ours.
-    let set_result = unsafe { SetClipboardData(CF_UNICODETEXT.0 as u32, Some(hmem)) };
+    fn read_text(&self) -> Result<String> {
+        let Some(lock) = self.lock_text()? else {
+            return Ok(String::new());
+        };
+        // An external owner may omit the NUL terminator or leave an odd trailing byte.
+        let units: Vec<u16> = lock
+            .as_bytes()
+            .chunks_exact(2)
+            .map(|c| u16::from_le_bytes([c[0], c[1]]))
+            .take_while(|&u| u != 0)
+            .collect();
+        Ok(String::from_utf16_lossy(&units))
+    }
 
-    // SAFETY: the clipboard was opened; close it regardless of the set result.
-    let _ = unsafe { CloseClipboard() };
+    fn write_text(&mut self, memory: OwnedHGlobal) -> Result<()> {
+        // SAFETY: the clipboard is open; the exclusive borrow excludes outstanding data locks.
+        unsafe { EmptyClipboard() }
+            .map_err(|e| GlassError::Backend(format!("EmptyClipboard failed: {e}")))?;
+        // SAFETY: the clipboard is open and empty; the initialized block is unlocked. Windows
+        // takes ownership only on success; otherwise `memory` frees the allocation on return.
+        unsafe { SetClipboardData(CF_UNICODETEXT.0 as u32, Some(HANDLE(memory.handle().0))) }
+            .map_err(|e| GlassError::Backend(format!("SetClipboardData failed: {e}")))?;
+        memory.into_raw();
+        Ok(())
+    }
+}
 
-    match set_result {
-        Ok(_) => {
-            mem.into_raw(); // system owns the block now — suppress the Drop free
-            Ok(())
-        }
-        // `mem` drops here -> GlobalFree (ownership never transferred).
-        Err(e) => Err(GlassError::Backend(format!("SetClipboardData failed: {e}"))),
+impl Drop for Clipboard {
+    fn drop(&mut self) {
+        // SAFETY: open succeeded on this thread; all borrowed data locks have ended.
+        let _ = unsafe { CloseClipboard() };
     }
 }

--- a/crates/glass-windows/src/clipboard/tests.rs
+++ b/crates/glass-windows/src/clipboard/tests.rs
@@ -1,0 +1,63 @@
+use super::*;
+
+fn can_open_on_another_thread() -> bool {
+    std::thread::spawn(|| Clipboard::open().is_ok())
+        .join()
+        .unwrap()
+}
+
+fn assert_closed() {
+    // SAFETY: no guard should remain; a leaked open is closed here before failing the assertion.
+    assert!(
+        unsafe { CloseClipboard() }.is_err(),
+        "clipboard was still open"
+    );
+    assert!(
+        can_open_on_another_thread(),
+        "local clipboard access remained locked"
+    );
+}
+
+#[test]
+#[ignore = "on-box: needs the interactive Windows session; run serially via a scheduled task from SSH"]
+fn clipboard_closes_on_error_and_unwind() {
+    let result: Result<()> = (|| {
+        let _clipboard = Clipboard::open()?;
+        assert!(!can_open_on_another_thread());
+        Err(GlassError::Backend("inspection failed".into()))
+    })();
+    assert!(result.is_err());
+    assert_closed();
+
+    let result = std::panic::catch_unwind(|| {
+        let _clipboard = Clipboard::open().unwrap();
+        assert!(!can_open_on_another_thread());
+        panic!("inspection panicked");
+    });
+    assert!(result.is_err());
+    assert_closed();
+}
+
+#[test]
+#[ignore = "on-box: needs the interactive Windows session; run serially via a scheduled task from SSH"]
+fn text_roundtrip_preserves_transferred_and_borrowed_memory() {
+    for text in ["", "clipboard 🦀 日本語"] {
+        set(text).unwrap();
+        assert_eq!(get().unwrap(), text);
+        // Reading closes and unlocks the borrowed data without freeing the system's allocation.
+        assert_eq!(get().unwrap(), text);
+        assert_closed();
+    }
+}
+
+#[test]
+#[ignore = "on-box: needs the interactive Windows session; run serially via a scheduled task from SSH"]
+fn missing_text_closes_the_clipboard() {
+    {
+        let _clipboard = Clipboard::open().unwrap();
+        // SAFETY: this fixture owns the open clipboard and holds no data locks.
+        unsafe { EmptyClipboard() }.unwrap();
+    }
+    assert_eq!(get().unwrap(), "");
+    assert_closed();
+}


### PR DESCRIPTION
Clipboard reads and writes manually closed the clipboard, and global-memory locks relied on callers to keep their owners alive. Add a thread-bound clipboard guard that closes on return or unwind, and tie text locks to that guard. Reject overlapping Glass access within a process: native testing showed that a second thread's `OpenClipboard(None)` can otherwise succeed and close the first call's clipboard.

Add `OwnedHGlobal::lock` with an owner-bound lifetime, zero-initialize allocations including padding, and remove mutable byte views from borrowed locks. Raw FFI handles retain an explicit unsafe contract. Transfer memory ownership immediately after `SetClipboardData` succeeds; failed writes retain automatic cleanup.

Validation:

- Native Windows/MSVC: clippy with warnings denied; **241 library tests passed**, 11 ignored; **one lifetime compile-fail doctest passed**.
- Interactive Windows session 1 via scheduled task: **all seven clipboard tests passed**, including three new lifecycle tests and all four existing Sandboxie tests (text, multiple formats, OLE/user32 coherence, CF_HDROP, ambient clipboard isolation).
- The concurrent-open check failed before process-local serialization and passed afterward. Allocation tests verify initialized bytes, lock counts, unwind cleanup, and ownership transfer.
- Linux workspace: formatting and clippy passed; **3,741 tests passed**, 363 ignored.
- Windows GNU target: workspace/all-targets clippy with warnings denied passed. `git diff --check` passed.

No dependency versions changed; a test-only Windows feature enables lock-count queries.
