### PR TITLE
Fix agent recovery from unsupported accessibility text writes

### DIFF
--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -315,40 +315,44 @@ async fn set_value_async(
     let path = node.inner().path().to_owned();
     // Numeric/range widgets go through Value only (see `writes_value_only`): a GtkSpinButton
     // also exposes EditableText, but writing its entry buffer doesn't commit to the adjustment.
-    // Text widgets prefer EditableText, falling back to Value for anything numeric that lacks it.
-    // The builder `.ok()` chaining mirrors the working ComponentProxy build in `extents`.
+    // Text widgets require EditableText; an editable state alone does not promise that interface.
     if writes_editable_text(role) {
-        let editable = atspi::proxy::editable_text::EditableTextProxy::builder(&conn)
-            .destination(dest.clone())
-            .ok()
-            .and_then(|b| b.path(path.clone()).ok());
-        if let Some(b) = editable
-            && let Ok(et) = b.build().await
+        if !node
+            .get_interfaces()
+            .await
+            .map_err(bus_err)?
+            .contains(atspi_common::Interface::EditableText)
         {
-            // The baseline for the confirmation below: without one, only an exact read-back
-            // confirms.
-            let before = read_text(&node, &conn).await;
-            match dispatch
-                .dispatch_async(async { et.set_text_contents(text).await.map_err(bus_err) })
-                .await
-            {
-                Ok(true) => {
-                    return confirm_write(
-                        &node,
-                        &conn,
-                        WrittenVia::EditableText,
-                        before,
-                        text,
-                        target.id.0,
-                        ctx.deadline,
-                    )
-                    .await;
-                }
-                // EditableText is present but rejected the write — don't try Value.
-                Ok(false) => return Err(GlassError::AxElementNotEditable(target.id.0)),
-                Err(error) => return Err(error),
-            }
+            return Err(GlassError::AxElementNotEditable(target.id.0));
         }
+        let et = atspi::proxy::editable_text::EditableTextProxy::builder(&conn)
+            .destination(dest)
+            .map_err(bus_err)?
+            .path(path)
+            .map_err(bus_err)?
+            .build()
+            .await
+            .map_err(bus_err)?;
+        let before = read_text(&node, &conn).await;
+        return match dispatch
+            .dispatch_async(async { et.set_text_contents(text).await.map_err(bus_err) })
+            .await
+        {
+            Ok(true) => {
+                confirm_write(
+                    &node,
+                    &conn,
+                    WrittenVia::EditableText,
+                    before,
+                    text,
+                    target.id.0,
+                    ctx.deadline,
+                )
+                .await
+            }
+            Ok(false) => Err(GlassError::AxElementNotEditable(target.id.0)),
+            Err(error) => Err(error),
+        };
     }
     if writes_value_only(role, text)
         && let Ok(v) = text.parse::<f64>()

--- a/crates/glass-a11y-linux/tests/egui.rs
+++ b/crates/glass-a11y-linux/tests/egui.rs
@@ -1,0 +1,96 @@
+//! Live AccessKit text-write refusal and keyboard recovery. Build glass-fixture-egui first.
+
+#![cfg(target_os = "linux")]
+
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use glass_core::{
+    AppSpec, AxNode, AxRole, AxTree, Backend, BaselineStore, BoundDispatch, Glass, GlassError,
+    KeyEvent, SandboxLevel,
+};
+
+fn find_role(node: &AxNode, role: AxRole) -> Option<&AxNode> {
+    if node.role == role {
+        Some(node)
+    } else {
+        node.children
+            .iter()
+            .find_map(|child| find_role(child, role))
+    }
+}
+
+fn wait_for_value(glass: &mut Glass, role: AxRole, expected: &str) -> AxTree {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let tree = glass.a11y_snapshot(None);
+        if let Ok(tree) = &tree
+            && find_role(&tree.root, role)
+                .is_some_and(|node| node.value.as_deref().unwrap_or("") == expected)
+        {
+            return tree.clone();
+        }
+        assert!(Instant::now() < deadline, "value {expected:?}: {tree:?}");
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+#[test]
+#[ignore = "needs Xvfb, AT-SPI and a built glass-fixture-egui; optionally set GLASS_EGUI_FIXTURE"]
+fn missing_editable_text_refuses_before_dispatch_and_keyboard_recovery_works() {
+    let fixture = std::env::var_os("GLASS_EGUI_FIXTURE")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("../glass-fixture-egui/target/release/glass-fixture-egui")
+        });
+    assert!(fixture.is_file(), "build the egui fixture: {fixture:?}");
+    let dir = tempfile::tempdir().unwrap();
+    let mut glass = Glass::new(
+        Box::new(|_| {
+            Ok(Backend {
+                platform: Box::new(glass_x11::X11Platform::from_env()?),
+                accessibility: Some(Box::new(glass_a11y_linux::LinuxA11y::new())),
+            })
+        }),
+        "x11".into(),
+        BaselineStore::new(dir.path().join("baselines")),
+        100,
+    );
+    glass
+        .start(&AppSpec {
+            build: None,
+            run: vec![fixture.to_string_lossy().into_owned()],
+            cwd: None,
+            env: vec![("LIBGL_ALWAYS_SOFTWARE".into(), "1".into())],
+            window_hint: None,
+            timeout_ms: 10_000,
+            sandbox: SandboxLevel::Off,
+            a11y: true,
+        })
+        .expect("launch egui");
+    let tree = wait_for_value(&mut glass, AxRole::TextField, "");
+    let field = find_role(&tree.root, AxRole::TextField).unwrap();
+    assert!(field.states.editable);
+
+    let error = glass.set_value(field.id, "recovered").unwrap_err();
+    assert!(
+        matches!(error.cause(), GlassError::AxElementNotEditable(id) if *id == field.id.0),
+        "{error:?}"
+    );
+    assert_eq!(error.bound_dispatch(), Some(BoundDispatch::NotDispatched));
+    assert!(!error.set_value_failed_after_writing());
+    let tree = wait_for_value(&mut glass, AxRole::TextField, "");
+
+    let field = find_role(&tree.root, AxRole::TextField).unwrap();
+    glass.click_element(field.id).expect("focus text field");
+    glass
+        .key(&KeyEvent::Text("recovered".into()))
+        .expect("type");
+    let tree = wait_for_value(&mut glass, AxRole::TextField, "recovered");
+
+    let number = find_role(&tree.root, AxRole::SpinButton).unwrap();
+    glass.set_value(number.id, "73").expect("numeric write");
+    wait_for_value(&mut glass, AxRole::SpinButton, "73");
+    glass.stop().expect("stop egui");
+}

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -135,7 +135,9 @@ impl SafeErrorCategory {
             Self::UnsupportedMode => "semantic action mode is unsupported",
             Self::NoActiveSession => "no active session",
             Self::StaleElement => "element is stale or missing",
-            Self::NotEditable => "element is not editable",
+            Self::NotEditable => {
+                "element has no writable accessibility value; do not retry set_value. For text input, focus with click_element, select existing text with key if replacing it, then type; use the glass_* tools or glass_do actions"
+            }
             Self::InvalidValue => "element expects a boolean value",
             Self::OptionNotFound => "requested option was not found",
             Self::UnsupportedAccessibility => "accessibility operation is unsupported",

--- a/crates/glass-mcp/src/tools/semantic_action.rs
+++ b/crates/glass-mcp/src/tools/semantic_action.rs
@@ -1,6 +1,6 @@
 use glass_core::{
     ActionMethod, ActionMode, ActionTarget, ActionabilityReport, AxNodeId, ClickTargetParams,
-    ElementInfo, MatchField, MatchTier, MutationReport, ResolutionReport,
+    ElementInfo, GlassError, MatchField, MatchTier, MutationReport, ResolutionReport,
     SEMANTIC_ACTION_DEFAULT_TIMEOUT_MS, SEMANTIC_ACTION_MAX_TIMEOUT_MS, ScopeResolution,
     SemanticActionError, SemanticActionFailureKind, SemanticActionOutcome, SemanticMatch,
     SetValueTargetParams, TypeTargetParams, Whose,
@@ -446,6 +446,15 @@ pub(crate) fn semantic_error(
 ) -> ContextualError {
     let error = error.into();
     let category = semantic_category(&error);
+    let post_write = error
+        .source
+        .as_ref()
+        .is_some_and(GlassError::set_value_failed_after_writing);
+    let safe_summary = if post_write {
+        category.post_write_summary()
+    } else {
+        category.summary()
+    };
     let include_text = tool != "glass_type";
     let mut siblings = Vec::new();
     if !error.candidates.is_empty() {
@@ -464,14 +473,14 @@ pub(crate) fn semantic_error(
     };
     ContextualError {
         code: category.code(),
-        message: category.summary().into(),
+        message: safe_summary.into(),
         category,
-        safe_summary: category.summary(),
+        safe_summary,
         sequence_deadline_exceeded: category == SafeErrorCategory::SequenceDeadlineExceeded,
         bound_dispatch: Some(bound_dispatch),
         result: Some(failure_result(&error)),
         siblings,
-        post_write: false,
+        post_write,
     }
 }
 

--- a/crates/glass-mcp/src/tools/semantic_action/tests.rs
+++ b/crates/glass-mcp/src/tools/semantic_action/tests.rs
@@ -1281,6 +1281,39 @@ fn caller_owned_or_expired_semantic_context_uses_sequence_deadline_and_keeps_evi
 }
 
 #[test]
+fn semantic_set_value_uncertainty_requires_observation_before_keyboard_recovery() {
+    for source in [
+        GlassError::AxElementNotEditable(4),
+        GlassError::Backend("APP CONTROLLED BACKEND DETAIL".into()),
+    ] {
+        let mut failure =
+            semantic_failure(SemanticActionFailureKind::ActionFailed, None, None, vec![]);
+        failure.source = Some(GlassError::write_unconfirmed_because(
+            4,
+            "APP CONTROLLED WRITE DETAIL",
+            source,
+        ));
+        failure.action_dispatch = DispatchStatus::MayHaveDispatched;
+        failure.retry = RetryGuidance::DoNotRetry;
+        let contextual = semantic_error("glass_set_value", failure);
+        assert!(contextual.post_write);
+        let output = erase_semantic_context("glass_set_value", Err(contextual)).unwrap_err();
+        let envelope = error_envelope(&output);
+        let summary = envelope["error"]["summary"].as_str().unwrap();
+        assert!(summary.contains("re-snapshot"), "{summary}");
+        assert!(!summary.contains("click_element"), "{summary}");
+        assert_eq!(envelope["result"]["dispatch"], "may_have_dispatched");
+        assert_eq!(envelope["result"]["retry"], "do_not_retry");
+        assert!(
+            !output
+                .render_text_blocks()
+                .join("\n")
+                .contains("APP CONTROLLED")
+        );
+    }
+}
+
+#[test]
 fn structured_backend_stale_and_deadline_errors_do_not_format_backend_source() {
     let mut stale = semantic_failure(SemanticActionFailureKind::ActionFailed, None, None, vec![]);
     stale.source = Some(GlassError::AxElementChanged(4));

--- a/crates/glass-mcp/src/tools/tests.rs
+++ b/crates/glass-mcp/src/tools/tests.rs
@@ -532,6 +532,115 @@ fn set_value_tool_ok_and_errors() {
 }
 
 #[test]
+fn set_value_without_writable_accessibility_value_guides_keyboard_recovery() {
+    struct KeyboardOnlyText(glass_core::AxTree);
+    impl glass_core::Accessibility for KeyboardOnlyText {
+        fn snapshot(
+            &mut self,
+            _: &glass_core::AxContext,
+        ) -> glass_core::Result<glass_core::AxTree> {
+            Ok(self.0.clone())
+        }
+
+        fn state_coverage(&self) -> glass_core::AxStateCoverage {
+            glass_core::AxStateCoverage {
+                enabled: true,
+                visible: true,
+                focusable: true,
+                editable: true,
+                ..glass_core::AxStateCoverage::NONE
+            }
+        }
+
+        fn set_value(
+            &mut self,
+            _: &glass_core::AxContext,
+            target: &glass_core::AxTarget,
+            _: &str,
+        ) -> glass_core::Result<()> {
+            Err(glass_core::GlassError::AxElementNotEditable(target.id.0).before_dispatch())
+        }
+    }
+
+    for semantic in [false, true] {
+        for batched in [false, true] {
+            let mut tree = fake_tree();
+            let field = &mut tree.root.children[0];
+            field.role = glass_core::AxRole::TextField;
+            field.name = Some("Text".into());
+            field.states.editable = true;
+            field.states.visible = true;
+            let dir = tempfile::tempdir().unwrap();
+            let mut glass = Glass::new(
+                Box::new(move |_| {
+                    Ok(glass_core::Backend {
+                        platform: Box::new(FakePlatform::new(100, 100)),
+                        accessibility: Some(Box::new(KeyboardOnlyText(tree.clone()))),
+                    })
+                }),
+                "x11".into(),
+                glass_core::BaselineStore::new(dir.path().join("baselines")),
+                100,
+            );
+            start(&mut glass, &start_args()).unwrap();
+            a11y_snapshot(&mut glass, &A11ySnapshotArgs { max_nodes: None }).unwrap();
+            let target = if semantic {
+                json!({"target": {"query": "Text", "role": "TextField"}, "text": "private input"})
+            } else {
+                json!({"id": 1, "text": "private input"})
+            };
+            let args: SetValueArgs = serde_json::from_value(target).unwrap();
+            let output = if batched {
+                do_actions(
+                    &mut glass,
+                    &DoArgs {
+                        actions: vec![
+                            Action::SetValue(args),
+                            Action::Key(KeyArgs {
+                                chord: "Return".into(),
+                            }),
+                        ],
+                        then: None,
+                        timeout_ms: None,
+                        encoded_argument_bytes: 0,
+                    },
+                )
+                .unwrap_err()
+            } else {
+                set_value(&mut glass, &args).unwrap_err()
+            };
+            let blocks = output.render_text_blocks();
+            let envelope: serde_json::Value = serde_json::from_str(&blocks[0]).unwrap();
+            let failure = if batched {
+                assert_eq!(envelope["outcome"]["steps"][1]["status"], "unexecuted");
+                &envelope["outcome"]["steps"][0]
+            } else {
+                &envelope
+            };
+            assert_eq!(failure["error"]["category"], "not_editable", "{envelope}");
+            let summary = failure["error"]["summary"].as_str().unwrap();
+            assert!(summary.contains("do not retry set_value"), "{summary}");
+            assert!(
+                summary.contains("click_element") && summary.contains("type"),
+                "{summary}"
+            );
+            let result = if batched { failure } else { &failure["result"] };
+            assert_eq!(
+                result["side_effects_may_have_occurred"], false,
+                "{envelope}"
+            );
+            if !batched {
+                assert_eq!(result["dispatch"], "not_dispatched", "{envelope}");
+                if semantic {
+                    assert_eq!(result["retry"], "correct_request", "{envelope}");
+                }
+            }
+            assert!(!blocks.join("\n").contains("private input"));
+        }
+    }
+}
+
+#[test]
 fn set_value_tool_rejects_uneditable_and_stale() {
     let spec = AppSpec {
         build: None,

--- a/docs/how-to/verify-a-change.md
+++ b/docs/how-to/verify-a-change.md
@@ -95,6 +95,17 @@ On Debian/Ubuntu, install the full AT-SPI suite's fixtures with
 
 Pass a substring to run one test.
 
+The egui text-write recovery test also needs the workspace-excluded fixture:
+
+```bash
+cargo build --release --manifest-path crates/glass-fixture-egui/Cargo.toml
+cargo test -p glass-a11y-linux --test egui -- --ignored
+```
+
+Set `GLASS_EGUI_FIXTURE` to use an already-built fixture at another path. This test checks that a
+missing text-write interface refuses before dispatch, keyboard input recovers, and numeric
+accessibility writes still work.
+
 The X11 and Wayland **backend crates** also keep their display-backed unit tests behind
 `#[ignore]`, and no harness script runs those — if you changed `glass-x11` or `glass-wayland`,
 the command above covers the end-to-end suite but not them:

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -899,6 +899,12 @@ element, clears it and types, then reads the element back to confirm — up to t
 field may commit a frame or two later. Errors if the element isn't editable, changed since the
 snapshot, does not hold the requested value afterwards, or the app exposes no accessibility tree.
 
+On Linux, a text field can advertise `editable` while exposing no AT-SPI `EditableText` interface
+(for example, egui/AccessKit). Glass checks that interface before attempting the write and returns
+`not_editable` with `dispatch:"not_dispatched"`. Do not repeat `set_value` for that field: focus it
+with `glass_click_element`, select existing text with `glass_key` if replacing it, then use
+`glass_type` and verify the value. The corresponding `glass_do` actions follow the same rule.
+
 The does-not-hold error names both values — what you asked for and what the element holds — because
 three outcomes look alike without them. An element that **transformed** the write holds your text in
 another form and writing again will not change that: a field that reformats (`"1234567890"` becoming


### PR DESCRIPTION
## Description

An egui/AccessKit text field can advertise `editable` while omitting AT-SPI `EditableText`. Glass previously attempted the missing method and reported an uncertain transport failure, sending agents through unnecessary observations and repeated writes.

Check the advertised interfaces before attempting a text write. A missing interface now returns `not_editable` with `not_dispatched`, and the response explicitly directs the agent to stop retrying `set_value` and use focus plus keyboard input. This guidance survives standalone, semantic-target, and `glass_do` responses. Actual post-write uncertainty retains the instruction to observe before recovery.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` — 3,745 passed, 364 ignored
- `./scripts/test-a11y.sh set_value` — all six live GTK tests passed
- New live egui regression test, using `GLASS_EGUI_FIXTURE` to select a prebuilt fixture: failed before the fix with `UnknownInterface`, then passed with refusal before dispatch, keyboard recovery, and a successful numeric write
- MCP regression coverage for ID/semantic targets, standalone/batched calls, stopped batches, payload redaction, and uncertain-write guidance
- Two fresh agent trials both recovered after one refusal without repeating the text write; each verified the exact text, numeric value, and Apply event in application logs
