### PR TITLE
Replace Windows static detours and switch to stable Rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       # rustup installs the pinned toolchain + rustfmt from rust-toolchain.toml,
-      # so CI formats with the same nightly the build uses.
+      # so CI formats with the same toolchain the build uses.
       - name: Install pinned toolchain
         run: rustup show
       - run: cargo fmt --all --check
@@ -39,7 +39,7 @@ jobs:
       - name: Test interaction benchmark
         run: python3 -m unittest discover -s tools/interaction-bench/tests
       # rustup auto-installs the pinned toolchain + components from
-      # rust-toolchain.toml (single source of truth for the nightly).
+      # rust-toolchain.toml (single source of truth for the toolchain).
       - name: Install pinned toolchain
         run: rustup show
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -151,7 +151,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       # rustup auto-installs the pinned toolchain + components from
-      # rust-toolchain.toml (single source of truth for the nightly).
+      # rust-toolchain.toml (single source of truth for the toolchain).
       - name: Install pinned toolchain
         run: rustup show
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ cargo test -p glass-wayland -- --include-ignored  # + its 64 sway-backed unit te
 ./scripts/test-wayland.sh [name]          # Wayland suite (needs sway >=1.12)
 ./scripts/test-a11y.sh [name]             # AT-SPI suite
 ```
-The workspace is pinned to nightly via `rust-toolchain.toml`.
+The workspace is pinned to stable Rust via `rust-toolchain.toml`.
 
 Those cover Linux. They do **not** compile `cfg(target_os = "macos")` or `cfg(windows)` code, so on
 a change to a platform crate they report clean without having looked at it —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ cargo test -p glass-wayland -- --include-ignored  # + its 64 sway-backed unit te
 ./scripts/test-wayland.sh [name]          # Wayland suite (needs sway >=1.12)
 ./scripts/test-a11y.sh [name]             # AT-SPI suite
 ```
-The workspace is pinned to nightly via `rust-toolchain.toml`.
+The workspace is pinned to stable Rust via `rust-toolchain.toml`.
 
 Those cover Linux. They do **not** compile `cfg(target_os = "macos")` or `cfg(windows)` code, so on
 a change to a platform crate they report clean without having looked at it —

--- a/crates/glass-clip-shim-windows/Cargo.toml
+++ b/crates/glass-clip-shim-windows/Cargo.toml
@@ -34,10 +34,8 @@ windows = { version = "0.62", features = [
 # `windows::core` is only an alias, not that crate name). Depend on `windows-core` directly — same
 # 0.62.2 the umbrella `windows` pins, so the COM/IUnknown types unify with the ones above.
 windows-core = "0.62"
-# Inline detours. License verified permissive in this task's Step 6 (MIT/BSD); IAT fallback documented.
-# `static-detour` enables the `static_detour!` macro (the type-safe detour table); it pulls in the
-# `nightly` feature — fine, the workspace is pinned to nightly (rust-toolchain.toml).
-retour = { version = "0.3", features = ["static-detour"] }
+# Typed inline detours; GenericDetour works without nightly features.
+retour = "0.3"
 
 [target.'cfg(windows)'.dev-dependencies]
 windows = { version = "0.62", features = ["Win32_System_WindowsProgramming"] }

--- a/crates/glass-clip-shim-windows/examples/clipprobe.rs
+++ b/crates/glass-clip-shim-windows/examples/clipprobe.rs
@@ -222,7 +222,9 @@ fn run_multi() -> i32 {
         let text_rb = read_global_bytes(cf_text)
             .map(|b| {
                 let units: Vec<u16> = b
-                    .chunks_exact(2)
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
                     .map(|c| u16::from_le_bytes([c[0], c[1]]))
                     .collect();
                 let len = units.iter().position(|&u| u == 0).unwrap_or(units.len());
@@ -491,7 +493,9 @@ impl windows::Win32::System::Com::IDataObject_Impl for ProbeData_Impl {
 #[cfg(windows)]
 fn utf16_to_string(bytes: &[u8]) -> String {
     let units: Vec<u16> = bytes
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|c| u16::from_le_bytes([c[0], c[1]]))
         .collect();
     let len = units.iter().position(|&u| u == 0).unwrap_or(units.len());

--- a/crates/glass-clip-shim-windows/src/hook.rs
+++ b/crates/glass-clip-shim-windows/src/hook.rs
@@ -30,6 +30,7 @@ use windows::Win32::System::DataExchange::{GetClipboardFormatNameW, RegisterClip
 use crate::proto::{self, FormatKey, Request, Response};
 
 mod dataobject;
+mod detour;
 mod detour_impl;
 mod ole;
 
@@ -295,7 +296,9 @@ pub(crate) fn alloc_hglobal_bytes(bytes: &[u8]) -> Option<HGLOBAL> {
 pub(crate) fn unicode_to_codepage(utf16_bytes: &[u8], oem: bool) -> Vec<u8> {
     use windows::Win32::Globalization::{CP_ACP, CP_OEMCP, WideCharToMultiByte};
     let units: Vec<u16> = utf16_bytes
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|c| u16::from_le_bytes([c[0], c[1]]))
         .collect();
     let cp = if oem { CP_OEMCP } else { CP_ACP };

--- a/crates/glass-clip-shim-windows/src/hook/detour.rs
+++ b/crates/glass-clip-shim-windows/src/hook/detour.rs
@@ -1,0 +1,90 @@
+//! Typed inline hooks retained for the injected DLL's lifetime.
+
+use std::sync::OnceLock;
+
+use retour::{Error, Function, GenericDetour, HookableWith};
+
+pub(super) struct Detour<T: Function>(OnceLock<GenericDetour<T>>);
+
+impl<T: HookableWith<T>> Detour<T> {
+    pub(super) const fn new() -> Self {
+        Self(OnceLock::new())
+    }
+
+    /// # Safety
+    /// Both functions must remain executable for the DLL's lifetime, and `replacement` must
+    /// satisfy the target's calling contract. Installation must not race with calls to, or
+    /// other modifications of, the target's prologue.
+    pub(super) unsafe fn install(&'static self, target: T, replacement: T) -> retour::Result<()> {
+        if self.0.get().is_some() {
+            return Err(Error::AlreadyInitialized);
+        }
+        // SAFETY: the caller supplies live functions with matching ABIs and exclusive patching.
+        let hook = unsafe { GenericDetour::new(target, replacement) }?;
+        self.0.set(hook).map_err(|_| Error::AlreadyInitialized)?;
+        let hook = self.0.get().expect("detour was just stored");
+        // SAFETY: static storage retains the trampoline and any relay before the patch goes live,
+        // including if enabling fails. The caller guarantees exclusive access to the prologue.
+        unsafe { hook.enable() }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::hint::black_box;
+
+    use super::*;
+
+    type BinaryFn = unsafe extern "system" fn(usize, usize) -> usize;
+
+    // Keep distinct, patchable bodies and opaque calls even in release builds.
+    #[inline(never)]
+    unsafe extern "system" fn add(a: usize, b: usize) -> usize {
+        black_box(a).wrapping_add(black_box(b))
+    }
+
+    #[inline(never)]
+    unsafe extern "system" fn subtract(a: usize, b: usize) -> usize {
+        black_box(a).wrapping_sub(black_box(b))
+    }
+
+    #[inline(never)]
+    unsafe extern "system" fn multiply(a: usize, b: usize) -> usize {
+        black_box(a).wrapping_mul(black_box(b))
+    }
+
+    #[test]
+    fn installed_hook_survives_return_and_rejects_reinitialization() {
+        static HOOK: Detour<BinaryFn> = Detour::new();
+        let target = black_box(add as BinaryFn);
+        // SAFETY: these integer-only functions are live for the process lifetime. Only this test
+        // calls or patches `add`, and all calls happen outside installation.
+        unsafe {
+            assert_eq!(target(19, 7), 26);
+            HOOK.install(target, subtract).unwrap();
+            assert_eq!(target(19, 7), 12);
+            assert!(matches!(
+                HOOK.install(target, multiply),
+                Err(Error::AlreadyInitialized)
+            ));
+            assert_eq!(target(19, 7), 12);
+        }
+    }
+
+    #[test]
+    fn failed_creation_leaves_hook_available_for_retry() {
+        static HOOK: Detour<BinaryFn> = Detour::new();
+        let target = black_box(multiply as BinaryFn);
+        // SAFETY: only this test calls or patches `multiply`. Both functions have matching ABIs,
+        // accept all integer inputs, and stay executable for the process lifetime.
+        unsafe {
+            assert!(matches!(
+                HOOK.install(target, target),
+                Err(Error::SameAddress)
+            ));
+            assert_eq!(target(19, 7), 133);
+            HOOK.install(target, subtract).unwrap();
+            assert_eq!(target(19, 7), 12);
+        }
+    }
+}

--- a/crates/glass-clip-shim-windows/src/hook/detour_impl.rs
+++ b/crates/glass-clip-shim-windows/src/hook/detour_impl.rs
@@ -1,4 +1,4 @@
-//! The `retour` static-detour table for the user32 clipboard APIs.
+//! The `retour` typed detours for the user32 clipboard APIs.
 //!
 //! Each detour mirrors the exact Win32 ABI of its export (raw newtypes, `extern "system"`), is
 //! resolved to an absolute address via `GetProcAddress` (so *every* call site in the process is
@@ -12,13 +12,13 @@
 
 use std::cell::{Cell, RefCell};
 
-use retour::static_detour;
 use windows::Win32::Foundation::{GlobalFree, HANDLE, HGLOBAL, HWND};
 use windows::Win32::Graphics::Gdi::{DeleteObject, HBITMAP, HGDIOBJ};
 use windows::core::BOOL;
 
 use crate::proto::FormatKey;
 
+use super::detour::Detour;
 use super::{
     CF_BITMAP, CF_DIBV5, CF_LOCALE, CF_OEMTEXT, CF_TEXT, alloc_hglobal_bytes, id_of, key_of,
     locale_blob, read_bytes_from_hglobal, store_empty, store_get_bytes, store_list, store_seq,
@@ -37,17 +37,15 @@ type FnCountClipboardFormats = unsafe extern "system" fn() -> i32;
 type FnEnumClipboardFormats = unsafe extern "system" fn(u32) -> u32;
 type FnGetClipboardSequenceNumber = unsafe extern "system" fn() -> u32;
 
-static_detour! {
-    static OpenClipboardHook: unsafe extern "system" fn(HWND) -> BOOL;
-    static CloseClipboardHook: unsafe extern "system" fn() -> BOOL;
-    static EmptyClipboardHook: unsafe extern "system" fn() -> BOOL;
-    static SetClipboardDataHook: unsafe extern "system" fn(u32, HANDLE) -> HANDLE;
-    static GetClipboardDataHook: unsafe extern "system" fn(u32) -> HANDLE;
-    static IsClipboardFormatAvailableHook: unsafe extern "system" fn(u32) -> BOOL;
-    static CountClipboardFormatsHook: unsafe extern "system" fn() -> i32;
-    static EnumClipboardFormatsHook: unsafe extern "system" fn(u32) -> u32;
-    static GetClipboardSequenceNumberHook: unsafe extern "system" fn() -> u32;
-}
+static OPEN_CLIPBOARD_HOOK: Detour<FnOpenClipboard> = Detour::new();
+static CLOSE_CLIPBOARD_HOOK: Detour<FnCloseClipboard> = Detour::new();
+static EMPTY_CLIPBOARD_HOOK: Detour<FnEmptyClipboard> = Detour::new();
+static SET_CLIPBOARD_DATA_HOOK: Detour<FnSetClipboardData> = Detour::new();
+static GET_CLIPBOARD_DATA_HOOK: Detour<FnGetClipboardData> = Detour::new();
+static IS_CLIPBOARD_FORMAT_AVAILABLE_HOOK: Detour<FnIsClipboardFormatAvailable> = Detour::new();
+static COUNT_CLIPBOARD_FORMATS_HOOK: Detour<FnCountClipboardFormats> = Detour::new();
+static ENUM_CLIPBOARD_FORMATS_HOOK: Detour<FnEnumClipboardFormats> = Detour::new();
+static GET_CLIPBOARD_SEQUENCE_NUMBER_HOOK: Detour<FnGetClipboardSequenceNumber> = Detour::new();
 
 /// What kind of resource the cached handle is, so it is freed via the right Win32 destructor.
 #[derive(Clone, Copy, PartialEq)]
@@ -194,7 +192,7 @@ fn make_bitmap_handle(dib: &[u8]) -> Option<HANDLE> {
 // invariant, even though the closures touch raw pointers / thread-local `Cell`s.
 
 /// `OpenClipboard(hwnd)` → mark open; always succeed. Never touches the real clipboard.
-fn open_clipboard(_hwnd: HWND) -> BOOL {
+unsafe extern "system" fn open_clipboard(_hwnd: HWND) -> BOOL {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         free_cached_handle();
         CLIP_OPEN.with(|c| c.set(true));
@@ -205,7 +203,7 @@ fn open_clipboard(_hwnd: HWND) -> BOOL {
 
 /// `CloseClipboard()` → mark closed; commit the pending multi-format copy as one atomic `SetAll`
 /// (one transaction / one seq bump); free the cached handle. Always succeed.
-fn close_clipboard() -> BOOL {
+unsafe extern "system" fn close_clipboard() -> BOOL {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         CLIP_OPEN.with(|c| c.set(false));
         let items = PENDING.with(|p| std::mem::take(&mut *p.borrow_mut()));
@@ -219,7 +217,7 @@ fn close_clipboard() -> BOOL {
 }
 
 /// `EmptyClipboard()` → drop any pending copy, clear the host store, free the cached handle.
-fn empty_clipboard() -> BOOL {
+unsafe extern "system" fn empty_clipboard() -> BOOL {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         PENDING.with(|p| p.borrow_mut().clear());
         store_empty();
@@ -233,7 +231,7 @@ fn empty_clipboard() -> BOOL {
 /// set (committed atomically on `CloseClipboard`). Returns `h` (the contract: the clipboard now
 /// "owns" it; we keep the store as the source of truth). `h == NULL` is delayed rendering — out of
 /// scope (OLE apps covered separately in 2a-ii): skip, no change.
-fn set_clipboard_data(fmt: u32, h: HANDLE) -> HANDLE {
+unsafe extern "system" fn set_clipboard_data(fmt: u32, h: HANDLE) -> HANDLE {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         if h.0.is_null() {
             return HANDLE::default(); // delayed rendering unsupported
@@ -255,7 +253,7 @@ fn set_clipboard_data(fmt: u32, h: HANDLE) -> HANDLE {
 /// `GetClipboardData(fmt)` → resolve the format's bytes (stored verbatim or synthesized), then hand
 /// back a handle the app needn't free (we free on next open/empty/close): a GDI `HBITMAP` for
 /// `CF_BITMAP`, otherwise a fresh `HGLOBAL`. NULL if unavailable or the pipe is down.
-fn get_clipboard_data(fmt: u32) -> HANDLE {
+unsafe extern "system" fn get_clipboard_data(fmt: u32) -> HANDLE {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         let key = key_of(fmt);
         let Some(bytes) = resolve_bytes(fmt, &key) else {
@@ -276,7 +274,7 @@ fn get_clipboard_data(fmt: u32) -> HANDLE {
 }
 
 /// `IsClipboardFormatAvailable(fmt)` → TRUE iff `fmt` is among the stored/synthesizable formats.
-fn is_clipboard_format_available(fmt: u32) -> BOOL {
+unsafe extern "system" fn is_clipboard_format_available(fmt: u32) -> BOOL {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         BOOL(available_ids().contains(&fmt) as i32)
     }))
@@ -284,7 +282,7 @@ fn is_clipboard_format_available(fmt: u32) -> BOOL {
 }
 
 /// `CountClipboardFormats()` → the number of stored/synthesizable formats.
-fn count_clipboard_formats() -> i32 {
+unsafe extern "system" fn count_clipboard_formats() -> i32 {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         available_ids().len() as i32
     }))
@@ -293,7 +291,7 @@ fn count_clipboard_formats() -> i32 {
 
 /// `EnumClipboardFormats(prev)` → walk the stored/synthesizable formats in order: `0` yields the
 /// first; otherwise the one after `prev`; `0` again at the end of the list.
-fn enum_clipboard_formats(prev: u32) -> u32 {
+unsafe extern "system" fn enum_clipboard_formats(prev: u32) -> u32 {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         let ids = available_ids();
         match prev {
@@ -310,7 +308,7 @@ fn enum_clipboard_formats(prev: u32) -> u32 {
 }
 
 /// `GetClipboardSequenceNumber()` → the host store's sequence number (bumps on every set/empty).
-fn get_clipboard_sequence_number() -> u32 {
+unsafe extern "system" fn get_clipboard_sequence_number() -> u32 {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(store_seq)).unwrap_or(0)
 }
 
@@ -320,89 +318,47 @@ fn get_clipboard_sequence_number() -> u32 {
 /// unresolved/uninitialisable export is logged-by-omission and skipped, never panicking (a panic
 /// across the FFI boundary in `InjectDllMain` would take down the boxed app).
 pub(super) fn install() {
-    // SAFETY (whole block): each `user32_proc` returns the absolute address of the named export,
-    // which we transmute to that export's exact ABI signature (verified against windows-rs `link!`
-    // declarations). `retour`'s `initialize` then trampolines the target and routes calls to our
-    // hook; `enable` patches the prologue. Both are `unsafe` by contract. Every step is fallible
-    // and we `let _ =` / `if let` to stay fail-soft — we never unwrap across the FFI boundary.
+    // SAFETY: user32_proc resolves live exports with the exact signatures below. Initialization
+    // runs once during DLL injection, before the app resumes calling these APIs. Each replacement
+    // implements its export's calling contract and remains loaded with the shim.
     unsafe {
         if let Some(p) = user32_proc(b"OpenClipboard\0") {
             let target: FnOpenClipboard = std::mem::transmute(p);
-            if OpenClipboardHook.initialize(target, open_clipboard).is_ok() {
-                let _ = OpenClipboardHook.enable();
-            }
+            let _ = OPEN_CLIPBOARD_HOOK.install(target, open_clipboard);
         }
         if let Some(p) = user32_proc(b"CloseClipboard\0") {
             let target: FnCloseClipboard = std::mem::transmute(p);
-            if CloseClipboardHook
-                .initialize(target, close_clipboard)
-                .is_ok()
-            {
-                let _ = CloseClipboardHook.enable();
-            }
+            let _ = CLOSE_CLIPBOARD_HOOK.install(target, close_clipboard);
         }
         if let Some(p) = user32_proc(b"EmptyClipboard\0") {
             let target: FnEmptyClipboard = std::mem::transmute(p);
-            if EmptyClipboardHook
-                .initialize(target, empty_clipboard)
-                .is_ok()
-            {
-                let _ = EmptyClipboardHook.enable();
-            }
+            let _ = EMPTY_CLIPBOARD_HOOK.install(target, empty_clipboard);
         }
         if let Some(p) = user32_proc(b"SetClipboardData\0") {
             let target: FnSetClipboardData = std::mem::transmute(p);
-            if SetClipboardDataHook
-                .initialize(target, set_clipboard_data)
-                .is_ok()
-            {
-                let _ = SetClipboardDataHook.enable();
-            }
+            let _ = SET_CLIPBOARD_DATA_HOOK.install(target, set_clipboard_data);
         }
         if let Some(p) = user32_proc(b"GetClipboardData\0") {
             let target: FnGetClipboardData = std::mem::transmute(p);
-            if GetClipboardDataHook
-                .initialize(target, get_clipboard_data)
-                .is_ok()
-            {
-                let _ = GetClipboardDataHook.enable();
-            }
+            let _ = GET_CLIPBOARD_DATA_HOOK.install(target, get_clipboard_data);
         }
         if let Some(p) = user32_proc(b"IsClipboardFormatAvailable\0") {
             let target: FnIsClipboardFormatAvailable = std::mem::transmute(p);
-            if IsClipboardFormatAvailableHook
-                .initialize(target, is_clipboard_format_available)
-                .is_ok()
-            {
-                let _ = IsClipboardFormatAvailableHook.enable();
-            }
+            let _ =
+                IS_CLIPBOARD_FORMAT_AVAILABLE_HOOK.install(target, is_clipboard_format_available);
         }
         if let Some(p) = user32_proc(b"CountClipboardFormats\0") {
             let target: FnCountClipboardFormats = std::mem::transmute(p);
-            if CountClipboardFormatsHook
-                .initialize(target, count_clipboard_formats)
-                .is_ok()
-            {
-                let _ = CountClipboardFormatsHook.enable();
-            }
+            let _ = COUNT_CLIPBOARD_FORMATS_HOOK.install(target, count_clipboard_formats);
         }
         if let Some(p) = user32_proc(b"EnumClipboardFormats\0") {
             let target: FnEnumClipboardFormats = std::mem::transmute(p);
-            if EnumClipboardFormatsHook
-                .initialize(target, enum_clipboard_formats)
-                .is_ok()
-            {
-                let _ = EnumClipboardFormatsHook.enable();
-            }
+            let _ = ENUM_CLIPBOARD_FORMATS_HOOK.install(target, enum_clipboard_formats);
         }
         if let Some(p) = user32_proc(b"GetClipboardSequenceNumber\0") {
             let target: FnGetClipboardSequenceNumber = std::mem::transmute(p);
-            if GetClipboardSequenceNumberHook
-                .initialize(target, get_clipboard_sequence_number)
-                .is_ok()
-            {
-                let _ = GetClipboardSequenceNumberHook.enable();
-            }
+            let _ =
+                GET_CLIPBOARD_SEQUENCE_NUMBER_HOOK.install(target, get_clipboard_sequence_number);
         }
     }
     super::ole::install_ole();

--- a/crates/glass-clip-shim-windows/src/hook/ole.rs
+++ b/crates/glass-clip-shim-windows/src/hook/ole.rs
@@ -8,7 +8,6 @@ use std::ffi::c_void;
 use std::mem::ManuallyDrop;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 
-use retour::static_detour;
 use windows::Win32::Foundation::{S_FALSE, S_OK};
 use windows::Win32::System::Com::{
     DATADIR_GET, FORMATETC, IDataObject, IStream, STREAM_SEEK_SET, TYMED_HGLOBAL, TYMED_ISTREAM,
@@ -19,6 +18,7 @@ use windows::core::{HRESULT, Interface};
 use crate::proto::{FormatKey, MAX_ITEM_BYTES, MAX_TOTAL_BYTES};
 
 use super::dataobject::StoreDataObject;
+use super::detour::Detour;
 use super::{
     key_of, ole32_proc, read_bytes_from_hglobal, store_empty, store_get_all, store_seq,
     store_set_all,
@@ -29,12 +29,10 @@ type FnOleGet = unsafe extern "system" fn(*mut *mut c_void) -> HRESULT;
 type FnOleFlush = unsafe extern "system" fn() -> HRESULT;
 type FnOleIsCurrent = unsafe extern "system" fn(*mut c_void) -> HRESULT;
 
-static_detour! {
-    static OleSetClipboardHook: unsafe extern "system" fn(*mut c_void) -> HRESULT;
-    static OleGetClipboardHook: unsafe extern "system" fn(*mut *mut c_void) -> HRESULT;
-    static OleFlushClipboardHook: unsafe extern "system" fn() -> HRESULT;
-    static OleIsCurrentClipboardHook: unsafe extern "system" fn(*mut c_void) -> HRESULT;
-}
+static OLE_SET_CLIPBOARD_HOOK: Detour<FnOleSet> = Detour::new();
+static OLE_GET_CLIPBOARD_HOOK: Detour<FnOleGet> = Detour::new();
+static OLE_FLUSH_CLIPBOARD_HOOK: Detour<FnOleFlush> = Detour::new();
+static OLE_IS_CURRENT_CLIPBOARD_HOOK: Detour<FnOleIsCurrent> = Detour::new();
 
 thread_local! {
     /// (last `OleSetClipboard` object pointer, store seq right after that SetAll) — for
@@ -147,7 +145,7 @@ unsafe fn marshal(data: &IDataObject) -> Vec<(FormatKey, Vec<u8>)> {
     out
 }
 
-fn ole_set_clipboard(p: *mut c_void) -> HRESULT {
+unsafe extern "system" fn ole_set_clipboard(p: *mut c_void) -> HRESULT {
     catch_unwind(AssertUnwindSafe(|| {
         if p.is_null() {
             store_empty();
@@ -166,7 +164,7 @@ fn ole_set_clipboard(p: *mut c_void) -> HRESULT {
     .unwrap_or(S_OK)
 }
 
-fn ole_get_clipboard(pp: *mut *mut c_void) -> HRESULT {
+unsafe extern "system" fn ole_get_clipboard(pp: *mut *mut c_void) -> HRESULT {
     catch_unwind(AssertUnwindSafe(|| {
         if pp.is_null() {
             return S_OK;
@@ -180,12 +178,12 @@ fn ole_get_clipboard(pp: *mut *mut c_void) -> HRESULT {
     .unwrap_or(S_OK)
 }
 
-fn ole_flush_clipboard() -> HRESULT {
+unsafe extern "system" fn ole_flush_clipboard() -> HRESULT {
     // We've eagerly stored; flush is a no-op. (Do not call the real OLE — we substitute it.)
     S_OK
 }
 
-fn ole_is_current_clipboard(p: *mut c_void) -> HRESULT {
+unsafe extern "system" fn ole_is_current_clipboard(p: *mut c_void) -> HRESULT {
     catch_unwind(AssertUnwindSafe(|| {
         let (last_p, last_seq) = LAST_SET.with(|c| c.get());
         if !p.is_null() && p as isize == last_p && store_seq() == last_seq {
@@ -199,38 +197,25 @@ fn ole_is_current_clipboard(p: *mut c_void) -> HRESULT {
 
 /// Resolve + enable the 4 ole32 detours. Fail-soft (a missing export is skipped).
 pub(super) fn install_ole() {
-    // SAFETY: each `ole32_proc` returns the export's absolute address, transmuted to its exact ABI;
-    // retour initialize/enable are unsafe by contract; every step is fallible and stays fail-soft.
+    // SAFETY: ole32_proc resolves live exports with the exact signatures below. Initialization
+    // runs once during DLL injection, before the app resumes calling these APIs. Each replacement
+    // implements its export's calling contract and remains loaded with the shim.
     unsafe {
         if let Some(p) = ole32_proc(b"OleSetClipboard\0") {
-            let t: FnOleSet = std::mem::transmute(p);
-            if OleSetClipboardHook.initialize(t, ole_set_clipboard).is_ok() {
-                let _ = OleSetClipboardHook.enable();
-            }
+            let target: FnOleSet = std::mem::transmute(p);
+            let _ = OLE_SET_CLIPBOARD_HOOK.install(target, ole_set_clipboard);
         }
         if let Some(p) = ole32_proc(b"OleGetClipboard\0") {
-            let t: FnOleGet = std::mem::transmute(p);
-            if OleGetClipboardHook.initialize(t, ole_get_clipboard).is_ok() {
-                let _ = OleGetClipboardHook.enable();
-            }
+            let target: FnOleGet = std::mem::transmute(p);
+            let _ = OLE_GET_CLIPBOARD_HOOK.install(target, ole_get_clipboard);
         }
         if let Some(p) = ole32_proc(b"OleFlushClipboard\0") {
-            let t: FnOleFlush = std::mem::transmute(p);
-            if OleFlushClipboardHook
-                .initialize(t, ole_flush_clipboard)
-                .is_ok()
-            {
-                let _ = OleFlushClipboardHook.enable();
-            }
+            let target: FnOleFlush = std::mem::transmute(p);
+            let _ = OLE_FLUSH_CLIPBOARD_HOOK.install(target, ole_flush_clipboard);
         }
         if let Some(p) = ole32_proc(b"OleIsCurrentClipboard\0") {
-            let t: FnOleIsCurrent = std::mem::transmute(p);
-            if OleIsCurrentClipboardHook
-                .initialize(t, ole_is_current_clipboard)
-                .is_ok()
-            {
-                let _ = OleIsCurrentClipboardHook.enable();
-            }
+            let target: FnOleIsCurrent = std::mem::transmute(p);
+            let _ = OLE_IS_CURRENT_CLIPBOARD_HOOK.install(target, ole_is_current_clipboard);
         }
     }
 }

--- a/crates/glass-clip-shim-windows/src/store.rs
+++ b/crates/glass-clip-shim-windows/src/store.rs
@@ -77,7 +77,9 @@ impl PrivateClipboard {
     pub fn get_text(&self) -> Option<String> {
         let bytes = self.get(&FormatKey::Standard(CF_UNICODETEXT))?;
         let units: Vec<u16> = bytes
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|c| u16::from_le_bytes([c[0], c[1]]))
             .collect();
         Some(crate::text::utf16_nul_to_string(&units))

--- a/crates/glass-testapp/tests/software_render.rs
+++ b/crates/glass-testapp/tests/software_render.rs
@@ -55,7 +55,7 @@ fn is_uniform(frame: &glass_core::Frame) -> bool {
     let Some(first) = frame.pixels.get(0..4) else {
         return true;
     };
-    frame.pixels.chunks_exact(4).all(|px| px == first)
+    frame.pixels.as_chunks::<4>().0.iter().all(|px| px == first)
 }
 
 enum RenderOutcome {

--- a/crates/glass-wayland/src/pixels.rs
+++ b/crates/glass-wayland/src/pixels.rs
@@ -100,7 +100,12 @@ fn unpack24(
     for y in 0..h {
         let s = &src[y * stride..y * stride + row];
         let d = &mut out[y * dst_row..y * dst_row + dst_row];
-        for (px, dst) in s.chunks_exact(3).zip(d.chunks_exact_mut(4)) {
+        for (px, dst) in s
+            .as_chunks::<3>()
+            .0
+            .iter()
+            .zip(d.as_chunks_mut::<4>().0.iter_mut())
+        {
             let (r, b) = match order {
                 SourceOrder::Bgr => (px[2], px[0]),
                 SourceOrder::Rgb => (px[0], px[2]),

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -4205,7 +4205,7 @@ mod session_tests {
     //! connection, so there is nothing underneath them to fake; [`crate::testw`] launches a
     //! private session and observes it over a connection the backend does not own.
     use std::collections::VecDeque;
-    use std::io::{Read as _, Write as _};
+    use std::io::Read as _;
     use std::os::unix::net::UnixStream;
 
     use super::*;

--- a/crates/glass-windows/examples/onbox.rs
+++ b/crates/glass-windows/examples/onbox.rs
@@ -37,15 +37,17 @@ mod imp {
 
     /// True if every pixel is identical (a uniform/blank frame — WGC didn't return real pixels).
     fn is_blank(px: &[u8]) -> bool {
-        match px.chunks_exact(4).next() {
-            Some(first) => px.chunks_exact(4).all(|c| c == first),
+        match px.as_chunks::<4>().0.first() {
+            Some(first) => px.as_chunks::<4>().0.iter().all(|c| c == first),
             None => true,
         }
     }
     /// Count of differing pixels between two equal-size RGBA buffers.
     fn changed(a: &[u8], b: &[u8]) -> usize {
-        a.chunks_exact(4)
-            .zip(b.chunks_exact(4))
+        a.as_chunks::<4>()
+            .0
+            .iter()
+            .zip(b.as_chunks::<4>().0.iter())
             .filter(|(x, y)| x != y)
             .count()
     }

--- a/crates/glass-windows/examples/onbox_windows.rs
+++ b/crates/glass-windows/examples/onbox_windows.rs
@@ -27,14 +27,16 @@ mod imp {
     use glass_windows::WindowsPlatform;
 
     fn is_blank(px: &[u8]) -> bool {
-        match px.chunks_exact(4).next() {
-            Some(first) => px.chunks_exact(4).all(|c| c == first),
+        match px.as_chunks::<4>().0.first() {
+            Some(first) => px.as_chunks::<4>().0.iter().all(|c| c == first),
             None => true,
         }
     }
     fn changed(a: &[u8], b: &[u8]) -> usize {
-        a.chunks_exact(4)
-            .zip(b.chunks_exact(4))
+        a.as_chunks::<4>()
+            .0
+            .iter()
+            .zip(b.as_chunks::<4>().0.iter())
             .filter(|(x, y)| x != y)
             .count()
     }

--- a/crates/glass-windows/src/clipboard.rs
+++ b/crates/glass-windows/src/clipboard.rs
@@ -85,7 +85,9 @@ impl Clipboard {
         // An external owner may omit the NUL terminator or leave an odd trailing byte.
         let units: Vec<u16> = lock
             .as_bytes()
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|c| u16::from_le_bytes([c[0], c[1]]))
             .take_while(|&u| u != 0)
             .collect();

--- a/crates/glass-windows/src/host_fs.rs
+++ b/crates/glass-windows/src/host_fs.rs
@@ -318,7 +318,7 @@ fn parse_directory_records(bytes: &[u8]) -> Result<Vec<DirectoryEntryRecord>, Ho
             .filter(|end| *end <= bytes.len())
             .ok_or(HostFsError::Integrity)?;
         let mut units = Vec::with_capacity(name_bytes / 2);
-        for pair in bytes[offset + fixed..end].chunks_exact(2) {
+        for pair in bytes[offset + fixed..end].as_chunks::<2>().0 {
             units.push(u16::from_le_bytes([pair[0], pair[1]]));
         }
         let name = std::ffi::OsString::from_wide(&units);

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -299,15 +299,17 @@ fn scroll_evidence(p: &mut WindowsPlatform, geo: &WindowGeometry) -> (Vec<String
 }
 
 fn is_blank(px: &[u8]) -> bool {
-    match px.chunks_exact(4).next() {
-        Some(first) => px.chunks_exact(4).all(|c| c == first),
+    match px.as_chunks::<4>().0.first() {
+        Some(first) => px.as_chunks::<4>().0.iter().all(|c| c == first),
         None => true,
     }
 }
 
 fn changed(a: &[u8], b: &[u8]) -> usize {
-    a.chunks_exact(4)
-        .zip(b.chunks_exact(4))
+    a.as_chunks::<4>()
+        .0
+        .iter()
+        .zip(b.as_chunks::<4>().0.iter())
         .filter(|(x, y)| x != y)
         .count()
 }

--- a/crates/glass-x11/src/pixels.rs
+++ b/crates/glass-x11/src/pixels.rs
@@ -65,7 +65,9 @@ mod tests {
 
     /// Scalar reference: BGRX -> RGBA with alpha forced to 255.
     fn reference(data: &[u8]) -> Vec<u8> {
-        data.chunks_exact(4)
+        data.as_chunks::<4>()
+            .0
+            .iter()
             .flat_map(|p| [p[2], p[1], p[0], 255])
             .collect()
     }

--- a/docs/how-to/benchmarking.md
+++ b/docs/how-to/benchmarking.md
@@ -18,8 +18,7 @@ three backends, so name the crate with `-p` to flamegraph one.
 
 Pixel normalization and frame comparison use `fearless_simd`, with CPU features detected once
 and cached. On x86 this selects the available SSE2, SSE4.2, AVX2, or AVX-512 backend; AArch64 uses NEON.
-The core SIMD code works on stable Rust. The workspace still pins nightly for the Windows
-clipboard shim's `retour` static detours.
+The workspace uses stable Rust, including the Windows clipboard shim's typed `retour` detours.
 
 When comparing portable builds, clear local CPU-specific flags (such as `target-cpu=native` or
 `target-cpu=haswell`), so both builds target the same baseline:

--- a/docs/how-to/build-from-source.md
+++ b/docs/how-to/build-from-source.md
@@ -12,7 +12,7 @@ cd glass
 cargo build --release -p glass-mcp        # → target/release/glass-mcp
 ```
 
-glass pins a nightly toolchain in `rust-toolchain.toml`, which rustup installs automatically on the
+glass pins a stable Rust toolchain in `rust-toolchain.toml`, which rustup installs automatically on the
 first build — there's no toolchain to choose. On every platform the build also needs **`cmake` and a
 C compiler** on `PATH`: the TLS stack behind `glass-mcp update` compiles `aws-lc-sys` from C sources
 (`apt install cmake build-essential`, or the equivalent for your distro). On **macOS**, building

--- a/docs/tutorial/first-drive.md
+++ b/docs/tutorial/first-drive.md
@@ -33,7 +33,7 @@ From a clone of the glass repo, build the server:
 cargo build --release -p glass-mcp
 ```
 
-This produces `target/release/glass-mcp`. The first build pulls the pinned nightly toolchain
+This produces `target/release/glass-mcp`. The first build pulls the pinned stable Rust toolchain
 automatically, so it may take a few minutes; later builds are fast. You don't build the demo app
 yourself — in Step 3 your agent builds it *through* glass, which is the whole point.
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2026-06-01"
+channel = "1.98.1"
 components = ["clippy", "rustfmt"]

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Measure test coverage with cargo-llvm-cov (nightly toolchain, picked up
+# Measure test coverage with cargo-llvm-cov (pinned toolchain, picked up
 # automatically via rust-toolchain.toml).
 #
 # Why this wrapper rather than a bare `cargo llvm-cov`: glass's most security- and


### PR DESCRIPTION
## Description

The Windows clipboard shim's `retour::static_detour!` is the workspace's remaining nightly requirement. Replace all 13 hooks with typed `GenericDetour` instances and pin the workspace to stable Rust 1.98.1.

Each hook is stored in a static `OnceLock` before enabling it, retaining its trampoline and relay for the DLL's lifetime. Callbacks use their exact `unsafe extern "system"` signatures and preserve the existing clipboard substitution and panic guards. The locked `retour` version stays at 0.3.1; its nightly-dependent `static-detour` feature is removed.

Add tests for hook lifetime, duplicate installation, and retry after failed creation. Update compiler documentation and make the mechanical fixed-size slice iteration/import changes required by stable Clippy.

## Validation

- Formatting, workspace all-target builds, and Clippy with denied warnings passed on Linux, Apple Silicon macOS, and native Windows/MSVC using Rust 1.98.1.
- Linux workspace: **3,743 tests passed**.
- Apple Silicon workspace libraries: **3,155 tests passed**.
- Native Windows workspace: **2,711 tests passed**, including all **43 shim tests**. The two detour lifecycle tests also passed in release mode.
- All four native Sandboxie clipboard probes passed in **debug and release** in the interactive desktop session: text, multiple formats (HTML/DIB/synthesized bitmap), OLE with user32 coherence, and HDROP. Each verified that the ambient clipboard sentinel remained unchanged.
- Windows GNU cross-compilation and Wine debug/release detour checks also passed.
