### PR TITLE
Reduce glass_do response verbosity

### DIFF
--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -1076,7 +1076,7 @@ impl GlassServer {
             destructive_hint = false,
             open_world_hint = false
         ),
-        description = "Run one action or fixed static ordered actions: click, move, drag, scroll, type, key, settle, click_element, set_value, wait_for_element, scroll_to_element. Maximum 64 actions and 65536 compact argument bytes. timeout_ms defaults to 30000; range 1 through 120000; one deadline includes terminal observations. Fail-fast on action errors, deadline or unmatched batched predicates; standalone predicates remain soft. Inspect completed, failed, unexecuted and terminal_steps before recovery. Preflight invalid_sequence has no step outcomes. Terminal settle/diff/screenshot runs after actions; terminal failure retains completed action outcomes. No branching, bindings, loops, retries or generated steps. Semantic targets resolve fresh; targeted type requires confirmed focus; set_value requires confirmation. Never replay completed or possibly dispatched mutations; observe after uncertainty."
+        description = "Run one action or fixed static ordered actions: click, move, drag, scroll, type, key, settle, click_element, set_value, wait_for_element, scroll_to_element. Maximum 64 actions and 65536 compact argument bytes. timeout_ms defaults to 30000; range 1 through 120000; one deadline includes terminal observations. Fail-fast on action errors, deadline or unmatched batched predicates; standalone predicates remain soft. Success without then returns ordered steps with result and content_blocks; ok:true means all actions completed. Failures and then retain completed, failed, unexecuted and terminal_steps; inspect before recovery. Preflight invalid_sequence has no step outcomes. Terminal settle/diff/screenshot runs after actions; terminal failure retains completed action outcomes. No branching, bindings, loops, retries or generated steps. Semantic targets resolve fresh; targeted type requires confirmed focus; set_value requires confirmation. Never replay completed or possibly dispatched mutations; observe after uncertainty."
     )]
     async fn glass_do(
         &self,
@@ -1679,6 +1679,8 @@ mod tests {
             "Fail-fast",
             "action errors, deadline or unmatched batched predicates",
             "standalone predicates remain soft",
+            "ordered steps with result and content_blocks",
+            "ok:true means all",
             "completed, failed, unexecuted and terminal_steps",
             "Preflight invalid_sequence has no step outcomes",
             "Terminal settle/diff/screenshot",
@@ -1706,6 +1708,8 @@ mod tests {
         for instructions in [&full, &lean] {
             for required in [
                 "Batch known work; observe before choosing dependent steps",
+                "ordered steps with result and content_blocks",
+                "ok:true means all",
                 "completed, failed, unexecuted and terminal_steps",
                 "unmatched predicate",
                 "Post-write uncertainty is terminal",

--- a/crates/glass-mcp/src/tool_profile.rs
+++ b/crates/glass-mcp/src/tool_profile.rs
@@ -50,7 +50,8 @@ pub(crate) const SHARED_INSTRUCTIONS: &str = "Glass drives external native GUI a
     types. Input dispatch does not prove runtime state. Post-write uncertainty is terminal: observe before \
     recovery; never blindly replay an action or completed sequence after possible dispatch.\n\n\
     glass_do runs one action or a fixed known sequence. Batch known work; observe before choosing dependent \
-    steps. Inspect completed, failed, unexecuted and terminal_steps outcomes. Batched wait_for_element and \
+    steps. Success without then returns ordered steps with result and content_blocks; ok:true means all \
+    actions completed. Failures and then retain completed, failed, unexecuted and terminal_steps outcomes. Batched wait_for_element and \
     scroll_to_element fail the sequence on an unmatched predicate; standalone predicates time out softly. \
     A settle step may complete with settled:false; the overall sequence deadline still fails execution.\n\n\
     glass_screenshot provides current visual evidence when semantics are insufficient. Input and region \

--- a/crates/glass-mcp/src/tools/batch.rs
+++ b/crates/glass-mcp/src/tools/batch.rs
@@ -330,10 +330,11 @@ fn step_failure(
         _ => &error.message,
     };
     let content_start = siblings.len() + 1;
-    let content_count = error.siblings.len() + 1;
     siblings.append(&mut error.siblings);
-    siblings.push(OutContent::untrusted_observation(detail));
-    let content_blocks = (content_start..content_start + content_count).collect();
+    if detail != error.safe_summary {
+        siblings.push(OutContent::untrusted_observation(detail));
+    }
+    let content_blocks = (content_start..siblings.len() + 1).collect();
     steps.push(StepOutcome::Failed {
         index,
         action: action.kind(),

--- a/crates/glass-mcp/src/tools/batch.rs
+++ b/crates/glass-mcp/src/tools/batch.rs
@@ -215,8 +215,8 @@ pub fn do_actions(glass: &mut Glass, a: &DoArgs) -> BatchToolResult {
         }
     }
 
-    let mut result = json!({ "status": "completed", "executed": n, "steps": steps });
-    if let Some(then) = &a.then {
+    let mut result = if let Some(then) = &a.then {
+        let mut result = json!({ "status": "completed", "executed": n, "steps": steps });
         match run_then(glass, then, context, siblings.len() + 1) {
             Ok(mut terminal) => {
                 result["then"] = terminal.meta;
@@ -250,7 +250,21 @@ pub fn do_actions(glass: &mut Glass, a: &DoArgs) -> BatchToolResult {
                 ));
             }
         }
-    }
+        result
+    } else {
+        let steps: Vec<_> = steps
+            .into_iter()
+            .map(|step| match step {
+                StepOutcome::Completed {
+                    result,
+                    content_blocks,
+                    ..
+                } => json!({ "result": result, "content_blocks": content_blocks }),
+                _ => unreachable!("successful sequence contains only completed steps"),
+            })
+            .collect();
+        json!({ "steps": steps })
+    };
     result["elapsed_ms"] = json!(started.elapsed().as_millis());
     Ok(ToolOutput::result_with("glass_do", result, siblings))
 }

--- a/crates/glass-mcp/src/tools/batch/tests.rs
+++ b/crates/glass-mcp/src/tools/batch/tests.rs
@@ -719,6 +719,11 @@ fn type_secret_failure_preserves_no_active_session_without_echoing_input() {
         envelope(&error)["outcome"]["steps"][0]["error"]["category"],
         "no_active_session"
     );
+    assert_eq!(
+        envelope(&error)["outcome"]["steps"][0]["content_blocks"],
+        json!([])
+    );
+    assert_eq!(error.0.len(), 1);
     assert_secret_absent(&error, secret);
 }
 
@@ -2797,7 +2802,7 @@ fn sequence_deadline_after_focus_prevents_type_and_marks_side_effects_possible()
     assert_eq!(step["side_effects_may_have_occurred"], true);
     assert_eq!(step["result"]["dispatch"], "not_dispatched");
     assert_eq!(step["result"]["focus"]["dispatch"], "dispatched");
-    assert_eq!(step["content_blocks"], json!([1, 2]));
+    assert_eq!(step["content_blocks"], json!([1]));
     assert_eq!(*events.lock().unwrap(), vec!["focus"]);
     assert!(!output_text(&error).contains("secret"));
 }
@@ -2831,8 +2836,8 @@ fn semantic_failure_keeps_resolution_actionability_dispatch_and_content_blocks()
     assert!(step["result"]["resolution"].is_object());
     assert!(step["result"]["actionability"].is_array());
     assert_eq!(step["result"]["dispatch"], "not_dispatched");
-    assert_eq!(step["content_blocks"], json!([1, 2]));
-    assert_eq!(error.0.len(), 3);
+    assert_eq!(step["content_blocks"], json!([1]));
+    assert_eq!(error.0.len(), 2);
     assert!(output_text(&error).contains("Save"));
     assert!(events.lock().unwrap().is_empty());
 }

--- a/crates/glass-mcp/src/tools/batch/tests.rs
+++ b/crates/glass-mcp/src/tools/batch/tests.rs
@@ -2036,7 +2036,7 @@ fn click(x: i32, y: i32) -> Action {
 }
 
 #[test]
-fn success_retains_existing_fields_and_adds_every_step_result() {
+fn success_without_then_omits_bookkeeping_and_retains_every_step_result() {
     let log = Arc::new(Mutex::new(Vec::new()));
     let mut g = started(FakePlatform::new(100, 100).with_event_log(log.clone()));
     let out = do_actions(
@@ -2067,8 +2067,7 @@ fn success_retains_existing_fields_and_adds_every_step_result() {
         vec!["click(10,20)", "type(alice)", "key(Tab)"]
     );
     let result = assert_envelope(&out, "glass_do");
-    assert_eq!(result["status"], "completed");
-    assert_eq!(result["executed"], json!(3));
+    assert_eq!(result.as_object().unwrap().len(), 2);
     assert!(result["elapsed_ms"].is_u64());
     assert!(result.get("then").is_none());
     assert!(result.get("terminal_steps").is_none());
@@ -2076,15 +2075,15 @@ fn success_retains_existing_fields_and_adds_every_step_result() {
     assert_eq!(
         result["steps"],
         json!([
-            {"status":"completed","index":0,"action":"click","result":{},"content_blocks":[]},
-            {"status":"completed","index":1,"action":"type","result":{},"content_blocks":[]},
-            {"status":"completed","index":2,"action":"key","result":{},"content_blocks":[]},
+            {"result":{},"content_blocks":[]},
+            {"result":{},"content_blocks":[]},
+            {"result":{},"content_blocks":[]},
         ])
     );
 }
 
 #[test]
-fn type_return_snapshot_is_retained_in_content_blocks() {
+fn successful_steps_keep_observations_in_response_order() {
     let log = Arc::new(Mutex::new(Vec::new()));
     let frame = Frame::solid(100, 100, [0, 0, 0, 255]);
     let mut g = started_a11y(
@@ -2095,25 +2094,43 @@ fn type_return_snapshot_is_retained_in_content_blocks() {
     let out = do_actions(
         &mut g,
         &DoArgs {
-            actions: vec![Action::Type(TypeArgs {
-                target: None,
-                focus_mode: None,
-                timeout_ms: None,
-                max_nodes: None,
-                text: "hi".into(),
-                return_: Some("snapshot".into()),
-            })],
+            actions: vec![
+                Action::Type(TypeArgs {
+                    target: None,
+                    focus_mode: None,
+                    timeout_ms: None,
+                    max_nodes: None,
+                    text: "hi".into(),
+                    return_: Some("snapshot".into()),
+                }),
+                Action::Key(KeyArgs {
+                    chord: "Tab".into(),
+                }),
+                parsed_action(r#"{"action":"wait_for_element","name":"Save","timeout_ms":0}"#),
+            ],
             then: None,
             timeout_ms: None,
             encoded_argument_bytes: 0,
         },
     )
     .unwrap();
-    assert_eq!(*log.lock().unwrap(), vec!["type(hi)"]);
+    assert_eq!(*log.lock().unwrap(), vec!["type(hi)", "key(Tab)"]);
     let result = assert_envelope(&out, "glass_do");
-    assert_eq!(result["executed"], json!(1));
+    assert_eq!(result["steps"].as_array().unwrap().len(), 3);
+    assert_eq!(result["steps"][1], json!({"result":{},"content_blocks":[]}));
+    assert_eq!(result["steps"][2]["result"]["matched"], true);
+    assert_eq!(result["steps"][2]["content_blocks"], json!([2]));
     assert_eq!(result["steps"][0]["content_blocks"], json!([1]));
-    assert_eq!(out.0.len(), 2, "snapshot outline is retained as a sibling");
+    assert_eq!(
+        out.0.len(),
+        3,
+        "snapshot and matched node are retained as siblings"
+    );
+    let OutContent::Text(matched) = &out.0[2] else {
+        panic!("matched node sibling must be text");
+    };
+    assert!(matched.as_str().contains("untrusted content"));
+    assert!(matched.as_str().contains("Save"));
     let OutContent::Text(snapshot) = &out.0[1] else {
         panic!("snapshot sibling must be text");
     };
@@ -2148,7 +2165,7 @@ fn type_action_with_return_none_is_allowed() {
     .unwrap();
     assert_eq!(*log.lock().unwrap(), vec!["type(hi)"]);
     let result = assert_envelope(&out, "glass_do");
-    assert_eq!(result["executed"], json!(1));
+    assert_eq!(result["steps"].as_array().unwrap().len(), 1);
 }
 
 #[test]
@@ -2183,6 +2200,10 @@ fn action_failure_is_structured_and_lists_unexecuted_steps() {
     );
     assert!(!err.contains("coordinate (100,10)"));
     assert_eq!(error["outcome"]["executed"], 1);
+    assert_eq!(
+        error["outcome"]["steps"][0],
+        json!({"status":"completed","index":0,"action":"click","result":{},"content_blocks":[]})
+    );
     assert_eq!(error["outcome"]["steps"][2]["status"], "unexecuted");
     assert_eq!(
         *log.lock().unwrap(),
@@ -2646,10 +2667,7 @@ fn semantic_actions_delegate_and_retain_standalone_results() {
     .unwrap();
     assert_eq!(*log.lock().unwrap(), vec!["click(20,20)"]);
     let result = assert_envelope(&out, "glass_do");
-    assert_eq!(result["steps"][0]["action"], "click_element");
-    assert_eq!(result["steps"][1]["action"], "set_value");
-    assert_eq!(result["steps"][2]["action"], "wait_for_element");
-    assert_eq!(result["steps"][3]["action"], "scroll_to_element");
+    assert_eq!(result["steps"].as_array().unwrap().len(), 4);
     assert_eq!(
         result["steps"][0]["result"]
             .as_object()
@@ -2713,7 +2731,13 @@ fn semantic_step_selector_resolves_at_execution_time() {
     )
     .unwrap();
 
-    assert_eq!(assert_envelope(&output, "glass_do")["executed"], 2);
+    assert_eq!(
+        assert_envelope(&output, "glass_do")["steps"]
+            .as_array()
+            .unwrap()
+            .len(),
+        2
+    );
     assert!(changed.load(Ordering::SeqCst));
     assert_eq!(*events.lock().unwrap(), vec!["click(1,1)", "click_element"]);
     assert_eq!(
@@ -2738,7 +2762,13 @@ fn semantic_step_timeout_is_bounded_by_the_earlier_sequence_deadline() {
     )
     .unwrap();
 
-    assert_eq!(assert_envelope(&output, "glass_do")["executed"], 1);
+    assert_eq!(
+        assert_envelope(&output, "glass_do")["steps"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
     let deadline = accessibility_deadlines.lock().unwrap()[0];
     let remaining = deadline.remaining().unwrap();
     assert!(remaining <= Duration::from_millis(100));
@@ -2760,7 +2790,13 @@ fn semantic_step_uses_its_ten_second_default_inside_a_longer_sequence() {
     )
     .unwrap();
 
-    assert_eq!(assert_envelope(&output, "glass_do")["executed"], 1);
+    assert_eq!(
+        assert_envelope(&output, "glass_do")["steps"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
     let deadline = accessibility_deadlines.lock().unwrap()[0];
     let remaining = deadline.remaining().unwrap();
     assert!(remaining <= Duration::from_secs(10));
@@ -4220,7 +4256,13 @@ fn invalid_sequence_accepts_exact_action_limit() {
         },
     )
     .unwrap();
-    assert_eq!(assert_envelope(&out, "glass_do")["executed"], MAX_ACTIONS);
+    assert_eq!(
+        assert_envelope(&out, "glass_do")["steps"]
+            .as_array()
+            .unwrap()
+            .len(),
+        MAX_ACTIONS
+    );
 }
 
 #[test]
@@ -4238,7 +4280,7 @@ fn exactly_maximum_sequence_timeout_is_accepted() {
     .unwrap();
     let maximum_result = assert_envelope(&output, "glass_do");
 
-    assert_eq!(maximum_result["status"], "completed");
+    assert_eq!(maximum_result["steps"].as_array().unwrap().len(), 1);
 }
 
 #[test]
@@ -4254,7 +4296,13 @@ fn omitted_sequence_timeout_records_about_thirty_seconds() {
         },
     )
     .unwrap();
-    assert_eq!(assert_envelope(&output, "glass_do")["status"], "completed");
+    assert_eq!(
+        assert_envelope(&output, "glass_do")["steps"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
     let default_remaining = deadlines.lock().unwrap()[0]
         .remaining()
         .expect("the omitted sequence timeout must still be bounded");

--- a/crates/glass-mcp/tests/android_session_loop.rs
+++ b/crates/glass-mcp/tests/android_session_loop.rs
@@ -430,25 +430,18 @@ async fn ime_form_proof(client: Peer<RoleClient>, fixture: String) {
     )
     .await;
 
-    assert_eq!(result["status"], json!("completed"), "{all_text}");
-    assert_eq!(result["executed"], json!(4), "{all_text}");
+    assert_eq!(result.as_object().unwrap().len(), 2, "{all_text}");
     assert!(result["elapsed_ms"].is_number(), "{all_text}");
     let steps = result["steps"].as_array().expect("four batch steps");
     assert_eq!(steps.len(), 4, "{all_text}");
-    for (index, (step, action)) in steps
-        .iter()
-        .zip([
-            "set_value",
-            "wait_for_element",
-            "click_element",
-            "wait_for_element",
-        ])
-        .enumerate()
-    {
-        assert_eq!(step["index"], json!(index), "{all_text}");
-        assert_eq!(step["status"], json!("completed"), "{all_text}");
-        assert_eq!(step["action"], json!(action), "{all_text}");
+    for step in steps {
+        assert_eq!(step.as_object().unwrap().len(), 2, "{all_text}");
+        assert!(step["result"].is_object(), "{all_text}");
+        assert!(step["content_blocks"].is_array(), "{all_text}");
     }
+    assert_eq!(steps[0]["result"]["id"], json!(name_id), "{all_text}");
+    assert_eq!(steps[1]["result"]["matched"], json!(true), "{all_text}");
+    assert_eq!(steps[3]["result"]["matched"], json!(true), "{all_text}");
     assert_eq!(
         steps[2]["result"]["method"],
         json!("native-action"),

--- a/crates/glass-testapp/tests/verification_cost.rs
+++ b/crates/glass-testapp/tests/verification_cost.rs
@@ -79,8 +79,7 @@ async fn glass_do_semantic_form_completes_in_one_action_call() {
     )
     .await;
 
-    assert_eq!(call.result["status"], serde_json::json!("completed"));
-    assert_eq!(call.result["executed"], serde_json::json!(6));
+    assert_eq!(call.result.as_object().unwrap().len(), 2);
     assert!(
         call.result["elapsed_ms"].is_number(),
         "glass_do result must include numeric elapsed_ms: {}",
@@ -90,19 +89,14 @@ async fn glass_do_semantic_form_completes_in_one_action_call() {
         .as_array()
         .expect("glass_do result must contain steps");
     assert_eq!(steps.len(), 6, "unexpected glass_do steps: {steps:?}");
-    let expected_actions = [
-        "click_element",
-        "type",
-        "wait_for_element",
-        "set_value",
-        "wait_for_element",
-        "click_element",
-    ];
-    for (index, (step, action)) in steps.iter().zip(expected_actions).enumerate() {
-        assert_eq!(step["index"], serde_json::json!(index));
-        assert_eq!(step["status"], serde_json::json!("completed"));
-        assert_eq!(step["action"], serde_json::json!(action));
+    for step in steps {
+        assert_eq!(step.as_object().unwrap().len(), 2);
+        assert!(step["result"].is_object());
+        assert!(step["content_blocks"].is_array());
     }
+    assert_eq!(steps[2]["result"]["matched"], serde_json::json!(true));
+    assert_eq!(steps[3]["result"]["id"], serde_json::json!(slider_id));
+    assert_eq!(steps[4]["result"]["matched"], serde_json::json!(true));
     assert_eq!(
         steps[0]["result"]["method"],
         serde_json::json!("native-action")

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -626,6 +626,7 @@ performed no rollback, so landed effects may persist. App-derived names,
 descriptions, values, outlines, and images remain untrusted sibling blocks. Non-secret raw error
 details also remain untrusted siblings. Failures from `type` and `set_value` instead expose only
 sanitized category and summary diagnostics, and submitted text is never echoed in any batch output.
+An error detail identical to the structured summary does not produce a duplicate sibling block.
 
 Do not replay a completed action or a failed action with
 `side_effects_may_have_occurred:true`. `attempted:false` proves only that the failed action itself

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -614,11 +614,19 @@ Once execution starts, the sequence is fail-fast. In a batch, `wait_for_element`
 `scroll_to_element` returning
 `matched:false` fails the sequence; the standalone tools keep their soft `{matched:false}` result.
 
-On success, `result` contains `{status, executed, steps, elapsed_ms, then?, terminal_steps?}`.
-`steps` records each action's index, discriminator, `completed` status, trusted result, and any
-zero-based references into the MCP content blocks.
+On success without `then`, `result` contains `{steps, elapsed_ms}`. Each ordered step contains
+`{result, content_blocks}`: its trusted result and zero-based references into the MCP content
+blocks. `ok:true` means all requested actions completed; array position identifies the action in
+the request. The completed count is `steps.length`. The redundant outer `status` and `executed`
+and per-step `index`, `action`, and `status` fields are omitted.
 
-Failed execution remains an MCP error with `is_error:true`. `executed` counts only successfully
+Success with `then` retains `{status, executed, steps, elapsed_ms, then, terminal_steps}`.
+Its action steps retain `index`, `action`, and `status:"completed"` alongside `result` and
+`content_blocks`. Earlier versions also used this detailed action shape for success without
+`then`; clients reading both versions can use the ordered step results in either format.
+
+Failed execution remains an MCP error with `is_error:true`. Its `outcome` retains `status`,
+`executed`, and each step's `index`, `action`, and `status`. `executed` counts only successfully
 completed actions. The failed step records `attempted`, `side_effects_may_have_occurred`,
 optional `result?` evidence produced before the failure, `error.{code,summary,category?}`, and
 `content_blocks`; later steps use `status:"unexecuted"`. `effects_rolled_back:false` means Glass

--- a/docs/tutorial/first-drive.md
+++ b/docs/tutorial/first-drive.md
@@ -116,7 +116,7 @@ glass_do {
     { "action": "type", "text": "hello glass" }
   ]
 }
-// → { "executed": 3 }
+// → ok:true; result.steps contains three ordered results
 ```
 
 The **Text:** field now reads `hello glass`.


### PR DESCRIPTION
`glass_do` repeats success metadata that is already implied by the request and ordered results, and some failures repeat their structured summary in an extra observation block. This combines two reductions: compact successful sequences without `then`, and omit an error-detail sibling when it exactly matches the structured summary.

**Response compatibility:** Success without `then` now returns `{steps, elapsed_ms}`, with `{result, content_blocks}` for each ordered step. Outer `status`/`executed` and per-step `index`/`action`/`status` are omitted. Clients derive completion from `ok:true`, count from `steps.length`, and action identity from request order. Both tool profiles use this shape. Failure and terminal-observation outcomes retain detailed bookkeeping; results, timing, actionability, dispatch uncertainty, and untrusted observation boundaries are preserved. Public guidance and consuming tests are updated.

A focused Firefox/X11 lean-profile check (three measured attempts plus one warm-up per case) measured these task response-text reductions:

| Case | Before | After | Reduction |
|---|---:|---:|---:|
| Large-form | 9,004 B | 8,368 B | 7.1% |
| Disabled refusal | 4,440 B | 3,876 B | 12.7% |
| Duplicate refusal | 6,310 B | 5,751 B | 8.9% |

Updated tool and initialization guidance adds 267 initial bytes. These are UTF-8 byte measurements, with no token or timing-performance claim.

Validation:

- `cargo test -p glass-mcp --locked`: 844 passed; 7 device/environment tests ignored.
- `scripts/verification-cost.sh glass_do_`: all three native sequence tests passed, covering successful semantic actions, terminal images, and terminal failure recovery.
- MCP Clippy with all targets/features, Clippy for the changed native test target, formatting, and diff checks passed.
- All 20 fresh fixture attempts validated offline with an identical regenerated summary. Measured outcomes: six completions, six expected refusals, and three existing occlusion conformance failures. Artifact retrieval and the occlusion dispatch evidence remain intact.
