### PR TITLE
fix: preserve dispatch evidence in stale ID responses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,9 @@ do, most of which run from any host.
   named feature branch for the issue or task.
 - If work began on `master`, move the changes to a feature branch before committing. Do not advance
   local `master` with task commits.
+- Include a user-facing `CHANGELOG.md` entry under `[Unreleased]` in the same PR as each behavior
+  change, as required by [the stability policy](docs/reference/stability.md). Reuse the existing
+  Added, Changed, or Fixed heading; omit internal refactors, CI, and test-only changes.
 
 ## Invariants
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,6 @@ internal refactors, CI, or test-only changes.
 
 ## [Unreleased]
 
-### Fixed
-- Concurrent artifact publications no longer race retention accounting or rollback on Windows, preventing valid responses from failing when another response changes the artifact directory.
-
 ### Added
 - Optional `max_width`/`max_height` shrink screenshots and settle/diff/region-wait image attachments, with source rectangles, returned dimensions and scaling metadata. Baseline verification and input coordinates remain in native pixels.
 - Optional `--trace-dir` retains supplied tool inputs and requested results in a bounded private session trace. Offline `trace inspect` and `trace export` validate and package evidence after the server stops, with explicit omissions and unchanged tool execution when recording reaches a limit or fails.
@@ -31,8 +28,19 @@ internal refactors, CI, or test-only changes.
 - Tool responses now share an 8 KiB text ceiling, with oversized logical blocks recoverable exactly through read-only `glass-artifact://` MCP resources backed by secure, ephemeral server-process artifacts.
 
 ### Changed
+- Successful `glass_do` calls without `then` now return compact ordered steps containing `result` and `content_blocks`, plus total `elapsed_ms`. Redundant `status`, `executed`, `index`, and `action` fields are omitted; use array order and `steps.length` to identify and count completed actions. Failures and calls with `then` retain their detailed outcomes.
+- Source builds now use stable Rust instead of nightly; rustup installs the toolchain pinned in `rust-toolchain.toml` automatically.
 - Shortened MCP tool and parameter guidance and centralized cross-tool instructions while retaining action limits, mutation warnings and existing tool contracts. Capability reports identify the selected tool profile and link only to its exposed tools.
 - Contained Linux launches now require Bubblewrap support for `--unshare-pid`, private `--proc`, and `--json-status-fd`; launch fails closed with upgrade guidance when the installed Bubblewrap lacks them.
+
+### Fixed
+- `glass_click_element` and `glass_set_value` now report `not_dispatched` when an ID is missing from the current accessibility snapshot and advise taking a fresh snapshot before retrying with the current ID or a semantic target. Stale failures after possible dispatch advise inspecting state before retrying. In `glass_do`, a refused stale-ID step is unattempted, earlier completed steps remain completed, and later steps remain unexecuted.
+- On Linux, `glass_set_value` now detects controls that do not expose accessibility text editing before attempting a write. The error directs agents to focus the field and use keyboard input instead of repeating `glass_set_value`; failures where a write may already have landed still require observing state before recovery.
+- `glass_do` no longer repeats an error detail in a separate content block when it is identical to the structured error summary.
+- Targeted `glass_type` no longer spends its focus-confirmation timeout polling a backend that cannot report focused state, such as the iOS Simulator reader. It reports unconfirmed focus after one confirmation read and sends no text.
+- On Windows, releasing an abandoned launch now terminates its suspended app even when explicit teardown was skipped.
+- On Windows, overlapping clipboard operations in one server process now fail cleanly, and an operation interrupted by a panic releases the clipboard so later reads and writes can proceed.
+- Concurrent artifact publications no longer race retention accounting or rollback on Windows, preventing valid responses from failing when another response changes the artifact directory.
 
 ## [1.7.0] - 2026-08-31
 

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -174,6 +174,18 @@ impl SafeErrorCategory {
         }
     }
 
+    fn summary_for_dispatch(self, dispatch: Option<BoundDispatch>) -> &'static str {
+        match (self, dispatch) {
+            (Self::StaleElement, Some(BoundDispatch::NotDispatched)) => {
+                "element is stale or missing; this action was not dispatched. Take a fresh glass_a11y_snapshot and retry with the current ID or a semantic target"
+            }
+            (Self::StaleElement, _) => {
+                "element is stale or missing; this action may already have happened. Inspect current state before retrying; do not replay completed actions"
+            }
+            _ => self.summary(),
+        }
+    }
+
     fn post_write_summary(self) -> &'static str {
         match self {
             Self::TransportFailure => {
@@ -232,7 +244,7 @@ impl ContextualError {
             safe_summary: if post_write {
                 category.post_write_summary()
             } else {
-                category.summary()
+                category.summary_for_dispatch(bound_dispatch)
             },
             sequence_deadline_exceeded: error.bound_owner() == Some(glass_core::Whose::Caller),
             bound_dispatch,
@@ -279,7 +291,16 @@ impl ContextualError {
     }
 
     pub fn after_dispatch(mut self) -> Self {
+        let message_was_summary = self.message == self.safe_summary;
         self.bound_dispatch = Some(BoundDispatch::MayHaveDispatched);
+        self.safe_summary = if self.post_write {
+            self.category.post_write_summary()
+        } else {
+            self.category.summary_for_dispatch(self.bound_dispatch)
+        };
+        if message_was_summary {
+            self.message = self.safe_summary.into();
+        }
         self
     }
 
@@ -844,14 +865,7 @@ pub(crate) fn click_element_with(
             if semantic {
                 semantic_action::semantic_error("glass_click_element", error)
             } else {
-                let message = error.to_string();
-                match error.source {
-                    Some(source) => ContextualError::from_caller_bound(source, context),
-                    None => ContextualError::from_caller_bound(
-                        glass_core::GlassError::Backend(message),
-                        context,
-                    ),
-                }
+                semantic_action::id_error(error, context)
             }
         })?;
     let action_context = ToolContext {
@@ -926,17 +940,7 @@ pub(crate) fn set_value_with(
             if semantic {
                 semantic_action::semantic_error("glass_set_value", error)
             } else {
-                let message = error.to_string();
-                match error.source {
-                    Some(source) => {
-                        ContextualError::from_caller_bound(source, context).scrub_message()
-                    }
-                    None => ContextualError::from_caller_bound(
-                        glass_core::GlassError::Backend(message),
-                        context,
-                    )
-                    .scrub_message(),
-                }
+                semantic_action::id_error(error, context).scrub_message()
             }
         })?;
     let action_context = ToolContext {

--- a/crates/glass-mcp/src/tools/batch/tests.rs
+++ b/crates/glass-mcp/src/tools/batch/tests.rs
@@ -2921,6 +2921,59 @@ fn standalone_and_batch_semantic_click_results_match_except_for_sequence_fields(
 }
 
 #[test]
+fn stale_id_failure_keeps_completed_batch_steps_and_stops_remaining_actions() {
+    for set_value in [false, true] {
+        let platform = FakePlatform::new(100, 100);
+        let events = platform.events.clone();
+        let mut glass = started_a11y(platform);
+        let stale = if set_value {
+            Action::SetValue(SetValueArgs {
+                id: Some(99),
+                target: None,
+                timeout_ms: None,
+                max_nodes: None,
+                text: "private input".into(),
+                return_: None,
+            })
+        } else {
+            Action::ClickElement(ClickElementArgs {
+                id: Some(99),
+                target: None,
+                mode: None,
+                timeout_ms: None,
+                max_nodes: None,
+                return_: None,
+            })
+        };
+        let output = do_actions(
+            &mut glass,
+            &do_args(
+                vec![
+                    Action::Key(KeyArgs {
+                        chord: "Tab".into(),
+                    }),
+                    stale,
+                    Action::Key(KeyArgs {
+                        chord: "Return".into(),
+                    }),
+                ],
+                1_000,
+            ),
+        )
+        .unwrap_err();
+        let envelope = envelope(&output);
+        let steps = &envelope["outcome"]["steps"];
+        assert_eq!(steps[0]["status"], "completed");
+        assert_eq!(steps[1]["error"]["code"], "stale_element");
+        assert_eq!(steps[1]["attempted"], false);
+        assert_eq!(steps[1]["side_effects_may_have_occurred"], false);
+        assert_eq!(steps[2]["status"], "unexecuted");
+        assert_eq!(*events.lock().unwrap(), vec!["key(Tab)"]);
+        assert_secret_absent(&output, "private input");
+    }
+}
+
+#[test]
 fn click_element_stale_target_stops_with_structured_detail() {
     let mut g = started_a11y(FakePlatform::new(100, 100));
     let err = error_text(
@@ -2951,8 +3004,8 @@ fn click_element_stale_target_stops_with_structured_detail() {
     let step = &error["outcome"]["steps"][0];
     assert_eq!(error["error"]["code"], "stale_element");
     assert_eq!(step["action"], "click_element");
-    assert_eq!(step["attempted"], true);
-    assert_eq!(step["side_effects_may_have_occurred"], true);
+    assert_eq!(step["attempted"], false);
+    assert_eq!(step["side_effects_may_have_occurred"], false);
     assert!(step.get("result").is_none());
     assert_eq!(error["outcome"]["steps"][1]["status"], "unexecuted");
 }

--- a/crates/glass-mcp/src/tools/semantic_action.rs
+++ b/crates/glass-mcp/src/tools/semantic_action.rs
@@ -10,7 +10,7 @@ use serde_json::{Value, json};
 use crate::params::{Action, ActionModeArg, ClickElementArgs, SetValueArgs, TypeArgs};
 use crate::tools::find::semantic_target;
 use crate::tools::{
-    ContextualError, OutContent, SafeErrorCategory, ToolOutput, validate_return,
+    ContextualError, OutContent, SafeErrorCategory, ToolContext, ToolOutput, validate_return,
     validate_settle_args,
 };
 
@@ -440,6 +440,23 @@ fn failure_result(error: &SemanticActionError) -> Value {
     result
 }
 
+pub(crate) fn id_error(
+    error: impl Into<Box<SemanticActionError>>,
+    context: ToolContext,
+) -> ContextualError {
+    let error = error.into();
+    let may_have_dispatched = error.side_effects_may_have_occurred();
+    let message = error.to_string();
+    let source = error.source.unwrap_or(GlassError::Backend(message));
+    // The action layer knows whether it reached dispatch; retain stronger source evidence too.
+    let source = if may_have_dispatched || source.set_value_failed_after_writing() {
+        source.after_dispatch()
+    } else {
+        source.before_dispatch()
+    };
+    ContextualError::from_caller_bound(source, context)
+}
+
 pub(crate) fn semantic_error(
     tool: &'static str,
     error: impl Into<Box<SemanticActionError>>,
@@ -450,10 +467,15 @@ pub(crate) fn semantic_error(
         .source
         .as_ref()
         .is_some_and(GlassError::set_value_failed_after_writing);
+    let bound_dispatch = if error.side_effects_may_have_occurred() {
+        glass_core::BoundDispatch::MayHaveDispatched
+    } else {
+        glass_core::BoundDispatch::NotDispatched
+    };
     let safe_summary = if post_write {
         category.post_write_summary()
     } else {
-        category.summary()
+        category.summary_for_dispatch(Some(bound_dispatch))
     };
     let include_text = tool != "glass_type";
     let mut siblings = Vec::new();
@@ -466,11 +488,6 @@ pub(crate) fn semantic_error(
             &json!({ "target": element_json(target, include_text) }).to_string(),
         ));
     }
-    let bound_dispatch = if error.side_effects_may_have_occurred() {
-        glass_core::BoundDispatch::MayHaveDispatched
-    } else {
-        glass_core::BoundDispatch::NotDispatched
-    };
     ContextualError {
         code: category.code(),
         message: safe_summary.into(),

--- a/crates/glass-mcp/src/tools/semantic_action/tests.rs
+++ b/crates/glass-mcp/src/tools/semantic_action/tests.rs
@@ -1314,12 +1314,95 @@ fn semantic_set_value_uncertainty_requires_observation_before_keyboard_recovery(
 }
 
 #[test]
+fn id_error_preserves_action_focus_and_source_dispatch_evidence() {
+    for (action_dispatch, focus_dispatch, source, expected) in [
+        (
+            DispatchStatus::NotDispatched,
+            None,
+            GlassError::NoAxSnapshot,
+            BoundDispatch::NotDispatched,
+        ),
+        (
+            DispatchStatus::NotDispatched,
+            None,
+            GlassError::AxElementNotFound(99),
+            BoundDispatch::NotDispatched,
+        ),
+        (
+            DispatchStatus::MayHaveDispatched,
+            None,
+            GlassError::AxElementChanged(4),
+            BoundDispatch::MayHaveDispatched,
+        ),
+        (
+            DispatchStatus::NotDispatched,
+            Some(DispatchStatus::Dispatched),
+            GlassError::AxElementGone(4),
+            BoundDispatch::MayHaveDispatched,
+        ),
+        (
+            DispatchStatus::NotDispatched,
+            None,
+            GlassError::AxElementChanged(4).after_dispatch(),
+            BoundDispatch::MayHaveDispatched,
+        ),
+    ] {
+        let mut failure =
+            semantic_failure(SemanticActionFailureKind::ActionFailed, None, None, vec![]);
+        failure.action_dispatch = action_dispatch;
+        failure.focus = focus_dispatch.map(|dispatch| MutationReport {
+            method: ActionMethod::NativeAction { actuated: None },
+            dispatch,
+            confirmation: ConfirmationStatus::Unconfirmed,
+        });
+        failure.source = Some(source);
+        let contextual = super::id_error(failure, ToolContext::UNBOUNDED);
+        assert_eq!(contextual.bound_dispatch, Some(expected));
+        let summary = contextual.safe_summary;
+        if expected == BoundDispatch::NotDispatched {
+            assert!(
+                summary.contains("not dispatched") && summary.contains("current ID"),
+                "{summary}"
+            );
+        } else {
+            assert!(
+                summary.contains("Inspect current state before retrying"),
+                "{summary}"
+            );
+            assert!(!summary.contains("not dispatched"), "{summary}");
+        }
+    }
+}
+
+#[test]
+fn stale_return_observation_after_dispatch_does_not_claim_the_action_was_refused() {
+    let contextual = ContextualError::from_core(
+        GlassError::NoAxSnapshot.before_dispatch(),
+        ToolContext::UNBOUNDED,
+    )
+    .scrub_message()
+    .after_dispatch();
+    assert_eq!(
+        contextual.bound_dispatch,
+        Some(BoundDispatch::MayHaveDispatched)
+    );
+    assert!(
+        contextual
+            .safe_summary
+            .contains("Inspect current state before retrying")
+    );
+    assert!(!contextual.message.contains("not dispatched"));
+}
+
+#[test]
 fn structured_backend_stale_and_deadline_errors_do_not_format_backend_source() {
     let mut stale = semantic_failure(SemanticActionFailureKind::ActionFailed, None, None, vec![]);
     stale.source = Some(GlassError::AxElementChanged(4));
     let stale = semantic_error("glass_click_element", stale);
     assert_eq!(stale.code, "stale_element");
     assert_eq!(stale.category, SafeErrorCategory::StaleElement);
+    assert!(stale.safe_summary.contains("not dispatched"));
+    assert!(stale.safe_summary.contains("fresh glass_a11y_snapshot"));
 
     for (kind, owner, code) in [
         (

--- a/crates/glass-mcp/src/tools/tests.rs
+++ b/crates/glass-mcp/src/tools/tests.rs
@@ -529,6 +529,8 @@ fn set_value_tool_ok_and_errors() {
     .unwrap_err();
     let err = structured_error(&err, "glass_set_value");
     assert_eq!(err["error"]["code"], "stale_element");
+    assert_eq!(err["result"]["dispatch"], "not_dispatched");
+    assert_eq!(err["result"]["side_effects_may_have_occurred"], false);
 }
 
 #[test]
@@ -744,6 +746,12 @@ fn click_element_tool_ok_and_errors() {
     .unwrap_err();
     let err = structured_error(&err, "glass_click_element");
     assert_eq!(err["error"]["code"], "stale_element");
+    assert_eq!(err["result"]["dispatch"], "not_dispatched");
+    assert_eq!(err["result"]["side_effects_may_have_occurred"], false);
+    let summary = err["error"]["summary"].as_str().unwrap();
+    assert!(summary.contains("not dispatched"), "{summary}");
+    assert!(summary.contains("fresh glass_a11y_snapshot"), "{summary}");
+    assert!(summary.contains("current ID"), "{summary}");
 }
 
 #[test]

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -827,6 +827,12 @@ follow as siblings (the legend untrusted-wrapped), per the image ordering above.
 substring over accessible name, description, and non-secure value, `role` uses Glass's normalized
 roles, and every supplied field and state is AND-combined. Secure values are never searched.
 
+An ID missing from the current snapshot returns `stale_element` with `dispatch:"not_dispatched"`.
+Take a fresh `glass_a11y_snapshot` and retry with the current ID or a semantic target. In `glass_do`,
+that failed step is unattempted and later steps are unexecuted; earlier completed steps remain
+completed. A stale-element failure after possible dispatch instead requires inspecting the current
+state before retrying, including when the action succeeded but its return observation failed.
+
 A selector action performs fresh reads until exactly one target exists in exactly one optional
 scope. It refuses zero matches as `no_match`, duplicate targets as `ambiguous_target`, duplicate
 scopes as `ambiguous_scope`, and a truncated, unreadable, or withheld tree as `incomplete_tree` when


### PR DESCRIPTION
## Description

When an ID is missing from the cached accessibility snapshot, `glass_click_element` and `glass_set_value` reject the request before dispatch. Their MCP handlers dropped that verdict and reported `may_have_dispatched`, leaving agents unsure whether to retry.

Preserve the core action's dispatch evidence and return `not_dispatched` with instructions to take a fresh `glass_a11y_snapshot` and use the current ID or a semantic target. Stale failures after possible dispatch instead instruct agents to inspect current state before retrying and avoid replaying completed actions. Semantic-target responses use the same wording, and return-observation failures retain the earlier action's dispatch.

In `glass_do`, a refused stale-ID step is marked unattempted, earlier completed steps remain completed, and later steps remain unexecuted.

Update the unreleased changelog for this fix and backfill missing batch-response, Linux text-write recovery, focus-confirmation, Windows launch/clipboard, and stable-Rust entries. Restore Added/Changed/Fixed ordering and make the existing same-PR changelog requirement explicit in `AGENTS.md`.

## Validation

- Regression assertion failed before the fix and passes afterward. Coverage includes standalone click/value errors, stopped batches, prior focus and source dispatch evidence, and return-observation failures after dispatch.
- Live egui verification through the stdio MCP server compared old and patched binaries: missing snapshot and stale click/write IDs now report no dispatch; app logs show no Apply before recovery and exactly one after refreshing the snapshot and clicking the current ID.
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` — 3,748 passed, 364 ignored.
- Changelog entries checked against the implementing commits; all existing entries, released history, and compare links preserved. `git diff --check` passes. The follow-up changes only documentation.
