### PR TITLE
Handle null AT-SPI parents in pointer action checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ internal refactors, CI, or test-only changes.
 - Contained Linux launches now require Bubblewrap support for `--unshare-pid`, private `--proc`, and `--json-status-fd`; launch fails closed with upgrade guidance when the installed Bubblewrap lacks them.
 
 ### Fixed
+- On Linux, pointer action checks recognize null accessibility parent properties. A hit on an unrelated container now reports the failed actionability check instead of a misleading backend transport failure.
 
 - Linux accessibility sessions keep a registry listener active between operations, preventing Electron crashes when a short-lived reader disconnects during keyboard input. Accessibility property reads also avoid bulk `GetAll` requests that can abort Electron on numeric fields.
 - Native Wayland apps receive a valid keyboard map before launch, preventing Electron from crashing on startup before the first keyboard action.

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -925,6 +925,23 @@ async fn pointer_accessible<'a>(
         .map_err(|e| pointer_reference_error(format!("accessible proxy: {e}")))
 }
 
+async fn pointer_parent(deadline: Deadline, proxy: &AccessibleProxy<'_>) -> Result<ObjectRefOwned> {
+    // atspi's property-value conversion loses the null ObjectRef variant.
+    let (name, path): (String, zbus::zvariant::OwnedObjectPath) = pointer_bus_call(
+        deadline,
+        "accessible parent",
+        proxy.inner().get_property("Parent"),
+    )
+    .await?;
+    if path.as_str() == "/org/a11y/atspi/null" {
+        return Ok(ObjectRefOwned::new(atspi_common::ObjectRef::Null));
+    }
+    Ok(ObjectRefOwned::new(atspi_common::ObjectRef::Owned {
+        name: name.try_into().map_err(pointer_reference_error)?,
+        path: path.into_inner(),
+    }))
+}
+
 async fn pointer_component<'a>(
     ctx: &AxContext,
     conn: &'a zbus::Connection,
@@ -1089,8 +1106,7 @@ async fn containing_window_root(
         if is_window_coordinate_root(role) {
             return Ok(current);
         }
-        let parent =
-            pointer_bus_call(ctx.deadline, "target ancestor parent", proxy.parent()).await?;
+        let parent = pointer_parent(ctx.deadline, &proxy).await?;
         if parent.is_null() {
             return Err(pointer_reference_error(
                 "target has no containing window, frame, or dialog",
@@ -1113,8 +1129,7 @@ async fn first_interactable_ancestor(
     let mut seen = vec![current.clone()];
     for _ in 0..ctx.limits.depth {
         let current_proxy = pointer_accessible(conn, &current).await?;
-        let parent =
-            pointer_bus_call(ctx.deadline, "ancestor parent", current_proxy.parent()).await?;
+        let parent = pointer_parent(ctx.deadline, &current_proxy).await?;
         if parent.is_null() {
             return Ok(None);
         }
@@ -1167,7 +1182,7 @@ async fn classify_pointer_hit(
         if map_role(role).is_interactable() {
             return Ok(PointerHit::Other);
         }
-        let parent = pointer_bus_call(ctx.deadline, "hit parent", current_proxy.parent()).await?;
+        let parent = pointer_parent(ctx.deadline, &current_proxy).await?;
         if parent.is_null() {
             return Ok(PointerHit::Other);
         }
@@ -1608,6 +1623,92 @@ mod tests {
     use atspi_common::ObjectRef;
 
     use super::*;
+
+    struct ParentProperty {
+        name: String,
+        path: zbus::zvariant::OwnedObjectPath,
+    }
+
+    #[zbus::interface(name = "org.a11y.atspi.Accessible")]
+    impl ParentProperty {
+        fn get_role(&self) -> u32 {
+            atspi_common::Role::Panel as u32
+        }
+
+        #[zbus(property)]
+        fn parent(&self) -> (String, zbus::zvariant::OwnedObjectPath) {
+            (self.name.clone(), self.path.clone())
+        }
+    }
+
+    #[test]
+    #[ignore = "starts a private D-Bus; run via scripts/test-a11y.sh"]
+    fn pointer_parent_reads_null_valid_and_malformed_properties() {
+        let bus = glass_dbus_linux::PrivateBus::start().expect("private bus");
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            let service = zbus::connection::Builder::address(bus.a11y_bus_address())
+                .unwrap()
+                .build()
+                .await
+                .unwrap();
+            let client = zbus::connection::Builder::address(bus.a11y_bus_address())
+                .unwrap()
+                .build()
+                .await
+                .unwrap();
+            for (name, path, succeeds) in [
+                ("", "/org/a11y/atspi/null", true),
+                (":1.42", "/org/a11y/atspi/accessible/root", true),
+                ("", "/org/a11y/atspi/accessible/root", false),
+                ("not a bus name", "/org/a11y/atspi/accessible/root", false),
+            ] {
+                let node_path = "/org/a11y/atspi/accessible/parent_test";
+                service.object_server().at(node_path, ParentProperty {
+                    name: name.into(),
+                    path: path.try_into().unwrap(),
+                }).await.unwrap();
+                let proxy = AccessibleProxy::builder(&client)
+                    .cache_properties(zbus::proxy::CacheProperties::No)
+                    .destination(service.unique_name().unwrap()).unwrap()
+                    .path(node_path).unwrap().build().await.unwrap();
+                let result = pointer_parent(Deadline::from_millis(1000), &proxy).await;
+                assert_eq!(result.is_ok(), succeeds, "parent ({name:?}, {path:?}): {result:?}");
+                if succeeds {
+                    let parent = result.unwrap();
+                    assert_eq!(parent.is_null(), path == "/org/a11y/atspi/null");
+                    assert_eq!(parent.path_as_str(), path);
+                    assert_eq!(parent.name_as_str(), (!name.is_empty()).then_some(name));
+                    if parent.is_null() {
+                        let ctx = AxContext {
+                            pids: vec![],
+                            window: glass_core::WindowGeometry::default(),
+                            window_handle: None,
+                            a11y_bus_addr: None,
+                            limits: glass_core::WalkLimits::DEFAULT,
+                            deadline: Deadline::from_millis(1000),
+                        };
+                        let target = ObjectRefOwned::from_static_str_unchecked(
+                            ":1.42", "/org/a11y/atspi/accessible/target",
+                        );
+                        let hit = ObjectRefOwned::new(ObjectRef::Owned {
+                            name: service.unique_name().unwrap().clone().into(),
+                            path: node_path.try_into().unwrap(),
+                        });
+                        assert_eq!(
+                            classify_pointer_hit(&ctx, &client, &target, None, hit).await.unwrap(),
+                            PointerHit::Other,
+                            "an unrelated panel with no parent is a hit mismatch, not a transport error",
+                        );
+                    }
+                }
+                service.object_server().remove::<ParentProperty, _>(node_path).await.unwrap();
+            }
+        });
+    }
 
     struct NumericProperties(std::sync::Arc<std::sync::atomic::AtomicUsize>);
 


### PR DESCRIPTION
Linux pointer checks can report `transport_failure` when an unrelated hit object's ancestry ends at a null AT-SPI parent. The property-value conversion in `atspi-common` represents that null as a live object, so Glass attempts to build a proxy with an empty destination.

Read `Parent` as its wire tuple, recognize the null path, and validate non-null bus names in all three pointer ancestry walks. An unrelated container now produces `not_actionable` with a failed `non_occluded` check and no input dispatched. Add a private-bus regression covering null, valid and malformed parents, plus hit classification at a null parent.

This follows #582. Electron's default empty `BrowserWindow.contentView` still intercepts the window-level accessibility hit test on the tested fixture. Strict pointer focus continues to refuse on that unchanged fixture; this PR adds no document-only hit-test bypass or focus fallback. Hiding the empty view in a diagnostic fixture copy makes strict pointer focus succeed, confirming the separate Electron limitation.

Validation on isolated Xvfb/headless Wayland displays with private session buses:

- `cargo fmt --all --check`
- `cargo clippy -p glass-a11y-linux --all-targets --locked -- -D warnings`
- `cargo test -p glass-a11y-linux --lib --locked`: 87 passed
- `./scripts/test-a11y.sh`: 43 passed, including native/pointer focus, stability and occlusion coverage
- Electron: all 10 original workflow reruns passed; six unchanged-fixture strict-pointer attempts correctly refused before dispatch; six hidden-content-view diagnostic attempts passed. The refusals remain failed typing tasks, and the modified-fixture results are causal diagnostics.
