### PR TITLE
Revert stronger batching discovery guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ internal refactors, CI, or test-only changes.
 - Tool responses now share an 8 KiB text ceiling, with oversized logical blocks recoverable exactly through read-only `glass-artifact://` MCP resources backed by secure, ephemeral server-process artifacts.
 
 ### Changed
+- Restored the earlier `glass_do` discovery guidance, removing batching redirects from standalone tool descriptions and the opening shared instructions. Batching remains available in both profiles.
 - Successful `glass_do` calls without `then` now return compact ordered steps containing `result` and `content_blocks`, plus total `elapsed_ms`. Redundant `status`, `executed`, `index`, and `action` fields are omitted; use array order and `steps.length` to identify and count completed actions. Failures and calls with `then` retain their detailed outcomes.
 - Source builds now use stable Rust instead of nightly; rustup installs the toolchain pinned in `rust-toolchain.toml` automatically.
 - Shortened MCP tool and parameter guidance and centralized cross-tool instructions while retaining action limits, mutation warnings and existing tool contracts. Capability reports identify the selected tool profile and link only to its exposed tools.
@@ -35,7 +36,6 @@ internal refactors, CI, or test-only changes.
 
 ### Fixed
 - Log tool guidance now directs verification of completed actions to buffered output and explains saving a cursor before repeated events. The already-buffered timeout note discourages repeating a wait that watches only future lines.
-- Restored `glass_do` batching cues in standalone action descriptions and early shared instructions, so agents discovering tools can choose one call for two or more known steps and pause when later steps depend on new observations.
 - Targeted `glass_type` with `return:"snapshot"` now returns current app-visible names, descriptions, and editable values instead of silently clearing all text. Standalone and batched typing use the same snapshot rendering as `glass_a11y_snapshot`, including secure-value redaction; action metadata and errors still do not echo submitted text.
 - `glass_click_element` and `glass_set_value` now report `not_dispatched` when an ID is missing from the current accessibility snapshot and advise taking a fresh snapshot before retrying with the current ID or a semantic target. Stale failures after possible dispatch advise inspecting state before retrying. In `glass_do`, a refused stale-ID step is unattempted, earlier completed steps remain completed, and later steps remain unexecuted.
 - On Linux, `glass_set_value` now detects controls that do not expose accessibility text editing before attempting a write. The error directs agents to focus the field and use keyboard input instead of repeating `glass_set_value`; failures where a write may already have landed still require observing state before recovery.

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -581,7 +581,7 @@ impl GlassServer {
 
     #[tool(
         annotations(read_only_hint = true, open_world_hint = false),
-        description = "Wait for visual quiescence and return the last frame, not that an expected semantic state or pixel design was reached. Use include_image:false for text-only metadata. A timeout returns settled:false. window_id observes without selecting that window. For 2+ known active-window steps, use glass_do."
+        description = "Wait for visual quiescence and return the last frame, not that an expected semantic state or pixel design was reached. Use include_image:false for text-only metadata. A timeout returns settled:false. window_id observes without selecting that window."
     )]
     async fn glass_wait_stable(
         &self,
@@ -602,7 +602,7 @@ impl GlassServer {
             destructive_hint = false,
             open_world_hint = false
         ),
-        description = "Click a window-relative point, optionally with a button, click count and held modifiers. For 2+ known steps, use glass_do."
+        description = "Click a window-relative point, optionally with a button, click count and held modifiers."
     )]
     async fn glass_click(
         &self,
@@ -621,7 +621,7 @@ impl GlassServer {
             destructive_hint = false,
             open_world_hint = false
         ),
-        description = "Move the pointer to a window-relative point. For 2+ known steps, use glass_do."
+        description = "Move the pointer to a window-relative point."
     )]
     async fn glass_move(
         &self,
@@ -640,7 +640,7 @@ impl GlassServer {
             destructive_hint = false,
             open_world_hint = false
         ),
-        description = "Drag one pointer from (x1,y1) to (x2,y2), holding the button and modifiers throughout. Motion spans duration_ms. Either endpoint outside the window is refused. Use glass_gesture for multi-touch. For 2+ known steps, use glass_do."
+        description = "Drag one pointer from (x1,y1) to (x2,y2), holding the button and modifiers throughout. Motion spans duration_ms. Either endpoint outside the window is refused. Use glass_gesture for multi-touch."
     )]
     async fn glass_drag(
         &self,
@@ -659,7 +659,7 @@ impl GlassServer {
             destructive_hint = false,
             open_world_hint = false
         ),
-        description = "Scroll the container under (x,y) by horizontal/vertical wheel notches, optionally holding modifiers. Notches are not pixels. For 2+ known steps, use glass_do."
+        description = "Scroll the container under (x,y) by horizontal/vertical wheel notches, optionally holding modifiers. Notches are not pixels."
     )]
     async fn glass_scroll(
         &self,
@@ -702,7 +702,7 @@ impl GlassServer {
             destructive_hint = false,
             open_world_hint = false
         ),
-        description = "Type text once. Without `target`, focused-window typing sends keystrokes to current focus. A target resolves one fresh unique element; focus_mode auto, native or pointer confirms focus then types once. Unconfirmed focus never types or tries another path. Newlines do not press Return: use a key action. No value confirmation; verify the resulting field. Never replay after uncertain dispatch. For 2+ known steps, use glass_do."
+        description = "Type text once. Without `target`, focused-window typing sends keystrokes to current focus. A target resolves one fresh unique element; focus_mode auto, native or pointer confirms focus then types once. Unconfirmed focus never types or tries another path. Newlines do not press Return: use a key action. No value confirmation; verify the resulting field. Never replay after uncertain dispatch."
     )]
     async fn glass_type(
         &self,
@@ -721,7 +721,7 @@ impl GlassServer {
             destructive_hint = false,
             open_world_hint = false
         ),
-        description = "Press a key chord (for example ctrl+s or Return), releasing modifiers afterwards. Unknown keys/modifiers fail before input. Use type for literal text; it cannot express shortcuts. For 2+ known steps, use glass_do."
+        description = "Press a key chord (for example ctrl+s or Return), releasing modifiers afterwards. Unknown keys/modifiers fail before input. Use type for literal text; it cannot express shortcuts."
     )]
     async fn glass_key(
         &self,
@@ -913,7 +913,7 @@ impl GlassServer {
 
     #[tool(
         annotations(read_only_hint = true, open_world_hint = false),
-        description = "Read current semantic state: IDs, roles, name/description, bounded editable `value`, bounds and states. Values can be absent, redacted or truncated; use wait_for_element for exact verification. IDs refresh each snapshot. A childless Document notice calls for one fresh read, then pixels; an unpublished-content placeholder requires pixels. Errors without an accessibility tree; use glass_screenshot. Batch known actions and checks with glass_do."
+        description = "Read current semantic state: IDs, roles, name/description, bounded editable `value`, bounds and states. Values can be absent, redacted or truncated; use wait_for_element for exact verification. IDs refresh each snapshot. A childless Document notice calls for one fresh read, then pixels; an unpublished-content placeholder requires pixels. Errors without an accessibility tree; use glass_screenshot."
     )]
     async fn glass_a11y_snapshot(
         &self,
@@ -934,7 +934,7 @@ impl GlassServer {
             destructive_hint = false,
             open_world_hint = false
         ),
-        description = "Click exactly one id or target. A target resolves fresh and uniquely within timeout_ms (10 seconds by default). Mode auto prefers native then pointer fallback; native requires native action; pointer waits for stability and reports actionability, including unproven checks. ID targets remain immediate. Native actions may bypass occlusion or focus text editors. method/native_fallback/actuated_id disclose the path; popover actions restore the prior window. Glass never retries after possible dispatch. For 2+ known steps, use glass_do."
+        description = "Click exactly one id or target. A target resolves fresh and uniquely within timeout_ms (10 seconds by default). Mode auto prefers native then pointer fallback; native requires native action; pointer waits for stability and reports actionability, including unproven checks. ID targets remain immediate. Native actions may bypass occlusion or focus text editors. method/native_fallback/actuated_id disclose the path; popover actions restore the prior window. Glass never retries after possible dispatch."
     )]
     async fn glass_click_element(
         &self,
@@ -955,7 +955,7 @@ impl GlassServer {
             destructive_hint = false,
             open_world_hint = false
         ),
-        description = "Set exactly one editable id or target with backend confirmation. A target resolves fresh and uniquely (10 seconds by default); IDs remain immediate. Writes directly or focuses/clears/types as supported, then reads back. Errors distinguish mismatch from unconfirmed writes; post-write uncertainty is terminal. Do not write again on uncertainty: observe where input landed before recovery. For 2+ known steps, use glass_do."
+        description = "Set exactly one editable id or target with backend confirmation. A target resolves fresh and uniquely (10 seconds by default); IDs remain immediate. Writes directly or focuses/clears/types as supported, then reads back. Errors distinguish mismatch from unconfirmed writes; post-write uncertainty is terminal. Do not write again on uncertainty: observe where input landed before recovery."
     )]
     async fn glass_set_value(
         &self,
@@ -1000,7 +1000,7 @@ impl GlassServer {
 
     #[tool(
         annotations(read_only_hint = true, open_world_hint = false),
-        description = "Wait for semantic transition completion, not pixels/stability. Select by name, description and/or role; `value` is exact, value_contains is a substring. Supports appears/disappears and state conditions. Returns matched, elapsed_ms and the element; timeout is matched:false. Waits for initial tree publication, but errors if no tree appeared. Batched use fails the sequence on an unmatched predicate. For 2+ known steps, use glass_do."
+        description = "Wait for semantic transition completion, not pixels/stability. Select by name, description and/or role; `value` is exact, value_contains is a substring. Supports appears/disappears and state conditions. Returns matched, elapsed_ms and the element; timeout is matched:false. Waits for initial tree publication, but errors if no tree appeared. Batched use fails the sequence on an unmatched predicate."
     )]
     async fn glass_wait_for_element(
         &self,
@@ -1021,7 +1021,7 @@ impl GlassServer {
             destructive_hint = false,
             open_world_hint = false
         ),
-        description = "Scroll until a semantic element is actually on-screen; returns matched, elapsed_ms, element and scrolled details. Sweeps the chosen/inferred direction, then reverses. No match after both ends or timeout returns matched:false; no tree errors. Batched use fails the sequence on an unmatched predicate. For 2+ known steps, use glass_do."
+        description = "Scroll until a semantic element is actually on-screen; returns matched, elapsed_ms, element and scrolled details. Sweeps the chosen/inferred direction, then reverses. No match after both ends or timeout returns matched:false; no tree errors. Batched use fails the sequence on an unmatched predicate."
     )]
     async fn glass_scroll_to_element(
         &self,
@@ -1076,7 +1076,7 @@ impl GlassServer {
             destructive_hint = false,
             open_world_hint = false
         ),
-        description = "Batch 2+ known actions or waits here; observe before choosing dependent steps. Run one action or fixed static ordered actions: click, move, drag, scroll, type, key, settle, click_element, set_value, wait_for_element, scroll_to_element. Maximum 64 actions and 65536 compact argument bytes. timeout_ms defaults to 30000; range 1 through 120000; one deadline includes terminal observations. Fail-fast on action errors, deadline or unmatched batched predicates; standalone predicates remain soft. Success without then returns ordered steps with result and content_blocks; ok:true means all actions completed. Failures and then retain completed, failed, unexecuted and terminal_steps; inspect before recovery. Preflight invalid_sequence has no step outcomes. Terminal settle/diff/screenshot runs after actions; terminal failure retains completed action outcomes. No branching, bindings, loops, retries or generated steps. Semantic targets resolve fresh; targeted type requires confirmed focus; set_value requires confirmation. Never replay completed or possibly dispatched mutations; observe after uncertainty."
+        description = "Run one action or fixed static ordered actions: click, move, drag, scroll, type, key, settle, click_element, set_value, wait_for_element, scroll_to_element. Maximum 64 actions and 65536 compact argument bytes. timeout_ms defaults to 30000; range 1 through 120000; one deadline includes terminal observations. Fail-fast on action errors, deadline or unmatched batched predicates; standalone predicates remain soft. Success without then returns ordered steps with result and content_blocks; ok:true means all actions completed. Failures and then retain completed, failed, unexecuted and terminal_steps; inspect before recovery. Preflight invalid_sequence has no step outcomes. Terminal settle/diff/screenshot runs after actions; terminal failure retains completed action outcomes. No branching, bindings, loops, retries or generated steps. Semantic targets resolve fresh; targeted type requires confirmed focus; set_value requires confirmation. Never replay completed or possibly dispatched mutations; observe after uncertainty."
     )]
     async fn glass_do(
         &self,
@@ -1667,7 +1667,6 @@ mod tests {
         assert!(!has_property(&schema, "encoded_argument_bytes"), "{schema}");
 
         let description = tool.description.as_deref().expect("description");
-        assert!(description.starts_with("Batch 2+ known actions or waits here"));
         for required in [
             "fixed static ordered actions",
             "64 actions",
@@ -1701,59 +1700,12 @@ mod tests {
     }
 
     #[test]
-    fn batch_eligible_standalone_descriptions_redirect_known_sequences() {
-        let tools = GlassServer::tool_router().list_all();
-        for name in [
-            "glass_click",
-            "glass_move",
-            "glass_drag",
-            "glass_scroll",
-            "glass_type",
-            "glass_key",
-            "glass_wait_stable",
-            "glass_click_element",
-            "glass_set_value",
-            "glass_wait_for_element",
-            "glass_scroll_to_element",
-        ] {
-            let description = tools
-                .iter()
-                .find(|tool| tool.name == name)
-                .and_then(|tool| tool.description.as_deref())
-                .expect("standalone tool description");
-            assert!(
-                description.contains("For 2+ known") && description.contains("steps, use glass_do"),
-                "{name} missing batching cue"
-            );
-        }
-        let snapshot = tools
-            .iter()
-            .find(|tool| tool.name == "glass_a11y_snapshot")
-            .unwrap();
-        assert!(
-            snapshot
-                .description
-                .as_deref()
-                .unwrap()
-                .contains("glass_do")
-        );
-    }
-
-    #[test]
     fn shared_guidance_routes_known_work_and_preserves_recovery_rules() {
         let full = ToolProfile::Full.instructions();
         let lean = ToolProfile::Lean.instructions();
         assert!(full.contains("Prefer glass_do whenever at least two"));
         assert!(lean.contains("Use glass_do even for a single action"));
         for instructions in [&full, &lean] {
-            let batching = instructions
-                .find("Prefer glass_do whenever at least two")
-                .unwrap();
-            let actions = instructions.find("Use semantic targets first").unwrap();
-            assert!(
-                batching < actions,
-                "route known work before individual actions"
-            );
             for required in [
                 "Batch known work; observe before choosing dependent steps",
                 "ordered steps with result and content_blocks",

--- a/crates/glass-mcp/src/tool_profile.rs
+++ b/crates/glass-mcp/src/tool_profile.rs
@@ -36,9 +36,6 @@ const LEAN_TOOLS: &[&str] = &[
 
 pub(crate) const SHARED_INSTRUCTIONS: &str = "Glass drives external native GUI apps. One active session: \
     glass_start launches and captures logs; glass_stop ends it. Check glass_capabilities for runtime support.\n\n\
-    Prefer glass_do whenever at least two upcoming actions or verification waits are already known. \
-    Example: write a known field, click Apply, then wait for the expected state, each with its own selector. \
-    Batch known work; observe before choosing dependent steps.\n\n\
     Use semantic targets first: give a unique intended target directly to an action. Use glass_find_elements \
     for approximate or duplicate candidates, glass_a11y_snapshot for broad structure. A target is a \
     case-insensitive substring query over name, description and non-secure value, with optional role and \
@@ -52,8 +49,8 @@ pub(crate) const SHARED_INSTRUCTIONS: &str = "Glass drives external native GUI a
     requires backend confirmation; targeted type confirms focus then types once. Unconfirmed focus never \
     types. Input dispatch does not prove runtime state. Post-write uncertainty is terminal: observe before \
     recovery; never blindly replay an action or completed sequence after possible dispatch.\n\n\
-    glass_do runs one action or a fixed known sequence. Success without then returns ordered steps with \
-    result and content_blocks; ok:true means all \
+    glass_do runs one action or a fixed known sequence. Batch known work; observe before choosing dependent \
+    steps. Success without then returns ordered steps with result and content_blocks; ok:true means all \
     actions completed. Failures and then retain completed, failed, unexecuted and terminal_steps outcomes. Batched wait_for_element and \
     scroll_to_element fail the sequence on an unmatched predicate; standalone predicates time out softly. \
     A settle step may complete with settled:false; the overall sequence deadline still fails execution.\n\n\
@@ -82,8 +79,9 @@ impl ToolProfile {
     pub(crate) fn instructions(self) -> String {
         let routing = match self {
             Self::Full => {
-                "Profile: full. All tools are available. Standalone action tools support steps chosen \
-                after observing new state."
+                "Profile: full. All tools are available. Prefer glass_do whenever at least two \
+                upcoming actions or verification waits are already known. Standalone action tools support \
+                steps chosen after observing new state."
             }
             Self::Lean => {
                 "Profile: lean. Use glass_do even for a single action: for example \


### PR DESCRIPTION
Reverts the stronger batching promotion from #576, restoring the earlier standalone tool descriptions and shared instructions. This removes the repeated redirects to `glass_do` and the early batching example while retaining batching support and existing full/lean profile routing.

The rollback is limited to #576. The `set_value` recovery, stale-ID dispatch evidence, targeted typing snapshots, and buffered-log guidance from #573–575 and #577 remain. The unreleased changelog records the rollback.

Validation:
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` — 3,750 passed, 364 ignored
- Verified the built full-profile inventory preserves all 31 tools and their schemas, with only the 13 reverted descriptions and shared instructions changed.

Checks ran under an owned Xvfb display and private session bus; cleanup completed successfully. This is a guidance rollback, not a claim of restored benchmark performance.
