### PR TITLE
Fix Electron accessibility and keyboard startup on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ internal refactors, CI, or test-only changes.
 
 ### Fixed
 
+- Linux accessibility sessions keep a registry listener active between operations, preventing Electron crashes when a short-lived reader disconnects during keyboard input. Accessibility property reads also avoid bulk `GetAll` requests that can abort Electron on numeric fields.
+- Native Wayland apps receive a valid keyboard map before launch, preventing Electron from crashing on startup before the first keyboard action.
 - Wayland and Windows input now allow 50 ms after dispatched pointer and keyboard actions before returning, bounded by the caller deadline. This keeps rapid standalone calls and `glass_do` sequences from changing the click target or focus before a frame-based app consumes the previous action. Deadline expiry preserves possible-dispatch reporting; app transitions still require checking the expected state.
 - X11 input now allows 50 ms after each dispatched pointer or keyboard action before returning, bounded by the caller deadline. This prevents rapid action sequences from combining clicks or a final typed character with a later focus change in the same UI frame. Both standalone input tools and `glass_do` use the same pacing; successful dispatch still requires verifying the app's expected state.
 - Log tool guidance now directs verification of completed actions to buffered output and explains saving a cursor before repeated events. The already-buffered timeout note discourages repeating a wait that watches only future lines.

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -326,6 +326,7 @@ async fn set_value_async(
             return Err(GlassError::AxElementNotEditable(target.id.0));
         }
         let et = atspi::proxy::editable_text::EditableTextProxy::builder(&conn)
+            .cache_properties(zbus::proxy::CacheProperties::No)
             .destination(dest)
             .map_err(bus_err)?
             .path(path)
@@ -358,6 +359,7 @@ async fn set_value_async(
         && let Ok(v) = text.parse::<f64>()
     {
         let value_proxy = atspi::proxy::value::ValueProxy::builder(&conn)
+            .cache_properties(zbus::proxy::CacheProperties::No)
             .destination(dest)
             .ok()
             .and_then(|b| b.path(path).ok());
@@ -673,6 +675,7 @@ async fn try_action(
     let dest = node.inner().destination().to_owned();
     let path = node.inner().path().to_owned();
     let Some(action) = atspi::proxy::action::ActionProxy::builder(conn)
+        .cache_properties(zbus::proxy::CacheProperties::No)
         .destination(dest)
         .ok()
         .and_then(|b| b.path(path).ok())
@@ -929,6 +932,7 @@ async fn pointer_component<'a>(
 ) -> Result<ComponentProxy<'a>> {
     let identity = required_object_identity(object)?;
     let builder = ComponentProxy::builder(conn)
+        .cache_properties(zbus::proxy::CacheProperties::No)
         .destination(identity.bus_name)
         .map_err(|e| pointer_reference_error(format!("component destination: {e}")))?
         .path(identity.object_path)
@@ -1285,6 +1289,7 @@ async fn focus_text_editor(
     let dest = node.inner().destination().to_owned();
     let path = node.inner().path().to_owned();
     let builder = ComponentProxy::builder(conn)
+        .cache_properties(zbus::proxy::CacheProperties::No)
         .destination(dest)
         .map_err(|_| GlassError::AxActionUnavailable(id))?
         .path(path)
@@ -1473,6 +1478,7 @@ async fn extents(proxy: &AccessibleProxy<'_>, conn: &zbus::Connection) -> Option
     let dest = proxy.inner().destination().to_owned();
     let path = proxy.inner().path().to_owned();
     let comp = ComponentProxy::builder(conn)
+        .cache_properties(zbus::proxy::CacheProperties::No)
         .destination(dest)
         .ok()?
         .path(path)
@@ -1516,6 +1522,7 @@ async fn read_value(
 /// [`read_back_confirms`] must never mistake for a value.
 async fn read_text(proxy: &AccessibleProxy<'_>, conn: &zbus::Connection) -> Option<String> {
     let text = atspi::proxy::text::TextProxy::builder(conn)
+        .cache_properties(zbus::proxy::CacheProperties::No)
         .destination(proxy.inner().destination().to_owned())
         .ok()?
         .path(proxy.inner().path().to_owned())
@@ -1531,6 +1538,7 @@ async fn read_text(proxy: &AccessibleProxy<'_>, conn: &zbus::Connection) -> Opti
 /// `None` when the interface is absent or the call failed.
 async fn read_number(proxy: &AccessibleProxy<'_>, conn: &zbus::Connection) -> Option<String> {
     let val = atspi::proxy::value::ValueProxy::builder(conn)
+        .cache_properties(zbus::proxy::CacheProperties::No)
         .destination(proxy.inner().destination().to_owned())
         .ok()?
         .path(proxy.inner().path().to_owned())
@@ -1600,6 +1608,97 @@ mod tests {
     use atspi_common::ObjectRef;
 
     use super::*;
+
+    struct NumericProperties(std::sync::Arc<std::sync::atomic::AtomicUsize>);
+
+    #[zbus::interface(name = "org.a11y.atspi.Value")]
+    impl NumericProperties {
+        #[zbus(property)]
+        fn current_value(&self) -> f64 {
+            42.0
+        }
+
+        #[zbus(property)]
+        fn minimum_value(&self) -> zbus::fdo::Result<f64> {
+            self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Err(zbus::fdo::Error::NotSupported("unused property".into()))
+        }
+    }
+
+    struct TextProperties(std::sync::Arc<std::sync::atomic::AtomicUsize>);
+
+    #[zbus::interface(name = "org.a11y.atspi.Text")]
+    impl TextProperties {
+        #[zbus(property)]
+        fn character_count(&self) -> i32 {
+            5
+        }
+
+        #[zbus(property)]
+        fn caret_offset(&self) -> zbus::fdo::Result<i32> {
+            self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Err(zbus::fdo::Error::NotSupported("unused property".into()))
+        }
+
+        fn get_text(&self, start: i32, end: i32) -> String {
+            assert_eq!((start, end), (0, 5));
+            "hello".into()
+        }
+    }
+
+    #[test]
+    #[ignore = "starts a private D-Bus and AT-SPI registry; run via scripts/test-a11y.sh"]
+    fn value_reads_do_not_request_unrelated_properties() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let bus = glass_dbus_linux::PrivateBus::start().expect("private bus");
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            let unrequested_reads = Arc::new(AtomicUsize::new(0));
+            let path = "/org/a11y/atspi/accessible/properties";
+            let service = zbus::connection::Builder::address(bus.a11y_bus_address())
+                .unwrap()
+                .serve_at(path, NumericProperties(Arc::clone(&unrequested_reads)))
+                .unwrap()
+                .serve_at(path, TextProperties(Arc::clone(&unrequested_reads)))
+                .unwrap()
+                .build()
+                .await
+                .unwrap();
+            let client = zbus::connection::Builder::address(bus.a11y_bus_address())
+                .unwrap()
+                .build()
+                .await
+                .unwrap();
+            let accessible = AccessibleProxy::builder(&client)
+                .cache_properties(zbus::proxy::CacheProperties::No)
+                .destination(service.unique_name().unwrap())
+                .unwrap()
+                .path(path)
+                .unwrap()
+                .build()
+                .await
+                .unwrap();
+
+            assert_eq!(
+                read_number(&accessible, &client).await.as_deref(),
+                Some("42")
+            );
+            assert_eq!(
+                read_text(&accessible, &client).await.as_deref(),
+                Some("hello")
+            );
+            assert_eq!(
+                unrequested_reads.load(Ordering::SeqCst),
+                0,
+                "GetAll reaches unrelated toolkit getters"
+            );
+        });
+    }
 
     #[test]
     fn linux_reader_declares_every_state_fact_its_atspi_mapping_populates() {

--- a/crates/glass-dbus-linux/src/lib.rs
+++ b/crates/glass-dbus-linux/src/lib.rs
@@ -6,6 +6,8 @@
 
 #![cfg(target_os = "linux")]
 
+mod registry;
+
 use std::ffi::{OsStr, OsString};
 use std::io::{BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
@@ -37,6 +39,9 @@ pub struct PrivateBus {
     atspi: Child,
     session_bus_address: String,
     a11y_bus_address: String,
+    // Last-client disconnects can remove Chromium's ATK key listener inside its callback.
+    // Keep one registration alive until the private bus itself has been stopped.
+    _registry: registry::RegistryClient,
     #[expect(dead_code, reason = "RAII: keep the dbus-daemon stdout pipe open")]
     dbus_stdout: ChildStdout,
     // at-spi-bus-launcher writes its socket under $XDG_RUNTIME_DIR/at-spi/; a private
@@ -149,12 +154,16 @@ impl PrivateBus {
             }
         };
 
-        match resolve_a11y_address(&session_bus_address) {
-            Ok(a11y_bus_address) => Ok(PrivateBus {
+        let resolved = resolve_a11y_address(&session_bus_address).and_then(|address| {
+            registry::RegistryClient::start(&address).map(|client| (address, client))
+        });
+        match resolved {
+            Ok((a11y_bus_address, registry)) => Ok(PrivateBus {
                 dbus,
                 atspi,
                 session_bus_address,
                 a11y_bus_address,
+                _registry: registry,
                 dbus_stdout,
                 runtime_dir,
             }),
@@ -1059,6 +1068,63 @@ mod tests {
         let b = PrivateBus::start().expect("bus b");
         assert_ne!(a.session_bus_address(), b.session_bus_address());
         assert_ne!(a.runtime_dir(), b.runtime_dir());
+    }
+
+    #[test]
+    #[ignore = "spawns a private AT-SPI registry; run via scripts/test-a11y.sh"]
+    fn registry_client_survives_reader_disconnects_and_releases_its_registration() {
+        let bus = PrivateBus::start().expect("private bus");
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        runtime.block_on(async {
+            let observer = atspi::AccessibilityConnection::from_address(
+                bus.a11y_bus_address().try_into().unwrap(),
+            )
+            .await
+            .expect("observer connection");
+            let registry = atspi::proxy::registry::RegistryProxy::new(observer.connection())
+                .await
+                .unwrap();
+            let initial = registry.registered_events().await.unwrap();
+            assert_eq!(
+                initial.len(),
+                1,
+                "a listener must exist before launching an app"
+            );
+            assert_eq!(initial[0].1, "Object::");
+
+            for _ in 0..4 {
+                let reader = registry::RegistryClient::start(bus.a11y_bus_address())
+                    .expect("temporary client");
+                assert_eq!(registry.registered_events().await.unwrap().len(), 2);
+                drop(reader);
+                tokio::time::timeout(Duration::from_secs(2), async {
+                    while registry.registered_events().await.unwrap() != initial {
+                        tokio::time::sleep(Duration::from_millis(10)).await;
+                    }
+                })
+                .await
+                .expect("the temporary registration must close while the session listener remains");
+            }
+        });
+    }
+
+    #[test]
+    #[ignore = "spawns a private bus without a registry service; run via scripts/test-a11y.sh"]
+    fn missing_registry_fails_startup_without_a_successful_client() {
+        let bus = PrivateBus::start().expect("private bus");
+        let error = match registry::RegistryClient::start(bus.session_bus_address()) {
+            Ok(_) => panic!("the session bus does not host the AT-SPI registry"),
+            Err(error) => error,
+        };
+        assert!(
+            error.to_string().contains("AT-SPI registry client"),
+            "{error}"
+        );
+        let _working = registry::RegistryClient::start(bus.a11y_bus_address())
+            .expect("a failed start must not prevent a later connection");
     }
 
     /// The private session bus must expose NO auto-activatable services. glass spawns

--- a/crates/glass-dbus-linux/src/registry.rs
+++ b/crates/glass-dbus-linux/src/registry.rs
@@ -1,0 +1,90 @@
+//! Keep toolkit accessibility active between short-lived reader connections.
+
+use std::sync::mpsc;
+use std::time::Duration;
+
+use glass_core::{GlassError, Result};
+use tokio::sync::oneshot;
+
+const START_TIMEOUT: Duration = Duration::from_secs(5);
+
+pub(crate) struct RegistryClient {
+    // Dropping the sender wakes the worker and closes its registered connection.
+    _shutdown: oneshot::Sender<()>,
+}
+
+impl RegistryClient {
+    pub(crate) fn start(address: &str) -> Result<Self> {
+        let address = address.to_owned();
+        let (ready_tx, ready_rx) = mpsc::sync_channel(1);
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        std::thread::Builder::new()
+            .name("glass-atspi-registry".into())
+            .spawn(move || {
+                let runtime = match tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
+                    Ok(runtime) => runtime,
+                    Err(error) => {
+                        let _ = ready_tx.send(Err(registry_error(error)));
+                        return;
+                    }
+                };
+                runtime.block_on(async {
+                    let connection = match tokio::time::timeout(START_TIMEOUT, register(&address))
+                        .await
+                    {
+                        Ok(Ok(connection)) => connection,
+                        Ok(Err(error)) => {
+                            let _ = ready_tx.send(Err(error));
+                            return;
+                        }
+                        Err(_) => {
+                            let _ = ready_tx.send(Err(registry_error("registration timed out")));
+                            return;
+                        }
+                    };
+                    if ready_tx.send(Ok(())).is_ok() {
+                        let _ = shutdown_rx.await;
+                    }
+                    drop(connection);
+                });
+            })
+            .map_err(registry_error)?;
+        ready_rx
+            .recv_timeout(START_TIMEOUT)
+            .map_err(registry_error)??;
+        Ok(Self {
+            _shutdown: shutdown_tx,
+        })
+    }
+}
+
+fn registry_error(error: impl std::fmt::Display) -> GlassError {
+    GlassError::Backend(format!(
+        "keep private AT-SPI registry client active: {error}"
+    ))
+}
+
+async fn register(address: &str) -> Result<zbus::Connection> {
+    let connection = zbus::connection::Builder::address(address)
+        .map_err(registry_error)?
+        .build()
+        .await
+        .map_err(registry_error)?;
+    let registry = zbus::Proxy::new(
+        &connection,
+        "org.a11y.atspi.Registry",
+        "/org/a11y/atspi/registry",
+        "org.a11y.atspi.Registry",
+    )
+    .await
+    .map_err(registry_error)?;
+    registry
+        .call::<_, _, ()>("RegisterEvent", &("object:",))
+        .await
+        .map_err(registry_error)?;
+    drop(registry);
+    Ok(connection)
+}

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -1534,6 +1534,21 @@ fn open_session(
     let pointer =
         vp_manager.create_virtual_pointer_with_output(Some(&seat), Some(&output), &qh, ());
     let keyboard = vk_manager.create_virtual_keyboard(&seat, &qh, ());
+    // A client can receive modifiers as soon as it maps, before any input action.
+    let initial_keymap = crate::keyboard::build_keymap(&[]);
+    let mut initial_keymap_file = tempfile::tempfile().map_err(GlassError::Io)?;
+    initial_keymap_file
+        .write_all(initial_keymap.as_bytes())
+        .map_err(GlassError::Io)?;
+    initial_keymap_file
+        .write_all(&[0])
+        .map_err(GlassError::Io)?;
+    keyboard.keymap(
+        1,
+        initial_keymap_file.as_fd(),
+        keymap_wire_len(&initial_keymap)?,
+    );
+    roundtrip_until(&conn, &mut queue, &mut state, deadline, "initial keymap")?;
 
     // The sway IPC socket appears in the private runtime dir alongside the wayland
     // socket; retry briefly in case it lands a moment later.
@@ -4235,6 +4250,13 @@ mod session_tests {
     const SCRIPTED_X_WINDOW_2: u32 = 0x201;
     const STALLED_X_REPLY: Duration = Duration::from_secs(1);
     const X_REPLY_DEADLINE: Duration = Duration::from_millis(50);
+
+    #[test]
+    #[ignore = "starts a private compositor and native client; needs sway and Mesa"]
+    fn a_native_client_receives_a_keymap_before_any_input_action() {
+        let mut session = Launch::new().start();
+        session.wait_for_log("keyboard: initial keymap valid=true");
+    }
 
     fn scripted_x_recovery(
         missing_before: &[u32],

--- a/crates/glass-wayland/src/testw.rs
+++ b/crates/glass-wayland/src/testw.rs
@@ -495,6 +495,7 @@ mod app {
         ignores_close: bool,
         pointer: Option<wl_pointer::WlPointer>,
         keyboard: Option<wl_keyboard::WlKeyboard>,
+        saw_keymap: bool,
         redraw: bool,
     }
 
@@ -547,7 +548,7 @@ mod app {
 
     impl Dispatch<wl_keyboard::WlKeyboard, ()> for App {
         fn event(
-            _: &mut Self,
+            app: &mut Self,
             _: &wl_keyboard::WlKeyboard,
             event: wl_keyboard::Event,
             _: &(),
@@ -555,6 +556,22 @@ mod app {
             _: &QueueHandle<Self>,
         ) {
             match event {
+                wl_keyboard::Event::Keymap { format, fd, size } if !app.saw_keymap => {
+                    use std::io::Read as _;
+
+                    app.saw_keymap = true;
+                    let mut contents = Vec::new();
+                    let read = std::fs::File::from(fd)
+                        .take(u64::from(size))
+                        .read_to_end(&mut contents);
+                    let valid =
+                        matches!(format.into_result(), Ok(wl_keyboard::KeymapFormat::XkbV1))
+                            && read.is_ok()
+                            && contents.len() == size as usize
+                            && contents.starts_with(b"xkb_keymap")
+                            && contents.last() == Some(&0);
+                    echo(format!("keyboard: initial keymap valid={valid}"));
+                }
                 wl_keyboard::Event::Key { key, state, .. } => echo(format!(
                     "input: key {key} {}",
                     state.into_result().map(|s| s as u32).unwrap_or(0)
@@ -722,6 +739,7 @@ mod app {
             ignores_close: std::env::var_os(super::IGNORES_CLOSE).is_some(),
             pointer: None,
             keyboard: None,
+            saw_keymap: false,
             redraw: false,
         };
         // Keep every proxy alive for the process's lifetime: dropping a wl_surface destroys the

--- a/scripts/test-a11y.sh
+++ b/scripts/test-a11y.sh
@@ -50,6 +50,7 @@ export XDG_RUNTIME_DIR="$A11Y_TEST_RUNTIME"
 # org.a11y.Status.ScreenReaderEnabled advertisement that accesskit-based apps gate on) run
 # under the same throwaway XDG_RUNTIME_DIR isolation.
 cargo test -p glass-dbus-linux --lib -- --ignored --test-threads=1 "$TEST_FILTER"
+cargo test -p glass-a11y-linux --lib -- --ignored --test-threads=1 "$TEST_FILTER"
 cargo test -p glass-a11y-linux --test integration -- --ignored --test-threads=1 "${SKIP_ARGS[@]}" "$TEST_FILTER"
 # Its own binary, so the environment it mutates is nothing else's (see the file's header).
 cargo test -p glass-a11y-linux --test launcher_override -- --ignored "$TEST_FILTER"


### PR DESCRIPTION
Electron could abort during accessibility lookup, intermittently crash after targeted X11 typing, and crash on native Wayland before the first input action.

Keep one AT-SPI registry client registered for each private accessibility session so short-lived reader connections cannot remove the last toolkit listener during keyboard delivery. Startup is bounded and the registration ends with the private bus. Disable property caching on the native proxies to avoid implicit `GetAll` requests, and upload the initial Wayland keymap before launching clients.

Validation:

- All five Electron 39.8.5 workflows pass 10/10 on X11 and 10/10 on native Wayland: 100/100 trials, with renderer-state and trusted-key-event checks.
- Regression tests cover registry registration lifetime and failure, selective property reads, and the initial keymap observed by a native Wayland client.
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` — 3,755 passed.
- `scripts/test-a11y.sh`, `scripts/test-x11.sh`, and `scripts/test-wayland.sh` — 130 passed; the additional native keymap regression also passed.

All Linux GUI validation ran under owned private displays and session buses. A separate strict pointer-focus diagnostic still refuses before dispatch because Electron's hit test returns a container rather than the requested field; that pre-existing limitation is outside these crash fixes. Native accessibility focus and the coordinate workflows pass.
