### PR TITLE
fix: preserve observed text in targeted typing snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ internal refactors, CI, or test-only changes.
 - Contained Linux launches now require Bubblewrap support for `--unshare-pid`, private `--proc`, and `--json-status-fd`; launch fails closed with upgrade guidance when the installed Bubblewrap lacks them.
 
 ### Fixed
+- Targeted `glass_type` with `return:"snapshot"` now returns current app-visible names, descriptions, and editable values instead of silently clearing all text. Standalone and batched typing use the same snapshot rendering as `glass_a11y_snapshot`, including secure-value redaction; action metadata and errors still do not echo submitted text.
 - `glass_click_element` and `glass_set_value` now report `not_dispatched` when an ID is missing from the current accessibility snapshot and advise taking a fresh snapshot before retrying with the current ID or a semantic target. Stale failures after possible dispatch advise inspecting state before retrying. In `glass_do`, a refused stale-ID step is unattempted, earlier completed steps remain completed, and later steps remain unexecuted.
 - On Linux, `glass_set_value` now detects controls that do not expose accessibility text editing before attempting a write. The error directs agents to focus the field and use keyboard input instead of repeating `glass_set_value`; failures where a write may already have landed still require observing state before recovery.
 - `glass_do` no longer repeats an error detail in a separate content block when it is identical to the structured error summary.

--- a/crates/glass-mcp/src/params.rs
+++ b/crates/glass-mcp/src/params.rs
@@ -289,7 +289,7 @@ pub struct TypeArgs {
     #[schemars(range(min = 0, max = 120000))]
     pub timeout_ms: Option<u64>,
     pub max_nodes: Option<u32>,
-    /// none (default): no observation; settle: text-only visual stability; snapshot: settle and refresh/fold the accessibility tree.
+    /// none (default): no observation; settle: text-only visual stability; snapshot: settle and read the current accessibility tree, including app-visible text, with secure values redacted.
     #[serde(rename = "return")]
     pub return_: Option<String>,
 }

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -1891,11 +1891,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn targeted_type_snapshot_resource_never_persists_submitted_or_coincident_text() {
+    async fn targeted_type_snapshot_resource_preserves_observed_text_and_redacts_secure_values() {
         const SENTINEL: &str = "SERVER_TARGETED_TYPE_SNAPSHOT_SENTINEL_76b1";
+        const SECURE: &str = "SERVER_TARGETED_TYPE_SECURE_SENTINEL_f280";
         let output = crate::tools::semantic_action::tests::targeted_type_snapshot_output_for_server(
-            SENTINEL,
+            SENTINEL, SENTINEL, SECURE,
         );
+        let expected_snapshot = output.render_text_blocks()[2].clone();
         assert!(output.text_bytes() > crate::output_policy::MAX_TEXT_BYTES);
         let root = tempfile::tempdir().unwrap();
         let store = ArtifactStore::for_test(root.path(), 1 << 20).unwrap();
@@ -1930,7 +1932,7 @@ mod tests {
                 .content
                 .iter()
                 .filter_map(|content| content.as_text())
-                .all(|text| !text.text.contains(SENTINEL))
+                .all(|text| !text.text.contains(SECURE))
         );
         let links = result
             .content
@@ -1941,14 +1943,22 @@ mod tests {
             !links.is_empty(),
             "oversized targeted type snapshot externalized"
         );
+        let mut recovered_snapshot = false;
         for link in links {
             let resource = server.read_resource_for_test(&link.uri).unwrap();
             assert_eq!(resource.contents.len(), 1);
             let ResourceContents::TextResourceContents { text, .. } = &resource.contents[0] else {
                 panic!("expected text resource")
             };
-            assert!(!text.contains(SENTINEL));
+            assert!(!text.contains(SECURE));
+            if text == &expected_snapshot {
+                recovered_snapshot = true;
+            }
         }
+        assert!(
+            recovered_snapshot,
+            "the exact observed snapshot remains readable"
+        );
     }
 
     #[test]

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -719,7 +719,6 @@ fn resolve_return_with(
     glass: &mut Glass,
     ret: Option<&str>,
     context: ToolContext,
-    include_application_text: bool,
 ) -> Result<ReturnObservation, ContextualError> {
     if !context.allow_wait && matches!(ret, Some("settle" | "snapshot")) {
         let category = if context.owner == Some(glass_core::Whose::Caller) {
@@ -782,13 +781,9 @@ fn resolve_return_with(
             }
             // Reuse the session's current limits so a fold after a raised/unbounded snapshot
             // isn't silently re-truncated to the default cap.
-            let mut tree = glass
+            let tree = glass
                 .a11y_resnapshot(context.deadline)
                 .map_err(|e| ContextualError::from_core(e, context))?;
-            if !include_application_text {
-                tree.subject = None;
-                scrub_ax_text(&mut tree.root);
-            }
             // Same shape as `a11y_snapshot`: the app-derived outline stays untrusted-wrapped;
             // glass's own steers are separate trusted blocks, not baked into that body.
             let body = glass_core::outline::render_compact(&tree);
@@ -806,16 +801,6 @@ fn resolve_return_with(
         Some(o) => Err(ContextualError::validation(format!(
             "unknown return '{o}' (use none/settle/snapshot)"
         ))),
-    }
-}
-
-fn scrub_ax_text(node: &mut glass_core::AxNode) {
-    node.raw_role.clear();
-    node.name = None;
-    node.description = None;
-    node.value = None;
-    for child in &mut node.children {
-        scrub_ax_text(child);
     }
 }
 
@@ -874,20 +859,18 @@ pub(crate) fn click_element_with(
         allow_wait: outcome.bound.allow_wait,
     };
     let (observed, extra, timed_out_by) =
-        resolve_return_with(glass, a.return_.as_deref(), action_context, true).map_err(
-            |error| {
-                if semantic {
-                    semantic_return_error(
-                        "glass_click_element",
-                        &outcome,
-                        error,
-                        "click was dispatched; return observe failed",
-                    )
-                } else {
-                    error.after_dispatch()
-                }
-            },
-        )?;
+        resolve_return_with(glass, a.return_.as_deref(), action_context).map_err(|error| {
+            if semantic {
+                semantic_return_error(
+                    "glass_click_element",
+                    &outcome,
+                    error,
+                    "click was dispatched; return observe failed",
+                )
+            } else {
+                error.after_dispatch()
+            }
+        })?;
     let output = if semantic {
         semantic_action::success_output("glass_click_element", &outcome, observed, extra)
     } else {
@@ -949,23 +932,21 @@ pub(crate) fn set_value_with(
         allow_wait: outcome.bound.allow_wait,
     };
     let (observed, extra, timed_out_by) =
-        resolve_return_with(glass, a.return_.as_deref(), action_context, true).map_err(
-            |error| {
-                let error = if semantic {
-                    semantic_return_error(
-                        "glass_set_value",
-                        &outcome,
-                        error,
-                        "set-value return observe failed",
-                    )
-                } else {
-                    error.after_dispatch()
-                };
-                error
-                    .scrub_message()
-                    .annotate("set-value return observe failed")
-            },
-        )?;
+        resolve_return_with(glass, a.return_.as_deref(), action_context).map_err(|error| {
+            let error = if semantic {
+                semantic_return_error(
+                    "glass_set_value",
+                    &outcome,
+                    error,
+                    "set-value return observe failed",
+                )
+            } else {
+                error.after_dispatch()
+            };
+            error
+                .scrub_message()
+                .annotate("set-value return observe failed")
+        })?;
     let output = if semantic {
         semantic_action::success_output("glass_set_value", &outcome, observed, extra)
     } else {

--- a/crates/glass-mcp/src/tools/input.rs
+++ b/crates/glass-mcp/src/tools/input.rs
@@ -222,13 +222,14 @@ pub(crate) fn type_text_with(
                 .key_by(&KeyEvent::Text(a.text.clone()), context.deadline)
                 .map_err(|e| ContextualError::from_caller_bound(e, context).scrub_message())?;
             let (observed, extra, timed_out_by) =
-                crate::tools::resolve_return_with(glass, a.return_.as_deref(), context, true)
-                    .map_err(|error| {
+                crate::tools::resolve_return_with(glass, a.return_.as_deref(), context).map_err(
+                    |error| {
                         error
                             .after_dispatch()
                             .scrub_message()
                             .annotate("text was typed; return observe failed")
-                    })?;
+                    },
+                )?;
             let mut result = serde_json::json!({});
             if let Some(observed) = observed {
                 result["observed"] = observed;
@@ -249,22 +250,18 @@ pub(crate) fn type_text_with(
                 owner: outcome.bound.owner,
                 allow_wait: outcome.bound.allow_wait,
             };
-            let (observed, extra, timed_out_by) = crate::tools::resolve_return_with(
-                glass,
-                a.return_.as_deref(),
-                action_context,
-                false,
-            )
-            .map_err(|error| {
-                semantic_return_error(
-                    "glass_type",
-                    &outcome,
-                    error,
-                    "text was typed; return observe failed",
-                )
-                .scrub_message()
-                .annotate("text was typed; return observe failed")
-            })?;
+            let (observed, extra, timed_out_by) =
+                crate::tools::resolve_return_with(glass, a.return_.as_deref(), action_context)
+                    .map_err(|error| {
+                        semantic_return_error(
+                            "glass_type",
+                            &outcome,
+                            error,
+                            "text was typed; return observe failed",
+                        )
+                        .scrub_message()
+                        .annotate("text was typed; return observe failed")
+                    })?;
             Ok(ContextualOutput::with_timeout(
                 crate::tools::semantic_action::success_output(
                     "glass_type",

--- a/crates/glass-mcp/src/tools/semantic_action/tests.rs
+++ b/crates/glass-mcp/src/tools/semantic_action/tests.rs
@@ -1447,8 +1447,18 @@ fn structured_type_failure_excludes_submitted_payload_from_blocks_and_artifacts(
     assert_forced_artifacts_exclude_payload(output, "glass_type", SENTINEL);
 }
 
-pub(crate) fn targeted_type_snapshot_output_for_server(sentinel: &str) -> crate::tools::ToolOutput {
+pub(crate) fn targeted_type_snapshot_output_for_server(
+    sentinel: &str,
+    submitted: &str,
+    secure_value: &str,
+) -> crate::tools::ToolOutput {
     let mut tree = semantic_control_tree(AxRole::TextField, "Account", Some(sentinel), true);
+    let mut password = tree.root.children[0].clone();
+    password.name = Some("Password".into());
+    password.value = Some(secure_value.into());
+    password.states.secure = true;
+    password.states.focused = false;
+    tree.root.children.push(password);
     tree.root.children.extend((0..600).map(|index| AxNode {
         id: AxNodeId(0),
         role: AxRole::Label,
@@ -1476,7 +1486,7 @@ pub(crate) fn targeted_type_snapshot_output_for_server(sentinel: &str) -> crate:
     let args: TypeArgs = serde_json::from_value(serde_json::json!({
         "target": {"query": "Account", "role": "TextField"},
         "focus_mode": "native",
-        "text": sentinel,
+        "text": submitted,
         "timeout_ms": 1_000,
         "max_nodes": 0,
         "return": "snapshot",
@@ -1486,16 +1496,101 @@ pub(crate) fn targeted_type_snapshot_output_for_server(sentinel: &str) -> crate:
 }
 
 #[test]
-fn targeted_type_snapshot_clears_submitted_and_coincident_text_before_output_policy() {
+fn targeted_type_snapshot_preserves_observed_text_without_synthesizing_submitted_text() {
     const SENTINEL: &str = "TARGETED_TYPE_SNAPSHOT_SENTINEL_ef317";
-    let output = targeted_type_snapshot_output_for_server(SENTINEL);
-    assert!(output.text_bytes() > crate::output_policy::MAX_TEXT_BYTES);
-    assert!(
-        output
-            .render_text_blocks()
-            .iter()
-            .all(|block| !block.contains(SENTINEL))
-    );
+    const SECURE: &str = "TARGETED_TYPE_SECURE_SENTINEL_85f3";
+    for submitted in [SENTINEL, "REQUEST_ONLY_SENTINEL_0ea8"] {
+        let output = targeted_type_snapshot_output_for_server(SENTINEL, submitted, SECURE);
+        assert!(output.text_bytes() > crate::output_policy::MAX_TEXT_BYTES);
+        let blocks = output.render_text_blocks();
+        assert!(!blocks[0].contains(SENTINEL));
+        assert!(!blocks[1].contains(SENTINEL));
+        assert!(blocks[2].contains(&format!("value=\"{SENTINEL}\"")));
+        assert!(blocks[2].contains("value=<redacted>"));
+        assert!(blocks.iter().all(|block| !block.contains(SECURE)));
+        if submitted != SENTINEL {
+            assert!(blocks.iter().all(|block| !block.contains(submitted)));
+        }
+    }
+}
+
+#[test]
+fn targeted_type_snapshot_matches_independent_observation_and_redacts_secure_values() {
+    for batch in [false, true] {
+        let mut tree =
+            semantic_control_tree(AxRole::TextField, "Account", Some("app read-back"), true);
+        tree.root.children[0].description = Some("Account description".into());
+        let mut number = tree.root.children[0].clone();
+        number.role = AxRole::SpinButton;
+        number.name = Some("Value".into());
+        number.value = Some("42".into());
+        number.states.focused = false;
+        let mut password = tree.root.children[0].clone();
+        password.name = Some("Password".into());
+        password.description = None;
+        password.value = Some("SECURE_VALUE_SENTINEL_6583".into());
+        password.states.secure = true;
+        password.states.focused = false;
+        tree.root.children.extend([number, password]);
+        tree.assign_ids();
+        let (mut glass, counters, _) = started_instrumented_glass_with(
+            tree,
+            AxStateCoverage {
+                focused: true,
+                ..semantic_control_coverage()
+            },
+            None,
+        );
+        let args: TypeArgs = serde_json::from_value(serde_json::json!({
+            "target": {"query": "Account", "role": "TextField"},
+            "focus_mode": "native",
+            "text": "REQUEST_ONLY_SENTINEL_99af",
+            "return": "snapshot",
+        }))
+        .unwrap();
+        let output = if batch {
+            do_actions(
+                &mut glass,
+                &DoArgs {
+                    actions: vec![Action::Type(args)],
+                    then: None,
+                    timeout_ms: Some(5_000),
+                    encoded_argument_bytes: 0,
+                },
+            )
+            .unwrap()
+        } else {
+            type_text(&mut glass, &args).unwrap()
+        };
+        {
+            let calls = counters.calls.lock().unwrap();
+            assert_eq!(calls.iter().filter(|call| **call == "key").count(), 1);
+            assert!(
+                calls.iter().rposition(|call| *call == "a11y_snapshot")
+                    > calls.iter().position(|call| *call == "key")
+            );
+        }
+        let fresh = crate::tools::a11y_snapshot(
+            &mut glass,
+            &crate::params::A11ySnapshotArgs { max_nodes: None },
+        )
+        .unwrap();
+        let attached = output.text_block(2).expect("attached snapshot");
+        let independent = fresh.text_block(1).expect("independent snapshot");
+        assert_eq!(
+            untrusted_body(&attached.body),
+            untrusted_body(&independent.body),
+            "batch={batch}"
+        );
+        assert!(attached.body.contains("Account description"));
+        assert!(attached.body.contains("value=\"app read-back\""));
+        assert!(attached.body.contains("value=\"42\""));
+        assert!(attached.body.contains("value=<redacted>"));
+        for block in output.render_text_blocks() {
+            assert!(!block.contains("REQUEST_ONLY_SENTINEL_99af"));
+            assert!(!block.contains("SECURE_VALUE_SENTINEL_6583"));
+        }
+    }
 }
 
 fn assert_forced_artifacts_exclude_payload(

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -505,6 +505,12 @@ single keyboard dispatch separately. Untargeted typing retains its existing empt
 form also includes `observed: {settled, saw_motion, observed_ms}` when `return:"settle"`, exactly as
 for `glass_click_element`.
 
+An explicit `return:"snapshot"` returns the same current app-visible names, descriptions, and bounded
+editable values as `glass_a11y_snapshot`, including text the app displays after typing. Secure values
+remain redacted. The requested observation stays in untrusted content blocks and, when oversized,
+read-only output artifacts. Action metadata, target/candidate details, and errors do not echo the
+submitted type text. This applies to standalone typing and `glass_do` type steps.
+
 ### `glass_key`
 
 Press a key chord.
@@ -633,7 +639,9 @@ optional `result?` evidence produced before the failure, `error.{code,summary,ca
 performed no rollback, so landed effects may persist. App-derived names,
 descriptions, values, outlines, and images remain untrusted sibling blocks. Non-secret raw error
 details also remain untrusted siblings. Failures from `type` and `set_value` instead expose only
-sanitized category and summary diagnostics, and submitted text is never echoed in any batch output.
+sanitized category and summary diagnostics; action metadata and error details never echo submitted
+text. Explicit observations can contain text read from the app, with the same secure-value redaction
+as standalone observations.
 An error detail identical to the structured summary does not produce a duplicate sibling block.
 
 Do not replay a completed action or a failed action with


### PR DESCRIPTION
## Description

Targeted `glass_type` with `return:"snapshot"` silently cleared every name, description, and value from the requested accessibility snapshot. A successful type could therefore return an unlabeled tree while an immediate standalone snapshot showed the entered value and unrelated controls correctly.

Use the normal snapshot renderer for explicitly requested observations, in standalone calls and `glass_do` type steps. These observations retain app-published text, including text displayed after typing, and may be externalized as read-only artifacts. Secure values retain standard snapshot redaction; action metadata, target/candidate details, and errors still omit submitted type text.

Remove the blanket text-filter flag and document the observation contract in the parameter guidance, tool reference, and changelog.

## Validation

- Regression comparison failed before the fix and passes afterward for standalone and batched typing. It verifies a fresh read after one keyboard dispatch, unrelated labels/values, and secure-value redaction.
- Coverage distinguishes submitted text from actual observed text and verifies oversized snapshots remain exactly readable through artifact resources. Existing error-redaction and dispatch tests pass.
- Live egui verification through the stdio MCP server: attached snapshots now show `recovered` / `batched`, the unrelated Value `42`, and Apply. Independent snapshots agree, and app logs show each completed text once.
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` — 3,749 passed, 364 ignored.
