### PR TITLE
Pace consecutive Wayland and Windows input actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ internal refactors, CI, or test-only changes.
 - Contained Linux launches now require Bubblewrap support for `--unshare-pid`, private `--proc`, and `--json-status-fd`; launch fails closed with upgrade guidance when the installed Bubblewrap lacks them.
 
 ### Fixed
+
+- Wayland and Windows input now allow 50 ms after dispatched pointer and keyboard actions before returning, bounded by the caller deadline. This keeps rapid standalone calls and `glass_do` sequences from changing the click target or focus before a frame-based app consumes the previous action. Deadline expiry preserves possible-dispatch reporting; app transitions still require checking the expected state.
 - X11 input now allows 50 ms after each dispatched pointer or keyboard action before returning, bounded by the caller deadline. This prevents rapid action sequences from combining clicks or a final typed character with a later focus change in the same UI frame. Both standalone input tools and `glass_do` use the same pacing; successful dispatch still requires verifying the app's expected state.
 - Log tool guidance now directs verification of completed actions to buffered output and explains saving a cursor before repeated events. The already-buffered timeout note discourages repeating a wait that watches only future lines.
 - Restored `glass_do` batching cues in standalone action descriptions and early shared instructions, so agents discovering tools can choose one call for two or more known steps and pause when later steps depend on new observations.

--- a/crates/glass-core/src/typing.rs
+++ b/crates/glass-core/src/typing.rs
@@ -15,10 +15,10 @@ use crate::{Deadline, GlassError};
 pub const TYPE_DWELL: Duration = Duration::from_millis(60);
 
 /// The per-backend primitive that [`run_type`] sequences. `character` must be
-/// **self-committed**: it performs the backend's commit barrier before returning — Windows
-/// one `SendInput`, X11 `XFlush`, Wayland a compositor roundtrip — so each keystroke is
-/// delivered before the next. A picky or heavy client (e.g. a browser) silently drops
-/// keystrokes that are merely queued and committed once at the end.
+/// **self-committed**: it submits the character before returning — Windows one `SendInput`,
+/// X11 `XFlush`, Wayland a compositor roundtrip. This does not acknowledge app consumption;
+/// backends also pace characters and completed actions where needed. A heavy client can drop
+/// keystrokes that are queued and committed only once at the end.
 pub trait TypeSink {
     /// Press and release one character, committing before returning.
     fn character(&mut self, c: char) -> crate::Result<()>;

--- a/crates/glass-mcp/Cargo.toml
+++ b/crates/glass-mcp/Cargo.toml
@@ -66,7 +66,7 @@ glass-sandbox-linux.workspace = true
 [target.'cfg(windows)'.dependencies]
 glass-windows = { path = "../glass-windows" }
 glass-a11y-windows = { path = "../glass-a11y-windows" }
-windows = { version = "0.62", features = ["Win32_Storage_FileSystem"] }
+windows = { version = "0.62", features = ["Win32_Storage_FileSystem", "Win32_UI_HiDpi"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 glass-macos = { path = "../glass-macos" }

--- a/crates/glass-mcp/src/tools/batch.rs
+++ b/crates/glass-mcp/src/tools/batch.rs
@@ -599,5 +599,5 @@ fn run_then(
 #[cfg(test)]
 mod tests;
 
-#[cfg(all(test, target_os = "linux"))]
+#[cfg(all(test, any(target_os = "linux", windows)))]
 mod egui_tests;

--- a/crates/glass-mcp/src/tools/batch/egui_tests.rs
+++ b/crates/glass-mcp/src/tools/batch/egui_tests.rs
@@ -47,35 +47,150 @@ fn actions(glass: &mut Glass, input: Vec<Value>, batched: bool) {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 #[ignore = "needs private Xvfb/AT-SPI and a built glass-fixture-egui"]
 fn consecutive_inputs_preserve_clicks_and_final_text_in_batches_and_standalone() {
+    consecutive_inputs("x11", false);
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+#[ignore = "needs headless sway/AT-SPI and a built glass-fixture-egui"]
+fn wayland_consecutive_inputs_preserve_clicks_and_final_text() {
+    consecutive_inputs("wayland", false);
+    consecutive_inputs("wayland", true);
+}
+
+#[test]
+#[cfg(windows)]
+#[ignore = "needs an interactive Windows desktop and a built glass-fixture-egui"]
+fn windows_consecutive_inputs_preserve_clicks_and_final_text() {
+    // SAFETY: one-time DPI setup for this dedicated on-box test process.
+    #[allow(unsafe_code)]
+    unsafe {
+        use windows::Win32::UI::HiDpi::{
+            DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2, SetProcessDpiAwarenessContext,
+        };
+        let _ = SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+    }
+    consecutive_inputs("windows", false);
+}
+
+#[cfg(target_os = "linux")]
+struct PausedApp {
+    pid: rustix::process::Pid,
+    resume: Option<std::thread::JoinHandle<()>>,
+}
+
+#[cfg(target_os = "linux")]
+impl PausedApp {
+    fn new(pid_file: &std::path::Path, fixture: &std::path::Path) -> Self {
+        use rustix::process::{Pid, Signal, kill_process};
+        let raw: i32 = std::fs::read_to_string(pid_file)
+            .unwrap()
+            .trim()
+            .parse()
+            .unwrap();
+        let pid = Pid::from_raw(raw).unwrap();
+        assert_eq!(
+            std::fs::read_link(format!("/proc/{raw}/exe")).unwrap(),
+            fixture.canonicalize().unwrap(),
+            "only suspend the fixture launched by this test"
+        );
+        kill_process(pid, Signal::STOP).unwrap();
+        let mut paused = Self { pid, resume: None };
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            let stat = std::fs::read_to_string(format!("/proc/{raw}/stat")).unwrap();
+            if stat.rsplit_once(')').unwrap().1.split_whitespace().next() == Some("T") {
+                break;
+            }
+            assert!(Instant::now() < deadline, "fixture did not stop");
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        paused.resume = Some(std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(40));
+            kill_process(pid, Signal::CONT).unwrap();
+        }));
+        paused
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl Drop for PausedApp {
+    fn drop(&mut self) {
+        let _ = rustix::process::kill_process(self.pid, rustix::process::Signal::CONT);
+        if let Some(resume) = self.resume.take() {
+            let _ = resume.join();
+        }
+    }
+}
+
+fn consecutive_inputs(backend: &'static str, stall: bool) {
     let fixture = std::env::var_os("GLASS_EGUI_FIXTURE")
         .map(PathBuf::from)
         .unwrap_or_else(|| {
             PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                .join("../glass-fixture-egui/target/release/glass-fixture-egui")
+                .join("../glass-fixture-egui/target/release")
+                .join(format!(
+                    "glass-fixture-egui{}",
+                    std::env::consts::EXE_SUFFIX
+                ))
         });
     assert!(fixture.is_file(), "build the egui fixture: {fixture:?}");
     let dir = tempfile::tempdir().unwrap();
-    let xvfb = glass_x11::Xvfb::start("1280x800x24").unwrap();
-    let display = xvfb.display.clone();
+    #[cfg(target_os = "linux")]
+    let xvfb = (backend == "x11").then(|| glass_x11::Xvfb::start("1280x800x24").unwrap());
+    #[cfg(target_os = "linux")]
+    let display = xvfb.as_ref().map(|xvfb| xvfb.display.clone());
     let mut glass = Glass::new(
         Box::new(move |_| {
-            Ok(Backend {
-                platform: Box::new(glass_x11::X11Platform::connect(Some(&display))?),
+            #[cfg(target_os = "linux")]
+            let backend = Backend {
+                platform: match backend {
+                    "x11" => Box::new(glass_x11::X11Platform::connect(display.as_deref())?),
+                    "wayland" => Box::new(glass_wayland::WaylandPlatform::new()?),
+                    _ => unreachable!(),
+                },
                 accessibility: Some(Box::new(glass_a11y_linux::LinuxA11y::new())),
-            })
+            };
+            #[cfg(windows)]
+            let backend = Backend {
+                platform: Box::new(glass_windows::WindowsPlatform::new()?),
+                accessibility: Some(Box::new(glass_a11y_windows::WindowsA11y::new())),
+            };
+            Ok(backend)
         }),
-        "x11".into(),
+        backend.into(),
         BaselineStore::new(dir.path().join("baselines")),
         1000,
     );
+    let fixture_run = vec![fixture.to_string_lossy().into_owned()];
+    #[cfg(target_os = "linux")]
+    let pid_file = dir.path().join("fixture.pid");
+    #[cfg(target_os = "linux")]
+    let fixture_run = if stall {
+        let launcher = dir.path().join("launch.sh");
+        std::fs::write(&launcher, "echo $$ > \"$1\"\nexec \"$2\"\n").unwrap();
+        vec![
+            "sh".into(),
+            launcher.to_string_lossy().into_owned(),
+            pid_file.to_string_lossy().into_owned(),
+            fixture.to_string_lossy().into_owned(),
+        ]
+    } else {
+        fixture_run
+    };
     glass
         .start(&AppSpec {
             build: None,
-            run: vec![fixture.to_string_lossy().into_owned()],
+            run: fixture_run,
             cwd: None,
-            env: vec![("LIBGL_ALWAYS_SOFTWARE".into(), "1".into())],
+            env: if backend == "x11" {
+                vec![("LIBGL_ALWAYS_SOFTWARE".into(), "1".into())]
+            } else {
+                vec![]
+            },
             window_hint: None,
             timeout_ms: 10_000,
             sandbox: SandboxLevel::Off,
@@ -110,6 +225,8 @@ fn consecutive_inputs_preserve_clicks_and_final_text_in_batches_and_standalone()
         for batched in [false, true] {
             let (_, cursor) = glass.logs(0, 1000, None, None).unwrap();
             let text = format!("sequence-{repetition}-{batched}.json");
+            #[cfg(target_os = "linux")]
+            let paused = stall.then(|| PausedApp::new(&pid_file, &fixture));
             actions(
                 &mut glass,
                 vec![
@@ -122,6 +239,8 @@ fn consecutive_inputs_preserve_clicks_and_final_text_in_batches_and_standalone()
                 ],
                 batched,
             );
+            #[cfg(target_os = "linux")]
+            drop(paused);
             let deadline = Instant::now() + Duration::from_secs(2);
             let applied = format!("[fixture] applied_text={text}");
             let lines = loop {
@@ -146,7 +265,7 @@ fn consecutive_inputs_preserve_clicks_and_final_text_in_batches_and_standalone()
                         .filter(|line| !line.starts_with("[fixture] key "))
                         .collect();
                     failures.push(format!(
-                        "batch={batched} repetition={repetition}: missing {expected}; {outcomes:?}"
+                        "backend={backend} stall={stall} batch={batched} repetition={repetition}: missing {expected}; {outcomes:?}"
                     ));
                 }
             }

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -51,6 +51,8 @@ const _: () = assert!(
 );
 
 const INPUT_SETTLE: Duration = Duration::from_millis(8);
+// Give frame-based clients time to consume an action before another changes its target or focus.
+const INPUT_ACTION_DWELL: Duration = Duration::from_millis(50);
 
 fn clamped_budget(deadline: Deadline, own: Duration, now: Instant) -> (Duration, Whose) {
     deadline.budget(own, now)
@@ -62,6 +64,17 @@ struct WaylandDispatch(Cell<bool>);
 impl WaylandDispatch {
     fn mark(&self) {
         self.0.set(true);
+    }
+
+    fn finish_input_by(&self, deadline: Deadline) {
+        if self.0.get() {
+            std::thread::sleep(
+                deadline
+                    .remaining()
+                    .unwrap_or(INPUT_ACTION_DWELL)
+                    .min(INPUT_ACTION_DWELL),
+            );
+        }
     }
 
     fn deadline_error(&self, op: &str) -> GlassError {
@@ -2706,6 +2719,7 @@ impl Platform for WaylandPlatform {
                 .conn
                 .flush()
                 .map_err(|e| GlassError::Backend(format!("flush: {e}")))?;
+            dispatch.finish_input_by(deadline);
             Ok(())
         })
     }
@@ -2757,6 +2771,7 @@ impl Platform for WaylandPlatform {
                 .conn
                 .flush()
                 .map_err(|e| GlassError::Backend(format!("flush: {e}")))?;
+            dispatch.finish_input_by(deadline);
             Ok(())
         })
     }
@@ -5228,6 +5243,66 @@ mod session_tests {
             lines.iter().any(|l| l.ends_with("25 15")),
             "the point must be relative to the window, not the output: {lines:#?}"
         );
+    }
+
+    #[test]
+    fn input_action_dwell_obeys_the_caller_deadline_after_dispatch() {
+        let deadline = Deadline::from_millis(40);
+        let error = run_wayland_call_by(deadline, "pointer input", |dispatch| {
+            dispatch.mark();
+            dispatch.finish_input_by(deadline);
+            Ok(())
+        })
+        .expect_err("action spacing spends the caller's remaining budget");
+        assert_eq!(error.bound_owner(), Some(Whose::Caller));
+        assert_eq!(
+            error.bound_dispatch(),
+            Some(BoundDispatch::MayHaveDispatched)
+        );
+    }
+
+    #[test]
+    fn input_action_without_dispatch_does_not_spend_the_dwell() {
+        let deadline = Deadline::from_millis(40);
+        run_wayland_call_by(deadline, "empty input", |dispatch| {
+            dispatch.finish_input_by(deadline);
+            Ok(())
+        })
+        .expect("an empty action needs no pacing");
+    }
+
+    #[test]
+    #[ignore = "starts a real compositor; needs sway and Mesa"]
+    fn input_action_dwell_deadline_keeps_dispatched_clicks_released() {
+        let mut s = Launch::new().start_mapped();
+        let error = s
+            .platform()
+            .send_pointer_by(
+                &PointerEvent::Click {
+                    x: 20,
+                    y: 20,
+                    button: glass_core::MouseButton::Left,
+                    count: 1,
+                    modifiers: vec![],
+                },
+                Deadline::from_millis(60),
+            )
+            .expect_err("deadline expires during action spacing");
+        assert_eq!(error.bound_owner(), Some(Whose::Caller));
+        assert_eq!(
+            error.bound_dispatch(),
+            Some(BoundDispatch::MayHaveDispatched)
+        );
+        let lines = s.wait_for_log_sequence(&[" 272 1", " 272 0"]);
+        assert!(
+            lines.iter().any(|line| line.ends_with(" 272 1")),
+            "{lines:?}"
+        );
+        assert!(
+            lines.iter().any(|line| line.ends_with(" 272 0")),
+            "{lines:?}"
+        );
+        assert!(s.platform().active.as_ref().unwrap().input_poison.is_none());
     }
 
     #[test]

--- a/crates/glass-windows/src/input.rs
+++ b/crates/glass-windows/src/input.rs
@@ -766,6 +766,7 @@ pub(crate) fn send_pointer_by(
                 return Err(crate::unsupported_multi_touch());
             }
         }
+        dispatch.finish_input_by(deadline);
         Ok(())
     })
 }
@@ -807,6 +808,9 @@ pub(crate) fn send_key_by(active_hwnd: isize, event: &KeyEvent, deadline: Deadli
                 };
                 glass_core::run_chord_by(&mut sink, deadline)?;
             }
+        }
+        if !matches!(event, KeyEvent::Text(text) if text.is_empty()) {
+            dispatch.finish_input_by(deadline);
         }
         Ok(())
     })

--- a/crates/glass-windows/src/lib.rs
+++ b/crates/glass-windows/src/lib.rs
@@ -43,6 +43,10 @@ pub use host_fs::{
 /// This backend's canonical name (matches the `glass_capabilities` / `GLASS_BACKEND` value).
 pub const BACKEND: &str = "windows";
 
+// Match X11 action spacing for clients that consume input once per UI frame.
+#[cfg(any(windows, test))]
+const INPUT_ACTION_DWELL: std::time::Duration = std::time::Duration::from_millis(50);
+
 #[cfg(any(windows, test))]
 #[derive(Default)]
 struct WindowsDispatch(std::cell::Cell<bool>);
@@ -51,6 +55,17 @@ struct WindowsDispatch(std::cell::Cell<bool>);
 impl WindowsDispatch {
     fn mark(&self) {
         self.0.set(true);
+    }
+
+    fn finish_input_by(&self, deadline: glass_core::Deadline) {
+        if self.0.get() {
+            std::thread::sleep(
+                deadline
+                    .remaining()
+                    .unwrap_or(INPUT_ACTION_DWELL)
+                    .min(INPUT_ACTION_DWELL),
+            );
+        }
     }
 
     fn deadline_error(&self, op: &str) -> glass_core::GlassError {
@@ -597,6 +612,32 @@ mod deadline_tests {
             std::thread::sleep(Duration::from_millis(10));
             Ok(())
         }
+    }
+
+    #[test]
+    fn input_action_dwell_obeys_the_caller_deadline_after_dispatch() {
+        let deadline = Deadline::from_millis(40);
+        let error = run_windows_call_by(deadline, "pointer input", |dispatch| {
+            dispatch.mark();
+            dispatch.finish_input_by(deadline);
+            Ok(())
+        })
+        .expect_err("action spacing spends the caller's remaining budget");
+        assert_eq!(error.bound_owner(), Some(Whose::Caller));
+        assert_eq!(
+            error.bound_dispatch(),
+            Some(BoundDispatch::MayHaveDispatched)
+        );
+    }
+
+    #[test]
+    fn input_action_without_dispatch_does_not_spend_the_dwell() {
+        let deadline = Deadline::from_millis(40);
+        run_windows_call_by(deadline, "empty input", |dispatch| {
+            dispatch.finish_input_by(deadline);
+            Ok(())
+        })
+        .expect("an empty action needs no pacing");
     }
 
     #[test]

--- a/docs/how-to/verify-a-change.md
+++ b/docs/how-to/verify-a-change.md
@@ -101,14 +101,28 @@ The egui text-write recovery test also needs the workspace-excluded fixture:
 cargo build --release --manifest-path crates/glass-fixture-egui/Cargo.toml
 cargo test -p glass-a11y-linux --test egui -- --ignored
 cargo test -p glass-mcp --lib consecutive_inputs_preserve_clicks_and_final_text_in_batches_and_standalone -- --ignored
+cargo test -p glass-mcp --lib wayland_consecutive_inputs_preserve_clicks_and_final_text -- --ignored
 ```
 
 Set `GLASS_EGUI_FIXTURE` to use an already-built fixture at another path. This test checks that a
 missing text-write interface refuses before dispatch, keyboard input recovers, and numeric
 accessibility writes still work.
 
-The MCP egui test checks consecutive coordinate clicks and typing followed by Apply, both as
-standalone tools and in `glass_do`. It starts its own Xvfb display and private accessibility bus.
+The MCP egui tests check consecutive coordinate clicks and typing followed by Apply, both as
+standalone tools and in `glass_do`. They start their own Xvfb display or headless sway compositor
+and private accessibility bus. The Wayland test also pauses its owned fixture for 40 ms before
+each sequence to check input consumption after a brief app stall.
+
+The same app-outcome regression runs on a Windows host in its interactive desktop session:
+
+```powershell
+cargo build --release --manifest-path crates/glass-fixture-egui/Cargo.toml
+cargo test -p glass-mcp --lib windows_consecutive_inputs_preserve_clicks_and_final_text -- --ignored --test-threads=1
+```
+
+Set `GLASS_EGUI_FIXTURE` to override the fixture executable on Windows as well. Build over SSH
+if needed, then run the test executable through the scheduled-task bridge described below so
+input and capture have access to the interactive session.
 
 The X11 and Wayland **backend crates** also keep their display-backed unit tests behind
 `#[ignore]`, and no harness script runs those — if you changed `glass-x11` or `glass-wayland`,


### PR DESCRIPTION
Rapid input sequences can move the pointer or change focus before a frame-based app consumes the previous action. The shared egui regression reproduced lost button clicks on Windows and on Wayland during a brief app stall, including when using standalone tools.

Extend the X11 pacing policy from #580 to Wayland and Windows: allow 50 ms after a dispatched pointer or keyboard action, bounded by the caller deadline. Both standalone tools and `glass_do` use this backend pacing. Deadline expiry preserves `may_have_dispatched`, and empty text adds no dwell. This adds approximately 50 ms per action; callers still need to check the expected app state after transitions.

The regression now checks consecutive clicks and complete text on Apply across X11, Wayland, and Windows. Wayland also exercises a controlled 40 ms app stall and verifies that deadline expiry during the pause leaves the click released.

Validation:

- Formatting and Linux workspace Clippy passed; workspace tests: 3,755 passed.
- Wayland backend including display tests: 334 passed; integration suite: 30 passed with `WLR_RENDERER=pixman` to avoid a host EGL startup failure.
- Native Windows Clippy passed; Windows unit tests: 202 passed.
- Live egui regressions passed on X11, Wayland, and Windows. With the final harness held fixed, Windows improved from 0/8 to 8/8 successful sequences; stalled Wayland improved from 0/8 to 8/8.
- Optimized Wayland application replays: 48/48 passed. All Linux GUI validation used owned displays and isolated session buses.
