### PR TITLE
Pace consecutive X11 input actions for frame-based clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ internal refactors, CI, or test-only changes.
 - Contained Linux launches now require Bubblewrap support for `--unshare-pid`, private `--proc`, and `--json-status-fd`; launch fails closed with upgrade guidance when the installed Bubblewrap lacks them.
 
 ### Fixed
+- X11 input now allows 50 ms after each dispatched pointer or keyboard action before returning, bounded by the caller deadline. This prevents rapid action sequences from combining clicks or a final typed character with a later focus change in the same UI frame. Both standalone input tools and `glass_do` use the same pacing; successful dispatch still requires verifying the app's expected state.
 - Log tool guidance now directs verification of completed actions to buffered output and explains saving a cursor before repeated events. The already-buffered timeout note discourages repeating a wait that watches only future lines.
 - Restored `glass_do` batching cues in standalone action descriptions and early shared instructions, so agents discovering tools can choose one call for two or more known steps and pause when later steps depend on new observations.
 - Targeted `glass_type` with `return:"snapshot"` now returns current app-visible names, descriptions, and editable values instead of silently clearing all text. Standalone and batched typing use the same snapshot rendering as `glass_a11y_snapshot`, including secure-value redaction; action metadata and errors still do not echo submitted text.

--- a/crates/glass-a11y-linux/tests/integration.rs
+++ b/crates/glass-a11y-linux/tests/integration.rs
@@ -1394,6 +1394,9 @@ fn scroll_to_element_reaches_a_virtualized_offscreen_row() {
 
     // The returned id is from the final snapshot → click it and confirm the fixture
     // selected exactly that row (via its stdout).
+    let (_, cursor) = glass
+        .logs(0, usize::MAX, None, None)
+        .expect("pre-click log cursor");
     glass
         .click_element(elem.id)
         .expect("click the realized row");
@@ -1401,12 +1404,12 @@ fn scroll_to_element_reaches_a_virtualized_offscreen_row() {
         .wait_for_log(&glass_core::WaitLogParams {
             contains: "SELECTED Row 060".into(),
             stream: None,
-            cursor: None,
+            cursor: Some(cursor),
             interval_ms: 100,
             timeout_ms: 4000,
         })
         .expect("wait_for_log");
-    assert!(seen.matched, "click did not select Row 060");
+    assert!(seen.matched, "click did not select Row 060: {seen:?}");
     glass.stop().expect("stop");
 }
 

--- a/crates/glass-fixture-egui/src/main.rs
+++ b/crates/glass-fixture-egui/src/main.rs
@@ -246,6 +246,7 @@ impl eframe::App for Fixture {
                 wrap_in_pane(ui, |ui| {
                     if ui.button("Apply").clicked() {
                         log("[fixture] apply");
+                        log(&format!("[fixture] applied_text={}", self.text));
                     }
                 });
             });

--- a/crates/glass-mcp/src/env.rs
+++ b/crates/glass-mcp/src/env.rs
@@ -351,6 +351,8 @@ pub(crate) const GLASS_ENV: &[EnvVarDoc] = &[
 /// no production reader, so it would otherwise be flagged dead code in a non-test build.
 #[cfg(test)]
 pub(crate) const INTERNAL_ENV: &[&str] = &[
+    // Selects an already-built egui fixture for live input tests.
+    "GLASS_EGUI_FIXTURE",
     // Not actually an environment variable: the X11 CLIPBOARD-selection transfer atom name
     // interned in glass-x11/src/clipboard.rs (`b"GLASS_CLIP"`). It shares the `GLASS_` prefix
     // the guard test scans for, so it needs an entry here even though `std::env::var` never

--- a/crates/glass-mcp/src/tools/batch.rs
+++ b/crates/glass-mcp/src/tools/batch.rs
@@ -598,3 +598,6 @@ fn run_then(
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(all(test, target_os = "linux"))]
+mod egui_tests;

--- a/crates/glass-mcp/src/tools/batch/egui_tests.rs
+++ b/crates/glass-mcp/src/tools/batch/egui_tests.rs
@@ -1,0 +1,157 @@
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use glass_core::{AppSpec, AxNode, AxRole, Backend, BaselineStore, Glass, SandboxLevel};
+use serde_json::{Value, json};
+
+use crate::params::Action;
+use crate::tools;
+
+fn find(node: &AxNode, name: &str, role: AxRole) -> Option<(i32, i32)> {
+    if node.name.as_deref() == Some(name) && node.role == role {
+        let bounds = node.bounds?;
+        Some((
+            bounds.x + i32::try_from(bounds.width / 2).unwrap(),
+            bounds.y + i32::try_from(bounds.height / 2).unwrap(),
+        ))
+    } else {
+        node.children
+            .iter()
+            .find_map(|child| find(child, name, role))
+    }
+}
+
+fn actions(glass: &mut Glass, input: Vec<Value>, batched: bool) {
+    if batched {
+        tools::do_actions(
+            glass,
+            &serde_json::from_value(json!({"actions": input})).unwrap(),
+        )
+        .unwrap();
+    } else {
+        for value in input {
+            match serde_json::from_value::<Action>(value).unwrap() {
+                Action::Click(args) => {
+                    tools::click(glass, &args).unwrap();
+                }
+                Action::Key(args) => {
+                    tools::key(glass, &args).unwrap();
+                }
+                Action::Type(args) => {
+                    tools::type_text(glass, &args).unwrap();
+                }
+                _ => unreachable!(),
+            }
+        }
+    }
+}
+
+#[test]
+#[ignore = "needs private Xvfb/AT-SPI and a built glass-fixture-egui"]
+fn consecutive_inputs_preserve_clicks_and_final_text_in_batches_and_standalone() {
+    let fixture = std::env::var_os("GLASS_EGUI_FIXTURE")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("../glass-fixture-egui/target/release/glass-fixture-egui")
+        });
+    assert!(fixture.is_file(), "build the egui fixture: {fixture:?}");
+    let dir = tempfile::tempdir().unwrap();
+    let xvfb = glass_x11::Xvfb::start("1280x800x24").unwrap();
+    let display = xvfb.display.clone();
+    let mut glass = Glass::new(
+        Box::new(move |_| {
+            Ok(Backend {
+                platform: Box::new(glass_x11::X11Platform::connect(Some(&display))?),
+                accessibility: Some(Box::new(glass_a11y_linux::LinuxA11y::new())),
+            })
+        }),
+        "x11".into(),
+        BaselineStore::new(dir.path().join("baselines")),
+        1000,
+    );
+    glass
+        .start(&AppSpec {
+            build: None,
+            run: vec![fixture.to_string_lossy().into_owned()],
+            cwd: None,
+            env: vec![("LIBGL_ALWAYS_SOFTWARE".into(), "1".into())],
+            window_hint: None,
+            timeout_ms: 10_000,
+            sandbox: SandboxLevel::Off,
+            a11y: true,
+        })
+        .unwrap();
+
+    let expected = [
+        ("Semantic Save", AxRole::Button),
+        ("Restart movement", AxRole::Button),
+        ("Text:", AxRole::TextField),
+        ("Apply", AxRole::Button),
+    ];
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let centers = loop {
+        if let Ok(tree) = glass.a11y_snapshot(None) {
+            let centers: Option<Vec<_>> = expected
+                .iter()
+                .map(|(name, role)| find(&tree.root, name, *role))
+                .collect();
+            if let Some(centers) = centers {
+                break centers;
+            }
+        }
+        assert!(Instant::now() < deadline, "fixture controls unavailable");
+        std::thread::sleep(Duration::from_millis(20));
+    };
+    let click =
+        |index: usize| json!({"action": "click", "x": centers[index].0, "y": centers[index].1});
+    let mut failures = Vec::new();
+    for repetition in 0..4 {
+        for batched in [false, true] {
+            let (_, cursor) = glass.logs(0, 1000, None, None).unwrap();
+            let text = format!("sequence-{repetition}-{batched}.json");
+            actions(
+                &mut glass,
+                vec![
+                    click(0),
+                    click(1),
+                    click(2),
+                    json!({"action": "key", "chord": "ctrl+a"}),
+                    json!({"action": "type", "text": text}),
+                    click(3),
+                ],
+                batched,
+            );
+            let deadline = Instant::now() + Duration::from_secs(2);
+            let applied = format!("[fixture] applied_text={text}");
+            let lines = loop {
+                let (lines, _) = glass.logs(cursor, 1000, None, None).unwrap();
+                if lines
+                    .iter()
+                    .any(|line| line.text.starts_with("[fixture] applied_text="))
+                    || Instant::now() >= deadline
+                {
+                    break lines.into_iter().map(|line| line.text).collect::<Vec<_>>();
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            };
+            for expected in [
+                "[fixture] semantic_save",
+                "[fixture] movement_restart",
+                &applied,
+            ] {
+                if !lines.iter().any(|line| line == expected) {
+                    let outcomes: Vec<_> = lines
+                        .iter()
+                        .filter(|line| !line.starts_with("[fixture] key "))
+                        .collect();
+                    failures.push(format!(
+                        "batch={batched} repetition={repetition}: missing {expected}; {outcomes:?}"
+                    ));
+                }
+            }
+        }
+    }
+    glass.stop().unwrap();
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -46,6 +46,10 @@ const XT_BTN_RELEASE: u8 = 5; // ButtonRelease
 const XT_KEY_PRESS: u8 = 2; // KeyPress
 const XT_KEY_RELEASE: u8 = 3; // KeyRelease
 
+// Separate input actions so frame-based clients can consume a click or final character
+// before a later action moves the pointer or changes focus.
+const INPUT_ACTION_DWELL: Duration = Duration::from_millis(50);
+
 fn modifier_keycodes_dispatched(keycodes: &[u8]) -> bool {
     !keycodes.is_empty()
 }
@@ -607,6 +611,19 @@ impl X11Platform {
         self.conn
             .flush()
             .map_err(|e| GlassError::Backend(format!("flush: {e}")))
+    }
+
+    fn finish_input_by(&self, dispatch: &X11Dispatch, deadline: Deadline) -> Result<()> {
+        self.commit()?;
+        if dispatch.sent.get() {
+            std::thread::sleep(
+                deadline
+                    .remaining()
+                    .unwrap_or(INPUT_ACTION_DWELL)
+                    .min(INPUT_ACTION_DWELL),
+            );
+        }
+        Ok(())
     }
 
     /// Intern an atom by name (small helper for the multi-window scans).
@@ -1707,7 +1724,7 @@ impl Platform for X11Platform {
                     return Err(crate::unsupported_multi_touch());
                 }
             }
-            self.commit()
+            self.finish_input_by(dispatch, deadline)
         })
     }
 
@@ -1741,7 +1758,7 @@ impl Platform for X11Platform {
                     glass_core::run_chord_by(&mut sink, deadline)?;
                 }
             }
-            self.commit()
+            self.finish_input_by(dispatch, deadline)
         })
     }
 
@@ -3610,6 +3627,46 @@ mod display_tests {
             vec![(3, 30, 40), (3, 30, 40)],
             "a double right-click is button 3 twice, at the point asked for"
         );
+    }
+
+    #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
+    fn input_dwell_deadline_keeps_dispatched_clicks_released() {
+        let x = TestX::start();
+        let mut plat = x.platform();
+        let win = x
+            .window()
+            .at(0, 0)
+            .sized(400, 400)
+            .watching_input()
+            .create();
+        plat.window = Some(win);
+        let _ = x.drain_events(Duration::from_millis(50));
+
+        let error = plat
+            .send_pointer_by(
+                &PointerEvent::Click {
+                    x: 30,
+                    y: 40,
+                    button: glass_core::MouseButton::Left,
+                    count: 1,
+                    modifiers: vec![],
+                },
+                Deadline::from_millis(25),
+            )
+            .expect_err("deadline expires during post-input dwell");
+
+        assert_eq!(error.bound(), Some(BoundKind::TimedOut));
+        assert_eq!(error.bound_owner(), Some(Whose::Caller));
+        assert_eq!(
+            error.bound_dispatch(),
+            Some(BoundDispatch::MayHaveDispatched)
+        );
+        let events = x.drain_events(Duration::from_millis(50));
+        assert!(events.iter().any(|event| matches!(event, x11rb::protocol::Event::ButtonPress(button) if button.detail == 1)));
+        assert!(events.iter().any(|event| matches!(event, x11rb::protocol::Event::ButtonRelease(button) if button.detail == 1)));
+        let pointer = plat.conn.query_pointer(win).unwrap().reply().unwrap();
+        assert!(!pointer.mask.contains(KeyButMask::BUTTON1));
     }
 
     #[test]

--- a/docs/how-to/verify-a-change.md
+++ b/docs/how-to/verify-a-change.md
@@ -100,11 +100,15 @@ The egui text-write recovery test also needs the workspace-excluded fixture:
 ```bash
 cargo build --release --manifest-path crates/glass-fixture-egui/Cargo.toml
 cargo test -p glass-a11y-linux --test egui -- --ignored
+cargo test -p glass-mcp --lib consecutive_inputs_preserve_clicks_and_final_text_in_batches_and_standalone -- --ignored
 ```
 
 Set `GLASS_EGUI_FIXTURE` to use an already-built fixture at another path. This test checks that a
 missing text-write interface refuses before dispatch, keyboard input recovers, and numeric
 accessibility writes still work.
+
+The MCP egui test checks consecutive coordinate clicks and typing followed by Apply, both as
+standalone tools and in `glass_do`. It starts its own Xvfb display and private accessibility bus.
 
 The X11 and Wayland **backend crates** also keep their display-backed unit tests behind
 `#[ignore]`, and no harness script runs those — if you changed `glass-x11` or `glass-wayland`,


### PR DESCRIPTION
Rapid X11 input sequences can lose clicks or the final typed character when a later action moves the pointer or changes focus before the app processes the earlier input. This reproduces with both `glass_do` and immediate standalone calls.

Add a 50 ms pause after dispatched pointer and keyboard actions in the shared X11 backend, bounded by the caller deadline. Empty typing adds no pause. Deadline expiry after dispatch retains possible-dispatch evidence; the change does not replay input. This adds latency per action and provides pacing, not confirmation of application state.

The live egui regression fails before this change and passes afterward. It checks consecutive coordinate clicks and the complete text observed when Apply is clicked, in both calling modes. A display-backed deadline test also checks that the button has been released when the pause reaches the caller deadline. The changelog and verification guide are updated. The existing AT-SPI row-selection test now captures its log cursor before clicking, so it also counts acknowledgements received before the click returns.

Validation, all under private Linux display/session-bus isolation:

- Formatting and workspace Clippy with warnings denied.
- Workspace tests: 3,751 passed, 366 ignored (`--test-threads=4`).
- X11 backend tests including ignored cases: 215 passed.
- Live egui regression: passed; original backend failed.
- X11 integration suite: 58 passed.
- AT-SPI suite: 39 passed, including the Wayland cases and bus tests.
- Corrected row-selection test: four focused runs passed.

Three unchanged accessibility-worker tests with 20 ms setup deadlines failed in the initial unrestricted parallel run. All 46 tests in that module passed serially, and the complete workspace subsequently passed with four test threads. A launch-only accessibility test timed out during desktop-service autostart on the isolated bus; the complete AT-SPI suite passed with service autostart disabled on that bus. All owned-session cleanup checks passed.

This branch retains the existing batching guidance. #579 remains a separate draft rollback.
