### PR TITLE
Replace std::simd with fearless_simd 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,6 +1003,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fearless_simd"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4beca3cb2444e3304ac30843cc091f44ed58932353cd492ce740067bfce6b12"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1301,6 +1307,7 @@ name = "glass-core"
 version = "0.0.0"
 dependencies = [
  "criterion",
+ "fearless_simd",
  "image",
  "serde",
  "serde_json",

--- a/crates/glass-core/Cargo.toml
+++ b/crates/glass-core/Cargo.toml
@@ -12,6 +12,7 @@ publish.workspace = true
 bench = false
 
 [dependencies]
+fearless_simd = "0.7.0"
 thiserror.workspace = true
 image.workspace = true
 serde = { workspace = true }

--- a/crates/glass-core/src/diff.rs
+++ b/crates/glass-core/src/diff.rs
@@ -1,7 +1,6 @@
 use crate::error::{GlassError, Result};
 use crate::frame::{Frame, Region};
-use std::simd::cmp::{SimdOrd, SimdPartialOrd};
-use std::simd::{Simd, u8x32};
+use fearless_simd::{dispatch, prelude::*, u8x32};
 
 /// Axis-aligned bounding box of changed pixels.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -217,6 +216,17 @@ pub fn diff_with_mask(
     tolerance: u8,
     mask: &IgnoreMask,
 ) -> Result<DiffResult> {
+    dispatch!(crate::simd_level(), simd => diff_with_mask_simd(simd, a, b, tolerance, mask))
+}
+
+#[inline(always)]
+fn diff_with_mask_simd<S: Simd>(
+    simd: S,
+    a: &Frame,
+    b: &Frame,
+    tolerance: u8,
+    mask: &IgnoreMask,
+) -> Result<DiffResult> {
     if a.width != b.width || a.height != b.height {
         return Err(GlassError::SizeMismatch {
             a: (a.width, a.height),
@@ -224,7 +234,7 @@ pub fn diff_with_mask(
         });
     }
     let row_bytes = a.width as usize * 4;
-    let tol_vec = Simd::splat(tolerance);
+    let tol_vec = u8x32::splat(simd, tolerance);
     let mut changed = 0u64;
     let (mut min_x, mut min_y, mut max_x, mut max_y) = (u32::MAX, u32::MAX, 0u32, 0u32);
 
@@ -244,22 +254,34 @@ pub fn diff_with_mask(
                 col = chunk_end;
                 continue;
             }
-            let va = u8x32::from_slice(&ra[off..off + LANES]);
-            let vb = u8x32::from_slice(&rb[off..off + LANES]);
-            let d = va.simd_max(vb) - va.simd_min(vb);
-            if d.simd_gt(tol_vec).any() {
-                for px in 0..(LANES / 4) {
-                    let cx = col + px as u32;
-                    if masked_row && mask.is_ignored(cx, y) {
-                        continue;
+            let va = u8x32::from_slice(simd, &ra[off..off + LANES]);
+            let vb = u8x32::from_slice(simd, &rb[off..off + LANES]);
+            let d = va.max(vb) - va.min(vb);
+            let byte_changes = d.simd_gt(tol_vec);
+            if byte_changes.any_true() {
+                let byte_flags =
+                    byte_changes.select(u8x32::splat(simd, 255), u8x32::splat(simd, 0));
+                // Four byte predicates form one nonzero word per changed RGBA pixel.
+                let word_flags: fearless_simd::u32x8<S> = byte_flags.bitcast();
+                let mut bits = word_flags
+                    .simd_gt(fearless_simd::u32x8::splat(simd, 0))
+                    .to_bitmask() as u8;
+                if masked_row {
+                    let mut remaining = bits;
+                    while remaining != 0 {
+                        let px = remaining.trailing_zeros();
+                        remaining &= remaining - 1;
+                        if mask.is_ignored(col + px, y) {
+                            bits &= !(1 << px);
+                        }
                     }
-                    if pixel_changed(ra, rb, off + px * 4, tolerance) {
-                        changed += 1;
-                        min_x = min_x.min(cx);
-                        min_y = min_y.min(y);
-                        max_x = max_x.max(cx);
-                        max_y = max_y.max(y);
-                    }
+                }
+                if bits != 0 {
+                    changed += u64::from(bits.count_ones());
+                    min_x = min_x.min(col + bits.trailing_zeros());
+                    max_x = max_x.max(col + 7 - bits.leading_zeros());
+                    min_y = min_y.min(y);
+                    max_y = max_y.max(y);
                 }
             }
             off += LANES;
@@ -491,6 +513,17 @@ pub fn diff_perceptual_with_mask(
     threshold: f32,
     mask: &IgnoreMask,
 ) -> Result<DiffResult> {
+    dispatch!(crate::simd_level(), simd => diff_perceptual_with_mask_simd(simd, a, b, threshold, mask))
+}
+
+#[inline(always)]
+fn diff_perceptual_with_mask_simd<S: Simd>(
+    simd: S,
+    a: &Frame,
+    b: &Frame,
+    threshold: f32,
+    mask: &IgnoreMask,
+) -> Result<DiffResult> {
     if a.width != b.width || a.height != b.height {
         return Err(GlassError::SizeMismatch {
             a: (a.width, a.height),
@@ -522,7 +555,9 @@ pub fn diff_perceptual_with_mask(
                 col = chunk_end;
                 continue;
             }
-            if u8x32::from_slice(&ra[off..off + LANES]) != u8x32::from_slice(&rb[off..off + LANES])
+            if u8x32::from_slice(simd, &ra[off..off + LANES])
+                .simd_eq(u8x32::from_slice(simd, &rb[off..off + LANES]))
+                .any_false()
             {
                 for px in 0..(LANES / 4) as u32 {
                     let cx = col + px;
@@ -1618,12 +1653,44 @@ mod tests {
             let b = make(w, h, 7);
             let masks = mask_matrix(w, h);
             for (label, m) in masks {
-                for tol in [0u8, 10] {
-                    assert_eq!(
-                        diff_with_mask(&a, &b, tol, &m).unwrap(),
-                        reference_diff_masked(&a, &b, tol, &m),
-                        "{w}x{h} tol={tol} mask={label}"
-                    );
+                for tol in [0u8, 1, 10, 127, 254, 255] {
+                    let expected = reference_diff_masked(&a, &b, tol, &m);
+                    for level in [fearless_simd::Level::baseline(), crate::simd_level()] {
+                        assert_eq!(
+                            dispatch!(level, simd => diff_with_mask_simd(simd, &a, &b, tol, &m))
+                                .unwrap(),
+                            expected,
+                            "{level:?} {w}x{h} tol={tol} mask={label}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn simd_pixel_bits_match_scalar_for_every_channel_and_mask() {
+        let (w, h) = (17, 3);
+        let a = Frame::solid(w, h, [0; 4]);
+        for pattern in 0u16..=255 {
+            for channel in 0..4 {
+                let mut b = a.clone();
+                for (px, pixel) in b.pixels.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+                    if pattern & (1 << (px % w as usize % 8)) != 0 {
+                        pixel[channel] = [1, 127, 128, 254, 255][px % 5];
+                    }
+                }
+                for (label, mask) in mask_matrix(w, h) {
+                    for tolerance in [0, 1, 127, 254, 255] {
+                        let expected = reference_diff_masked(&a, &b, tolerance, &mask);
+                        for level in [fearless_simd::Level::baseline(), crate::simd_level()] {
+                            assert_eq!(
+                                dispatch!(level, simd => diff_with_mask_simd(simd, &a, &b, tolerance, &mask)).unwrap(),
+                                expected,
+                                "{level:?} pattern={pattern:08b} channel={channel} tolerance={tolerance} mask={label}"
+                            );
+                        }
+                    }
                 }
             }
         }
@@ -1806,12 +1873,15 @@ mod tests {
             let a = make(w, h, 1);
             let b = make(w, h, 5);
             for (label, m) in mask_matrix(w, h) {
-                for thr in [0.02f32, 0.1, 0.4] {
-                    assert_eq!(
-                        diff_perceptual_with_mask(&a, &b, thr, &m).unwrap(),
-                        reference_perceptual_masked(&a, &b, thr, &m),
-                        "{w}x{h} thr={thr} mask={label}"
-                    );
+                for thr in [0.0f32, 0.02, 0.1, 0.4, 1.0] {
+                    let expected = reference_perceptual_masked(&a, &b, thr, &m);
+                    for level in [fearless_simd::Level::baseline(), crate::simd_level()] {
+                        assert_eq!(
+                            dispatch!(level, simd => diff_perceptual_with_mask_simd(simd, &a, &b, thr, &m)).unwrap(),
+                            expected,
+                            "{level:?} {w}x{h} thr={thr} mask={label}"
+                        );
+                    }
                 }
             }
         }

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(portable_simd)]
 //! glass-core: platform-agnostic core for the glass UI-automation harness.
 //!
 //! No OS/windowing types appear here; every backend detail lives behind the
@@ -132,3 +131,9 @@ pub use session::{
     SetValueTargetParams, TypeTargetParams, WaitElementOutcome, WaitElementParams, WaitLogOutcome,
     WaitLogParams, WaitRegionOutcome, WaitRegionParams, WaitStableOutcome, WaitStableParams,
 };
+
+fn simd_level() -> fearless_simd::Level {
+    static LEVEL: std::sync::LazyLock<fearless_simd::Level> =
+        std::sync::LazyLock::new(fearless_simd::Level::new);
+    *LEVEL
+}

--- a/crates/glass-core/src/pixels.rs
+++ b/crates/glass-core/src/pixels.rs
@@ -64,6 +64,10 @@ fn convert<S: Simd, const SWAP: bool>(simd: S, src: &[u8], dst: &mut [u8]) {
     }
     // Scalar tail (< 8 pixels). A trailing run shorter than one pixel is left
     // untouched, matching the per-backend buffers (always whole `w*h*4` pixels).
+    debug_assert!(
+        src.len() - off < LANES,
+        "SIMD loop must consume every full chunk"
+    );
     while off + 4 <= src.len() {
         let (r, b) = if SWAP {
             (src[off + 2], src[off])
@@ -84,6 +88,10 @@ fn convert_in_place<S: Simd, const SWAP: bool>(simd: S, buf: &mut [u8]) {
     let buf = if !SWAP && simd.level().as_avx2().is_some() {
         // Align whole pixels to avoid split AVX2 accesses on 16-byte-aligned buffers.
         let prefix = (buf.as_ptr().align_offset(LANES) & !3).min(buf.len() / 4 * 4);
+        debug_assert!(
+            prefix < LANES,
+            "alignment prefix must be shorter than one SIMD chunk"
+        );
         let (head, rest) = buf.split_at_mut(prefix);
         let alpha = fearless_simd::u8x16::simd_from(
             simd,

--- a/crates/glass-core/src/pixels.rs
+++ b/crates/glass-core/src/pixels.rs
@@ -7,20 +7,9 @@
 //! their own validation, stride handling, and buffer allocation; they call in here
 //! for the hot loop so the vectorized kernel exists in exactly one place.
 
-use std::simd::{simd_swizzle, u8x32};
+use fearless_simd::{dispatch, prelude::*, u8x32};
 
 const LANES: usize = 32; // 8 pixels per SIMD chunk (4 bytes each)
-
-/// `[B,G,R,_]` -> `[R,G,B,_]`: swap bytes 0 and 2 within each 4-byte pixel.
-const SWAP_RB: [usize; LANES] = [
-    2, 1, 0, 3, 6, 5, 4, 7, 10, 9, 8, 11, 14, 13, 12, 15, //
-    18, 17, 16, 19, 22, 21, 20, 23, 26, 25, 24, 27, 30, 29, 28, 31,
-];
-/// Identity: source is already `[R,G,B,_]`, only alpha needs forcing.
-const IDENTITY: [usize; LANES] = [
-    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, //
-    16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
-];
 
 /// Channel order of a 32-bit source pixel relative to the RGBA target.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -34,31 +23,43 @@ pub enum SourceOrder {
 
 /// OR-ing this onto a chunk forces each pixel's alpha lane to 255
 /// (`pad | 255 == 255`) and leaves R/G/B untouched (`x | 0 == x`).
-#[inline]
-fn alpha_mask() -> u8x32 {
-    u8x32::from_array([
-        0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, 255, //
-        0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, 255,
-    ])
+#[inline(always)]
+fn alpha_mask<S: Simd>(simd: S) -> u8x32<S> {
+    u8x32::simd_from(
+        simd,
+        [
+            0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, 255, //
+            0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, 255,
+        ],
+    )
 }
 
 /// Swizzle one 8-pixel chunk and force its alpha opaque. `SWAP` is a const
 /// generic so the unused branch is dropped at monomorphization.
-#[inline]
-fn swizzle_chunk<const SWAP: bool>(v: u8x32, alpha: u8x32) -> u8x32 {
+#[inline(always)]
+fn swizzle_chunk<S: Simd, const SWAP: bool>(v: u8x32<S>, alpha: u8x32<S>) -> u8x32<S> {
     if SWAP {
-        simd_swizzle!(v, SWAP_RB) | alpha
+        v.swizzle_dyn_within_blocks(u8x32::simd_from(
+            v.simd,
+            [
+                2, 1, 0, 3, 6, 5, 4, 7, 10, 9, 8, 11, 14, 13, 12, 15, 2, 1, 0, 3, 6, 5, 4, 7, 10,
+                9, 8, 11, 14, 13, 12, 15,
+            ],
+        )) | alpha
     } else {
-        simd_swizzle!(v, IDENTITY) | alpha
+        v | alpha
     }
 }
 
-fn convert<const SWAP: bool>(src: &[u8], dst: &mut [u8]) {
-    let alpha = alpha_mask();
+#[inline(always)]
+fn convert<S: Simd, const SWAP: bool>(simd: S, src: &[u8], dst: &mut [u8]) {
+    let dst = &mut dst[..src.len()];
+    let end = src.len() / LANES * LANES;
+    let alpha = alpha_mask(simd);
     let mut off = 0;
-    while off + LANES <= src.len() {
-        let v = u8x32::from_slice(&src[off..off + LANES]);
-        swizzle_chunk::<SWAP>(v, alpha).copy_to_slice(&mut dst[off..off + LANES]);
+    while off < end {
+        let v = u8x32::from_slice(simd, &src[off..off + LANES]);
+        swizzle_chunk::<S, SWAP>(v, alpha).store_slice(&mut dst[off..off + LANES]);
         off += LANES;
     }
     // Scalar tail (< 8 pixels). A trailing run shorter than one pixel is left
@@ -77,20 +78,39 @@ fn convert<const SWAP: bool>(src: &[u8], dst: &mut [u8]) {
     }
 }
 
-fn convert_in_place<const SWAP: bool>(buf: &mut [u8]) {
-    let alpha = alpha_mask();
-    let mut off = 0;
-    while off + LANES <= buf.len() {
-        let v = u8x32::from_slice(&buf[off..off + LANES]);
-        swizzle_chunk::<SWAP>(v, alpha).copy_to_slice(&mut buf[off..off + LANES]);
-        off += LANES;
-    }
-    while off + 4 <= buf.len() {
-        if SWAP {
-            buf.swap(off, off + 2);
+#[inline(always)]
+fn convert_in_place<S: Simd, const SWAP: bool>(simd: S, buf: &mut [u8]) {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    let buf = if !SWAP && simd.level().as_avx2().is_some() {
+        // Align whole pixels to avoid split AVX2 accesses on 16-byte-aligned buffers.
+        let prefix = (buf.as_ptr().align_offset(LANES) & !3).min(buf.len() / 4 * 4);
+        let (head, rest) = buf.split_at_mut(prefix);
+        let alpha = fearless_simd::u8x16::simd_from(
+            simd,
+            [0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, 255],
+        );
+        let (chunks, tail) = head.as_chunks_mut::<16>();
+        for chunk in chunks {
+            (fearless_simd::u8x16::from_slice(simd, chunk) | alpha).store_slice(chunk);
         }
-        buf[off + 3] = 255;
-        off += 4;
+        for pixel in tail.as_chunks_mut::<4>().0 {
+            pixel[3] = 255;
+        }
+        rest
+    } else {
+        buf
+    };
+    let alpha = alpha_mask(simd);
+    let (chunks, tail) = buf.as_chunks_mut::<LANES>();
+    for chunk in chunks {
+        let v = u8x32::from_slice(simd, chunk);
+        swizzle_chunk::<S, SWAP>(v, alpha).store_slice(chunk);
+    }
+    for pixel in tail.as_chunks_mut::<4>().0 {
+        if SWAP {
+            pixel.swap(0, 2);
+        }
+        pixel[3] = 255;
     }
 }
 
@@ -100,9 +120,22 @@ fn convert_in_place<const SWAP: bool>(buf: &mut [u8]) {
 /// whole 4-byte pixel are left untouched. Every alpha byte is forced to 255.
 pub fn to_opaque_rgba(src: &[u8], dst: &mut [u8], order: SourceOrder) {
     debug_assert_eq!(src.len(), dst.len(), "src and dst must be the same length");
+    // NEON is the baseline on these targets; direct dispatch also keeps tiny rows cheap.
+    #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+    if let Some(simd) = fearless_simd::Level::baseline().as_neon() {
+        match order {
+            SourceOrder::Bgr => convert::<_, true>(simd, src, dst),
+            SourceOrder::Rgb => convert::<_, false>(simd, src, dst),
+        }
+        return;
+    }
     match order {
-        SourceOrder::Bgr => convert::<true>(src, dst),
-        SourceOrder::Rgb => convert::<false>(src, dst),
+        SourceOrder::Bgr => {
+            dispatch!(crate::simd_level(), simd => convert::<_, true>(simd, src, dst))
+        }
+        SourceOrder::Rgb => {
+            dispatch!(crate::simd_level(), simd => convert::<_, false>(simd, src, dst))
+        }
     }
 }
 
@@ -110,8 +143,12 @@ pub fn to_opaque_rgba(src: &[u8], dst: &mut [u8], order: SourceOrder) {
 /// to opaque RGBA, swapping R/B per `order` and forcing every alpha byte to 255.
 pub fn to_opaque_rgba_in_place(buf: &mut [u8], order: SourceOrder) {
     match order {
-        SourceOrder::Bgr => convert_in_place::<true>(buf),
-        SourceOrder::Rgb => convert_in_place::<false>(buf),
+        SourceOrder::Bgr => {
+            dispatch!(crate::simd_level(), simd => convert_in_place::<_, true>(simd, buf))
+        }
+        SourceOrder::Rgb => {
+            dispatch!(crate::simd_level(), simd => convert_in_place::<_, false>(simd, buf))
+        }
     }
 }
 
@@ -121,7 +158,9 @@ mod tests {
 
     /// Scalar reference: swap R/B per `order`, force alpha to 255.
     fn reference(data: &[u8], order: SourceOrder) -> Vec<u8> {
-        data.chunks_exact(4)
+        data.as_chunks::<4>()
+            .0
+            .iter()
             .flat_map(|p| match order {
                 SourceOrder::Bgr => [p[2], p[1], p[0], 255],
                 SourceOrder::Rgb => [p[0], p[1], p[2], 255],
@@ -181,5 +220,58 @@ mod tests {
         let mut buf = vec![1u8, 2, 3, 4, 9, 9]; // one full px + 2 stray bytes
         to_opaque_rgba_in_place(&mut buf, SourceOrder::Bgr);
         assert_eq!(buf, vec![3, 2, 1, 255, 9, 9]);
+    }
+
+    #[test]
+    fn simd_backends_match_scalar_at_every_alignment_and_tail() {
+        for level in [fearless_simd::Level::baseline(), crate::simd_level()] {
+            for alignment in 0usize..64 {
+                for len in (0usize..1028).chain([4095, 4096, 4097, 8191, 8192, 8193]) {
+                    for order in [SourceOrder::Rgb, SourceOrder::Bgr] {
+                        let mut actual: Vec<u8> = (0..len + 128)
+                            .map(|i| i.wrapping_mul(73).rotate_left((i % 13) as u32) as u8)
+                            .collect();
+                        let offset = actual.as_ptr().align_offset(64) + alignment;
+                        let src = &actual[offset..offset + len];
+                        let converted = reference(src, order);
+                        let mut expected = actual.clone();
+                        expected[offset..offset + converted.len()].copy_from_slice(&converted);
+
+                        let mut out = vec![42; len + 128];
+                        let dst_offset = out.as_ptr().align_offset(64) + (alignment * 13 + 7) % 64;
+                        let mut expected_out = out.clone();
+                        expected_out[dst_offset..dst_offset + converted.len()]
+                            .copy_from_slice(&converted);
+                        let dst = &mut out[dst_offset..dst_offset + len];
+                        match order {
+                            SourceOrder::Bgr => {
+                                dispatch!(level, simd => convert::<_, true>(simd, src, dst))
+                            }
+                            SourceOrder::Rgb => {
+                                dispatch!(level, simd => convert::<_, false>(simd, src, dst))
+                            }
+                        }
+                        assert_eq!(
+                            out, expected_out,
+                            "out-of-place {level:?} alignment={alignment} len={len} {order:?}"
+                        );
+
+                        let buf = &mut actual[offset..offset + len];
+                        match order {
+                            SourceOrder::Bgr => {
+                                dispatch!(level, simd => convert_in_place::<_, true>(simd, buf))
+                            }
+                            SourceOrder::Rgb => {
+                                dispatch!(level, simd => convert_in_place::<_, false>(simd, buf))
+                            }
+                        }
+                        assert_eq!(
+                            actual, expected,
+                            "in-place {level:?} alignment={alignment} len={len} {order:?}"
+                        );
+                    }
+                }
+            }
+        }
     }
 }

--- a/crates/glass-core/src/session/mod.rs
+++ b/crates/glass-core/src/session/mod.rs
@@ -243,7 +243,6 @@ mod test_support;
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::session::test_support::*;
 
     #[test]

--- a/docs/how-to/benchmarking.md
+++ b/docs/how-to/benchmarking.md
@@ -16,6 +16,19 @@ cargo bench $PKGS -- --baseline main
 would reject criterion's `--save-baseline` / `--baseline` flags). The `pixels` bench exists in all
 three backends, so name the crate with `-p` to flamegraph one.
 
+Pixel normalization and frame comparison use `fearless_simd`, with CPU features detected once
+and cached. On x86 this selects the available SSE2, SSE4.2, AVX2, or AVX-512 backend; AArch64 uses NEON.
+The core SIMD code works on stable Rust. The workspace still pins nightly for the Windows
+clipboard shim's `retour` static detours.
+
+When comparing portable builds, clear local CPU-specific flags (such as `target-cpu=native` or
+`target-cpu=haswell`), so both builds target the same baseline:
+
+```bash
+env -u CARGO_ENCODED_RUSTFLAGS -u CARGO_BUILD_RUSTFLAGS RUSTFLAGS='' \
+  cargo +stable bench -p glass-core --locked
+```
+
 Profile a hot path as a flamegraph (needs
 [`cargo install flamegraph`](https://github.com/flamegraph-rs/flamegraph) and
 `kernel.perf_event_paranoid <= 1`):


### PR DESCRIPTION
Glass core currently needs nightly for `std::simd` in pixel conversion and frame comparison. Replace it with the published `fearless_simd` **0.7.0** release and cached CPU dispatch so the core builds on stable Rust. The lockfile adds only this dependency; its checksum and source match the crate used for performance validation.

Exact diff counts changed pixels with one bit per RGBA pixel while preserving tolerance, ignore-mask, and bounding-box behavior. Pixel conversion uses block-local channel shuffles, direct baseline NEON dispatch, and an AVX2 alignment prefix for in-place RGB buffers. Regression tests compare baseline and detected SIMD backends with scalar references across byte alignments, partial pixels, channel orders, change masks, and tolerance boundaries.

Debug assertions keep the scalar tail and AVX2 alignment prefix shorter than one SIMD chunk. This lets the tests catch mutations that still produce correct pixels while bypassing the intended SIMD work, without adding work to release builds.

The workspace remains pinned to nightly because the Windows clipboard shim still uses `retour` static detours. Migrating those detours and changing the workspace toolchain are separate work.

### Validation

All checks passed with CPU-specific Rust flags cleared:

- Pinned nightly: workspace build and Clippy with all targets on Linux x86-64 and Apple M4; formatting passes.
- Workspace tests: 3,743 passed on Linux; 3,155 passed on macOS with `--lib`.
- Stable Rust 1.98.1: workspace builds, core Clippy with all targets, and all 1,027 core unit tests pass on both hosts.
- Windows GNU cross-compilation: workspace/all-target Clippy passes with a fresh target directory. Native Windows/MSVC execution remains for CI.
- Normal release server tool schemas match the previous implementation.
- Reapplied the four pixel-conversion mutations reported by CI in an isolated checkout; all four fail the existing scalar parity test at the new bounds assertions.

Release performance comparisons covered 45 cases per host, with repeated runs, including conversion sizes through 4K and exact/perceptual frame comparisons. They found no consistent regression against the original nightly implementation in the measured paths; the final x86 1080p full-change exact diff was about 3.3× faster. Small timing differences were checked against repeated runs, generated instructions, and identical-binary controls. These are kernel/server-build measurements, not end-to-end GUI capture timings.
